### PR TITLE
6X Shuffle Orca Cost Models

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -464,9 +464,13 @@ CConfigParamMapping::PackConfigParamInBitset(
 			GPOPT_DISABLE_XFORM_TF(CXform::ExfJoinAssociativity));
 	}
 
-	if (OPTIMIZER_GPDB_EXPERIMENTAL == optimizer_cost_model)
+	if (OPTIMIZER_GPDB_LEGACY == optimizer_cost_model)
 	{
-		traceflag_bitset->ExchangeSet(EopttraceCalibratedBitmapIndexCostModel);
+		traceflag_bitset->ExchangeSet(EopttraceLegacyCostModel);
+	}
+	else if (OPTIMIZER_GPDB_EXPERIMENTAL == optimizer_cost_model)
+	{
+		traceflag_bitset->ExchangeSet(EopttraceExperimentalCostModel);
 	}
 
 	// enable nested loop index plans using nest params

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -79,7 +79,6 @@
 #include "naucrates/exception.h"
 
 #include "gpdbcost/CCostModelGPDB.h"
-#include "gpdbcost/CCostModelGPDBLegacy.h"
 
 
 #include "gpopt/gpdbwrappers.h"
@@ -429,17 +428,9 @@ COptTasks::SetCostModelParams(ICostModel *cost_model)
 	if (optimizer_nestloop_factor > 1.0)
 	{
 		// change NLJ cost factor
-		ICostModelParams::SCostParam *cost_param = NULL;
-		if (OPTIMIZER_GPDB_CALIBRATED >= optimizer_cost_model)
-		{
-			cost_param = cost_model->GetCostModelParams()->PcpLookup(
+		ICostModelParams::SCostParam *cost_param =
+			cost_model->GetCostModelParams()->PcpLookup(
 				CCostModelParamsGPDB::EcpNLJFactor);
-		}
-		else
-		{
-			cost_param = cost_model->GetCostModelParams()->PcpLookup(
-				CCostModelParamsGPDBLegacy::EcpNLJFactor);
-		}
 		CDouble nlj_factor(optimizer_nestloop_factor);
 		cost_model->GetCostModelParams()->SetParam(
 			cost_param->Id(), nlj_factor, nlj_factor - 0.5, nlj_factor + 0.5);
@@ -448,18 +439,15 @@ COptTasks::SetCostModelParams(ICostModel *cost_model)
 	if (optimizer_sort_factor > 1.0 || optimizer_sort_factor < 1.0)
 	{
 		// change sort cost factor
-		ICostModelParams::SCostParam *cost_param = NULL;
-		if (OPTIMIZER_GPDB_CALIBRATED >= optimizer_cost_model)
-		{
-			cost_param = cost_model->GetCostModelParams()->PcpLookup(
+		ICostModelParams::SCostParam *cost_param =
+			cost_model->GetCostModelParams()->PcpLookup(
 				CCostModelParamsGPDB::EcpSortTupWidthCostUnit);
 
-			CDouble sort_factor(optimizer_sort_factor);
-			cost_model->GetCostModelParams()->SetParam(
-				cost_param->Id(), cost_param->Get() * optimizer_sort_factor,
-				cost_param->GetLowerBoundVal() * optimizer_sort_factor,
-				cost_param->GetUpperBoundVal() * optimizer_sort_factor);
-		}
+		CDouble sort_factor(optimizer_sort_factor);
+		cost_model->GetCostModelParams()->SetParam(
+			cost_param->Id(), cost_param->Get() * optimizer_sort_factor,
+			cost_param->GetLowerBoundVal() * optimizer_sort_factor,
+			cost_param->GetUpperBoundVal() * optimizer_sort_factor);
 	}
 }
 
@@ -475,15 +463,7 @@ COptTasks::SetCostModelParams(ICostModel *cost_model)
 ICostModel *
 COptTasks::GetCostModel(CMemoryPool *mp, ULONG num_segments)
 {
-	ICostModel *cost_model = NULL;
-	if (optimizer_cost_model >= OPTIMIZER_GPDB_CALIBRATED)
-	{
-		cost_model = GPOS_NEW(mp) CCostModelGPDB(mp, num_segments);
-	}
-	else
-	{
-		cost_model = GPOS_NEW(mp) CCostModelGPDBLegacy(mp, num_segments);
-	}
+	ICostModel *cost_model = GPOS_NEW(mp) CCostModelGPDB(mp, num_segments);
 
 	SetCostModelParams(cost_model);
 

--- a/src/backend/gporca/data/dxl/minidump/AddEqualityPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddEqualityPredicates.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="23.718750" Rows="284.444444" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.097901" Rows="284.444444" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -212,7 +212,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="19.385417" Rows="284.444444" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.067249" Rows="284.444444" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Agg-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Agg-Limit.mdp
@@ -254,7 +254,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.210938" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -267,7 +267,7 @@
         <dxl:Filter/>
         <dxl:Limit>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.117188" Rows="10.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000361" Rows="10.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -276,7 +276,7 @@
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="10.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="10.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -287,7 +287,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Agg-NonSplittable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Agg-NonSplittable.mdp
@@ -282,7 +282,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="25.453125" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.073406" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -295,7 +295,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.812500" Rows="1000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.072510" Rows="1000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="3" Alias="four">
@@ -306,7 +306,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.906250" Rows="1000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.029150" Rows="1000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="four">

--- a/src/backend/gporca/data/dxl/minidump/AggWithSubqArgs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AggWithSubqArgs.mdp
@@ -291,7 +291,7 @@
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="27.005859" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.011526" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -304,7 +304,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="25.974609" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.011525" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -315,7 +315,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="24.970703" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.011489" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -328,7 +328,7 @@
                     </dxl:ParamList>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="2.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000528" Rows="2.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="a1">
@@ -344,7 +344,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:Materialize Eager="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="2.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000463" Rows="2.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="a1">
@@ -357,7 +357,7 @@
                         <dxl:Filter/>
                         <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000455" Rows="2.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="9" Alias="a1">
@@ -371,7 +371,7 @@
                           <dxl:SortingColumnList/>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="a1">
@@ -406,7 +406,7 @@
             <dxl:Filter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="20.048828" Rows="1000.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.011265" Rows="1000.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b2">

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
@@ -299,7 +299,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3217.917969" Rows="500.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.087505" Rows="500.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -313,7 +313,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3213.011719" Rows="500.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.051585" Rows="500.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -327,56 +327,9 @@
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.980469" Rows="2.000000" Width="1"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Limit>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.978516" Rows="1.000000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.976562" Rows="1000.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.488281" Rows="1000.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.031250" Rows="200.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.024651" Rows="200.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -408,6 +361,72 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.011439" Rows="2.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.011438" Rows="2.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Limit>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.011386" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.011385" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Limit>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.011380" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:GatherMotion>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
@@ -299,7 +299,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2415.183594" Rows="500.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.065812" Rows="500.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -313,7 +313,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2411.253906" Rows="500.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.038872" Rows="500.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -327,56 +327,9 @@
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.980469" Rows="2.000000" Width="1"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Limit>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.978516" Rows="1.000000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.976562" Rows="1000.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.488281" Rows="1000.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.273438" Rows="200.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.015682" Rows="200.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -408,6 +361,72 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.011439" Rows="2.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.011438" Rows="2.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Limit>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.011386" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.011385" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Limit>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.011380" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:GatherMotion>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -9,6 +9,14 @@
       <dxl:TraceFlags Value="103027,103001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.58.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.56.1.0"/>
+        <dxl:Commutator Mdid="0.59.1.0"/>
+        <dxl:InverseOp Mdid="0.1695.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:EqualityOp Mdid="0.410.1.0"/>
         <dxl:InequalityOp Mdid="0.411.1.0"/>
@@ -158,145 +166,233 @@
     <dxl:Plan Id="0" SpaceSize="1998">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="18.062500" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.000506" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="5" Alias="?column?">
-            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-              <dxl:TestExpr>
+            <dxl:If TypeMdid="0.16.1.0">
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:Comparison>
+              <dxl:If TypeMdid="0.16.1.0">
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                  <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                </dxl:Comparison>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:TestExpr>
-              <dxl:ParamList/>
-              <dxl:Result>
+              </dxl:If>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+            </dxl:If>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000505" Rows="2.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="0"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="7" Alias="ColRef_0007">
+              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
+                <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.16.1.0"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.23.1.0"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="0" Alias="">
+              <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000475" Rows="2.000000" Width="6"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+                <dxl:If TypeMdid="0.23.1.0">
+                  <dxl:IsNull>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:IsNull>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:If>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="">
+                <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1724.000463" Rows="2.000000" Width="6"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="">
+                  <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="?column?">
+                  <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                  <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.058594" Rows="1.000000" Width="5"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                    <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.16.1.0"/>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
+              </dxl:Sort>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000051" Rows="1.000000" Width="5"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="?column?">
+                    <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
-                <dxl:Result>
+                <dxl:Append IsTarget="false" IsZapped="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.058594" Rows="1.000000" Width="5"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="2" Alias="?column?">
                       <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Append IsTarget="false" IsZapped="false">
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4.041016" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="?column?">
                         <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="2" Alias="?column?">
-                          <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
+                    <dxl:Filter>
+                      <dxl:IsNotFalse>
                         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                         </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="1" Alias="">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="?column?">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        </dxl:OneTimeFilter>
-                      </dxl:Result>
-                    </dxl:Result>
+                      </dxl:IsNotFalse>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.017578" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                      </dxl:OneTimeFilter>
+                    </dxl:Result>
+                  </dxl:Result>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="4" Alias="?column?">
+                        <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:IsNotFalse>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:IsNotFalse>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="4" Alias="?column?">
-                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
+                      <dxl:Filter/>
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="4" Alias="?column?">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                          <dxl:ProjElem ColId="3" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:OneTimeFilter/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="3" Alias="">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                        </dxl:Result>
                       </dxl:Result>
                     </dxl:Result>
-                  </dxl:Append>
-                </dxl:Result>
+                  </dxl:Result>
+                </dxl:Append>
               </dxl:Result>
-            </dxl:SubPlan>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="">
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-        </dxl:Result>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
+        </dxl:Aggregate>
       </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmpAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmpAll.mdp
@@ -1333,7 +1333,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="16405.345119" Rows="60420.939579" Width="139"/>
+          <dxl:Cost StartupCost="0" TotalCost="480.305303" Rows="60420.939579" Width="139"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -1389,7 +1389,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12303.509865" Rows="60420.939579" Width="139"/>
+            <dxl:Cost StartupCost="0" TotalCost="442.595991" Rows="60420.939579" Width="139"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="l_orderkey">

--- a/src/backend/gporca/data/dxl/minidump/ArrayConcat.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayConcat.mdp
@@ -100,7 +100,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="{0,1,2,3}">
@@ -120,7 +120,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/ArrayRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayRef.mdp
@@ -376,7 +376,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.047852" Rows="1.000000" Width="22"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000163" Rows="1.000000" Width="22"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="14" Alias="a">
@@ -396,7 +396,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.037109" Rows="1.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="14" Alias="a">
@@ -460,7 +460,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
@@ -305,7 +305,7 @@ SELECT * FROM test WHERE a in (1, 47);
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="136.254605" Rows="2.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="387.964368" Rows="2.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -316,7 +316,7 @@ SELECT * FROM test WHERE a in (1, 47);
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="136.254570" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="387.964333" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
@@ -25,7 +25,7 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="101013,102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,103037,104003,104004,104005,104006,104007,105000"/>
+      <dxl:TraceFlags Value="101013,102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,103037,104003,104004,104005,104006,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolAnd.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolAnd.mdp
@@ -277,7 +277,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.062110" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -297,7 +297,7 @@
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.061980" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
@@ -287,7 +287,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.062813" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -307,7 +307,7 @@
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.062640" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOr.mdp
@@ -296,7 +296,7 @@ explain select * from r where a = 1 or b = 2;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.062110" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -316,7 +316,7 @@ explain select * from r where a = 1 or b = 2;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.061980" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
@@ -304,7 +304,7 @@ SELECT * FROM bitmap_test WHERE a in (1, 47);
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="136.254605" Rows="2.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="394.631034" Rows="2.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -315,7 +315,7 @@ SELECT * FROM bitmap_test WHERE a in (1, 47);
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="136.254570" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="394.631000" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
@@ -362,7 +362,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.130858" Rows="1.000000" Width="82"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.296956" Rows="1.000000" Width="82"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -412,7 +412,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.130552" Rows="1.000000" Width="82"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.296650" Rows="1.000000" Width="82"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">
@@ -541,7 +541,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
           </dxl:BroadcastMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.129637" Rows="1.000000" Width="37"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295735" Rows="1.000000" Width="37"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="14" Alias="c1">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
@@ -445,7 +445,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.128761" Rows="1.000000" Width="40"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.296270" Rows="1.000000" Width="40"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -495,7 +495,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.128611" Rows="1.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.296121" Rows="1.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">
@@ -624,7 +624,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2;
           </dxl:BroadcastMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.128069" Rows="1.000000" Width="15"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295578" Rows="1.000000" Width="15"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="14" Alias="c1">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
@@ -367,7 +367,7 @@ select * from x, y where x.i > y.j and y.k = 10;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.130120" Rows="1.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.297052" Rows="1.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -399,7 +399,7 @@ select * from x, y where x.i > y.j and y.k = 10;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.129941" Rows="1.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.296873" Rows="1.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -489,7 +489,7 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:BroadcastMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.128736" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295668" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -416,7 +416,7 @@ select * from x, y where x.i > y.j and y.k = 10;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.130142" Rows="1.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.297074" Rows="1.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -448,7 +448,7 @@ select * from x, y where x.i > y.j and y.k = 10;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.129963" Rows="1.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.296895" Rows="1.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -538,7 +538,7 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.128758" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295690" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="i">
@@ -605,7 +605,7 @@ select * from x, y where x.i > y.j and y.k = 10;
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.128758" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.295690" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1400,7 +1400,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="49.447266" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="889.240826" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1411,37 +1411,37 @@ ORDER BY 1 asc ;
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="48.443359" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="889.240790" Rows="1.000000" Width="8"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="23"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="fivemin">
               <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="47.419922" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="889.240790" Rows="1.000000" Width="8"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="23"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="fivemin">
                 <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="46.419922" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="889.240780" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1449,62 +1449,63 @@ ORDER BY 1 asc ;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:Result>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="45.416016" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="889.240780" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
-                    <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
-                      <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                        <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
-                        </dxl:OpExpr>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                      </dxl:OpExpr>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                    </dxl:OpExpr>
+                    <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="44.408203" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="889.240764" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="1" Alias="event_ts">
-                      <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="23" Alias="fivemin">
+                      <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
+                        <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                          <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+                          </dxl:OpExpr>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                        </dxl:OpExpr>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                      </dxl:OpExpr>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:OneTimeFilter/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="16.380859" Rows="840.000000" Width="25"/>
+                      <dxl:Cost StartupCost="0" TotalCost="889.240760" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="symbol">
-                        <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="event_ts">
                         <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5.126953" Rows="420.000000" Width="25"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.292687" Rows="840.000000" Width="25"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="symbol">
@@ -1515,60 +1516,38 @@ ORDER BY 1 asc ;
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.16166631.1.1" TableName="my_tt_agg_small">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="symbol" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:BroadcastMotion>
-                  <dxl:Sequence>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="27.019531" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="11" Alias="ets">
-                        <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="12" Alias="sym">
-                        <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="15" Alias="end_ts">
-                        <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:PartitionSelector RelationMdid="0.16166659.1.1" PartitionLevels="1" ScanId="1">
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.008085" Rows="420.000000" Width="25"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="symbol">
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="event_ts">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.16166631.1.1" TableName="my_tt_agg_small">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="symbol" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:BroadcastMotion>
+                    <dxl:Sequence>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:PartEqFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartEqFilters>
-                      <dxl:PartFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartFilters>
-                      <dxl:ResidualFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ResidualFilter>
-                      <dxl:PropagationExpression>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:PropagationExpression>
-                      <dxl:PrintableFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PrintableFilter>
-                    </dxl:PartitionSelector>
-                    <dxl:DynamicBitmapTableScan PartIndexId="1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="27.019531" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="11" Alias="ets">
@@ -1581,71 +1560,108 @@ ORDER BY 1 asc ;
                           <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                      <dxl:PartitionSelector RelationMdid="0.16166659.1.1" PartitionLevels="1" ScanId="1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:PartEqFilters>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PartEqFilters>
+                        <dxl:PartFilters>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PartFilters>
+                        <dxl:ResidualFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ResidualFilter>
+                        <dxl:PropagationExpression>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:PropagationExpression>
+                        <dxl:PrintableFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PrintableFilter>
+                      </dxl:PartitionSelector>
+                      <dxl:DynamicBitmapTableScan PartIndexId="1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="ets">
                             <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="sym">
+                            <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="15" Alias="end_ts">
                             <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                              <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                            </dxl:Cast>
-                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:Filter>
-                      <dxl:RecheckCond>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                            <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                            <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:RecheckCond>
-                      <dxl:BitmapIndexProbe>
-                        <dxl:IndexCondList>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                            <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                            <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.16166830.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                      </dxl:BitmapIndexProbe>
-                      <dxl:TableDescriptor Mdid="0.16166659.1.1" TableName="my_tq_agg_small">
-                        <dxl:Columns>
-                          <dxl:Column ColId="11" Attno="1" ColName="ets" TypeMdid="0.20.1.0"/>
-                          <dxl:Column ColId="12" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="13" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0"/>
-                          <dxl:Column ColId="15" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:DynamicBitmapTableScan>
-                  </dxl:Sequence>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
-            </dxl:RedistributeMotion>
-          </dxl:Sort>
-        </dxl:Aggregate>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                              <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                              <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                                <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                              </dxl:Cast>
+                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:And>
+                        </dxl:Filter>
+                        <dxl:RecheckCond>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                              <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                              <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:And>
+                        </dxl:RecheckCond>
+                        <dxl:BitmapIndexProbe>
+                          <dxl:IndexCondList>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                              <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                              <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:IndexCondList>
+                          <dxl:IndexDescriptor Mdid="0.16166830.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                        </dxl:BitmapIndexProbe>
+                        <dxl:TableDescriptor Mdid="0.16166659.1.1" TableName="my_tq_agg_small">
+                          <dxl:Columns>
+                            <dxl:Column ColId="11" Attno="1" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Column ColId="12" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                            <dxl:Column ColId="13" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="15" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:DynamicBitmapTableScan>
+                    </dxl:Sequence>
+                  </dxl:NestedLoopJoin>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
@@ -804,7 +804,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="204815.580059" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="10885.815339" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -836,7 +836,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="204815.579940" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="10885.815220" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -901,7 +901,7 @@
           </dxl:TableScan>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="204384.562327" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="10454.797607" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="empty_col">
@@ -924,7 +924,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="204384.562320" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="10454.797600" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -963,7 +963,7 @@
               </dxl:PartitionSelector>
               <dxl:DynamicBitmapTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="204384.562320" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="10454.797600" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="dist_a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
@@ -874,7 +874,7 @@ inferred from the second operator (c4 = 'f')
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="102.193886" Rows="1.000000" Width="30"/>
+          <dxl:Cost StartupCost="0" TotalCost="392.963707" Rows="1.000000" Width="30"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -903,7 +903,7 @@ inferred from the second operator (c4 = 'f')
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="102.193751" Rows="1.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="392.963572" Rows="1.000000" Width="30"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
@@ -428,7 +428,7 @@ see sql/BitmapIndexScan.sql
     <dxl:Plan Id="0" SpaceSize="50">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5184.781955" Rows="1.000000" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="6724.473435" Rows="1.000000" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fid">
@@ -439,7 +439,7 @@ see sql/BitmapIndexScan.sql
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5184.781934" Rows="1.000000" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="6724.473414" Rows="1.000000" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="fid">
@@ -554,7 +554,7 @@ see sql/BitmapIndexScan.sql
           </dxl:RedistributeMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.193484" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="388.116355" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="flex_value_set_id">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-    Test case: When `optimizer_cost_model` is set to experimental, we should choose a bitmap index scan that has a diff cost than master. The intent of this test is to ensure the traceflag properly works and changes the cost model.
+    Test case: When `optimizer_cost_model` is set to calibrated, we should choose a bitmap index scan that has a diff cost than master. The intent of this test is to ensure the traceflag properly works and changes the cost model.
     create table foo(a int);
     create index my_idx on foo using bitmap(a);
     insert into foo select i%100 from generate_series(1,100000)i;
     analyze foo;
-    set optimizer_cost_model=experimental;
+    set optimizer_cost_model=calibrated;
     explain select * from foo where a = 0;
                                        QUERY PLAN
     --------------------------------------------------------------------------------
@@ -31,7 +31,7 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,104003,104004,104005,104006,104007,105000"/>
+      <dxl:TraceFlags Value="102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,104003,104004,104005,104006,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
@@ -319,7 +319,7 @@
     <dxl:Plan Id="0" SpaceSize="138">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="454.683299" Rows="10.000000" Width="66"/>
+          <dxl:Cost StartupCost="0" TotalCost="831.034094" Rows="10.000000" Width="66"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="message_id">
@@ -333,7 +333,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="454.681828" Rows="10.000000" Width="66"/>
+            <dxl:Cost StartupCost="0" TotalCost="831.032623" Rows="10.000000" Width="66"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="message_id">
@@ -501,7 +501,7 @@
           </dxl:Aggregate>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="12.774694" Rows="1.000000" Width="66"/>
+              <dxl:Cost StartupCost="0" TotalCost="389.125489" Rows="1.000000" Width="66"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="message_id">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
@@ -15,147 +15,85 @@ set optimizer_enable_bitmapscan = on;
 
 explain select * from t where c4 != 't';
 
-Orca should fail to find a plan, because the inequality operator is not supported
-by the index and we don't have a mechanism to infer that it is equivalent to 
-c4 = 'f'
+Orca should still find a plan in spite of the inequality operator being
+undefined for Bitmap Index Scan. ORCA should find a plan transforming
+(c4 != 't') to (c4 = 'f')
 
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
-    <dxl:Stacktrace>1    0x00002b28a0245970 gpos::CException::Raise + 300
-2    0x00002b28a2b2b318 gpopt::CEngine::PexprExtractPlan + 978
-3    0x00002b28a2a828ef gpopt::COptimizer::PexprOptimize + 139
-4    0x00002b28a2a82313 gpopt::COptimizer::PdxlnOptimize + 1127
-5    0x00002b28a08e0d29 COptTasks::PvOptimizeTask + 1763
-6    0x00002b28a0215be3 gpos::CTask::Execute + 187
-7    0x00002b28a021163c gpos::CWorker::Execute + 188
-8    0x00002b28a021a023 gpos::CAutoTaskProxy::Execute + 287
-9    0x00002b28a0220eb3 gpos_exec + 953
-</dxl:Stacktrace>
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
-          <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:TraceFlags Value="103027,102004,102005,102006,102007,102024,102025,102121,103016"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102004,102005,102006,102007,102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.9" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.8" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.1" Name="c2" Width="5.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.25.1.0" Value="AAAACEhFQVA=" LintValue="146146156"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.25.1.0" Value="AAAACEhFQVA=" LintValue="146146156"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.0" Name="c1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:RelationStatistics Mdid="2.32778.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.32778.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="13,7" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c2" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c3" Attno="3" Mdid="0.1082.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c4" Attno="4" Mdid="0.16.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c5" Attno="5" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c6" Attno="6" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c7" Attno="7" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="0.32784.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -170,7 +108,14 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Index Mdid="0.32784.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -186,6 +131,8 @@ c4 = 'f'
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
         <dxl:EqualityOp Mdid="0.98.1.0"/>
         <dxl:InequalityOp Mdid="0.531.1.0"/>
         <dxl:LessThanOp Mdid="0.664.1.0"/>
@@ -200,7 +147,9 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -215,7 +164,9 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -230,7 +181,8 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -245,9 +197,10 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -260,117 +213,9 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.11" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.10" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.3" Name="c4" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.16.1.0" Value="true"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.16.1.0" Value="true"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.435.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7113.1.0"/>
         <dxl:EqualityOp Mdid="0.1093.1.0"/>
         <dxl:InequalityOp Mdid="0.1094.1.0"/>
         <dxl:LessThanOp Mdid="0.1095.1.0"/>
@@ -385,7 +230,9 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
         <dxl:EqualityOp Mdid="0.670.1.0"/>
         <dxl:InequalityOp Mdid="0.671.1.0"/>
         <dxl:LessThanOp Mdid="0.672.1.0"/>
@@ -400,431 +247,24 @@ c4 = 'f'
         <dxl:SumAgg Mdid="0.2111.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.22226372.1.1" Name="t" Rows="100.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.22226372.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="13,7">
-        <dxl:Columns>
-          <dxl:Column Name="c1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c2" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="5">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c3" Attno="3" Mdid="0.1082.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c4" Attno="4" Mdid="0.16.1.0" Nullable="true" ColWidth="1">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c5" Attno="5" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c6" Attno="6" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c7" Attno="7" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="0.22226400.1.0" IsPartial="false"/>
-        </dxl:IndexInfoList>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:Relation Mdid="0.22226372.1.1" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="13,7">
-        <dxl:Columns>
-          <dxl:Column Name="c1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c2" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="5">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c3" Attno="3" Mdid="0.1082.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c4" Attno="4" Mdid="0.16.1.0" Nullable="true" ColWidth="1">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c5" Attno="5" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c6" Attno="6" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c7" Attno="7" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="0.22226400.1.0" IsPartial="false"/>
-        </dxl:IndexInfoList>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.13" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.12" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.5" Name="c6" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.4" Name="c5" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAAAA+D8=" DoubleValue="1.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAAAAHkA=" DoubleValue="7.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAAAAHkA=" DoubleValue="7.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAAAAK0A=" DoubleValue="13.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAAAAK0A=" DoubleValue="13.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAACAM0A=" DoubleValue="19.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAACAM0A=" DoubleValue="19.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAACAOUA=" DoubleValue="25.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAACAOUA=" DoubleValue="25.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAACAP0A=" DoubleValue="31.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAACAP0A=" DoubleValue="31.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADAQkA=" DoubleValue="37.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADAQkA=" DoubleValue="37.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADARUA=" DoubleValue="43.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADARUA=" DoubleValue="43.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADASEA=" DoubleValue="49.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADASEA=" DoubleValue="49.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADAS0A=" DoubleValue="55.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADAS0A=" DoubleValue="55.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADATkA=" DoubleValue="61.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADATkA=" DoubleValue="61.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADgUEA=" DoubleValue="67.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADgUEA=" DoubleValue="67.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABgUkA=" DoubleValue="73.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABgUkA=" DoubleValue="73.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADgU0A=" DoubleValue="79.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADgU0A=" DoubleValue="79.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABgVUA=" DoubleValue="85.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABgVUA=" DoubleValue="85.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADgVkA=" DoubleValue="91.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADgVkA=" DoubleValue="91.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABgWEA=" DoubleValue="97.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABgWEA=" DoubleValue="97.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADgWUA=" DoubleValue="103.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADgWUA=" DoubleValue="103.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABgW0A=" DoubleValue="109.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABgW0A=" DoubleValue="109.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADgXEA=" DoubleValue="115.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADgXEA=" DoubleValue="115.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABgXkA=" DoubleValue="121.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABgXkA=" DoubleValue="121.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAADgX0A=" DoubleValue="127.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADgX0A=" DoubleValue="127.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAACwYEA=" DoubleValue="133.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAACwYEA=" DoubleValue="133.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABwYUA=" DoubleValue="139.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABwYUA=" DoubleValue="139.500000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAAAwYkA=" DoubleValue="145.500000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAAAwYkA=" DoubleValue="145.500000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAADAYkA=" DoubleValue="150.000000"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:GPDBScalarOp Mdid="0.85.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true">
+      <dxl:ColumnStatistics Mdid="1.32778.1.0.3" Name="c4" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.91.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.16.1.0"/>
         <dxl:RightType Mdid="0.16.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.84.1.0"/>
-        <dxl:Commutator Mdid="0.85.1.0"/>
-        <dxl:InverseOp Mdid="0.91.1.0"/>
-      </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.22226400.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+        <dxl:OpFunc Mdid="0.60.1.0"/>
+        <dxl:Commutator Mdid="0.91.1.0"/>
+        <dxl:InverseOp Mdid="0.85.1.0"/>
+        <dxl:HashOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7124.1.0"/>
         <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.3017.1.0"/>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.2222.1.0"/>
+          <dxl:Opfamily Mdid="0.7124.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
         </dxl:Opfamilies>
-      </dxl:Index>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.7" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.22226372.1.1.6" Name="c7" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="102"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.32778.1.0.0" Name="c1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -838,31 +278,124 @@ c4 = 'f'
       </dxl:OutputColumns>
       <dxl:CTEList/>
       <dxl:LogicalSelect>
-        <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.85.1.0">
+        <dxl:Not>
           <dxl:Ident ColId="4" ColName="c4" TypeMdid="0.16.1.0"/>
-          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-        </dxl:Comparison>
+        </dxl:Not>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.22226372.1.1" TableName="t">
+          <dxl:TableDescriptor Mdid="0.32778.1.0" TableName="t">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="2" ColName="c2" TypeMdid="0.25.1.0"/>
-              <dxl:Column ColId="3" Attno="3" ColName="c3" TypeMdid="0.1082.1.0"/>
-              <dxl:Column ColId="4" Attno="4" ColName="c4" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="5" Attno="5" ColName="c5" TypeMdid="0.701.1.0"/>
-              <dxl:Column ColId="6" Attno="6" ColName="c6" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="7" Attno="7" ColName="c7" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="8" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="9" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="10" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="11" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="12" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="1" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="c2" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c3" TypeMdid="0.1082.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="4" ColName="c4" TypeMdid="0.16.1.0" ColWidth="1"/>
+              <dxl:Column ColId="5" Attno="5" ColName="c5" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="6" ColName="c6" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="7" ColName="c7" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="9" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="0">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="68.129495" Rows="1.000000" Width="33"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="c1">
+            <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="c2">
+            <dxl:Ident ColId="1" ColName="c2" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c3">
+            <dxl:Ident ColId="2" ColName="c3" TypeMdid="0.1082.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="3" Alias="c4">
+            <dxl:Ident ColId="3" ColName="c4" TypeMdid="0.16.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="4" Alias="c5">
+            <dxl:Ident ColId="4" ColName="c5" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="5" Alias="c6">
+            <dxl:Ident ColId="5" ColName="c6" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="6" Alias="c7">
+            <dxl:Ident ColId="6" ColName="c7" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:BitmapTableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="68.129352" Rows="1.000000" Width="33"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="c1">
+              <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="c2">
+              <dxl:Ident ColId="1" ColName="c2" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c3">
+              <dxl:Ident ColId="2" ColName="c3" TypeMdid="0.1082.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="3" Alias="c4">
+              <dxl:Ident ColId="3" ColName="c4" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="4" Alias="c5">
+              <dxl:Ident ColId="4" ColName="c5" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="5" Alias="c6">
+              <dxl:Ident ColId="5" ColName="c6" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="6" Alias="c7">
+              <dxl:Ident ColId="6" ColName="c7" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:RecheckCond>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+              <dxl:Ident ColId="3" ColName="c4" TypeMdid="0.16.1.0"/>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+            </dxl:Comparison>
+          </dxl:RecheckCond>
+          <dxl:BitmapIndexProbe>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                <dxl:Ident ColId="3" ColName="c4" TypeMdid="0.16.1.0"/>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.32784.1.0" IndexName="idx_t_1"/>
+          </dxl:BitmapIndexProbe>
+          <dxl:TableDescriptor Mdid="0.32778.1.0" TableName="t">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="c2" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c3" TypeMdid="0.1082.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="4" ColName="c4" TypeMdid="0.16.1.0" ColWidth="1"/>
+              <dxl:Column ColId="4" Attno="5" ColName="c5" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="6" ColName="c6" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="7" ColName="c7" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="8" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:BitmapTableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
@@ -610,7 +610,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="76.842297" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="387.962523" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="hi_ndv">
@@ -624,7 +624,7 @@
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="76.842267" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="387.962493" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="hi_ndv">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
@@ -285,7 +285,7 @@ explain select * from indexonao where a = 21;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="102.190949" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="392.963271" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -296,7 +296,7 @@ explain select * from indexonao where a = 21;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="102.190928" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="392.963250" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
@@ -794,7 +794,7 @@ explain select * from t_ao where c2 = 'HEAP';
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="204.717960" Rows="100.000000" Width="30"/>
+          <dxl:Cost StartupCost="0" TotalCost="398.329030" Rows="100.000000" Width="30"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -823,7 +823,7 @@ explain select * from t_ao where c2 = 'HEAP';
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="204.701700" Rows="100.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="398.312770" Rows="100.000000" Width="30"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
@@ -244,7 +244,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="392.963445" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="x2">
@@ -255,7 +255,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="392.963445" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="x2">
@@ -269,7 +269,7 @@
           <dxl:SortingColumnList/>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="392.963409" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="x2">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
@@ -333,7 +333,7 @@ SELECT * FROM my_tq_agg_small tq WHERE 110 >= tq.ets;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.129420" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295838" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ets">
@@ -356,7 +356,7 @@ SELECT * FROM my_tq_agg_small tq WHERE 110 >= tq.ets;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.129281" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295699" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ets">

--- a/src/backend/gporca/data/dxl/minidump/CSQ-VolatileTVF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CSQ-VolatileTVF.mdp
@@ -783,7 +783,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1281522.531250" Rows="10010.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.736231" Rows="10010.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -803,7 +803,7 @@
               </dxl:ParamList>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="4.921875" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.001000" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -814,7 +814,7 @@
                 <dxl:Filter/>
                 <dxl:TableValuedFunction FuncId="0.1067.1.0" Name="generate_series" TypeMdid="0.23.1.0">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.953125" Rows="1000.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.001000" Rows="1000.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="generate_series">
@@ -831,7 +831,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="79.203125" Rows="10010.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.538638" Rows="10010.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -845,7 +845,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="39.101562" Rows="10010.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.104604" Rows="10010.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CTE-10.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-10.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.156250" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000538" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -271,7 +271,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTE-11.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-11.mdp
@@ -266,7 +266,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.156250" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000538" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="a">
@@ -280,7 +280,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
@@ -272,9 +272,9 @@
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="48">
-      <dxl:Sequence>
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.816406" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.003882" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="a">
@@ -290,21 +290,29 @@
             <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="0,1">
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.097656" Rows="10.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.003163" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="a">
+              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="19" Alias="b">
+              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="27" Alias="a">
+              <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="28" Alias="b">
+              <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:CTEProducer CTEId="0" Columns="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.078125" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000184" Rows="10.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -314,11 +322,9 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -343,37 +349,10 @@
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
-          </dxl:GatherMotion>
-        </dxl:CTEProducer>
-        <dxl:HashJoin JoinType="Inner">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.093750" Rows="10.000000" Width="16"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="18" Alias="a">
-              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="b">
-              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="27" Alias="a">
-              <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="28" Alias="b">
-              <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
-          <dxl:CTEConsumer CTEId="0" Columns="18,19">
+          </dxl:CTEProducer>
+          <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.078125" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.002899" Rows="10.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="a">
@@ -382,13 +361,6 @@
               <dxl:ProjElem ColId="19" Alias="b">
                 <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-            </dxl:ProjList>
-          </dxl:CTEConsumer>
-          <dxl:CTEConsumer CTEId="0" Columns="27,28">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.078125" Rows="10.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
               <dxl:ProjElem ColId="27" Alias="a">
                 <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
@@ -396,9 +368,63 @@
                 <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-          </dxl:CTEConsumer>
-        </dxl:HashJoin>
-      </dxl:Sequence>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:CTEConsumer CTEId="0" Columns="18,19">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="10.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="a">
+                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="b">
+                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+            </dxl:CTEConsumer>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000222" Rows="10.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="27" Alias="a">
+                  <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="28" Alias="b">
+                  <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:CTEConsumer CTEId="0" Columns="27,28">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="10.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="27" Alias="a">
+                    <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="28" Alias="b">
+                    <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+              </dxl:CTEConsumer>
+            </dxl:RedistributeMotion>
+          </dxl:HashJoin>
+        </dxl:Sequence>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CTE-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-5.mdp
@@ -457,7 +457,7 @@
     <dxl:Plan Id="0" SpaceSize="1820">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1291.686523" Rows="3.333333" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="10344.016560" Rows="3.333333" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -483,7 +483,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1289.569336" Rows="3.333333" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="10344.016201" Rows="3.333333" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">
@@ -514,7 +514,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.530273" Rows="2.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.003172" Rows="2.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="36" Alias="c">
@@ -534,7 +534,7 @@
             <dxl:SortingColumnList/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="7.514648" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.002753" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="36" Alias="c">
@@ -552,7 +552,7 @@
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="1" Columns="18,19,27,28">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.299805" Rows="3.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001871" Rows="3.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="c">
@@ -570,7 +570,7 @@
                 </dxl:ProjList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.296875" Rows="3.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.001870" Rows="3.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="c">
@@ -596,7 +596,7 @@
                   </dxl:HashCondList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="c">
@@ -623,7 +623,7 @@
                   </dxl:TableScan>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.062500" Rows="3.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000291" Rows="3.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="27" Alias="a">
@@ -657,7 +657,7 @@
               </dxl:CTEProducer>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.199219" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000874" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="36" Alias="c">
@@ -683,7 +683,7 @@
                 </dxl:HashCondList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="3.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000157" Rows="3.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="36" Alias="c">
@@ -708,7 +708,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:CTEConsumer CTEId="1" Columns="36,37,38,39">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.023438" Rows="3.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="3.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="36" Alias="c">
@@ -728,7 +728,7 @@
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="3.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="54" Alias="c">
@@ -744,7 +744,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:CTEConsumer CTEId="1" Columns="54,55,56,57">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="3.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="3.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="54" Alias="c">
@@ -767,7 +767,7 @@
           </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTE-6.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-6.mdp
@@ -193,7 +193,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.031250" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="b">
@@ -204,7 +204,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/CTE-7.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-7.mdp
@@ -402,7 +402,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.156250" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000538" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="a">
@@ -416,7 +416,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTE-8.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-8.mdp
@@ -262,7 +262,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.234375" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000538" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="e">
@@ -276,7 +276,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/CTE-9.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-9.mdp
@@ -402,7 +402,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.078125" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000538" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="c">
@@ -416,7 +416,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/CTE-PartTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-PartTbl.mdp
@@ -255,7 +255,7 @@
     <dxl:Plan Id="0" SpaceSize="408">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.267578" Rows="2.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000197" Rows="2.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="22" Alias="a">
@@ -267,7 +267,7 @@
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.017578" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -279,7 +279,7 @@
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -293,7 +293,7 @@
             <dxl:SortingColumnList/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -326,7 +326,7 @@
               </dxl:PartitionSelector>
               <dxl:DynamicTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -356,7 +356,7 @@
         </dxl:CTEProducer>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.203125" Rows="2.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000112" Rows="2.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="22" Alias="a">
@@ -369,11 +369,11 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="22" Alias="a">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="12" Alias="b">
                 <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
@@ -381,9 +381,9 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.054688" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="12"/>
@@ -394,9 +394,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:CTEConsumer CTEId="0" Columns="11,12">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="a">
@@ -406,26 +406,45 @@
                     <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-              </dxl:CTEConsumer>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:CTEConsumer CTEId="0" Columns="11,12">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="11" Alias="a">
+                      <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="12" Alias="b">
+                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Result>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="a">
                 <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="34" Alias="b">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.054688" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="23"/>
@@ -436,9 +455,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:CTEConsumer CTEId="0" Columns="23,24">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="a">
@@ -448,7 +467,26 @@
                     <dxl:Ident ColId="24" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-              </dxl:CTEConsumer>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:CTEConsumer CTEId="0" Columns="23,24">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="23" Alias="a">
+                      <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="24" Alias="b">
+                      <dxl:Ident ColId="24" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Result>
         </dxl:Append>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds1.mdp
@@ -236,7 +236,7 @@
     <dxl:Plan Id="0" SpaceSize="240">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="27.330566" Rows="2.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.000518" Rows="2.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="i">
@@ -250,7 +250,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="25.283691" Rows="2.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.000375" Rows="2.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="i">
@@ -262,7 +262,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="1" Columns="9,10">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="20.033691" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000175" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -274,7 +274,7 @@
             </dxl:ProjList>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="19.032715" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000174" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -288,36 +288,9 @@
               <dxl:JoinFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:JoinFilter>
-              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.001465" Rows="2.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">
-                    <dxl:Columns>
-                      <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="i">
@@ -353,11 +326,45 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="2.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">
+                      <dxl:Columns>
+                        <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
             </dxl:NestedLoopJoin>
           </dxl:CTEProducer>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.218750" Rows="2.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000184" Rows="2.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -372,9 +379,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Append IsTarget="false" IsZapped="false">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.125000" Rows="2.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000159" Rows="2.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="i">
@@ -385,9 +392,15 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Result>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="28" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000159" Rows="2.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="i">
@@ -397,16 +410,10 @@
                     <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:CTEConsumer CTEId="1" Columns="27,28">
+                <dxl:Filter/>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="27" Alias="i">
@@ -416,30 +423,30 @@
                       <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                </dxl:CTEConsumer>
-              </dxl:Result>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="45" Alias="i">
-                    <dxl:Ident ColId="45" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="46" Alias="j">
-                    <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:CTEConsumer CTEId="1" Columns="45,46">
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:CTEConsumer CTEId="1" Columns="27,28">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="27" Alias="i">
+                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="j">
+                        <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Result>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="45" Alias="i">
@@ -449,9 +456,29 @@
                       <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                </dxl:CTEConsumer>
-              </dxl:Result>
-            </dxl:Append>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:CTEConsumer CTEId="1" Columns="45,46">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="45" Alias="i">
+                        <dxl:Ident ColId="45" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="46" Alias="j">
+                        <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Result>
+              </dxl:Append>
+            </dxl:Sort>
           </dxl:Aggregate>
         </dxl:Sequence>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
@@ -259,10 +259,10 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17026">
+    <dxl:Plan Id="0" SpaceSize="1818">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="28.507324" Rows="3.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.000757" Rows="3.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="i">
@@ -276,7 +276,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="27.483887" Rows="3.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.000541" Rows="3.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="i">
@@ -288,7 +288,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.006836" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000022" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -300,7 +300,7 @@
             </dxl:ProjList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -326,9 +326,9 @@
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:CTEProducer>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="24.383301" Rows="3.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.000495" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -343,9 +343,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="23.242676" Rows="3.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.000458" Rows="3.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="i">
@@ -356,18 +356,15 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="28" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
               <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="22.219238" Rows="3.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2155.000378" Rows="3.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="i">
@@ -380,7 +377,7 @@
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="27" Alias="i">
@@ -399,7 +396,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:CTEConsumer CTEId="0" Columns="27,28">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="27" Alias="i">
@@ -413,7 +410,7 @@
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="36" Alias="i">
@@ -435,7 +432,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:CTEConsumer CTEId="0" Columns="36,37">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="36" Alias="i">
@@ -447,9 +444,9 @@
                     </dxl:ProjList>
                   </dxl:CTEConsumer>
                 </dxl:Result>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19.078613" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000211" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="45" Alias="i">
@@ -459,13 +456,19 @@
                       <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0">
+                        <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:OpExpr>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="2.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000178" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="45" Alias="i">
@@ -476,10 +479,12 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="45" Alias="i">
@@ -490,24 +495,15 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                            <dxl:Ident ColId="45" ColName="i" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                            <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0">
-                              <dxl:Ident ColId="46" ColName="j" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                            </dxl:OpExpr>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                          <dxl:Ident ColId="45" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                        </dxl:Comparison>
                       </dxl:Filter>
                       <dxl:OneTimeFilter/>
                       <dxl:CTEConsumer CTEId="0" Columns="45,46">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="45" Alias="i">
@@ -519,30 +515,45 @@
                         </dxl:ProjList>
                       </dxl:CTEConsumer>
                     </dxl:Result>
-                  </dxl:BroadcastMotion>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">
-                      <dxl:Columns>
-                        <dxl:Column ColId="47" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="48" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="50" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="51" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="52" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="53" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="54" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="55" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:NestedLoopJoin>
+                    <dxl:Materialize Eager="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="2.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">
+                            <dxl:Columns>
+                              <dxl:Column ColId="47" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="48" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="50" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="51" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="52" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="53" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="54" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="55" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:BroadcastMotion>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Result>
               </dxl:Append>
-            </dxl:RedistributeMotion>
+            </dxl:Sort>
           </dxl:Aggregate>
         </dxl:Sequence>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/CTE-SetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-SetOp.mdp
@@ -9,7 +9,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="2"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103003,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
@@ -99,7 +99,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.070312" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000059" Rows="3.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="one">
@@ -108,7 +108,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.011719" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="one">
@@ -117,7 +117,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
           </dxl:ProjList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="one">
@@ -128,7 +128,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="">
@@ -142,7 +142,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
         </dxl:CTEProducer>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="3.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000041" Rows="3.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="one">
@@ -152,7 +152,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
           <dxl:Filter/>
           <dxl:CTEConsumer CTEId="0" Columns="2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="one">
@@ -162,7 +162,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
           </dxl:CTEConsumer>
           <dxl:CTEConsumer CTEId="0" Columns="4">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="4" Alias="one">
@@ -172,7 +172,7 @@ SQL: with v as (select 1 as one) select one from v union all select one from v u
           </dxl:CTEConsumer>
           <dxl:CTEConsumer CTEId="0" Columns="6">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="6" Alias="one">

--- a/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
@@ -413,7 +413,7 @@
     <dxl:Plan Id="0" SpaceSize="52">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="19.769531" Rows="100.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.050688" Rows="100.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="a">
@@ -433,7 +433,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="17.597656" Rows="100.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.039912" Rows="100.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="a">
@@ -451,7 +451,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="9,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.050781" Rows="100.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.003945" Rows="100.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -463,7 +463,7 @@
             </dxl:ProjList>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.953125" Rows="100.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.003895" Rows="100.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -482,7 +482,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.367188" Rows="100.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.002017" Rows="100.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">
@@ -496,7 +496,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.195312" Rows="100.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -523,7 +523,7 @@
           </dxl:CTEProducer>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="9.203125" Rows="100.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.034767" Rows="100.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -549,7 +549,7 @@
             </dxl:HashCondList>
             <dxl:CTEConsumer CTEId="0" Columns="10,11">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.585938" Rows="100.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001446" Rows="100.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
@@ -562,7 +562,7 @@
             </dxl:CTEConsumer>
             <dxl:CTEConsumer CTEId="0" Columns="20,21">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.585938" Rows="100.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001446" Rows="100.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="20" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTEWithVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithVolatileFunction.mdp
@@ -153,7 +153,7 @@
     <dxl:Plan Id="0" SpaceSize="60">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="10.191406" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000209" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="sum">
@@ -162,7 +162,7 @@
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.019531" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="nextval">
@@ -171,7 +171,7 @@
           </dxl:ProjList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="nextval">
@@ -184,7 +184,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="">
@@ -198,7 +198,7 @@
         </dxl:CTEProducer>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.140625" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000183" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="4" Alias="sum">
@@ -209,7 +209,7 @@
           <dxl:SortingColumnList/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.132812" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000111" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="4" Alias="sum">
@@ -219,7 +219,7 @@
             <dxl:Filter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.062500" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="4" Alias="sum">
@@ -228,9 +228,9 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.062500" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="2"/>
@@ -246,9 +246,9 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="nextval">
@@ -256,28 +256,44 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:CTEConsumer CTEId="0" Columns="2">
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="2" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="nextval">
                         <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                </dxl:RedistributeMotion>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:CTEConsumer CTEId="0" Columns="2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="2" Alias="nextval">
+                          <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:RedistributeMotion>
+                </dxl:Sort>
               </dxl:Aggregate>
             </dxl:Result>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.054688" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="7" Alias="sum">
@@ -288,7 +304,7 @@
               <dxl:OneTimeFilter/>
               <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.046875" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="7" Alias="sum">
@@ -299,7 +315,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -312,7 +328,7 @@
                   <dxl:Filter/>
                   <dxl:CTEConsumer CTEId="0" Columns="5">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="5" Alias="nextval">

--- a/src/backend/gporca/data/dxl/minidump/CTG-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTG-Join.mdp
@@ -95,7 +95,7 @@
     <dxl:Plan Id="0" SpaceSize="32">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.128906" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000534" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="a">
@@ -115,7 +115,7 @@
         </dxl:HashCondList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -126,7 +126,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="">
@@ -139,7 +139,7 @@
         </dxl:Result>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="3" Alias="b">
@@ -150,7 +150,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10891,7 +10891,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
     <dxl:Plan Id="0" SpaceSize="188">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4370028.843255" Rows="13.696907" Width="127"/>
+          <dxl:Cost StartupCost="0" TotalCost="102938.691528" Rows="13.696907" Width="127"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -10908,7 +10908,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4370026.993886" Rows="13.696907" Width="127"/>
+            <dxl:Cost StartupCost="0" TotalCost="102938.683718" Rows="13.696907" Width="127"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -10929,7 +10929,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:Filter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4370020.897674" Rows="13.696907" Width="127"/>
+              <dxl:Cost StartupCost="0" TotalCost="102938.680472" Rows="13.696907" Width="127"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -10957,7 +10957,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
             </dxl:HashExprList>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4370019.048305" Rows="13.696907" Width="127"/>
+                <dxl:Cost StartupCost="0" TotalCost="102938.677750" Rows="13.696907" Width="127"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -10978,7 +10978,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
               <dxl:Filter/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="4324539.959998" Rows="183337.885509" Width="127"/>
+                  <dxl:Cost StartupCost="0" TotalCost="102898.499421" Rows="183337.885509" Width="127"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -11001,7 +11001,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
                 </dxl:HashCondList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1440101.500000" Rows="737331968.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="34698.503213" Rows="737331968.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="31" Alias="ss_item_sk">
@@ -11025,7 +11025,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
                 </dxl:TableScan>
                 <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="4216.937588" Rows="27.393814" Width="131"/>
+                    <dxl:Cost StartupCost="0" TotalCost="444.113986" Rows="27.393814" Width="131"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i_item_sk">
@@ -11045,7 +11045,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
                   <dxl:SortingColumnList/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4214.185347" Rows="13.696907" Width="131"/>
+                      <dxl:Cost StartupCost="0" TotalCost="444.067020" Rows="13.696907" Width="131"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="i_item_sk">

--- a/src/backend/gporca/data/dxl/minidump/CastOnSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CastOnSubquery.mdp
@@ -456,10 +456,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="326.335938" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001993" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -470,10 +470,93 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:JoinFilter>
+          <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1209.1.0">
+            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Cast>
+            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:Cast>
+          </dxl:Comparison>
+        </dxl:JoinFilter>
+        <dxl:Assert ErrorCode="P0003">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="325.320312" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000325" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="c">
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:AssertConstraintList>
+            <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+                <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Cast>
+              </dxl:Comparison>
+            </dxl:AssertConstraint>
+          </dxl:AssertConstraintList>
+          <dxl:Window PartitionColumns="">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="10.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="18" Alias="row_number">
+                <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="c">
+                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="10.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="c">
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="c">
+                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.217327.1.1" TableName="bar">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:GatherMotion>
+            <dxl:WindowKeyList>
+              <dxl:WindowKey>
+                <dxl:SortingColumnList/>
+              </dxl:WindowKey>
+            </dxl:WindowKeyList>
+          </dxl:Window>
+        </dxl:Assert>
+        <dxl:Materialize Eager="true">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000618" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -484,123 +567,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1209.1.0">
-              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:Cast>
-              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
-                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:Cast>
-            </dxl:Comparison>
-          </dxl:JoinFilter>
-          <dxl:Assert ErrorCode="P0003">
+          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.281250" Rows="2.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="c">
-                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:AssertConstraintList>
-              <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                  <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
-                  <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:Cast>
-                </dxl:Comparison>
-              </dxl:AssertConstraint>
-            </dxl:AssertConstraintList>
-            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.273438" Rows="20.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="c">
-                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="row_number">
-                  <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="10.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="c">
-                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="18" Alias="row_number">
-                    <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Window PartitionColumns="">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="10.000000" Width="12"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="row_number">
-                      <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="c">
-                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="10.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="9" Alias="c">
-                        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="9" Alias="c">
-                          <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.217327.1.1" TableName="bar">
-                        <dxl:Columns>
-                          <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:GatherMotion>
-                  <dxl:WindowKeyList>
-                    <dxl:WindowKey>
-                      <dxl:SortingColumnList/>
-                    </dxl:WindowKey>
-                  </dxl:WindowKeyList>
-                </dxl:Window>
-              </dxl:Result>
-            </dxl:BroadcastMotion>
-          </dxl:Assert>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000538" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -611,22 +580,37 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.217301.1.1" TableName="foo">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:NestedLoopJoin>
-      </dxl:GatherMotion>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.217301.1.1" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:Materialize>
+      </dxl:NestedLoopJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CheckAsUser.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CheckAsUser.mdp
@@ -183,7 +183,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.029297" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -197,7 +197,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -855,7 +855,7 @@
     <dxl:Plan Id="0" SpaceSize="5302">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="282440.388516" Rows="4.000000" Width="269"/>
+          <dxl:Cost StartupCost="0" TotalCost="38915.797885" Rows="4.000000" Width="269"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="datname">
@@ -889,7 +889,7 @@
               </dxl:ParamList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.140625" Rows="1.000000" Width="64"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.001303" Rows="1.000000" Width="64"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="90" Alias="spcname">
@@ -923,7 +923,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="72514.146328" Rows="8.000000" Width="205"/>
+            <dxl:Cost StartupCost="0" TotalCost="6920.082238" Rows="8.000000" Width="205"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="datname">
@@ -957,7 +957,7 @@
           </dxl:JoinFilter>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="315.603516" Rows="4.000000" Width="141"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.011733" Rows="4.000000" Width="141"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="datname">
@@ -990,7 +990,7 @@
             <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.962891" Rows="4.000000" Width="141"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.005337" Rows="4.000000" Width="141"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="datname">
@@ -1025,7 +1025,7 @@
               </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.714844" Rows="3.000000" Width="81"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000761" Rows="3.000000" Width="81"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="datname">
@@ -1076,7 +1076,7 @@
               </dxl:TableScan>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.070312" Rows="1.000000" Width="72"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="19" Alias="rolname">
@@ -1105,7 +1105,7 @@
           </dxl:Sort>
           <dxl:Assert ErrorCode="P0003">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.542813" Rows="1.000000" Width="64"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.001650" Rows="1.000000" Width="64"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="44" Alias="rolname">
@@ -1124,7 +1124,7 @@
             </dxl:AssertConstraintList>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.417813" Rows="1.000000" Width="72"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="72"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="107" Alias="row_number">
@@ -1137,7 +1137,7 @@
               <dxl:Filter/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.417813" Rows="1.000000" Width="64"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="64"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="44" Alias="rolname">
@@ -1154,7 +1154,7 @@
                 </dxl:HashCondList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.070312" Rows="1.000000" Width="72"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="44" Alias="rolname">
@@ -1181,7 +1181,7 @@
                 </dxl:TableScan>
                 <dxl:Assert ErrorCode="P0003">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.167813" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6.000756" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="70" Alias="datdba">
@@ -1200,7 +1200,7 @@
                   </dxl:AssertConstraintList>
                   <dxl:Window PartitionColumns="">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.160000" Rows="1.200000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="6.000752" Rows="1.200000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="106" Alias="row_number">
@@ -1213,7 +1213,7 @@
                     <dxl:Filter/>
                     <dxl:IndexScan IndexScanDirection="Forward">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.160000" Rows="1.200000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="6.000743" Rows="1.200000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="70" Alias="datdba">
@@ -1224,7 +1224,7 @@
                       <dxl:IndexCondList>
                         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
                           <dxl:Ident ColId="69" ColName="datname" TypeMdid="0.19.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGVtcGxhdGUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGVtcGxhdGUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
                         </dxl:Comparison>
                       </dxl:IndexCondList>
                       <dxl:IndexDescriptor Mdid="0.2671.1.0" IndexName="pg_database_datname_index"/>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -1934,7 +1934,7 @@ SELECT * FROM information_schema.tables;
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="36.095703" Rows="2.800000" Width="96"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.080500" Rows="2.800000" Width="96"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="66" Alias="table_catalog">
@@ -2019,7 +2019,7 @@ SELECT * FROM information_schema.tables;
                     <dxl:And>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
                         <dxl:Ident ColId="55" ColName="nspname" TypeMdid="0.19.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="cGdfY2F0YWxvZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="cGdfY2F0YWxvZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
                       </dxl:Comparison>
                       <dxl:Or>
                         <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1207.1.0">
@@ -2028,7 +2028,7 @@ SELECT * FROM information_schema.tables;
                         </dxl:Comparison>
                         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
                           <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z3BfZ2xvYmFsX3NlcXVlbmNlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z3BfZ2xvYmFsX3NlcXVlbmNlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
                         </dxl:Comparison>
                       </dxl:Or>
                     </dxl:And>
@@ -2058,7 +2058,7 @@ SELECT * FROM information_schema.tables;
                       </dxl:Comparison>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
                         <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z3BfZ2xvYmFsX3NlcXVlbmNlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z3BfZ2xvYmFsX3NlcXVlbmNlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
                       </dxl:Comparison>
                     </dxl:Or>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
@@ -2098,7 +2098,7 @@ SELECT * FROM information_schema.tables;
         <dxl:OneTimeFilter/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="34.570703" Rows="2.800000" Width="146"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.080231" Rows="2.800000" Width="146"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="relname">
@@ -2130,7 +2130,7 @@ SELECT * FROM information_schema.tables;
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.885938" Rows="2.800000" Width="72"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001171" Rows="2.800000" Width="72"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="55" Alias="nspname">
@@ -2163,7 +2163,7 @@ SELECT * FROM information_schema.tables;
           </dxl:TableScan>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="29.767578" Rows="2.000000" Width="78"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.073278" Rows="2.000000" Width="78"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="relname">
@@ -2192,7 +2192,7 @@ SELECT * FROM information_schema.tables;
             </dxl:HashCondList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="28.291016" Rows="2.000000" Width="78"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.071749" Rows="2.000000" Width="78"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="relname">
@@ -2272,7 +2272,7 @@ SELECT * FROM information_schema.tables;
             </dxl:TableScan>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="38" Alias="reloid">

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
@@ -356,7 +356,7 @@
     <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7996.320237" Rows="10000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="434.387393" Rows="10000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -371,9 +371,9 @@
           <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
           <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7956.257737" Rows="10000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="434.028193" Rows="10000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -390,7 +390,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7799.007737" Rows="10000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="433.965753" Rows="10000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -409,7 +409,7 @@
             <dxl:LimitOffset/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="39.062500" Rows="10000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-Nested.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-Nested.mdp
@@ -371,7 +371,7 @@
     <dxl:Plan Id="0" SpaceSize="2000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2160.330059" Rows="10000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="432.745947" Rows="10000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="x">
@@ -384,7 +384,7 @@
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2139.798809" Rows="10000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="432.566347" Rows="10000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -397,7 +397,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2060.673809" Rows="10000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="432.535127" Rows="10000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -412,7 +412,7 @@
             <dxl:LimitOffset/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="19.531250" Rows="10000.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-SingleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-SingleColumn.mdp
@@ -352,7 +352,7 @@
     <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2080.205059" Rows="10000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="432.745947" Rows="10000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -365,7 +365,7 @@
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2059.673809" Rows="10000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="432.566347" Rows="10000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -378,7 +378,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1980.548809" Rows="10000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="432.535127" Rows="10000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -393,7 +393,7 @@
             <dxl:LimitOffset/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="19.531250" Rows="10000.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-With-Agg-Funcs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-With-Agg-Funcs.mdp
@@ -242,7 +242,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.103516" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000120" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -257,14 +257,10 @@
           <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
           <dxl:SortingColumn ColId="9" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.097656" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="0"/>
-            <dxl:GroupingColumn ColId="9"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
@@ -274,41 +270,36 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            <dxl:SortingColumn ColId="9" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.062500" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="0"/>
+              <dxl:GroupingColumn ColId="9"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="sum">
-                <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="0" Alias="i">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="j">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="9" Alias="sum">
+                <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.062500" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="12"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="0"/>
-                <dxl:GroupingColumn ColId="1"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="sum">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="i">
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
@@ -318,11 +309,26 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableScan>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="0"/>
+                  <dxl:GroupingColumn ColId="1"/>
+                </dxl:GroupingColumns>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="sum">
+                    <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="0" Alias="i">
                     <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
@@ -331,23 +337,57 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.17049.1.1" TableName="x">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:Aggregate>
-          </dxl:Sort>
-        </dxl:Aggregate>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="i">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="j">
+                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="i">
+                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="j">
+                        <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.17049.1.1" TableName="x">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-Without-Agg-Funcs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-Without-Agg-Funcs.mdp
@@ -221,7 +221,7 @@
     <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.025391" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -232,37 +232,37 @@
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.023438" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="4"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="0"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.011719" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="4"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="0"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:TableScan>
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -270,22 +270,38 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.17049.1.1" TableName="x">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Sort>
-        </dxl:Aggregate>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="i">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.17049.1.1" TableName="x">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/ComputedGroupByCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ComputedGroupByCol.mdp
@@ -326,7 +326,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="15661.293213" Rows="84.375000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="515.600123" Rows="84.375000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="count">
@@ -337,7 +337,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="15659.963623" Rows="84.375000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="515.597093" Rows="84.375000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="count">
@@ -348,7 +348,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="15659.963623" Rows="84.375000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="515.597093" Rows="84.375000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="11"/>
@@ -366,7 +366,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="15656.326904" Rows="84.375000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="515.591803" Rows="84.375000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="?column?">
@@ -385,7 +385,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="15654.832520" Rows="84.375000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="515.590219" Rows="84.375000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="?column?">
@@ -399,7 +399,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="15654.832520" Rows="84.375000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="515.590219" Rows="84.375000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="11"/>
@@ -415,7 +415,7 @@
                   <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7826.921875" Rows="1001718.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="453.127951" Rows="1001718.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="?column?">
@@ -429,7 +429,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3912.960938" Rows="1001718.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="443.671733" Rows="1001718.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CountAny.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CountAny.mdp
@@ -728,7 +728,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="141.002930" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.131215" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -739,126 +739,152 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="139.963867" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.130856" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="?column?">
               <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                  <dxl:TestExpr/>
-                  <dxl:ParamList/>
-                  <dxl:Materialize Eager="false">
+                <dxl:Coalesce TypeMdid="0.20.1.0">
+                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:Coalesce>
+              </dxl:OpExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.130816" Rows="20.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.130736" Rows="20.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="count">
+                  <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.130168" Rows="2.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="count">
+                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.130160" Rows="2.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="count">
+                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="57.880859" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.129741" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="56.865234" Rows="2.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.129740" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="count">
-                          <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="55.849609" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.129704" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns/>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="18" Alias="count">
-                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
-                              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
+                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:AggFunc>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="54.818359" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                            <dxl:ProjElem ColId="9" Alias="i">
+                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="53.814453" Rows="1.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:GroupingColumns/>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
-                                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                </dxl:AggFunc>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="17.599609" Rows="9011.000000" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="9" Alias="i">
-                                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:Aggregate>
-                        </dxl:GatherMotion>
+                          <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
+                            <dxl:Columns>
+                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
                       </dxl:Aggregate>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:SubPlan>
-              </dxl:OpExpr>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="138.885742" Rows="1000.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/CountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CountStar.mdp
@@ -716,7 +716,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="101.403809" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.104056" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -727,16 +727,74 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="100.364746" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103696" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="?column?">
-              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList/>
-                <dxl:Materialize Eager="false">
+              <dxl:Coalesce TypeMdid="0.20.1.0">
+                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:Coalesce>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="count">
+                  <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="count">
+                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="18.281738" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="count">
@@ -744,100 +802,68 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:SortingColumnList/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="17.266113" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="16.250488" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
-                            <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                          </dxl:AggFunc>
+                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                      <dxl:SortingColumnList/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="15.219238" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns/>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                            <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="14.215332" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns/>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
+                          <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="4.399902" Rows="9011.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
-                              <dxl:Columns>
-                                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:Aggregate>
-                      </dxl:GatherMotion>
-                    </dxl:Aggregate>
-                  </dxl:BroadcastMotion>
-                </dxl:Materialize>
-              </dxl:SubPlan>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="99.286621" Rows="1000.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+                          <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
+                            <dxl:Columns>
+                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:Aggregate>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/DQA-1-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-1-RegularAgg.mdp
@@ -269,7 +269,7 @@
     <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="29339.205078" Rows="4.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="577.928905" Rows="4.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -283,7 +283,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29338.173828" Rows="4.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="577.928618" Rows="4.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
@@ -295,9 +295,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="29338.173828" Rows="4.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="577.928618" Rows="4.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -318,9 +318,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="29336.759766" Rows="11.250000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="577.928510" Rows="11.250000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -340,9 +340,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="29335.232422" Rows="11.250000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="577.928370" Rows="11.250000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -356,15 +356,15 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="29334.144531" Rows="11.250000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="577.927098" Rows="11.250000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -378,36 +378,42 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="29334.144531" Rows="11.250000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="577.926816" Rows="11.250000" Width="16"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="1"/>
-                      <dxl:GroupingColumn ColId="2"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="b">
                         <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="2" Alias="c">
                         <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                        <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableScan>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5866.593750" Rows="1001232.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="577.926816" Rows="11.250000" Width="16"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="1"/>
+                        <dxl:GroupingColumn ColId="2"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:AggFunc>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="1" Alias="b">
                           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -417,24 +423,41 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:Aggregate>
-                </dxl:Result>
-              </dxl:RedistributeMotion>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="c">
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
@@ -309,7 +309,7 @@
     <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="29339.823242" Rows="4.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="579.950342" Rows="4.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -326,7 +326,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29338.776367" Rows="4.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="579.949911" Rows="4.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
@@ -343,7 +343,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="29338.776367" Rows="4.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="579.949911" Rows="4.000000" Width="24"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -371,7 +371,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="29337.155273" Rows="11.250000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="579.949194" Rows="11.250000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -398,7 +398,7 @@
               <dxl:Filter/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="29335.364258" Rows="11.250000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="579.947738" Rows="11.250000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -423,7 +423,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="29334.232422" Rows="11.250000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="579.947315" Rows="11.250000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -443,7 +443,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="29334.232422" Rows="11.250000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="579.947315" Rows="11.250000" Width="24"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="1"/>
@@ -470,7 +470,7 @@
                     <dxl:Filter/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5866.593750" Rows="1001232.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Date-TimeStamp-HashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Date-TimeStamp-HashJoin.mdp
@@ -286,7 +286,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.218750" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000955" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -314,7 +314,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -328,7 +328,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -356,7 +356,7 @@
         </dxl:GatherMotion>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="i">
@@ -370,7 +370,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/DeduplicatePredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeduplicatePredicates.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="23.484375" Rows="400.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.087810" Rows="400.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -212,7 +212,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="18.578125" Rows="400.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.051890" Rows="400.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
@@ -205,7 +205,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLDelete Columns="0,1" ActionCol="9" OidCol="0" CtidCol="2" SegmentIdCol="8" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.099609" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.043052" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -231,7 +231,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.056641" Rows="1.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -254,7 +254,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RoutedDistributeMotion SegmentIdCol="8" InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.035156" Rows="1.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -274,7 +274,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.026367" Rows="1.000000" Width="18"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="18"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DeleteWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteWithTriggers.mdp
@@ -213,14 +213,14 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.153320" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.050888" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList/>
         <dxl:Filter/>
         <dxl:OneTimeFilter/>
         <dxl:RowTrigger RelationMdid="0.187376.1.1" Type="9" OldColumns="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.153320" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.050888" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="t1">
@@ -235,7 +235,7 @@
           </dxl:ProjList>
           <dxl:DMLDelete Columns="0,1,2" ActionCol="10" OidCol="0" CtidCol="3" SegmentIdCol="9" InputSorted="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.152344" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.050887" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:DirectDispatchInfo/>
             <dxl:ProjList>
@@ -265,7 +265,7 @@
             </dxl:TableDescriptor>
             <dxl:RowTrigger RelationMdid="0.187376.1.1" Type="11" OldColumns="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.101562" Rows="1.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000106" Rows="1.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="t1">
@@ -289,7 +289,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.076172" Rows="1.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="26"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="t1">
@@ -315,7 +315,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.050781" Rows="1.000000" Width="26"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000080" Rows="1.000000" Width="26"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="t1">

--- a/src/backend/gporca/data/dxl/minidump/DuplicateGrpCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DuplicateGrpCol.mdp
@@ -401,7 +401,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2591.296875" Rows="20.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="445.481435" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -412,7 +412,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2590.218750" Rows="20.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="445.480717" Rows="20.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
@@ -423,7 +423,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2590.218750" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="445.480717" Rows="20.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -445,7 +445,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2588.437500" Rows="20.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="445.478254" Rows="20.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -470,7 +470,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2587.281250" Rows="20.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="445.477753" Rows="20.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -487,7 +487,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2587.281250" Rows="20.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="445.477753" Rows="20.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -507,7 +507,7 @@
                   <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="995.218750" Rows="101808.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="432.849851" Rows="101808.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="?column?">
@@ -524,7 +524,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="198.843750" Rows="101808.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="432.063894" Rows="101808.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapBoolOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapBoolOp.mdp
@@ -379,7 +379,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.093750" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.064156" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -399,7 +399,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.063960" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -438,7 +438,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicBitmapTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.063960" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -481,7 +481,7 @@ see sql/DynamicBitmapIndexScan.sql
     <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5989.546228" Rows="1.000000" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="6763.875569" Rows="1.000000" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="24" Alias="fid">
@@ -492,7 +492,7 @@ see sql/DynamicBitmapIndexScan.sql
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5989.546208" Rows="1.000000" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="6763.875549" Rows="1.000000" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="24" Alias="fid">
@@ -607,7 +607,7 @@ see sql/DynamicBitmapIndexScan.sql
           </dxl:RedistributeMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="204.384553" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="397.966888" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
@@ -640,7 +640,7 @@ see sql/DynamicBitmapIndexScan.sql
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="204.384553" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="397.966888" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="flex_value_set_id">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -267,7 +267,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127612" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295570" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="x2">
@@ -278,7 +278,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="x2">
@@ -289,7 +289,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="x2">
@@ -325,7 +325,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="x2">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
@@ -369,7 +369,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.087891" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000200" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -386,7 +386,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -422,7 +422,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
@@ -271,7 +271,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="248.295375" Rows="9990.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="433.588464" Rows="9990.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -285,7 +285,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="247.098240" Rows="9990.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="432.843876" Rows="9990.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -301,24 +301,24 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:ResidualFilter>
             <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" Value="1"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:PropagationExpression>
             <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PrintableFilter>
           </dxl:PartitionSelector>
-          <dxl:DynamicBitmapTableScan PartIndexId="1">
+          <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="247.098240" Rows="9990.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="432.843876" Rows="9990.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -328,22 +328,12 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:RecheckCond>
+            <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.2972.1.0">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.2950.1.0"/>
-                <dxl:ConstValue TypeMdid="0.2950.1.0" IsNull="false" Value="An6J9DnRTROsv3WhVjnmNQ==" LintValue="4123921962"/>
+                <dxl:ConstValue TypeMdid="0.2950.1.0" Value="An6J9DnRTROsv3WhVjnmNQ==" LintValue="4123921962"/>
               </dxl:Comparison>
-            </dxl:RecheckCond>
-            <dxl:BitmapIndexProbe>
-              <dxl:IndexCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.2972.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.2950.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.2950.1.0" IsNull="false" Value="An6J9DnRTROsv3WhVjnmNQ==" LintValue="4123921962"/>
-                </dxl:Comparison>
-              </dxl:IndexCondList>
-              <dxl:IndexDescriptor Mdid="0.20403.1.0" IndexName="i_1_prt_1"/>
-            </dxl:BitmapIndexProbe>
+            </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.20355.1.0" TableName="test">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.2950.1.0" ColWidth="16"/>
@@ -353,7 +343,7 @@
                 <dxl:Column ColId="4" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
-          </dxl:DynamicBitmapTableScan>
+          </dxl:DynamicTableScan>
         </dxl:Sequence>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
@@ -307,7 +307,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.382161" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000279" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000154" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -360,7 +360,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000154" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
@@ -305,7 +305,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.382161" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000279" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -322,7 +322,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000154" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -358,7 +358,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000154" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -711,7 +711,7 @@
     <dxl:Plan Id="1" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="20.929688" Rows="20.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.029301" Rows="20.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -728,7 +728,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="19.812500" Rows="20.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.028223" Rows="20.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -764,7 +764,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="19.812500" Rows="20.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.028223" Rows="20.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -317,7 +317,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.993359" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000635" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -334,7 +334,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.983594" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000545" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -356,7 +356,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.917187" Rows="2.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000488" Rows="2.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -460,7 +460,7 @@
                       </dxl:And>
                     </dxl:And>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:If>
                 </dxl:If>
               </dxl:PropagationExpression>
@@ -473,7 +473,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.917187" Rows="2.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000488" Rows="2.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -489,7 +489,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.800000" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000319" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -527,7 +527,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
@@ -417,7 +417,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.515918" Rows="1.000000" Width="27"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000344" Rows="1.000000" Width="27"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="timest">
@@ -437,7 +437,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.450000" Rows="1.000000" Width="27"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000181" Rows="1.000000" Width="27"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="timest">
@@ -476,7 +476,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.450000" Rows="1.000000" Width="27"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000181" Rows="1.000000" Width="27"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="timest">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -308,7 +308,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.993359" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000652" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -325,7 +325,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.983594" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000562" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -347,7 +347,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.917187" Rows="2.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000505" Rows="2.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -482,7 +482,7 @@
                       </dxl:And>
                     </dxl:And>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:If>
                 </dxl:If>
               </dxl:PropagationExpression>
@@ -495,7 +495,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.917187" Rows="2.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000505" Rows="2.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="id">
@@ -511,7 +511,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.800000" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000333" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="id">
@@ -549,7 +549,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -290,7 +290,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.936667" Rows="1.280000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="12.001368" Rows="1.280000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -304,7 +304,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.926667" Rows="1.280000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.001276" Rows="1.280000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -323,7 +323,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.806667" Rows="6.400000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="12.001119" Rows="6.400000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -455,7 +455,7 @@
                       </dxl:And>
                     </dxl:And>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:If>
                 </dxl:If>
               </dxl:PropagationExpression>
@@ -468,7 +468,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.806667" Rows="6.400000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="12.001119" Rows="6.400000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -481,7 +481,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.853333" Rows="3.200000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000487" Rows="3.200000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -515,7 +515,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.853333" Rows="3.200000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000487" Rows="3.200000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -290,7 +290,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.079583" Rows="1.280000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000887" Rows="1.280000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -304,7 +304,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.069583" Rows="1.280000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000795" Rows="1.280000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -323,7 +323,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.979583" Rows="4.480000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000686" Rows="4.480000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -455,7 +455,7 @@
                       </dxl:And>
                     </dxl:And>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:If>
                 </dxl:If>
               </dxl:PropagationExpression>
@@ -468,7 +468,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.979583" Rows="4.480000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000686" Rows="4.480000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -481,7 +481,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.853333" Rows="3.200000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000487" Rows="3.200000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -515,7 +515,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.056250" Rows="1.280000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000116" Rows="1.280000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -536,7 +536,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.348698" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000538" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -550,7 +550,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.344792" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000502" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -569,7 +569,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.321354" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000461" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -714,7 +714,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.321354" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000461" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -727,7 +727,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.282292" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000352" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -766,7 +766,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -536,7 +536,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.348698" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000538" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -550,7 +550,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.344792" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000502" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -569,7 +569,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.321354" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000461" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -696,7 +696,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.321354" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000461" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -709,7 +709,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.282292" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000352" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -748,7 +748,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -284,7 +284,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.058594" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000137" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -301,7 +301,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -340,7 +340,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -290,7 +290,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.230729" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="443.000920" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -304,7 +304,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.222917" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="443.000849" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -323,7 +323,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.160417" Rows="3.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="443.000775" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -524,7 +524,7 @@
                         </dxl:Or>
                       </dxl:And>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                     </dxl:If>
                   </dxl:If>
                 </dxl:If>
@@ -538,7 +538,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.160417" Rows="3.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="443.000775" Rows="3.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -551,7 +551,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.533333" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000304" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -585,7 +585,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.533333" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000304" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">
@@ -619,7 +619,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="4" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -351,7 +351,7 @@
     <dxl:Plan Id="1" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.382161" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000292" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -368,7 +368,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -407,7 +407,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -335,7 +335,7 @@
     <dxl:Plan Id="1" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.382161" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000292" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -352,7 +352,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -391,7 +391,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.333333" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127616" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295574" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -271,7 +271,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295528" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -307,7 +307,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicBitmapTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295528" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -344,7 +344,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.660286" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000536" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -358,7 +358,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.654427" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000482" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -377,7 +377,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.611458" Rows="2.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000433" Rows="2.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -515,7 +515,7 @@
                       </dxl:And>
                     </dxl:And>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:If>
                 </dxl:If>
               </dxl:PropagationExpression>
@@ -528,7 +528,7 @@
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.611458" Rows="2.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000433" Rows="2.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -541,7 +541,7 @@
               <dxl:Filter/>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.533333" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000304" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -575,7 +575,7 @@
               </dxl:DynamicIndexScan>
               <dxl:DynamicTableScan PartIndexId="3" PrintablePartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
@@ -742,7 +742,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.302693" Rows="7.575000" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.004363" Rows="7.575000" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -756,7 +756,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.136250" Rows="7.575000" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.003869" Rows="7.575000" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -789,7 +789,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.136250" Rows="7.575000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.003869" Rows="7.575000" Width="9"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin.mdp
@@ -533,7 +533,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6943.131509" Rows="20.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="907.643201" Rows="20.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="b1">
@@ -553,7 +553,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6941.975259" Rows="20.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="907.641764" Rows="20.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="b1">
@@ -579,7 +579,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5390.104817" Rows="198401.416576" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="458.913642" Rows="198401.416576" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="b1">
@@ -611,7 +611,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.078125" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000209" Rows="20.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -10287,7 +10287,7 @@
     <dxl:Plan Id="0" SpaceSize="41">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="888.989563" Rows="3866.533707" Width="116"/>
+          <dxl:Cost StartupCost="0" TotalCost="865.874138" Rows="3866.533707" Width="116"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="sr_returned_date_sk">
@@ -10355,7 +10355,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="668.986677" Rows="3866.533707" Width="116"/>
+            <dxl:Cost StartupCost="0" TotalCost="863.860292" Rows="3866.533707" Width="116"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="sr_returned_date_sk">
@@ -10429,7 +10429,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="219.002886" Rows="3866.533707" Width="116"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.155241" Rows="3866.533707" Width="116"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="sr_returned_date_sk">
@@ -10555,7 +10555,7 @@
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="8.726941" Rows="53.379371" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.025248" Rows="53.379371" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="d_date_sk">
@@ -10566,7 +10566,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="7.622684" Rows="26.689686" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.022454" Rows="26.689686" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="d_date_sk">
@@ -10577,7 +10577,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="7.622684" Rows="26.689686" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.022454" Rows="26.689686" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="27" Alias="d_date_sk">
@@ -10616,7 +10616,7 @@
                   </dxl:PartitionSelector>
                   <dxl:DynamicTableScan PartIndexId="2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7.622684" Rows="26.689686" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.022454" Rows="26.689686" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="27" Alias="d_date_sk">

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
@@ -13132,9 +13132,9 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="622809.936874" Rows="716144.000000" Width="402"/>
+          <dxl:Cost StartupCost="0" TotalCost="3279.221480" Rows="716144.000000" Width="402"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -13295,10 +13295,16 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="Inner">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="4" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="41" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="482237.702499" Rows="716144.000000" Width="402"/>
+            <dxl:Cost StartupCost="0" TotalCost="1306.464556" Rows="716144.000000" Width="196"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -13403,72 +13409,12 @@
             <dxl:ProjElem ColId="33" Alias="ws_net_profit">
               <dxl:Ident ColId="33" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="41" Alias="c_customer_sk">
-              <dxl:Ident ColId="41" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="42" Alias="c_customer_id">
-              <dxl:Ident ColId="42" ColName="c_customer_id" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="43" Alias="c_current_cdemo_sk">
-              <dxl:Ident ColId="43" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="44" Alias="c_current_hdemo_sk">
-              <dxl:Ident ColId="44" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="45" Alias="c_current_addr_sk">
-              <dxl:Ident ColId="45" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="46" Alias="c_first_shipto_date_sk">
-              <dxl:Ident ColId="46" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="47" Alias="c_first_sales_date_sk">
-              <dxl:Ident ColId="47" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="48" Alias="c_salutation">
-              <dxl:Ident ColId="48" ColName="c_salutation" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="49" Alias="c_first_name">
-              <dxl:Ident ColId="49" ColName="c_first_name" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="50" Alias="c_last_name">
-              <dxl:Ident ColId="50" ColName="c_last_name" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="51" Alias="c_preferred_cust_flag">
-              <dxl:Ident ColId="51" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="52" Alias="c_birth_day">
-              <dxl:Ident ColId="52" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="53" Alias="c_birth_month">
-              <dxl:Ident ColId="53" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="54" Alias="c_birth_year">
-              <dxl:Ident ColId="54" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="55" Alias="c_birth_country">
-              <dxl:Ident ColId="55" ColName="c_birth_country" TypeMdid="0.1043.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="56" Alias="c_login">
-              <dxl:Ident ColId="56" ColName="c_login" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="57" Alias="c_email_address">
-              <dxl:Ident ColId="57" ColName="c_email_address" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="58" Alias="c_last_review_date">
-              <dxl:Ident ColId="58" ColName="c_last_review_date" TypeMdid="0.1042.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="4" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="41" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
+          <dxl:SortingColumnList/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68537.218750" Rows="716144.000000" Width="196"/>
+              <dxl:Cost StartupCost="0" TotalCost="475.508350" Rows="716144.000000" Width="196"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -13597,7 +13543,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68537.218750" Rows="716144.000000" Width="196"/>
+                <dxl:Cost StartupCost="0" TotalCost="475.508350" Rows="716144.000000" Width="196"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -13751,9 +13697,72 @@
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:Sequence>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+        </dxl:GatherMotion>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="499.029339" Rows="53633.712524" Width="206"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="41" Alias="c_customer_sk">
+              <dxl:Ident ColId="41" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="42" Alias="c_customer_id">
+              <dxl:Ident ColId="42" ColName="c_customer_id" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="43" Alias="c_current_cdemo_sk">
+              <dxl:Ident ColId="43" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="44" Alias="c_current_hdemo_sk">
+              <dxl:Ident ColId="44" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="45" Alias="c_current_addr_sk">
+              <dxl:Ident ColId="45" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="46" Alias="c_first_shipto_date_sk">
+              <dxl:Ident ColId="46" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="47" Alias="c_first_sales_date_sk">
+              <dxl:Ident ColId="47" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="48" Alias="c_salutation">
+              <dxl:Ident ColId="48" ColName="c_salutation" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="49" Alias="c_first_name">
+              <dxl:Ident ColId="49" ColName="c_first_name" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="50" Alias="c_last_name">
+              <dxl:Ident ColId="50" ColName="c_last_name" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="51" Alias="c_preferred_cust_flag">
+              <dxl:Ident ColId="51" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="52" Alias="c_birth_day">
+              <dxl:Ident ColId="52" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="53" Alias="c_birth_month">
+              <dxl:Ident ColId="53" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="54" Alias="c_birth_year">
+              <dxl:Ident ColId="54" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="55" Alias="c_birth_country">
+              <dxl:Ident ColId="55" ColName="c_birth_country" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="56" Alias="c_login">
+              <dxl:Ident ColId="56" ColName="c_login" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="57" Alias="c_email_address">
+              <dxl:Ident ColId="57" ColName="c_email_address" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="58" Alias="c_last_review_date">
+              <dxl:Ident ColId="58" ColName="c_last_review_date" TypeMdid="0.1042.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="31653.663633" Rows="107267.425048" Width="206"/>
+              <dxl:Cost StartupCost="0" TotalCost="449.421373" Rows="53633.712524" Width="206"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="41" Alias="c_customer_sk">
@@ -13811,107 +13820,44 @@
                 <dxl:Ident ColId="58" ColName="c_last_review_date" TypeMdid="0.1042.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="20863.069121" Rows="53633.712524" Width="206"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="41" Alias="c_customer_sk">
-                  <dxl:Ident ColId="41" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="c_customer_id">
-                  <dxl:Ident ColId="42" ColName="c_customer_id" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="c_current_cdemo_sk">
-                  <dxl:Ident ColId="43" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="44" Alias="c_current_hdemo_sk">
-                  <dxl:Ident ColId="44" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="45" Alias="c_current_addr_sk">
-                  <dxl:Ident ColId="45" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="46" Alias="c_first_shipto_date_sk">
-                  <dxl:Ident ColId="46" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="47" Alias="c_first_sales_date_sk">
-                  <dxl:Ident ColId="47" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="48" Alias="c_salutation">
-                  <dxl:Ident ColId="48" ColName="c_salutation" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="49" Alias="c_first_name">
-                  <dxl:Ident ColId="49" ColName="c_first_name" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="50" Alias="c_last_name">
-                  <dxl:Ident ColId="50" ColName="c_last_name" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="51" Alias="c_preferred_cust_flag">
-                  <dxl:Ident ColId="51" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="c_birth_day">
-                  <dxl:Ident ColId="52" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="53" Alias="c_birth_month">
-                  <dxl:Ident ColId="53" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="54" Alias="c_birth_year">
-                  <dxl:Ident ColId="54" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="55" Alias="c_birth_country">
-                  <dxl:Ident ColId="55" ColName="c_birth_country" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="56" Alias="c_login">
-                  <dxl:Ident ColId="56" ColName="c_login" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="57" Alias="c_email_address">
-                  <dxl:Ident ColId="57" ColName="c_email_address" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="58" Alias="c_last_review_date">
-                  <dxl:Ident ColId="58" ColName="c_last_review_date" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:Ident ColId="54" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1950"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.1974718.1.1" TableName="customer">
-                <dxl:Columns>
-                  <dxl:Column ColId="41" Attno="1" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="42" Attno="2" ColName="c_customer_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="43" Attno="3" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="44" Attno="4" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="45" Attno="5" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="46" Attno="6" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="47" Attno="7" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="48" Attno="8" ColName="c_salutation" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                  <dxl:Column ColId="49" Attno="9" ColName="c_first_name" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                  <dxl:Column ColId="50" Attno="10" ColName="c_last_name" TypeMdid="0.1042.1.0" ColWidth="30"/>
-                  <dxl:Column ColId="51" Attno="11" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                  <dxl:Column ColId="52" Attno="12" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="53" Attno="13" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="54" Attno="14" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="55" Attno="15" ColName="c_birth_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                  <dxl:Column ColId="56" Attno="16" ColName="c_login" TypeMdid="0.1042.1.0" ColWidth="13"/>
-                  <dxl:Column ColId="57" Attno="17" ColName="c_email_address" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                  <dxl:Column ColId="58" Attno="18" ColName="c_last_review_date" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                  <dxl:Column ColId="59" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="60" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="61" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="62" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="63" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="64" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="65" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
-        </dxl:HashJoin>
-      </dxl:GatherMotion>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                <dxl:Ident ColId="54" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1950"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.1974718.1.1" TableName="customer">
+              <dxl:Columns>
+                <dxl:Column ColId="41" Attno="1" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="42" Attno="2" ColName="c_customer_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                <dxl:Column ColId="43" Attno="3" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="44" Attno="4" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="45" Attno="5" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="46" Attno="6" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="47" Attno="7" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="48" Attno="8" ColName="c_salutation" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                <dxl:Column ColId="49" Attno="9" ColName="c_first_name" TypeMdid="0.1042.1.0" ColWidth="20"/>
+                <dxl:Column ColId="50" Attno="10" ColName="c_last_name" TypeMdid="0.1042.1.0" ColWidth="30"/>
+                <dxl:Column ColId="51" Attno="11" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                <dxl:Column ColId="52" Attno="12" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="53" Attno="13" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="54" Attno="14" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="55" Attno="15" ColName="c_birth_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
+                <dxl:Column ColId="56" Attno="16" ColName="c_login" TypeMdid="0.1042.1.0" ColWidth="13"/>
+                <dxl:Column ColId="57" Attno="17" ColName="c_email_address" TypeMdid="0.1042.1.0" ColWidth="50"/>
+                <dxl:Column ColId="58" Attno="18" ColName="c_last_review_date" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                <dxl:Column ColId="59" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="60" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="61" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="62" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="63" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="64" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="65" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/EffectsOfJoinFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectsOfJoinFilter.mdp
@@ -445,7 +445,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7068.957061" Rows="99.352229" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="925.946009" Rows="99.352229" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -465,7 +465,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7067.180871" Rows="99.352229" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="925.938871" Rows="99.352229" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -514,7 +514,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5485.875592" Rows="201205.075762" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="459.443180" Rows="201205.075762" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="b1">
@@ -552,7 +552,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.882812" Rows="141.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.006429" Rows="141.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/EqualityJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EqualityJoin.mdp
@@ -421,7 +421,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="11751.039062" Rows="200.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="969.461920" Rows="200.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -441,7 +441,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="11748.476562" Rows="200.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="969.447552" Rows="200.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -467,7 +467,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3912.960938" Rows="1001718.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="441.467953" Rows="1001718.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="b1">
@@ -494,7 +494,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.781250" Rows="200.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="200.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -1937,7 +1937,7 @@
     <dxl:Plan Id="0" SpaceSize="66">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3812117.890581" Rows="19097.637457" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="34972.709569" Rows="19097.637457" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -1948,7 +1948,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3812079.590507" Rows="19097.637457" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="34972.366576" Rows="19097.637457" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -1957,7 +1957,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="24">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3811891.090142" Rows="9548.818729" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="34110.198135" Rows="9548.818729" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -1966,7 +1966,7 @@
             </dxl:ProjList>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3811880.765123" Rows="9548.818729" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="34110.193360" Rows="9548.818729" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="24"/>
@@ -1979,7 +1979,7 @@
               <dxl:Filter/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="65666.078125" Rows="479510577.526431" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="5232.137626" Rows="479510577.526431" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -1996,7 +1996,7 @@
                 </dxl:HashCondList>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="23445.585938" Rows="6001814.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="776.434405" Rows="6001814.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="l_suppkey">
@@ -2012,7 +2012,7 @@
                   </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="11722.292969" Rows="6001814.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="716.536301" Rows="6001814.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="l_suppkey">
@@ -2037,7 +2037,7 @@
                 </dxl:RedistributeMotion>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3129.984375" Rows="801020.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="493.844024" Rows="801020.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -2053,7 +2053,7 @@
                   </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1564.492188" Rows="801020.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="485.849845" Rows="801020.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -2081,7 +2081,7 @@
           </dxl:CTEProducer>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="112.900219" Rows="19097.637457" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.130246" Rows="19097.637457" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -2091,7 +2091,7 @@
             <dxl:Filter/>
             <dxl:CTEConsumer CTEId="0" Columns="35">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="18.650037" Rows="9548.818729" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.046025" Rows="9548.818729" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -2101,7 +2101,7 @@
             </dxl:CTEConsumer>
             <dxl:CTEConsumer CTEId="0" Columns="70">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="18.650037" Rows="9548.818729" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.046025" Rows="9548.818729" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="70" Alias="ps_suppkey">

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -1939,7 +1939,7 @@
     <dxl:Plan Id="0" SpaceSize="484">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3812267.090873" Rows="9548.818729" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="34974.557438" Rows="9548.818729" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -1953,7 +1953,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3812228.790800" Rows="9548.818729" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="34974.214444" Rows="9548.818729" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -1965,7 +1965,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="24">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3811891.090142" Rows="9548.818729" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="34110.198135" Rows="9548.818729" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -1974,7 +1974,7 @@
             </dxl:ProjList>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3811880.765123" Rows="9548.818729" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="34110.193360" Rows="9548.818729" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="24"/>
@@ -1987,7 +1987,7 @@
               <dxl:Filter/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="65666.078125" Rows="479510577.526431" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="5232.137626" Rows="479510577.526431" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -2004,7 +2004,7 @@
                 </dxl:HashCondList>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="23445.585938" Rows="6001814.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="776.434405" Rows="6001814.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="l_suppkey">
@@ -2020,7 +2020,7 @@
                   </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="11722.292969" Rows="6001814.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="716.536301" Rows="6001814.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="l_suppkey">
@@ -2045,7 +2045,7 @@
                 </dxl:RedistributeMotion>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3129.984375" Rows="801020.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="493.844024" Rows="801020.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -2061,7 +2061,7 @@
                   </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1564.492188" Rows="801020.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="485.849845" Rows="801020.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="24" Alias="ps_suppkey">
@@ -2089,7 +2089,7 @@
           </dxl:CTEProducer>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="262.100512" Rows="9548.818729" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="863.978114" Rows="9548.818729" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -2109,7 +2109,7 @@
             </dxl:HashCondList>
             <dxl:CTEConsumer CTEId="0" Columns="35">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="18.650037" Rows="9548.818729" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.046025" Rows="9548.818729" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="35" Alias="ps_suppkey">
@@ -2119,7 +2119,7 @@
             </dxl:CTEConsumer>
             <dxl:CTEConsumer CTEId="0" Columns="70">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="18.650037" Rows="9548.818729" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.046025" Rows="9548.818729" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="70" Alias="ps_suppkey">

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
@@ -347,7 +347,7 @@
     <dxl:Plan Id="0" SpaceSize="907">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.560547" Rows="1.000000" Width="60"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.002536" Rows="1.000000" Width="60"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="r1">
@@ -382,7 +382,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.531250" Rows="1.000000" Width="60"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.002266" Rows="1.000000" Width="60"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="r1">
@@ -421,9 +421,9 @@
               <dxl:Ident ColId="20" ColName="t1" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.285156" Rows="1.000000" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001445" Rows="1.000000" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="r1">
@@ -446,58 +446,15 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Or>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="11" ColName="s2" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                  <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="12" ColName="s3" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:Or>
-            </dxl:JoinFilter>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="10" ColName="s1" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="11" ColName="s2" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.023438" Rows="1.000000" Width="24"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="s1">
-                  <dxl:Ident ColId="10" ColName="s1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="s2">
-                  <dxl:Ident ColId="11" ColName="s2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="12" Alias="s3">
-                  <dxl:Ident ColId="12" ColName="s3" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.824193.1.1" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="10" Attno="1" ColName="s1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="2" ColName="s2" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="12" Attno="3" ColName="s3" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="1.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.001358" Rows="1.000000" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="r1">
@@ -509,27 +466,102 @@
                 <dxl:ProjElem ColId="2" Alias="r3">
                   <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="s1">
+                  <dxl:Ident ColId="10" ColName="s1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="s2">
+                  <dxl:Ident ColId="11" ColName="s2" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="s3">
+                  <dxl:Ident ColId="12" ColName="s3" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.824216.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="r1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="r2" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="r3" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:HashJoin>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:JoinFilter>
+                <dxl:Or>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="11" ColName="s2" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                    <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="12" ColName="s3" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Or>
+              </dxl:JoinFilter>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="10" ColName="s1" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="24"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="s1">
+                    <dxl:Ident ColId="10" ColName="s1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="s2">
+                    <dxl:Ident ColId="11" ColName="s2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="s3">
+                    <dxl:Ident ColId="12" ColName="s3" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.824193.1.1" TableName="s">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="s1" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="s2" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="12" Attno="3" ColName="s3" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="20"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="r1">
+                    <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="r2">
+                    <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="r3">
+                    <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.824216.1.1" TableName="r">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="r1" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="r2" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="r3" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:HashJoin>
+          </dxl:RedistributeMotion>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="2.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="20" Alias="t1">
@@ -543,39 +575,21 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="20" Alias="t1">
-                  <dxl:Ident ColId="20" ColName="t1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="t2">
-                  <dxl:Ident ColId="21" ColName="t2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="t3">
-                  <dxl:Ident ColId="22" ColName="t3" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.824170.1.1" TableName="t">
-                <dxl:Columns>
-                  <dxl:Column ColId="20" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="21" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="22" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
+            <dxl:TableDescriptor Mdid="0.824170.1.1" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="21" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="22" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesIntersect.mdp
@@ -298,7 +298,7 @@
     <dxl:Plan Id="0" SpaceSize="80">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.261719" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000787" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -309,7 +309,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.257812" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000751" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -326,9 +326,9 @@
               </dxl:IsDistinctFrom>
             </dxl:Not>
           </dxl:HashCondList>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000131" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -339,39 +339,55 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableScan>
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.969810.1.1" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.969810.1.1" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Sort>
           </dxl:Aggregate>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.085938" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000146" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="10"/>
@@ -382,36 +398,52 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableScan>
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000134" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="x">
                   <dxl:Ident ColId="10" ColName="x" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="11" ColName="y" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="12" ColName="z" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.969833.1.1" TableName="bar">
-                <dxl:Columns>
-                  <dxl:Column ColId="10" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="2" ColName="y" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="12" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000134" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="x">
+                    <dxl:Ident ColId="10" ColName="x" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="11" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="12" ColName="z" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.969833.1.1" TableName="bar">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="12" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Sort>
           </dxl:Aggregate>
         </dxl:HashJoin>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesLimit.mdp
@@ -421,7 +421,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.647917" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.004536" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="x">
@@ -433,7 +433,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.632292" Rows="20.622222" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.004528" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="x">
@@ -445,9 +445,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:TableScan>
+          <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.551736" Rows="20.622222" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.004492" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="x">
@@ -457,36 +457,55 @@
                 <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:And>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.004488" Rows="20.622222" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="x">
                   <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="30"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="y">
                   <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="30"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:And>
-            </dxl:Filter>
-            <dxl:TableDescriptor Mdid="0.735897.1.1" TableName="foo">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="y" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="30"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="30"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.735897.1.1" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="y" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
         </dxl:GatherMotion>
         <dxl:LimitCount>
           <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesUnion.mdp
@@ -270,7 +270,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.140625" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000345" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -279,9 +279,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.132812" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000273" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -292,9 +292,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Append IsTarget="false" IsZapped="false">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.085938" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000260" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -302,66 +302,82 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableScan>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000260" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.969810.1.1" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="x">
-                  <dxl:Ident ColId="10" ColName="x" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="11" ColName="y" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="12" ColName="z" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.969833.1.1" TableName="bar">
-                <dxl:Columns>
-                  <dxl:Column ColId="10" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="2" ColName="y" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="12" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Append>
+              <dxl:Filter/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.969810.1.1" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000134" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="x">
+                    <dxl:Ident ColId="10" ColName="x" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="11" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="12" ColName="z" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.969833.1.1" TableName="bar">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="12" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Append>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Except-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Except-Volatile-Func.mdp
@@ -9,6 +9,14 @@
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103003,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -102,9 +110,9 @@
       </dxl:Difference>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="25">
-      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.089844" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000397" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -115,9 +123,9 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.066406" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="?column?">
@@ -125,67 +133,83 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Not>
-              <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="3" ColName="generate_series" TypeMdid="0.23.1.0"/>
-              </dxl:IsDistinctFrom>
-            </dxl:Not>
-          </dxl:HashCondList>
-          <dxl:Result>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="?column?">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="3" ColName="generate_series" TypeMdid="0.23.1.0"/>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:HashCondList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-            </dxl:Result>
-          </dxl:Result>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="3" Alias="generate_series">
-                <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                <dxl:ProjElem ColId="1" Alias="?column?">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:FuncExpr>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="2" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
-        </dxl:HashJoin>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="generate_series">
+                  <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:FuncExpr>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:HashJoin>
+        </dxl:Sort>
       </dxl:Aggregate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Except.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Except.mdp
@@ -321,7 +321,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.328125" Rows="4.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002254" Rows="4.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -330,9 +330,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.320312" Rows="4.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002182" Rows="4.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -343,9 +343,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.273438" Rows="4.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.002170" Rows="4.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -353,18 +353,14 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Not>
-                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:IsDistinctFrom>
-              </dxl:Not>
-            </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:HashJoin JoinType="LeftAntiSemiJoin">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.002125" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -372,43 +368,63 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.17825.1.1" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="8" Alias="a">
-                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.17802.1.1" TableName="bar">
-                <dxl:Columns>
-                  <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:HashJoin>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
+              </dxl:HashCondList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="10.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.17825.1.1" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="10.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="a">
+                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.17802.1.1" TableName="bar">
+                  <dxl:Columns>
+                    <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:HashJoin>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/ExceptAllCompatibleDataType.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExceptAllCompatibleDataType.mdp
@@ -416,7 +416,7 @@
     <dxl:Plan Id="0" SpaceSize="160">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="15.660156" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.003231" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="11" Alias="a">
@@ -430,7 +430,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="LeftAntiSemiJoin">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="14.654297" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.003178" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="a">
@@ -466,7 +466,7 @@
           </dxl:HashCondList>
           <dxl:Window PartitionColumns="11,12">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="10.341797" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001639" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="37" Alias="row_number">
@@ -482,7 +482,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="9.341797" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.001639" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="a">
@@ -501,7 +501,7 @@
               <dxl:LimitOffset/>
               <dxl:HashJoin JoinType="LeftAntiSemiJoin">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="8.341797" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001639" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="a">
@@ -537,7 +537,7 @@
                 </dxl:HashCondList>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.052734" Rows="1.000000" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000153" Rows="1.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="11" Alias="a">
@@ -559,7 +559,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4.033203" Rows="1.000000" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="a">
@@ -576,7 +576,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Window PartitionColumns="11,12">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="4.033203" Rows="1.000000" Width="20"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="20"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="35" Alias="row_number">
@@ -592,7 +592,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="3.033203" Rows="1.000000" Width="12"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="12"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="11" Alias="a">
@@ -611,7 +611,7 @@
                         <dxl:LimitOffset/>
                         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.033203" Rows="1.000000" Width="12"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="12"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="11" Alias="a">
@@ -633,7 +633,7 @@
                           </dxl:HashExprList>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.027344" Rows="1.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="11" Alias="a">
@@ -651,7 +651,7 @@
                             <dxl:OneTimeFilter/>
                             <dxl:TableScan>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="16"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="0" Alias="a">
@@ -689,7 +689,7 @@
                 </dxl:RedistributeMotion>
                 <dxl:Window PartitionColumns="13,14">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="36" Alias="row_number">
@@ -705,7 +705,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="13" Alias="a">
@@ -724,7 +724,7 @@
                     <dxl:LimitOffset/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="13" Alias="a">
@@ -766,7 +766,7 @@
           </dxl:Window>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.039062" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="24" Alias="a">
@@ -790,7 +790,7 @@
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="24" Alias="a">
@@ -807,7 +807,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Window PartitionColumns="24,25">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="38" Alias="row_number">
@@ -823,7 +823,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="24" Alias="a">
@@ -842,7 +842,7 @@
                   <dxl:LimitOffset/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="24" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Exists-SuperfluousEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Exists-SuperfluousEquality.mdp
@@ -381,7 +381,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="14.890625" Rows="400.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.070466" Rows="400.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -395,7 +395,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="11.546875" Rows="400.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.048914" Rows="400.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
@@ -221,10 +221,10 @@ select * from t full join s on t1 = s1;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="216">
+    <dxl:Plan Id="0" SpaceSize="256">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.582031" Rows="3.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.001789" Rows="3.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="11" Alias="s2">
@@ -238,7 +238,7 @@ select * from t full join s on t1 = s1;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.558594" Rows="3.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.001573" Rows="3.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="s2">
@@ -252,7 +252,7 @@ select * from t full join s on t1 = s1;
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.558594" Rows="3.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.001573" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="t3">
@@ -264,7 +264,7 @@ select * from t full join s on t1 = s1;
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.021484" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="20" Alias="t1">
@@ -297,7 +297,7 @@ select * from t full join s on t1 = s1;
               </dxl:ProjList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.020508" Rows="1.000000" Width="42"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="42"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="t1">
@@ -347,7 +347,7 @@ select * from t full join s on t1 = s1;
             </dxl:CTEProducer>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.490234" Rows="3.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.001498" Rows="3.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="2" Alias="t3">
@@ -359,7 +359,7 @@ select * from t full join s on t1 = s1;
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="1" Columns="30,31,32,33,34,35,36,37,38">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.021484" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="30" Alias="s1">
@@ -392,7 +392,7 @@ select * from t full join s on t1 = s1;
                 </dxl:ProjList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.020508" Rows="1.000000" Width="42"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="42"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="30" Alias="s1">
@@ -442,7 +442,7 @@ select * from t full join s on t1 = s1;
               </dxl:CTEProducer>
               <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="4.421875" Rows="3.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.001423" Rows="3.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="t3">
@@ -455,7 +455,7 @@ select * from t full join s on t1 = s1;
                 <dxl:Filter/>
                 <dxl:HashJoin JoinType="Left">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.218750" Rows="2.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000836" Rows="2.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="t3">
@@ -475,7 +475,7 @@ select * from t full join s on t1 = s1;
                   </dxl:HashCondList>
                   <dxl:CTEConsumer CTEId="0" Columns="0,2,3,4,5,6,7,8,9">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="t1">
@@ -509,7 +509,7 @@ select * from t full join s on t1 = s1;
                   </dxl:CTEConsumer>
                   <dxl:CTEConsumer CTEId="1" Columns="10,11,13,14,15,16,17,18,19">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="s1">
@@ -544,11 +544,11 @@ select * from t full join s on t1 = s1;
                 </dxl:HashJoin>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.156250" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000563" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="61" Alias="t3">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="50" Alias="s2">
                       <dxl:Ident ColId="50" ColName="s2" TypeMdid="0.23.1.0"/>
@@ -558,7 +558,7 @@ select * from t full join s on t1 = s1;
                   <dxl:OneTimeFilter/>
                   <dxl:HashJoin JoinType="LeftAntiSemiJoin">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.132812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000551" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="50" Alias="s2">
@@ -575,7 +575,7 @@ select * from t full join s on t1 = s1;
                     </dxl:HashCondList>
                     <dxl:CTEConsumer CTEId="1" Columns="49,50,51,52,53,54,55,56,57">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="49" Alias="s1">
@@ -609,7 +609,7 @@ select * from t full join s on t1 = s1;
                     </dxl:CTEConsumer>
                     <dxl:CTEConsumer CTEId="0" Columns="40,41,42,43,44,45,46,47,48">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="40" Alias="t1">

--- a/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin2.mdp
@@ -206,7 +206,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
     <dxl:Plan Id="0" SpaceSize="112">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="10.492188" Rows="3.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.001577" Rows="3.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -220,7 +220,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9.468750" Rows="3.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.001361" Rows="3.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -238,7 +238,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.421875" Rows="3.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.001312" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -250,7 +250,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="0" Columns="16,17,18,19,20,21,22,23">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.019531" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="a">
@@ -280,7 +280,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
               </dxl:ProjList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.018555" Rows="1.000000" Width="38"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="38"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="16" Alias="a">
@@ -325,7 +325,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
             </dxl:CTEProducer>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.355469" Rows="3.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.001243" Rows="3.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -337,7 +337,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="1" Columns="24,25,26,27,28,29,30,31">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.019531" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="24" Alias="a">
@@ -367,7 +367,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                 </dxl:ProjList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.018555" Rows="1.000000" Width="38"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="38"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="24" Alias="a">
@@ -412,7 +412,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
               </dxl:CTEProducer>
               <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="4.289062" Rows="3.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.001174" Rows="3.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -425,7 +425,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                 <dxl:Filter/>
                 <dxl:HashJoin JoinType="Left">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.109375" Rows="2.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000611" Rows="2.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -445,7 +445,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                   </dxl:HashCondList>
                   <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -476,7 +476,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                   </dxl:CTEConsumer>
                   <dxl:CTEConsumer CTEId="1" Columns="8,9,10,11,12,13,14,15">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="8" Alias="a">
@@ -508,11 +508,11 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                 </dxl:HashJoin>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.132812" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000539" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="48" Alias="a">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="40" Alias="a">
                       <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
@@ -522,7 +522,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                   <dxl:OneTimeFilter/>
                   <dxl:HashJoin JoinType="LeftAntiSemiJoin">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.109375" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000527" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="40" Alias="a">
@@ -539,7 +539,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                     </dxl:HashCondList>
                     <dxl:CTEConsumer CTEId="1" Columns="40,41,42,43,44,45,46,47">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="40" Alias="a">
@@ -570,7 +570,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
                     </dxl:CTEConsumer>
                     <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="32" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -868,7 +868,7 @@
     <dxl:Plan Id="0" SpaceSize="5456">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="274377996915268.812500" Rows="100.000000" Width="128"/>
+          <dxl:Cost StartupCost="0" TotalCost="31133.665595" Rows="100.000000" Width="128"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="73" Alias="char_length">
@@ -970,7 +970,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="274377996915242.812500" Rows="100.000000" Width="128"/>
+            <dxl:Cost StartupCost="0" TotalCost="31133.652795" Rows="100.000000" Width="128"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1107,7 +1107,7 @@
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="274377996915235.562500" Rows="100.000000" Width="128"/>
+              <dxl:Cost StartupCost="0" TotalCost="31133.595323" Rows="100.000000" Width="128"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1209,7 +1209,7 @@
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="274377996915222.062500" Rows="6151.200000" Width="128"/>
+                <dxl:Cost StartupCost="0" TotalCost="31133.588923" Rows="6151.200000" Width="128"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1348,7 +1348,7 @@
               <dxl:LimitOffset/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="274377995774872.031250" Rows="6151.200000" Width="128"/>
+                  <dxl:Cost StartupCost="0" TotalCost="31107.725807" Rows="6151.200000" Width="128"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1516,7 +1516,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="274377995774102.125000" Rows="6151.200000" Width="2274497"/>
+                    <dxl:Cost StartupCost="0" TotalCost="31107.332130" Rows="6151.200000" Width="2274497"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="c0">
@@ -1657,7 +1657,7 @@
                   </dxl:HashCondList>
                   <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="263141538846910.062500" Rows="193.600000" Width="1369700"/>
+                      <dxl:Cost StartupCost="0" TotalCost="3649.806038" Rows="193.600000" Width="1369700"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="30" Alias="c586">
@@ -1729,7 +1729,7 @@
                     </dxl:HashExprList>
                     <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="263141538717429.625000" Rows="193.600000" Width="1369700"/>
+                        <dxl:Cost StartupCost="0" TotalCost="3234.808853" Rows="193.600000" Width="1369700"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="c586">
@@ -1803,7 +1803,7 @@
                       </dxl:JoinFilter>
                       <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="26629051806206.457031" Rows="44.000000" Width="955900"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1566.853456" Rows="44.000000" Width="955900"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="30" Alias="c586">
@@ -1859,7 +1859,7 @@
                         </dxl:JoinFilter>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2402.094727" Rows="10.000000" Width="491949"/>
+                            <dxl:Cost StartupCost="0" TotalCost="433.748152" Rows="10.000000" Width="491949"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="30" Alias="c586">
@@ -1902,7 +1902,7 @@
                         </dxl:TableScan>
                         <dxl:Materialize Eager="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="18503.362305" Rows="20.000000" Width="541297"/>
+                            <dxl:Cost StartupCost="0" TotalCost="585.388194" Rows="20.000000" Width="541297"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="47" Alias="c1190">
@@ -1930,7 +1930,7 @@
                           <dxl:Filter/>
                           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="7930.155273" Rows="20.000000" Width="541297"/>
+                              <dxl:Cost StartupCost="0" TotalCost="579.975224" Rows="20.000000" Width="541297"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="47" Alias="c1190">
@@ -1959,7 +1959,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:TableScan>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2643.051758" Rows="10.000000" Width="541297"/>
+                                <dxl:Cost StartupCost="0" TotalCost="433.256672" Rows="10.000000" Width="541297"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="47" Alias="c1190">
@@ -2005,7 +2005,7 @@
                       </dxl:NestedLoopJoin>
                       <dxl:Materialize Eager="true">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="19222.161133" Rows="20.000000" Width="562327"/>
+                          <dxl:Cost StartupCost="0" TotalCost="590.788171" Rows="20.000000" Width="562327"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="61" Alias="c1047">
@@ -2036,7 +2036,7 @@
                         <dxl:Filter/>
                         <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="8238.211914" Rows="20.000000" Width="562327"/>
+                            <dxl:Cost StartupCost="0" TotalCost="585.164901" Rows="20.000000" Width="562327"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="61" Alias="c1047">
@@ -2068,7 +2068,7 @@
                           <dxl:SortingColumnList/>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="2745.737305" Rows="10.000000" Width="562327"/>
+                              <dxl:Cost StartupCost="0" TotalCost="432.746168" Rows="10.000000" Width="562327"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="61" Alias="c1047">
@@ -2119,7 +2119,7 @@
                   </dxl:RedistributeMotion>
                   <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="11236456157202.388672" Rows="100.000000" Width="1046589"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1704.764417" Rows="100.000000" Width="1046589"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c0">
@@ -2179,7 +2179,7 @@
                     </dxl:HashExprList>
                     <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="11236456106098.410156" Rows="100.000000" Width="1046589"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1540.973238" Rows="100.000000" Width="1046589"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="c0">
@@ -2232,47 +2232,9 @@
                       <dxl:JoinFilter>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                       </dxl:JoinFilter>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1780.169922" Rows="20.000000" Width="121458"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="c0">
-                            <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="c1">
-                            <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="593.056641" Rows="10.000000" Width="121458"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="0" Alias="c0">
-                              <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="c1">
-                              <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.90124.1.1" TableName="t0">
-                            <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="c0" TypeMdid="0.25.1.0"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="c1" TypeMdid="0.25.1.0"/>
-                              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:BroadcastMotion>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="4517.241211" Rows="10.000000" Width="925131"/>
+                          <dxl:Cost StartupCost="0" TotalCost="434.909012" Rows="10.000000" Width="925131"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="7" Alias="c910">
@@ -2337,6 +2299,58 @@
                           </dxl:Columns>
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="465.854720" Rows="20.000000" Width="121458"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="c0">
+                            <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="c1">
+                            <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="464.640140" Rows="20.000000" Width="121458"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="c0">
+                              <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="c1">
+                              <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.718949" Rows="10.000000" Width="121458"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="c0">
+                                <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="1" Alias="c1">
+                                <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.90124.1.1" TableName="t0">
+                              <dxl:Columns>
+                                <dxl:Column ColId="0" Attno="1" ColName="c0" TypeMdid="0.25.1.0"/>
+                                <dxl:Column ColId="1" Attno="2" ColName="c1" TypeMdid="0.25.1.0"/>
+                                <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
                     </dxl:NestedLoopJoin>
                   </dxl:RedistributeMotion>
                 </dxl:HashJoin>

--- a/src/backend/gporca/data/dxl/minidump/ExternalTable1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTable1.mdp
@@ -211,7 +211,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="23438.500000" Rows="1000000.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="575.930000" Rows="1000000.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="n_nationkey">
@@ -231,7 +231,7 @@
         <dxl:SortingColumnList/>
         <dxl:ExternalScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="11718.750000" Rows="1000000.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="445.850000" Rows="1000000.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="n_nationkey">

--- a/src/backend/gporca/data/dxl/minidump/ExternalTable2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTable2.mdp
@@ -178,7 +178,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7813.500000" Rows="1000000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="484.810000" Rows="1000000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="x">
@@ -189,7 +189,7 @@
         <dxl:SortingColumnList/>
         <dxl:ExternalScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3906.250000" Rows="1000000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441.450000" Rows="1000000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="x">

--- a/src/backend/gporca/data/dxl/minidump/ExternalTable3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTable3.mdp
@@ -178,7 +178,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:ExternalScan>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7812.500000" Rows="1000000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="451.900000" Rows="1000000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="x">

--- a/src/backend/gporca/data/dxl/minidump/ExternalTable4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTable4.mdp
@@ -178,7 +178,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7813.500000" Rows="1000000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="484.810000" Rows="1000000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="x">
@@ -189,7 +189,7 @@
         <dxl:SortingColumnList/>
         <dxl:ExternalScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3906.250000" Rows="1000000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441.450000" Rows="1000000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="x">

--- a/src/backend/gporca/data/dxl/minidump/ExternalTableWithFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTableWithFilter.mdp
@@ -225,7 +225,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="203029.343750" Rows="400000.000000" Width="189"/>
+          <dxl:Cost StartupCost="0" TotalCost="916.327000" Rows="400000.000000" Width="189"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="n_nationkey">
@@ -245,7 +245,7 @@
         <dxl:SortingColumnList/>
         <dxl:ExternalScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="166114.281250" Rows="400000.000000" Width="189"/>
+            <dxl:Cost StartupCost="0" TotalCost="576.883000" Rows="400000.000000" Width="189"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="n_nationkey">

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -14560,7 +14560,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
     <dxl:Plan Id="0" SpaceSize="7792">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1858510.030318" Rows="20169.272000" Width="76"/>
+          <dxl:Cost StartupCost="0" TotalCost="5944.261371" Rows="20169.272000" Width="76"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="customer_id">
@@ -14598,7 +14598,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1857760.561240" Rows="20169.272000" Width="76"/>
+            <dxl:Cost StartupCost="0" TotalCost="5937.378808" Rows="20169.272000" Width="76"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="c_customer_id">
@@ -14691,7 +14691,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1856262.623084" Rows="2880896.000000" Width="80"/>
+              <dxl:Cost StartupCost="0" TotalCost="5747.815851" Rows="2880896.000000" Width="80"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="91" Alias="sale_type">
@@ -14732,7 +14732,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1631191.623084" Rows="2880896.000000" Width="147"/>
+                <dxl:Cost StartupCost="0" TotalCost="5632.580011" Rows="2880896.000000" Width="147"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -14785,7 +14785,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
               <dxl:Filter/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="356731.748084" Rows="2880896.000000" Width="153"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3744.666923" Rows="2880896.000000" Width="153"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="c_customer_id">
@@ -14832,7 +14832,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                 </dxl:HashCondList>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="131761.446326" Rows="2880896.000000" Width="26"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1579.340980" Rows="2880896.000000" Width="26"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="28" Alias="ss_customer_sk">
@@ -14863,7 +14863,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                   </dxl:HashExprList>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="95186.571326" Rows="2880896.000000" Width="26"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1462.117322" Rows="2880896.000000" Width="26"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="28" Alias="ss_customer_sk">
@@ -14892,7 +14892,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                     </dxl:HashCondList>
                     <dxl:DynamicTableScan PartIndexId="1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="30947.125000" Rows="2880896.000000" Width="22"/>
+                        <dxl:Cost StartupCost="0" TotalCost="561.720656" Rows="2880896.000000" Width="22"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="25" Alias="ss_sold_date_sk">
@@ -14962,7 +14962,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                       </dxl:PrintableFilter>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1437.940435" Rows="12874.750453" Width="12"/>
+                          <dxl:Cost StartupCost="0" TotalCost="438.249254" Rows="12874.750453" Width="12"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="55" Alias="d_date_sk">
@@ -14979,7 +14979,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                         <dxl:SortingColumnList/>
                         <dxl:Sequence>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1361.502444" Rows="6437.375227" Width="12"/>
+                            <dxl:Cost StartupCost="0" TotalCost="436.227274" Rows="6437.375227" Width="12"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="55" Alias="d_date_sk">
@@ -15015,7 +15015,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                           </dxl:PartitionSelector>
                           <dxl:DynamicTableScan PartIndexId="2">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1361.502444" Rows="6437.375227" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="436.227274" Rows="6437.375227" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="55" Alias="d_date_sk">
@@ -15076,7 +15076,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                 </dxl:RedistributeMotion>
                 <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19803.680664" Rows="200276.000000" Width="135"/>
+                    <dxl:Cost StartupCost="0" TotalCost="803.921422" Rows="200276.000000" Width="135"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -15108,7 +15108,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                   <dxl:SortingColumnList/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6600.893555" Rows="100138.000000" Width="135"/>
+                      <dxl:Cost StartupCost="0" TotalCost="437.498956" Rows="100138.000000" Width="135"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c_customer_sk">

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -36,6 +36,14 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
       <dxl:TraceFlags Value="103027,102024,102025,102115,102116,102117,102119,102146"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.15667489.1.1.9" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.15667489.1.1.8" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.15667489.1.1.0" Name="item_sk" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
@@ -446,10 +454,10 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8480">
+    <dxl:Plan Id="0" SpaceSize="8900">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.843750" Rows="1.000000" Width="64"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cid">
@@ -484,7 +492,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.812500" Rows="1.000000" Width="64"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.002565" Rows="1.000000" Width="64"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cid">
@@ -516,26 +524,49 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
+          <dxl:JoinFilter>
+            <dxl:Or>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+                  <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                </dxl:Comparison>
+              </dxl:And>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+                  <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Or>
+          </dxl:JoinFilter>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="10" ColName="date_sk" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.468750" Rows="1.000000" Width="40"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001065" Rows="1.000000" Width="40"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="10" Alias="date_sk">
-                <dxl:Ident ColId="10" ColName="date_sk" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="0" Alias="cid">
+                <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="year">
-                <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="1" Alias="firstname">
+                <dxl:Ident ColId="1" ColName="firstname" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="moy">
-                <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="2" Alias="lastname">
+                <dxl:Ident ColId="2" ColName="lastname" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="22" Alias="cid">
                 <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
@@ -548,83 +579,26 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
-                    <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                  </dxl:Comparison>
-                </dxl:And>
-                <dxl:And>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
-                    <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                  </dxl:Comparison>
-                </dxl:And>
-              </dxl:Or>
-            </dxl:JoinFilter>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="10" ColName="date_sk" TypeMdid="0.23.1.0"/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
                 <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000987" Rows="1.000000" Width="40"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="date_sk">
-                  <dxl:Ident ColId="10" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="0" Alias="cid">
+                  <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="year">
-                  <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="1" Alias="firstname">
+                  <dxl:Ident ColId="1" ColName="firstname" TypeMdid="0.25.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="12" Alias="moy">
-                  <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="2" Alias="lastname">
+                  <dxl:Ident ColId="2" ColName="lastname" TypeMdid="0.25.1.0"/>
                 </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Or>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                  </dxl:Comparison>
-                </dxl:Or>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.15667463.1.1" TableName="datedim">
-                <dxl:Columns>
-                  <dxl:Column ColId="10" Attno="1" ColName="date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="12" Attno="3" ColName="moy" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.195312" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
                 <dxl:ProjElem ColId="22" Alias="cid">
                   <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
@@ -636,15 +610,47 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:Result>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.179688" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="24"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="cid">
+                    <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="firstname">
+                    <dxl:Ident ColId="1" ColName="firstname" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="lastname">
+                    <dxl:Ident ColId="2" ColName="lastname" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.15667435.1.1" TableName="cust">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="cid" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="firstname" TypeMdid="0.25.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="lastname" TypeMdid="0.25.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000193" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="cid">
@@ -657,48 +663,54 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                     <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Or>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
-                      <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
-                      <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                    </dxl:Comparison>
-                  </dxl:Or>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.148438" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000143" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="22"/>
-                    <dxl:GroupingColumn ColId="23"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="32" Alias="tickets_cnt">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
-                        <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="22" Alias="cid">
                       <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="23" Alias="date_sk">
                       <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="32" Alias="tickets_cnt">
+                      <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:Filter>
+                    <dxl:Or>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+                        <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                      </dxl:Comparison>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+                        <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="22"/>
+                      <dxl:GroupingColumn ColId="23"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="ticket_number">
-                        <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="32" Alias="tickets_cnt">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
+                          <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="22" Alias="cid">
                         <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
@@ -708,101 +720,198 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="21" Alias="ticket_number">
-                          <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="22" Alias="cid">
                           <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="23" Alias="date_sk">
                           <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                          <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.15667489.1.1" TableName="sales">
-                        <dxl:Columns>
-                          <dxl:Column ColId="20" Attno="1" ColName="item_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="21" Attno="2" ColName="ticket_number" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="22" Attno="3" ColName="cid" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="23" Attno="4" ColName="date_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                </dxl:Aggregate>
-              </dxl:Result>
-            </dxl:RedistributeMotion>
-          </dxl:HashJoin>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="22" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="22" Alias="cid">
+                            <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="23" Alias="date_sk">
+                            <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                            <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="22" Alias="cid">
+                              <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="23" Alias="date_sk">
+                              <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                              <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
+                            </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="22"/>
+                              <dxl:GroupingColumn ColId="23"/>
+                            </dxl:GroupingColumns>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
+                                  <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                </dxl:AggFunc>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="22" Alias="cid">
+                                <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="23" Alias="date_sk">
+                                <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:Sort SortDiscardDuplicates="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="24"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="21" Alias="ticket_number">
+                                  <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="22" Alias="cid">
+                                  <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="23" Alias="date_sk">
+                                  <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="22" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="24"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="21" Alias="ticket_number">
+                                    <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="22" Alias="cid">
+                                    <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="23" Alias="date_sk">
+                                    <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.15667489.1.1" TableName="sales">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="20" Attno="1" ColName="item_sk" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="21" Attno="2" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="22" Attno="3" ColName="cid" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="23" Attno="4" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:Sort>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
+          </dxl:RedistributeMotion>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="2.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000134" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="cid">
-                <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="10" Alias="date_sk">
+                <dxl:Ident ColId="10" ColName="date_sk" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="firstname">
-                <dxl:Ident ColId="1" ColName="firstname" TypeMdid="0.25.1.0"/>
+              <dxl:ProjElem ColId="11" Alias="year">
+                <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="lastname">
-                <dxl:Ident ColId="2" ColName="lastname" TypeMdid="0.25.1.0"/>
+              <dxl:ProjElem ColId="12" Alias="moy">
+                <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.023438" Rows="1.000000" Width="24"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="cid">
-                  <dxl:Ident ColId="0" ColName="cid" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="firstname">
-                  <dxl:Ident ColId="1" ColName="firstname" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="lastname">
-                  <dxl:Ident ColId="2" ColName="lastname" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.15667435.1.1" TableName="cust">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="cid" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="firstname" TypeMdid="0.25.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="lastname" TypeMdid="0.25.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="12" ColName="moy" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                </dxl:Comparison>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.15667463.1.1" TableName="datedim">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="11" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="12" Attno="3" ColName="moy" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Factorized-Preds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Factorized-Preds.mdp
@@ -278,7 +278,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.220703" Rows="1.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000890" Rows="1.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -298,7 +298,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.207031" Rows="1.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000765" Rows="1.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -324,7 +324,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000116" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -362,7 +362,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/FoldedArrayCmp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FoldedArrayCmp.mdp
@@ -198,7 +198,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="19.187500" Rows="400.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.062688" Rows="400.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -212,7 +212,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="15.062500" Rows="400.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.033952" Rows="400.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Gb-on-keys.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gb-on-keys.mdp
@@ -188,7 +188,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -202,7 +202,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
@@ -246,7 +246,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295510" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127102" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295509" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -270,7 +270,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127072" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295479" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -281,7 +281,7 @@
             <dxl:Filter/>
             <dxl:BitmapTableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127071" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.295478" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
@@ -246,7 +246,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295510" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127102" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295509" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -270,7 +270,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127072" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295479" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -281,7 +281,7 @@
             <dxl:Filter/>
             <dxl:BitmapTableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127071" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.295478" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
@@ -246,7 +246,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295510" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127102" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295509" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -270,7 +270,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127072" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295479" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -281,7 +281,7 @@
             <dxl:Filter/>
             <dxl:BitmapTableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127071" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.295478" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
@@ -261,7 +261,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127302" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295517" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -274,7 +274,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
         </dxl:SortingColumnList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127288" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295502" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -285,7 +285,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
           <dxl:OneTimeFilter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127288" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295502" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -303,7 +303,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
             <dxl:LimitOffset/>
             <dxl:BitmapTableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127285" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.295500" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-IndexPlan.mdp
@@ -353,7 +353,7 @@ Result  (cost=0.00..8.00 rows=2 width=36)
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.002212" Rows="4.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupByEmptySetNoAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupByEmptySetNoAgg.mdp
@@ -197,7 +197,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.015625" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="?column?">
@@ -208,37 +208,45 @@
         <dxl:OneTimeFilter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.007812" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.001953" Rows="2.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000977" Rows="2.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="1"/>
               </dxl:Properties>
+              <dxl:GroupingColumns/>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.179990.1.1" TableName="gpb">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.179990.1.1" TableName="gpb">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:Aggregate>
       </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
@@ -323,7 +323,7 @@ where t.a in (select count(s.i) from s);
     <dxl:Plan Id="0" SpaceSize="24">
       <dxl:HashJoin JoinType="In">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.171875" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000729" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -345,7 +345,7 @@ where t.a in (select count(s.i) from s);
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -359,7 +359,7 @@ where t.a in (select count(s.i) from s);
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -387,51 +387,65 @@ where t.a in (select count(s.i) from s);
         </dxl:GatherMotion>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.046875" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="count">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
+                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
               </dxl:AggFunc>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="i">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="8"/>
               </dxl:Properties>
+              <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="i">
-                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.839968.1.1" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="i">
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.839968.1.1" TableName="s">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:Aggregate>
       </dxl:HashJoin>

--- a/src/backend/gporca/data/dxl/minidump/GroupingSets.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingSets.mdp
@@ -243,7 +243,7 @@
     <dxl:Plan Id="0" SpaceSize="44">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.255859" Rows="2.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000205" Rows="2.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="a">
@@ -255,7 +255,7 @@
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.013672" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -267,7 +267,7 @@
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -281,7 +281,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -310,7 +310,7 @@
         </dxl:CTEProducer>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.195312" Rows="2.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000104" Rows="2.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="a">
@@ -323,11 +323,11 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="a">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="18" Alias="count">
                 <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
@@ -335,9 +335,9 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.054688" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="10"/>
@@ -351,9 +351,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:CTEConsumer CTEId="0" Columns="9,10">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">
@@ -363,12 +363,31 @@
                     <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-              </dxl:CTEConsumer>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:CTEConsumer CTEId="0" Columns="9,10">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="a">
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="b">
+                      <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Result>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="20"/>
@@ -382,9 +401,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:CTEConsumer CTEId="0" Columns="20,21">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="20" Alias="a">
@@ -394,7 +413,26 @@
                   <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-            </dxl:CTEConsumer>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:CTEConsumer CTEId="0" Columns="20,21">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="20" Alias="a">
+                    <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="b">
+                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+              </dxl:CTEConsumer>
+            </dxl:Sort>
           </dxl:Aggregate>
         </dxl:Append>
       </dxl:Sequence>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -828,7 +828,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="635.393021" Rows="22.230000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="828.979625" Rows="22.230000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -854,7 +854,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="635.390625" Rows="22.230000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="828.977230" Rows="22.230000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">
@@ -890,7 +890,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
           </dxl:HashCondList>
           <dxl:DynamicBitmapTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="204.385855" Rows="3.705000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="397.972460" Rows="3.705000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="c1">

--- a/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -359,7 +359,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
     <dxl:Plan Id="0" SpaceSize="2345">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.324219" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001510" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="i">
@@ -382,7 +382,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.308594" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001367" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="i">
@@ -419,7 +419,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="i">
@@ -450,7 +450,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.144531" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -474,7 +474,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
             </dxl:HashExprList>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.132812" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000602" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -497,7 +497,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
               </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -524,7 +524,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
               </dxl:TableScan>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -4554,7 +4554,7 @@
     <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2419556.187988" Rows="1.000000" Width="275"/>
+          <dxl:Cost StartupCost="0" TotalCost="11941.357050" Rows="1.000000" Width="275"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -4637,7 +4637,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2419555.053711" Rows="1.000000" Width="275"/>
+            <dxl:Cost StartupCost="0" TotalCost="11941.355816" Rows="1.000000" Width="275"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -4742,7 +4742,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="404515.801758" Rows="6003249.000000" Width="138"/>
+              <dxl:Cost StartupCost="0" TotalCost="708.350104" Rows="6003249.000000" Width="138"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -4825,7 +4825,7 @@
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="201001.941406" Rows="1502372.000000" Width="137"/>
+              <dxl:Cost StartupCost="0" TotalCost="1013.116567" Rows="1502372.000000" Width="137"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="o_orderkey">
@@ -4865,7 +4865,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="100500.470703" Rows="1502372.000000" Width="137"/>
+                <dxl:Cost StartupCost="0" TotalCost="499.583282" Rows="1502372.000000" Width="137"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="o_orderkey">

--- a/src/backend/gporca/data/dxl/minidump/HashJoinOnRelabeledColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HashJoinOnRelabeledColumns.mdp
@@ -268,7 +268,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.117188" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -282,7 +282,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.109375" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000569" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -306,7 +306,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -329,7 +329,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/IDF-NotNullConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IDF-NotNullConstant.mdp
@@ -266,7 +266,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.776402" Rows="99.172600" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.004730" Rows="99.172600" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -277,7 +277,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.582705" Rows="99.172600" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002949" Rows="99.172600" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IDF-NullConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IDF-NullConstant.mdp
@@ -266,7 +266,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.600621" Rows="69.172600" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.004080" Rows="69.172600" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -277,7 +277,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.465518" Rows="69.172600" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002837" Rows="69.172600" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -287,7 +287,7 @@
           <dxl:Filter>
             <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:IsDistinctFrom>
           </dxl:Filter>
           <dxl:TableDescriptor Mdid="0.2428752.1.1" TableName="idf">

--- a/src/backend/gporca/data/dxl/minidump/IN-ArrayCmp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IN-ArrayCmp.mdp
@@ -254,7 +254,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.222656" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000856" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -274,7 +274,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.210938" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000748" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -300,7 +300,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -336,7 +336,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IN.mdp
@@ -1011,7 +1011,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="16123.176758" Rows="2.000000" Width="165"/>
+          <dxl:Cost StartupCost="0" TotalCost="444.968210" Rows="2.000000" Width="165"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -1046,7 +1046,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="16122.015625" Rows="2.000000" Width="165"/>
+            <dxl:Cost StartupCost="0" TotalCost="444.966728" Rows="2.000000" Width="165"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">

--- a/src/backend/gporca/data/dxl/minidump/INDF-NotNullConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/INDF-NotNullConstant.mdp
@@ -268,7 +268,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.207031" Rows="2.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.002623" Rows="2.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -279,7 +279,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.203125" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002587" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/INDF-NullConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/INDF-NullConstant.mdp
@@ -268,7 +268,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.371094" Rows="30.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.003230" Rows="30.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -279,7 +279,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.312500" Rows="30.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002692" Rows="30.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -290,7 +290,7 @@
             <dxl:Not>
               <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:IsDistinctFrom>
             </dxl:Not>
           </dxl:Filter>
@@ -310,7 +310,7 @@
       </dxl:GatherMotion>
       <dxl:DirectDispatchInfo>
         <dxl:KeyValue>
-          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
         </dxl:KeyValue>
       </dxl:DirectDispatchInfo>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
@@ -9994,7 +9994,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1630541875973909504.000000" Rows="28304179680000000.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="104085991423480.859375" Rows="28304179680000000.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="17" Alias="ws_order_number">
@@ -10011,7 +10011,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1630320749570159616.000000" Rows="28304179680000000.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="102052619155269.656250" Rows="28304179680000000.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="17" Alias="ws_order_number">
@@ -10031,46 +10031,9 @@
               <dxl:Ident ColId="56" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1079860.375000" Rows="368592000.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="56" Alias="ws_warehouse_sk">
-                <dxl:Ident ColId="56" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="359953.125000" Rows="184296000.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="56" Alias="ws_warehouse_sk">
-                  <dxl:Ident ColId="56" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.25732.1.1" TableName="web_sales">
-                <dxl:Columns>
-                  <dxl:Column ColId="44" Attno="4" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="56" Attno="16" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="58" Attno="18" ColName="ws_order_number" TypeMdid="0.20.1.0"/>
-                  <dxl:Column ColId="75" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="76" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="77" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="78" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="79" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="80" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="81" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1079859.375000" Rows="184296000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="12138.403400" Rows="184296000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="15" Alias="ws_warehouse_sk">
@@ -10096,6 +10059,54 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="100000000013561.171875" Rows="368592000.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="56" Alias="ws_warehouse_sk">
+                <dxl:Ident ColId="56" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="100000000012823.984375" Rows="368592000.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="56" Alias="ws_warehouse_sk">
+                  <dxl:Ident ColId="56" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="12138.403400" Rows="184296000.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="56" Alias="ws_warehouse_sk">
+                    <dxl:Ident ColId="56" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.25732.1.1" TableName="web_sales">
+                  <dxl:Columns>
+                    <dxl:Column ColId="44" Attno="4" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="56" Attno="16" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="58" Attno="18" ColName="ws_order_number" TypeMdid="0.20.1.0"/>
+                    <dxl:Column ColId="75" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="76" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="77" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="78" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="79" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="80" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="81" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
@@ -515,7 +515,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
     <dxl:Plan Id="1" SpaceSize="12">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="270.551953" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2598.003284" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -524,7 +524,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="23,24,25,26,27,28,29,30,31">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.042969" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000245" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="symbol">
@@ -557,7 +557,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.041016" Rows="1.000000" Width="42"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000244" Rows="1.000000" Width="42"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="symbol">
@@ -592,7 +592,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.020508" Rows="1.000000" Width="42"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="42"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="symbol">
@@ -644,7 +644,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
         </dxl:CTEProducer>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="267.493359" Rows="3.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2167.003031" Rows="3.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -655,7 +655,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
           <dxl:SortingColumnList/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="265.458203" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="2167.002912" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -788,7 +788,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                         </dxl:And>
                       </dxl:And>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                     </dxl:If>
                   </dxl:If>
                 </dxl:If>
@@ -799,7 +799,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
             </dxl:PartitionSelector>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="265.458203" Rows="3.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="2167.002912" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -809,7 +809,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
               <dxl:Filter/>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.072396" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.001030" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -822,7 +822,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                 </dxl:JoinFilter>
                 <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -833,7 +833,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                   <dxl:SortingColumnList/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -844,7 +844,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                     <dxl:OneTimeFilter/>
                     <dxl:CTEConsumer CTEId="0" Columns="0,1,4,5,6,7,8,9,10">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="symbol">
@@ -880,7 +880,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                 </dxl:BroadcastMotion>
                 <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.033333" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6.000557" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
@@ -913,7 +913,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
               </dxl:NestedLoopJoin>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.307682" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.000944" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="37" Alias="event_ts">
@@ -926,7 +926,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                 </dxl:JoinFilter>
                 <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="37" Alias="event_ts">
@@ -937,7 +937,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                   <dxl:SortingColumnList/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="37" Alias="event_ts">
@@ -948,7 +948,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                     <dxl:OneTimeFilter/>
                     <dxl:CTEConsumer CTEId="0" Columns="36,37,38,39,40,41,42,43,44">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="36" Alias="symbol">
@@ -984,7 +984,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                 </dxl:BroadcastMotion>
                 <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="3" PrintablePartIndexId="1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.268620" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6.000473" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="49" Alias="end_ts">
@@ -1024,7 +1024,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
               </dxl:NestedLoopJoin>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="259.054688" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000926" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="60" Alias="event_ts">
@@ -1046,7 +1046,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                 </dxl:JoinFilter>
                 <dxl:DynamicTableScan PartIndexId="4" PrintablePartIndexId="1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="68" Alias="ets">
@@ -1076,7 +1076,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                 </dxl:DynamicTableScan>
                 <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000446" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="60" Alias="event_ts">
@@ -1086,7 +1086,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                   <dxl:Filter/>
                   <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="60" Alias="event_ts">
@@ -1097,7 +1097,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                     <dxl:SortingColumnList/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="60" Alias="event_ts">
@@ -1108,7 +1108,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
                       <dxl:OneTimeFilter/>
                       <dxl:CTEConsumer CTEId="0" Columns="59,60,61,62,63,64,65,66,67">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="59" Alias="symbol">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
@@ -543,7 +543,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="50">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="13.466016" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1305.002085" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -554,37 +554,37 @@ ORDER BY 1 asc ;
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.464063" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1305.002067" Rows="1.000000" Width="4"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="1"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="event_ts">
               <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="11.444531" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1305.002067" Rows="1.000000" Width="4"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="1"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="event_ts">
                 <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="10.444531" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1305.002062" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -592,214 +592,43 @@ ORDER BY 1 asc ;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:Sequence>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="9.440625" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1305.002062" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="event_ts">
                     <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:CTEProducer CTEId="0" Columns="23,24,25,26,27,28,29,30,31">
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.021484" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1305.002054" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="symbol">
-                      <dxl:Ident ColId="23" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="event_ts">
-                      <dxl:Ident ColId="24" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="ctid">
-                      <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="xmin">
-                      <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="27" Alias="cmin">
-                      <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="xmax">
-                      <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="cmax">
-                      <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="tableoid">
-                      <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="31" Alias="gp_segment_id">
-                      <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.020508" Rows="1.000000" Width="42"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="symbol">
-                        <dxl:Ident ColId="23" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="24" Alias="event_ts">
-                        <dxl:Ident ColId="24" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="25" Alias="ctid">
-                        <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="26" Alias="xmin">
-                        <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="27" Alias="cmin">
-                        <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="28" Alias="xmax">
-                        <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="29" Alias="cmax">
-                        <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="30" Alias="tableoid">
-                        <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="31" Alias="gp_segment_id">
-                        <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.16032548.1.1" TableName="my_tt_agg_small">
-                      <dxl:Columns>
-                        <dxl:Column ColId="23" Attno="1" ColName="symbol" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                        <dxl:Column ColId="24" Attno="2" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="32" Attno="3" ColName="trade_price" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="33" Attno="4" ColName="trade_volume" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:CTEProducer>
-                <dxl:Sequence>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.395703" Rows="2.000000" Width="8"/>
-                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="1"/>
+                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="event_ts">
                       <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="0.16032574.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Filter/>
+                  <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
-                      <dxl:If TypeMdid="0.23.1.0">
-                        <dxl:And>
-                          <dxl:Not>
-                            <dxl:DefaultPart Level="0"/>
-                          </dxl:Not>
-                          <dxl:And>
-                            <dxl:Or>
-                              <dxl:And>
-                                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                  <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                                </dxl:Comparison>
-                                <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                              </dxl:And>
-                              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                              </dxl:Comparison>
-                            </dxl:Or>
-                            <dxl:Or>
-                              <dxl:And>
-                                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
-                                  <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                                </dxl:Comparison>
-                                <dxl:Not>
-                                  <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                                </dxl:Not>
-                              </dxl:And>
-                              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
-                                <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                              </dxl:Comparison>
-                            </dxl:Or>
-                          </dxl:And>
-                        </dxl:And>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        <dxl:If TypeMdid="0.23.1.0">
-                          <dxl:And>
-                            <dxl:Not>
-                              <dxl:DefaultPart Level="0"/>
-                            </dxl:Not>
-                            <dxl:And>
-                              <dxl:Or>
-                                <dxl:And>
-                                  <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
-                                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                                  </dxl:Comparison>
-                                  <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                                </dxl:And>
-                                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
-                                  <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                                </dxl:Comparison>
-                              </dxl:Or>
-                              <dxl:Or>
-                                <dxl:And>
-                                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900000"/>
-                                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                                  </dxl:Comparison>
-                                  <dxl:Not>
-                                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                                  </dxl:Not>
-                                </dxl:And>
-                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="900000"/>
-                                  <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                                </dxl:Comparison>
-                              </dxl:Or>
-                            </dxl:And>
-                          </dxl:And>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-                        </dxl:If>
-                      </dxl:If>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:Append IsTarget="false" IsZapped="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6.395703" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1305.002049" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -807,33 +636,213 @@ ORDER BY 1 asc ;
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:Sequence>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.072396" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1305.002049" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="event_ts">
                           <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:JoinFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:JoinFilter>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:CTEProducer CTEId="0" Columns="23,24,25,26,27,28,29,30,31">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="23" Alias="symbol">
+                            <dxl:Ident ColId="23" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="24" Alias="event_ts">
+                            <dxl:Ident ColId="24" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="25" Alias="ctid">
+                            <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="26" Alias="xmin">
+                            <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="cmin">
+                            <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="xmax">
+                            <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="cmax">
+                            <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="tableoid">
+                            <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="gp_segment_id">
+                            <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="42"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="23" Alias="symbol">
+                              <dxl:Ident ColId="23" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="24" Alias="event_ts">
+                              <dxl:Ident ColId="24" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="25" Alias="ctid">
+                              <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="26" Alias="xmin">
+                              <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="27" Alias="cmin">
+                              <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="28" Alias="xmax">
+                              <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="29" Alias="cmax">
+                              <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="30" Alias="tableoid">
+                              <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="31" Alias="gp_segment_id">
+                              <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.16032548.1.1" TableName="my_tt_agg_small">
+                            <dxl:Columns>
+                              <dxl:Column ColId="23" Attno="1" ColName="symbol" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                              <dxl:Column ColId="24" Attno="2" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="32" Attno="3" ColName="trade_price" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="33" Attno="4" ColName="trade_volume" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:CTEProducer>
+                      <dxl:Sequence>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="874.001981" Rows="2.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="1" Alias="event_ts">
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Result>
+                        <dxl:PartitionSelector RelationMdid="0.16032574.1.1" PartitionLevels="1" ScanId="1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:PartEqFilters>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:PartEqFilters>
+                          <dxl:PartFilters>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:PartFilters>
+                          <dxl:ResidualFilter>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ResidualFilter>
+                          <dxl:PropagationExpression>
+                            <dxl:If TypeMdid="0.23.1.0">
+                              <dxl:And>
+                                <dxl:Not>
+                                  <dxl:DefaultPart Level="0"/>
+                                </dxl:Not>
+                                <dxl:And>
+                                  <dxl:Or>
+                                    <dxl:And>
+                                      <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                                      </dxl:Comparison>
+                                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                                    </dxl:And>
+                                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                                    </dxl:Comparison>
+                                  </dxl:Or>
+                                  <dxl:Or>
+                                    <dxl:And>
+                                      <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
+                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                                      </dxl:Comparison>
+                                      <dxl:Not>
+                                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                                      </dxl:Not>
+                                    </dxl:And>
+                                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
+                                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                                    </dxl:Comparison>
+                                  </dxl:Or>
+                                </dxl:And>
+                              </dxl:And>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                              <dxl:If TypeMdid="0.23.1.0">
+                                <dxl:And>
+                                  <dxl:Not>
+                                    <dxl:DefaultPart Level="0"/>
+                                  </dxl:Not>
+                                  <dxl:And>
+                                    <dxl:Or>
+                                      <dxl:And>
+                                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
+                                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                                        </dxl:Comparison>
+                                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                                      </dxl:And>
+                                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="200000"/>
+                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                                      </dxl:Comparison>
+                                    </dxl:Or>
+                                    <dxl:Or>
+                                      <dxl:And>
+                                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="900000"/>
+                                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                                        </dxl:Comparison>
+                                        <dxl:Not>
+                                          <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                                        </dxl:Not>
+                                      </dxl:And>
+                                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="900000"/>
+                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                                      </dxl:Comparison>
+                                    </dxl:Or>
+                                  </dxl:And>
+                                </dxl:And>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                              </dxl:If>
+                            </dxl:If>
+                          </dxl:PropagationExpression>
+                          <dxl:PrintableFilter>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:PrintableFilter>
+                        </dxl:PartitionSelector>
+                        <dxl:Append IsTarget="false" IsZapped="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="874.001981" Rows="2.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -841,193 +850,230 @@ ORDER BY 1 asc ;
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:CTEConsumer CTEId="0" Columns="0,1,4,5,6,7,8,9,10">
+                          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="437.001030" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="symbol">
-                                <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="1" Alias="event_ts">
                                 <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="4" Alias="ctid">
-                                <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="5" Alias="xmin">
-                                <dxl:Ident ColId="5" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="6" Alias="cmin">
-                                <dxl:Ident ColId="6" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="7" Alias="xmax">
-                                <dxl:Ident ColId="7" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="8" Alias="cmax">
-                                <dxl:Ident ColId="8" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="9" Alias="tableoid">
-                                <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="10" Alias="gp_segment_id">
-                                <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                             </dxl:ProjList>
-                          </dxl:CTEConsumer>
-                        </dxl:Result>
-                      </dxl:BroadcastMotion>
-                      <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.033333" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList/>
-                        <dxl:Filter/>
-                        <dxl:IndexCondList>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                            <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                            <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.16032679.1.0" IndexName="my_tq_agg_small_part_ets_end_ts_ix_1"/>
-                        <dxl:TableDescriptor Mdid="0.16032574.1.1" TableName="my_tq_agg_small_part">
-                          <dxl:Columns>
-                            <dxl:Column ColId="11" Attno="1" ColName="ets" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="13" Attno="3" ColName="bid_price" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="15" Attno="5" ColName="end_ts" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:DynamicIndexScan>
-                    </dxl:NestedLoopJoin>
-                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.307682" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="37" Alias="event_ts">
-                          <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:JoinFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:JoinFilter>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="37" Alias="event_ts">
-                            <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="37" Alias="event_ts">
-                              <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:CTEConsumer CTEId="0" Columns="36,37,38,39,40,41,42,43,44">
+                            <dxl:Filter/>
+                            <dxl:JoinFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:JoinFilter>
+                            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="2.000000" Width="8"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="1" Alias="event_ts">
+                                  <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:Result>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="1" Alias="event_ts">
+                                    <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
+                                <dxl:CTEConsumer CTEId="0" Columns="0,1,4,5,6,7,8,9,10">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="symbol">
+                                      <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="1" Alias="event_ts">
+                                      <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="4" Alias="ctid">
+                                      <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="5" Alias="xmin">
+                                      <dxl:Ident ColId="5" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="6" Alias="cmin">
+                                      <dxl:Ident ColId="6" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="7" Alias="xmax">
+                                      <dxl:Ident ColId="7" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="8" Alias="cmax">
+                                      <dxl:Ident ColId="8" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="9" Alias="tableoid">
+                                      <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="10" Alias="gp_segment_id">
+                                      <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                </dxl:CTEConsumer>
+                              </dxl:Result>
+                            </dxl:BroadcastMotion>
+                            <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2" PrintablePartIndexId="1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="6.000557" Rows="1.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList/>
+                              <dxl:Filter/>
+                              <dxl:IndexCondList>
+                                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                                  <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                                  <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:IndexCondList>
+                              <dxl:IndexDescriptor Mdid="0.16032679.1.0" IndexName="my_tq_agg_small_part_ets_end_ts_ix_1"/>
+                              <dxl:TableDescriptor Mdid="0.16032574.1.1" TableName="my_tq_agg_small_part">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="11" Attno="1" ColName="ets" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="13" Attno="3" ColName="bid_price" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="15" Attno="5" ColName="end_ts" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:DynamicIndexScan>
+                          </dxl:NestedLoopJoin>
+                          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="437.000944" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="36" Alias="symbol">
-                                <dxl:Ident ColId="36" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="37" Alias="event_ts">
                                 <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="38" Alias="ctid">
-                                <dxl:Ident ColId="38" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="39" Alias="xmin">
-                                <dxl:Ident ColId="39" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="40" Alias="cmin">
-                                <dxl:Ident ColId="40" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="41" Alias="xmax">
-                                <dxl:Ident ColId="41" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="42" Alias="cmax">
-                                <dxl:Ident ColId="42" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="43" Alias="tableoid">
-                                <dxl:Ident ColId="43" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="44" Alias="gp_segment_id">
-                                <dxl:Ident ColId="44" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                             </dxl:ProjList>
-                          </dxl:CTEConsumer>
-                        </dxl:Result>
-                      </dxl:BroadcastMotion>
-                      <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="3" PrintablePartIndexId="1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.268620" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="49" Alias="end_ts">
-                            <dxl:Ident ColId="49" ColName="end_ts" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                            <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="49" ColName="end_ts" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:IndexCondList>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                            <dxl:Ident ColId="45" ColName="ets" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.16032698.1.0" IndexName="my_tq_agg_small_part_ets_end_ts_ix_3"/>
-                        <dxl:TableDescriptor Mdid="0.16032574.1.1" TableName="my_tq_agg_small_part">
-                          <dxl:Columns>
-                            <dxl:Column ColId="45" Attno="1" ColName="ets" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="46" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="47" Attno="3" ColName="bid_price" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="48" Attno="4" ColName="ask_price" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="49" Attno="5" ColName="end_ts" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="50" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="51" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="52" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="53" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="54" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="55" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="56" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:DynamicIndexScan>
-                    </dxl:NestedLoopJoin>
-                  </dxl:Append>
-                </dxl:Sequence>
-              </dxl:Sequence>
-            </dxl:RedistributeMotion>
-          </dxl:Sort>
-        </dxl:Aggregate>
+                            <dxl:Filter/>
+                            <dxl:JoinFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:JoinFilter>
+                            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="2.000000" Width="8"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="37" Alias="event_ts">
+                                  <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:Result>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="37" Alias="event_ts">
+                                    <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
+                                <dxl:CTEConsumer CTEId="0" Columns="36,37,38,39,40,41,42,43,44">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="36" Alias="symbol">
+                                      <dxl:Ident ColId="36" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="37" Alias="event_ts">
+                                      <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="38" Alias="ctid">
+                                      <dxl:Ident ColId="38" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="39" Alias="xmin">
+                                      <dxl:Ident ColId="39" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="40" Alias="cmin">
+                                      <dxl:Ident ColId="40" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="41" Alias="xmax">
+                                      <dxl:Ident ColId="41" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="42" Alias="cmax">
+                                      <dxl:Ident ColId="42" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="43" Alias="tableoid">
+                                      <dxl:Ident ColId="43" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="44" Alias="gp_segment_id">
+                                      <dxl:Ident ColId="44" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                </dxl:CTEConsumer>
+                              </dxl:Result>
+                            </dxl:BroadcastMotion>
+                            <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="3" PrintablePartIndexId="1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="6.000473" Rows="1.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="49" Alias="end_ts">
+                                  <dxl:Ident ColId="49" ColName="end_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                                  <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="49" ColName="end_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:Filter>
+                              <dxl:IndexCondList>
+                                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                                  <dxl:Ident ColId="45" ColName="ets" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="37" ColName="event_ts" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:IndexCondList>
+                              <dxl:IndexDescriptor Mdid="0.16032698.1.0" IndexName="my_tq_agg_small_part_ets_end_ts_ix_3"/>
+                              <dxl:TableDescriptor Mdid="0.16032574.1.1" TableName="my_tq_agg_small_part">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="45" Attno="1" ColName="ets" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="46" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                                  <dxl:Column ColId="47" Attno="3" ColName="bid_price" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="48" Attno="4" ColName="ask_price" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="49" Attno="5" ColName="end_ts" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="50" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="51" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="52" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="53" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="54" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="55" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="56" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:DynamicIndexScan>
+                          </dxl:NestedLoopJoin>
+                        </dxl:Append>
+                      </dxl:Sequence>
+                    </dxl:Sequence>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -827,7 +827,7 @@
     <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="224.883678" Rows="1000.888592" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -850,7 +850,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="214.109375" Rows="1000.888592" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="863.341752" Rows="1000.888592" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -879,7 +879,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="71.398438" Rows="9011.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.274025" Rows="9011.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="i">
@@ -898,7 +898,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="35.199219" Rows="9011.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="i">
@@ -926,7 +926,7 @@
           </dxl:RedistributeMotion>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="12.718750" Rows="1000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.041490" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -948,7 +948,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5.859375" Rows="1000.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011550" Rows="1000.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -833,7 +833,7 @@
     <dxl:Plan Id="0" SpaceSize="31">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="188.675781" Rows="1000.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="864.151759" Rows="1000.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -856,7 +856,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="177.910156" Rows="1000.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="864.061959" Rows="1000.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -889,7 +889,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="35.199219" Rows="9011.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="i">
@@ -916,7 +916,7 @@
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="12.718750" Rows="1000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.041490" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -938,7 +938,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5.859375" Rows="1000.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011550" Rows="1000.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
@@ -805,7 +805,7 @@
     <dxl:Plan Id="0" SpaceSize="17">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="52.876302" Rows="100.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.992066" Rows="100.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -823,9 +823,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="51.095052" Rows="100.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.984882" Rows="100.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -842,12 +842,16 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="35.199219" Rows="9011.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -872,9 +876,9 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="13.333333" Rows="0.011098" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -885,13 +889,6 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:IndexCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:IndexCondList>
-            <dxl:IndexDescriptor Mdid="0.9385692.1.0" IndexName="index_ri"/>
             <dxl:TableDescriptor Mdid="0.9385666.1.1" TableName="r">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
@@ -905,8 +902,8 @@
                 <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
-          </dxl:IndexScan>
-        </dxl:NestedLoopJoin>
+          </dxl:TableScan>
+        </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -827,7 +827,7 @@
     <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="224.883678" Rows="1000.888592" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -850,7 +850,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="214.109375" Rows="1000.888592" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="863.341752" Rows="1000.888592" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -879,7 +879,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="71.398438" Rows="9011.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.274025" Rows="9011.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="i">
@@ -898,7 +898,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="35.199219" Rows="9011.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="i">
@@ -926,7 +926,7 @@
           </dxl:RedistributeMotion>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="12.718750" Rows="1000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.041490" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -948,7 +948,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5.859375" Rows="1000.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011550" Rows="1000.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -819,7 +819,7 @@
     <dxl:Plan Id="0" SpaceSize="25">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="53.884122" Rows="100.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="863.780122" Rows="100.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -837,9 +837,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="52.102872" Rows="100.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="863.772938" Rows="100.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -856,12 +856,20 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="35.199219" Rows="9011.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -886,9 +894,9 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="14.341153" Rows="0.000111" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -898,19 +906,7 @@
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:Filter>
-            <dxl:IndexCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:IndexCondList>
-            <dxl:IndexDescriptor Mdid="0.9385692.1.0" IndexName="index_ri"/>
+            <dxl:Filter/>
             <dxl:TableDescriptor Mdid="0.9385666.1.1" TableName="r">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
@@ -924,8 +920,8 @@
                 <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
-          </dxl:IndexScan>
-        </dxl:NestedLoopJoin>
+          </dxl:TableScan>
+        </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnMasterOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnMasterOnlyTable.mdp
@@ -1871,10 +1871,10 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+    <dxl:Plan Id="0" SpaceSize="9">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="54903.394792" Rows="9011.000000" Width="180"/>
+          <dxl:Cost StartupCost="0" TotalCost="1413.359893" Rows="9011.000000" Width="180"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="relname">
@@ -1975,54 +1975,10 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter>
-          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-        </dxl:JoinFilter>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="71.398438" Rows="9011.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="38" Alias="i">
-              <dxl:Ident ColId="38" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="39" Alias="j">
-              <dxl:Ident ColId="39" ColName="j" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="35.199219" Rows="9011.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="38" Alias="i">
-                <dxl:Ident ColId="38" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="39" Alias="j">
-                <dxl:Ident ColId="39" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
-              <dxl:Columns>
-                <dxl:Column ColId="38" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="39" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="40" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="41" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="42" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="43" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="44" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="45" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="46" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:GatherMotion>
-        <dxl:IndexScan IndexScanDirection="Forward">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="51663.066667" Rows="1.000000" Width="172"/>
+            <dxl:Cost StartupCost="0" TotalCost="1406.077203" Rows="9011.000000" Width="180"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="relname">
@@ -2115,61 +2071,296 @@
             <dxl:ProjElem ColId="29" Alias="reloptions">
               <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="38" Alias="i">
+              <dxl:Ident ColId="38" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="39" Alias="j">
+              <dxl:Ident ColId="39" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:IndexCondList>
+          <dxl:JoinFilter>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
               <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
               <dxl:Cast TypeMdid="0.26.1.0" FuncId="0.0.0.0">
                 <dxl:Ident ColId="38" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:Cast>
             </dxl:Comparison>
-          </dxl:IndexCondList>
-          <dxl:IndexDescriptor Mdid="0.2662.1.0" IndexName="pg_class_oid_index"/>
-          <dxl:TableDescriptor Mdid="0.1259.1.1" TableName="pg_class">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="relname" TypeMdid="0.19.1.0"/>
-              <dxl:Column ColId="1" Attno="2" ColName="relnamespace" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="2" Attno="3" ColName="reltype" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="3" Attno="4" ColName="relowner" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="4" Attno="5" ColName="relam" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="5" Attno="6" ColName="relfilenode" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="6" Attno="7" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="7" Attno="8" ColName="relpages" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="8" Attno="9" ColName="reltuples" TypeMdid="0.700.1.0"/>
-              <dxl:Column ColId="9" Attno="10" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="10" Attno="11" ColName="reltoastidxid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="11" Attno="12" ColName="relaosegrelid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="12" Attno="13" ColName="relaosegidxid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="13" Attno="14" ColName="relhasindex" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="14" Attno="15" ColName="relisshared" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="15" Attno="16" ColName="relkind" TypeMdid="0.18.1.0"/>
-              <dxl:Column ColId="16" Attno="17" ColName="relstorage" TypeMdid="0.18.1.0"/>
-              <dxl:Column ColId="17" Attno="18" ColName="relnatts" TypeMdid="0.21.1.0"/>
-              <dxl:Column ColId="18" Attno="19" ColName="relchecks" TypeMdid="0.21.1.0"/>
-              <dxl:Column ColId="19" Attno="20" ColName="reltriggers" TypeMdid="0.21.1.0"/>
-              <dxl:Column ColId="20" Attno="21" ColName="relukeys" TypeMdid="0.21.1.0"/>
-              <dxl:Column ColId="21" Attno="22" ColName="relfkeys" TypeMdid="0.21.1.0"/>
-              <dxl:Column ColId="22" Attno="23" ColName="relrefs" TypeMdid="0.21.1.0"/>
-              <dxl:Column ColId="23" Attno="24" ColName="relhasoids" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="24" Attno="25" ColName="relhaspkey" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="25" Attno="26" ColName="relhasrules" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="26" Attno="27" ColName="relhassubclass" TypeMdid="0.16.1.0"/>
-              <dxl:Column ColId="27" Attno="28" ColName="relfrozenxid" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="28" Attno="29" ColName="relacl" TypeMdid="0.1034.1.0"/>
-              <dxl:Column ColId="29" Attno="30" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-              <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="31" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:IndexScan>
-      </dxl:NestedLoopJoin>
+          </dxl:JoinFilter>
+          <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="434.326561" Rows="674.000000" Width="180"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="relname">
+                <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="relnamespace">
+                <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="reltype">
+                <dxl:Ident ColId="2" ColName="reltype" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="relowner">
+                <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="4" Alias="relam">
+                <dxl:Ident ColId="4" ColName="relam" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="5" Alias="relfilenode">
+                <dxl:Ident ColId="5" ColName="relfilenode" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="6" Alias="reltablespace">
+                <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="relpages">
+                <dxl:Ident ColId="7" ColName="relpages" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="reltuples">
+                <dxl:Ident ColId="8" ColName="reltuples" TypeMdid="0.700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="reltoastrelid">
+                <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="reltoastidxid">
+                <dxl:Ident ColId="10" ColName="reltoastidxid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="relaosegrelid">
+                <dxl:Ident ColId="11" ColName="relaosegrelid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="relaosegidxid">
+                <dxl:Ident ColId="12" ColName="relaosegidxid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="relhasindex">
+                <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="relisshared">
+                <dxl:Ident ColId="14" ColName="relisshared" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="relkind">
+                <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="relstorage">
+                <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="relnatts">
+                <dxl:Ident ColId="17" ColName="relnatts" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="relchecks">
+                <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="reltriggers">
+                <dxl:Ident ColId="19" ColName="reltriggers" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="relukeys">
+                <dxl:Ident ColId="20" ColName="relukeys" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="relfkeys">
+                <dxl:Ident ColId="21" ColName="relfkeys" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="relrefs">
+                <dxl:Ident ColId="22" ColName="relrefs" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="23" Alias="relhasoids">
+                <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="24" Alias="relhaspkey">
+                <dxl:Ident ColId="24" ColName="relhaspkey" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="25" Alias="relhasrules">
+                <dxl:Ident ColId="25" ColName="relhasrules" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="26" Alias="relhassubclass">
+                <dxl:Ident ColId="26" ColName="relhassubclass" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="27" Alias="relfrozenxid">
+                <dxl:Ident ColId="27" ColName="relfrozenxid" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="28" Alias="relacl">
+                <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="29" Alias="reloptions">
+                <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="oid">
+                <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.038182" Rows="337.000000" Width="180"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="relname">
+                  <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="relnamespace">
+                  <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="reltype">
+                  <dxl:Ident ColId="2" ColName="reltype" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="3" Alias="relowner">
+                  <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="4" Alias="relam">
+                  <dxl:Ident ColId="4" ColName="relam" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="5" Alias="relfilenode">
+                  <dxl:Ident ColId="5" ColName="relfilenode" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="6" Alias="reltablespace">
+                  <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="relpages">
+                  <dxl:Ident ColId="7" ColName="relpages" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="reltuples">
+                  <dxl:Ident ColId="8" ColName="reltuples" TypeMdid="0.700.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="reltoastrelid">
+                  <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="reltoastidxid">
+                  <dxl:Ident ColId="10" ColName="reltoastidxid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="relaosegrelid">
+                  <dxl:Ident ColId="11" ColName="relaosegrelid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="relaosegidxid">
+                  <dxl:Ident ColId="12" ColName="relaosegidxid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="13" Alias="relhasindex">
+                  <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="relisshared">
+                  <dxl:Ident ColId="14" ColName="relisshared" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="relkind">
+                  <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="relstorage">
+                  <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="relnatts">
+                  <dxl:Ident ColId="17" ColName="relnatts" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="relchecks">
+                  <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="reltriggers">
+                  <dxl:Ident ColId="19" ColName="reltriggers" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="relukeys">
+                  <dxl:Ident ColId="20" ColName="relukeys" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="relfkeys">
+                  <dxl:Ident ColId="21" ColName="relfkeys" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="relrefs">
+                  <dxl:Ident ColId="22" ColName="relrefs" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="23" Alias="relhasoids">
+                  <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="24" Alias="relhaspkey">
+                  <dxl:Ident ColId="24" ColName="relhaspkey" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="25" Alias="relhasrules">
+                  <dxl:Ident ColId="25" ColName="relhasrules" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="26" Alias="relhassubclass">
+                  <dxl:Ident ColId="26" ColName="relhassubclass" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="27" Alias="relfrozenxid">
+                  <dxl:Ident ColId="27" ColName="relfrozenxid" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="28" Alias="relacl">
+                  <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="29" Alias="reloptions">
+                  <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="31" Alias="oid">
+                  <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.1259.1.1" TableName="pg_class">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="relname" TypeMdid="0.19.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="reltype" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="relowner" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="4" Attno="5" ColName="relam" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="5" Attno="6" ColName="relfilenode" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="6" Attno="7" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="7" Attno="8" ColName="relpages" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="8" Attno="9" ColName="reltuples" TypeMdid="0.700.1.0"/>
+                  <dxl:Column ColId="9" Attno="10" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="10" Attno="11" ColName="reltoastidxid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="11" Attno="12" ColName="relaosegrelid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="12" Attno="13" ColName="relaosegidxid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="13" Attno="14" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="14" Attno="15" ColName="relisshared" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="15" Attno="16" ColName="relkind" TypeMdid="0.18.1.0"/>
+                  <dxl:Column ColId="16" Attno="17" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                  <dxl:Column ColId="17" Attno="18" ColName="relnatts" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="18" Attno="19" ColName="relchecks" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="19" Attno="20" ColName="reltriggers" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="20" Attno="21" ColName="relukeys" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="21" Attno="22" ColName="relfkeys" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="22" Attno="23" ColName="relrefs" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="23" Attno="24" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="24" Attno="25" ColName="relhaspkey" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="25" Attno="26" ColName="relhasrules" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="26" Attno="27" ColName="relhassubclass" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="27" Attno="28" ColName="relfrozenxid" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="28" Attno="29" ColName="relacl" TypeMdid="0.1034.1.0"/>
+                  <dxl:Column ColId="29" Attno="30" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                  <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="31" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:BroadcastMotion>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="38" Alias="i">
+                <dxl:Ident ColId="38" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="39" Alias="j">
+                <dxl:Ident ColId="39" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
+              <dxl:Columns>
+                <dxl:Column ColId="38" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="39" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="40" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="41" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="42" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="43" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="44" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="45" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="46" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
@@ -503,7 +503,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="585.257377" Rows="5.000000" Width="40"/>
+          <dxl:Cost StartupCost="0" TotalCost="1231.893294" Rows="5.000000" Width="40"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -541,7 +541,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="585.256632" Rows="5.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="1231.892548" Rows="5.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -581,7 +581,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
           </dxl:JoinFilter>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="517.128720" Rows="4.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="840.416678" Rows="4.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -767,7 +767,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
             </dxl:NestedLoopJoin>
             <dxl:BitmapTableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="0.333333" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="391.415528" Rows="0.333333" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="a">
@@ -806,7 +806,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
           </dxl:NestedLoopJoin>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127601" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.475559" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="32" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -293,7 +293,7 @@
     <dxl:Plan Id="0" SpaceSize="27">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.128146" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.296104" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -313,7 +313,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.128086" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.296044" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -377,7 +377,7 @@
           </dxl:BroadcastMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
@@ -276,7 +276,7 @@
     <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.127716" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.295674" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -296,7 +296,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.127656" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.295615" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -345,7 +345,7 @@
           </dxl:TableScan>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -402,7 +402,7 @@ Table X (int i, int j) is distributed by i, column j has index
     <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="10.262370" Rows="33.333333" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.008187" Rows="33.333333" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -417,9 +417,9 @@ Table X (int i, int j) is distributed by i, column j has index
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9.067057" Rows="33.333333" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.006391" Rows="33.333333" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -438,7 +438,7 @@ Table X (int i, int j) is distributed by i, column j has index
           </dxl:JoinFilter>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="?column?">
@@ -449,7 +449,7 @@ Table X (int i, int j) is distributed by i, column j has index
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="">
@@ -462,7 +462,7 @@ Table X (int i, int j) is distributed by i, column j has index
           </dxl:Result>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.666667" Rows="33.333333" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.005312" Rows="33.333333" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -1401,7 +1401,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="380.525391" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2951.636128" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1412,37 +1412,37 @@ ORDER BY 1 asc ;
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="379.521484" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2951.636092" Rows="1.000000" Width="8"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="23"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="fivemin">
               <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="378.498047" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="2951.636092" Rows="1.000000" Width="8"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="23"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="fivemin">
                 <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="377.498047" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="2951.636082" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1450,62 +1450,63 @@ ORDER BY 1 asc ;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:Result>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="23" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="376.494141" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2951.636082" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
-                    <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
-                      <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                        <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
-                        </dxl:OpExpr>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                      </dxl:OpExpr>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                    </dxl:OpExpr>
+                    <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="375.486328" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2951.636066" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="1" Alias="event_ts">
-                      <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="23" Alias="fivemin">
+                      <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
+                        <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                          <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+                          </dxl:OpExpr>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                        </dxl:OpExpr>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                      </dxl:OpExpr>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:OneTimeFilter/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="16.380859" Rows="840.000000" Width="25"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2951.636062" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="symbol">
-                        <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="event_ts">
                         <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5.126953" Rows="420.000000" Width="25"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.292687" Rows="840.000000" Width="25"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="symbol">
@@ -1516,60 +1517,38 @@ ORDER BY 1 asc ;
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.16166631.1.1" TableName="my_tt_agg_small">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="symbol" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:BroadcastMotion>
-                  <dxl:Sequence>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="358.097656" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="11" Alias="ets">
-                        <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="12" Alias="sym">
-                        <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="15" Alias="end_ts">
-                        <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:PartitionSelector RelationMdid="0.16166659.1.1" PartitionLevels="1" ScanId="1">
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.008085" Rows="420.000000" Width="25"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="symbol">
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="event_ts">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.16166631.1.1" TableName="my_tt_agg_small">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="symbol" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:BroadcastMotion>
+                    <dxl:Sequence>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:PartEqFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartEqFilters>
-                      <dxl:PartFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartFilters>
-                      <dxl:ResidualFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ResidualFilter>
-                      <dxl:PropagationExpression>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:PropagationExpression>
-                      <dxl:PrintableFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PrintableFilter>
-                    </dxl:PartitionSelector>
-                    <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="358.097656" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="11" Alias="ets">
@@ -1582,8 +1561,61 @@ ORDER BY 1 asc ;
                           <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:And>
+                      <dxl:PartitionSelector RelationMdid="0.16166659.1.1" PartitionLevels="1" ScanId="1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:PartEqFilters>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PartEqFilters>
+                        <dxl:PartFilters>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PartFilters>
+                        <dxl:ResidualFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ResidualFilter>
+                        <dxl:PropagationExpression>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:PropagationExpression>
+                        <dxl:PrintableFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PrintableFilter>
+                      </dxl:PartitionSelector>
+                      <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="ets">
+                            <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="sym">
+                            <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="15" Alias="end_ts">
+                            <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                              <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                              <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                                <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                              </dxl:Cast>
+                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:And>
+                        </dxl:Filter>
+                        <dxl:IndexCondList>
                           <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
@@ -1592,47 +1624,31 @@ ORDER BY 1 asc ;
                             <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                           </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                              <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                            </dxl:Cast>
-                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:Filter>
-                      <dxl:IndexCondList>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                          <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
-                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                        </dxl:Comparison>
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                          <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IndexCondList>
-                      <dxl:IndexDescriptor Mdid="0.16166830.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                      <dxl:TableDescriptor Mdid="0.16166659.1.1" TableName="my_tq_agg_small">
-                        <dxl:Columns>
-                          <dxl:Column ColId="11" Attno="1" ColName="ets" TypeMdid="0.20.1.0"/>
-                          <dxl:Column ColId="12" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="13" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0"/>
-                          <dxl:Column ColId="15" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:DynamicIndexScan>
-                  </dxl:Sequence>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
-            </dxl:RedistributeMotion>
-          </dxl:Sort>
-        </dxl:Aggregate>
+                        </dxl:IndexCondList>
+                        <dxl:IndexDescriptor Mdid="0.16166830.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                        <dxl:TableDescriptor Mdid="0.16166659.1.1" TableName="my_tq_agg_small">
+                          <dxl:Columns>
+                            <dxl:Column ColId="11" Attno="1" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Column ColId="12" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                            <dxl:Column ColId="13" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="15" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:DynamicIndexScan>
+                    </dxl:Sequence>
+                  </dxl:NestedLoopJoin>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -391,7 +391,7 @@ Table X (int i, int j) is distributed by i, column i has index
     <dxl:Plan Id="0" SpaceSize="39">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.231250" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000265" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -406,9 +406,9 @@ Table X (int i, int j) is distributed by i, column i has index
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.225391" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000211" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -427,7 +427,7 @@ Table X (int i, int j) is distributed by i, column i has index
           </dxl:JoinFilter>
           <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.013672" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="?column?">
@@ -443,7 +443,7 @@ Table X (int i, int j) is distributed by i, column i has index
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="?column?">
@@ -454,7 +454,7 @@ Table X (int i, int j) is distributed by i, column i has index
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="">
@@ -468,7 +468,7 @@ Table X (int i, int j) is distributed by i, column i has index
           </dxl:RedistributeMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.200000" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000159" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply1.mdp
@@ -724,7 +724,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="147678207.187500" Rows="2036160000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="4033567.934727" Rows="2036160000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -735,7 +735,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="143701331.187500" Rows="2036160000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3996998.501127" Rows="2036160000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -748,7 +748,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3580.187500" Rows="1221696.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="503.611502" Rows="1221696.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -759,7 +759,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1193.062500" Rows="610848.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -783,7 +783,7 @@
           </dxl:BroadcastMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="135744000.000000" Rows="3333.333333" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="3974665.766400" Rows="3333.333333" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply2.mdp
@@ -717,7 +717,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="147678207.187500" Rows="2036160000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="4033567.934727" Rows="2036160000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -728,7 +728,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="143701331.187500" Rows="2036160000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3996998.501127" Rows="2036160000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -741,7 +741,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3580.187500" Rows="1221696.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="503.611502" Rows="1221696.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -752,7 +752,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1193.062500" Rows="610848.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -776,7 +776,7 @@
           </dxl:BroadcastMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="135744000.000000" Rows="3333.333333" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="3974665.766400" Rows="3333.333333" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
@@ -727,7 +727,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="177213132.187500" Rows="2443392000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="4107162.901767" Rows="2443392000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -738,7 +738,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="172440881.187500" Rows="2443392000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="4063279.581447" Rows="2443392000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -751,7 +751,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3580.187500" Rows="1221696.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="503.611502" Rows="1221696.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -762,7 +762,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1193.062500" Rows="610848.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -786,7 +786,7 @@
           </dxl:BroadcastMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="162892800.000000" Rows="4000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="4036581.319680" Rows="4000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply4.mdp
@@ -730,7 +730,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="177216711.375000" Rows="2443392000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="4107230.617933" Rows="2443392000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -739,9 +739,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="172444460.375000" Rows="2443392000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="4063347.297613" Rows="2443392000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -754,7 +754,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7159.375000" Rows="1221696.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="569.839642" Rows="1221696.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -768,7 +768,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2386.125000" Rows="610848.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -796,7 +796,7 @@
           </dxl:BroadcastMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="162892800.000000" Rows="4000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="4036581.319680" Rows="4000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -263,7 +263,7 @@
     <dxl:Plan Id="0" SpaceSize="40">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.477604" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.001095" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -289,7 +289,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.274479" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000239" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -303,7 +303,7 @@
           <dxl:SortingColumnList/>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.266667" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -338,7 +338,7 @@
         </dxl:GatherMotion>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000097" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">
@@ -352,7 +352,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
@@ -404,7 +404,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
     <dxl:Plan Id="0" SpaceSize="56">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1072.381940" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1265.966969" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -418,7 +418,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1072.381880" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1265.966909" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -431,7 +431,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
           <dxl:Filter/>
           <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="635.381459" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="828.966488" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -466,7 +466,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
             </dxl:TableScan>
             <dxl:BitmapTableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="204.381428" Rows="1.000000" Width="2"/>
+                <dxl:Cost StartupCost="0" TotalCost="397.966457" Rows="1.000000" Width="2"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-IndexOnPartitionsWithDifferentStorageTypes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-IndexOnPartitionsWithDifferentStorageTypes.mdp
@@ -279,7 +279,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.128210" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295655" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -299,7 +299,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.128140" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295585" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
@@ -215,7 +215,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.128210" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295655" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -235,7 +235,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.128140" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295585" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-AO.mdp
@@ -310,7 +310,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.128210" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295655" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -330,7 +330,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.128140" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295585" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-AO.mdp
@@ -255,7 +255,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.128210" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295655" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -275,7 +275,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.128140" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295585" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-AOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-AOTable.mdp
@@ -287,7 +287,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.069824" Rows="1.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000261" Rows="1.000000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -304,7 +304,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.063477" Rows="1.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000203" Rows="1.000000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolFalse.mdp
@@ -225,7 +225,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.274479" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000233" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -239,7 +239,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.266667" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000147" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
@@ -223,7 +223,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.274479" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000233" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -237,7 +237,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.266667" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000147" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-DroppedColumns.mdp
@@ -198,7 +198,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.274479" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000239" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -212,7 +212,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.266667" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-Relabel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-Relabel.mdp
@@ -673,7 +673,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.157027" Rows="1.017051" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000569" Rows="1.017051" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -687,7 +687,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.152558" Rows="1.017051" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000519" Rows="1.017051" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
@@ -363,7 +363,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="635.382908" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="828.966783" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -383,7 +383,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="635.382848" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="828.966723" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -466,7 +466,7 @@
           </dxl:Sequence>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="204.382710" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="397.966585" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">
@@ -499,7 +499,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="204.382710" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="397.966585" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/InnerJoin-With-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoin-With-OuterRefs.mdp
@@ -528,50 +528,52 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="35">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3219.015625" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="2164.937855" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="?column?">
-            <dxl:Ident ColId="27" ColName="?column?" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3216.062500" Rows="1000.000000" Width="4"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="27" Alias="?column?">
-              <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList>
-                  <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ParamList>
-                <dxl:Result>
+            <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+              <dxl:TestExpr/>
+              <dxl:ParamList>
+                <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ParamList>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1302.877629" Rows="0.100000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="i">
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:OpExpr>
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
+                <dxl:Materialize Eager="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1608.203125" Rows="0.200000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.007629" Rows="100.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="i">
                       <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="i">
+                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:OpExpr>
-                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="false">
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1606.421875" Rows="200.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.006829" Rows="100.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="i">
@@ -582,9 +584,10 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:SortingColumnList/>
+                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1603.859375" Rows="200.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.003237" Rows="100.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="i">
@@ -595,26 +598,23 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                      <dxl:JoinFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:JoinFilter>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1602.078125" Rows="100.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.001189" Rows="20.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
                             <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="18" Alias="i">
-                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:JoinFilter>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1.058594" Rows="20.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="9" Alias="i">
@@ -622,66 +622,66 @@
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="9" Alias="i">
-                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
-                              <dxl:Columns>
-                                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="18" Alias="i">
-                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
+                          <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
                             <dxl:Columns>
-                              <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:Columns>
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
-                      </dxl:NestedLoopJoin>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
-              </dxl:SubPlan>
+                      </dxl:BroadcastMotion>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="18" Alias="i">
+                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
+                          <dxl:Columns>
+                            <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:NestedLoopJoin>
+                  </dxl:GatherMotion>
+                </dxl:Materialize>
+              </dxl:Result>
+            </dxl:SubPlan>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.032130" Rows="1000.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
+          <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3211.156250" Rows="1000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -702,8 +702,8 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:Result>
-      </dxl:GatherMotion>
+        </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -231,7 +231,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.052734" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023471" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -253,7 +253,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.029297" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -270,7 +270,7 @@
           <dxl:OneTimeFilter/>
           <dxl:PartitionSelector RelationMdid="0.1319741.1.1" PartitionLevels="1" ScanId="0">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -290,14 +290,14 @@
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:ResidualFilter>
             <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:PropagationExpression>
             <dxl:PrintableFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PrintableFilter>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
@@ -231,7 +231,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="true">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.068359" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031288" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -253,7 +253,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.037109" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -273,7 +273,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.021484" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -294,7 +294,7 @@
             <dxl:LimitOffset/>
             <dxl:PartitionSelector RelationMdid="0.1319741.1.1" PartitionLevels="1" ScanId="0">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.021484" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -317,14 +317,14 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:ResidualFilter>
               <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:PropagationExpression>
               <dxl:PrintableFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PrintableFilter>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet.mdp
@@ -212,7 +212,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.052734" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031280" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -234,7 +234,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.021484" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -254,7 +254,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Insert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert.mdp
@@ -181,7 +181,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="1,0" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023484" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -207,7 +207,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.023438" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">
@@ -224,7 +224,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -243,7 +243,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertCheckConstraint.mdp
@@ -282,7 +282,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="1,2,3,4" ActionCol="5" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.177734" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.039178" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -320,7 +320,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.138672" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000116" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -348,7 +348,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23514">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.119141" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000061" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
@@ -389,7 +389,7 @@
             </dxl:AssertConstraintList>
             <dxl:Assert ErrorCode="23502">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.080078" Rows="1.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000041" Rows="1.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="a">
@@ -419,17 +419,17 @@
               </dxl:AssertConstraintList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.041016" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000021" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="5" Alias="ColRef_0005">
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="3" Alias="c">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="4" Alias="d">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="1" Alias="a">
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
@@ -442,7 +442,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTuple.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTuple.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.060547" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.023474" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -223,9 +223,9 @@
             <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.037109" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000037" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -235,47 +235,59 @@
               <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:HashExprList>
-            <dxl:HashExpr>
-              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:HashExpr>
-          </dxl:HashExprList>
-          <dxl:Result>
+          <dxl:OneTimeFilter/>
+          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.025391" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000031" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="b">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="1" Alias="a">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="b">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
-        </dxl:RedistributeMotion>
+          </dxl:RedistributeMotion>
+        </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
@@ -233,7 +233,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.083984" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.023495" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.060547" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000058" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="id">
@@ -281,7 +281,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000025" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="id">
@@ -305,7 +305,7 @@
             </dxl:AssertConstraintList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.025391" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="ColRef_0003">
@@ -326,7 +326,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
@@ -223,7 +223,7 @@
     <dxl:Plan Id="0" SpaceSize="5">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.095703" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.046900" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -249,7 +249,7 @@
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000025" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -273,7 +273,7 @@
           </dxl:AssertConstraintList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.025391" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="ColRef_0003">
@@ -294,7 +294,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
@@ -213,11 +213,11 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="3,1,2" ActionCol="4" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.138672" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.039158" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
-            <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+            <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
           </dxl:KeyValue>
         </dxl:DirectDispatchInfo>
         <dxl:ProjList>
@@ -247,7 +247,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.099609" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000096" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="3" Alias="col1">
@@ -272,7 +272,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.080078" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000041" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="col1">
@@ -299,14 +299,14 @@
             </dxl:AssertConstraintList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.041016" Rows="1.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000021" Rows="1.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="4" Alias="ColRef_0004">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="col1">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="col2">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
@@ -319,7 +319,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTable.mdp
@@ -236,7 +236,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.136719" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.093882" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -260,9 +260,9 @@
             <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.042969" Rows="2.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000132" Rows="2.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -272,14 +272,14 @@
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:Result>
+          <dxl:OneTimeFilter/>
+          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="2.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -288,15 +288,12 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
+            <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -321,8 +318,8 @@
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
-          </dxl:Result>
-        </dxl:GatherMotion>
+          </dxl:GatherMotion>
+        </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTableConstTuple.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTableConstTuple.mdp
@@ -177,7 +177,7 @@
     <dxl:Plan Id="0" SpaceSize="5">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.072266" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.046888" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -203,7 +203,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.025391" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -220,7 +220,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
@@ -169,11 +169,11 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="1" ActionCol="2" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.056641" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015664" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
-            <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+            <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
           </dxl:KeyValue>
         </dxl:DirectDispatchInfo>
         <dxl:ProjList>
@@ -195,7 +195,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.041016" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000039" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -214,7 +214,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.033203" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
@@ -235,21 +235,21 @@
             </dxl:AssertConstraintList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="2" Alias="ColRef_0002">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="a">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertNotNullCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNotNullCols.mdp
@@ -215,7 +215,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.068359" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031288" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -241,7 +241,7 @@
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.037109" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -265,7 +265,7 @@
           </dxl:AssertConstraintList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.021484" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -282,7 +282,7 @@
             <dxl:OneTimeFilter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertPrimaryKeyFromMOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertPrimaryKeyFromMOTable.mdp
@@ -238,7 +238,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.179688" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.047060" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -264,7 +264,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.132812" Rows="2.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000185" Rows="2.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -286,7 +286,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.109375" Rows="2.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000120" Rows="2.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -310,7 +310,7 @@
             </dxl:AssertConstraintList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.062500" Rows="2.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="2.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -327,7 +327,7 @@
               <dxl:OneTimeFilter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="2.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/InsertWithDroppedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertWithDroppedCol.mdp
@@ -243,7 +243,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.083984" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.023495" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -273,7 +273,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.060547" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000058" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -295,7 +295,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23514">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000025" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
@@ -321,7 +321,7 @@
             </dxl:AssertConstraintList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.025391" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="ColRef_0003">
@@ -338,7 +338,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/InsertWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertWithTriggers.mdp
@@ -246,14 +246,14 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.094727" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031337" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList/>
         <dxl:Filter/>
         <dxl:OneTimeFilter/>
         <dxl:RowTrigger RelationMdid="0.187376.1.1" Type="5" NewColumns="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.094727" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.031337" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="s1">
@@ -268,7 +268,7 @@
           </dxl:ProjList>
           <dxl:DMLInsert Columns="0,1,2" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.093750" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.031337" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:DirectDispatchInfo>
               <dxl:KeyValue>
@@ -302,7 +302,7 @@
             </dxl:TableDescriptor>
             <dxl:RowTrigger RelationMdid="0.187376.1.1" Type="7" NewColumns="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.062500" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="s1">
@@ -320,7 +320,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.046875" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="s1">
@@ -340,7 +340,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="s1">

--- a/src/backend/gporca/data/dxl/minidump/Int2Predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Int2Predicate.mdp
@@ -935,7 +935,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5894620.302042" Rows="65153219.439000" Width="46"/>
+          <dxl:Cost StartupCost="0" TotalCost="18863.539496" Rows="65153219.439000" Width="46"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="mgrs_coord">
@@ -958,7 +958,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4431216.912299" Rows="65153219.439000" Width="46"/>
+            <dxl:Cost StartupCost="0" TotalCost="5406.793553" Rows="65153219.439000" Width="46"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="mgrs_coord">

--- a/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1416,7 +1416,7 @@
     <dxl:Plan Id="0" SpaceSize="13920">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="17.551612" Rows="77.229878" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.065290" Rows="77.229878" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1436,7 +1436,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="15.948253" Rows="77.229878" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.059742" Rows="77.229878" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1462,7 +1462,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.562500" Rows="100.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.005257" Rows="100.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1487,7 +1487,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.781250" Rows="100.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001265" Rows="100.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -1523,7 +1523,7 @@
           </dxl:RedistributeMotion>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="9.314857" Rows="77.229878" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.035778" Rows="77.229878" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="12" Alias="b">
@@ -1542,7 +1542,7 @@
             </dxl:HashCondList>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.562500" Rows="100.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.008398" Rows="100.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="12"/>
@@ -1555,7 +1555,7 @@
               <dxl:Filter/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.390625" Rows="100.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.002263" Rows="100.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="b">
@@ -1571,7 +1571,7 @@
                 </dxl:HashExprList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.195312" Rows="100.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001265" Rows="100.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="12" Alias="b">
@@ -1597,7 +1597,7 @@
             </dxl:Aggregate>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.496161" Rows="95.517235" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.008915" Rows="95.517235" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="23"/>
@@ -1610,7 +1610,7 @@
               <dxl:Filter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.224609" Rows="115.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.001455" Rows="115.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
@@ -9,6 +9,14 @@
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103003,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -104,7 +112,7 @@
     <dxl:Plan Id="0" SpaceSize="935">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.113281" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000404" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="?column?">
@@ -121,9 +129,9 @@
             </dxl:IsDistinctFrom>
           </dxl:Not>
         </dxl:HashCondList>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.033203" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -134,34 +142,50 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Result>
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="?column?">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="1" Alias="?column?">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
+          </dxl:Sort>
         </dxl:Aggregate>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.033203" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="3"/>
@@ -172,33 +196,49 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Result>
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="generate_series">
-                <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:FuncExpr>
+                <dxl:Ident ColId="3" ColName="generate_series" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="3" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="2" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="3" Alias="generate_series">
+                  <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:FuncExpr>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:HashJoin>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/IsNullUnionAllIsNotNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IsNullUnionAllIsNotNull.mdp
@@ -233,7 +233,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.722656" Rows="50.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.003801" Rows="50.000000" Width="4"/>
           <dxl:DerivedRelationStats Rows="50.000000" EmptyRelation="false">
             <dxl:DerivedColumnStats ColId="0" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000">
               <dxl:StatsBucket Frequency="0.080000" DistinctValues="1.000000">
@@ -288,7 +288,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.625000" Rows="50.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002903" Rows="50.000000" Width="4"/>
             <dxl:DerivedRelationStats Rows="50.000000" EmptyRelation="false">
               <dxl:DerivedColumnStats ColId="0" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000">
                 <dxl:StatsBucket Frequency="0.080000" DistinctValues="1.000000">
@@ -342,7 +342,7 @@
           <dxl:Filter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.175781" Rows="10.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001364" Rows="10.000000" Width="4"/>
               <dxl:DerivedRelationStats Rows="10.000000" EmptyRelation="false">
                 <dxl:DerivedColumnStats ColId="0" Width="4.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
               </dxl:DerivedRelationStats>
@@ -372,7 +372,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.253906" Rows="40.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001439" Rows="40.000000" Width="4"/>
               <dxl:DerivedRelationStats Rows="40.000000" EmptyRelation="false">
                 <dxl:DerivedColumnStats ColId="8" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
                   <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
@@ -456,7 +456,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.533203" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.022378" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -470,7 +470,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.527344" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.022324" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -492,7 +492,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.394531" Rows="101.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001055" Rows="101.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="i">
@@ -515,7 +515,7 @@
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.390625" Rows="100.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001933" Rows="100.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -533,7 +533,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.195312" Rows="100.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000935" Rows="100.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
@@ -652,7 +652,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="14.621094" Rows="10000.000000" Width="14"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.566515" Rows="10000.000000" Width="14"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -682,7 +682,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.367188" Rows="200.000000" Width="7"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.010008" Rows="200.000000" Width="7"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="i">
@@ -696,7 +696,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.683594" Rows="200.000000" Width="7"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.002420" Rows="200.000000" Width="7"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -724,7 +724,7 @@
         </dxl:GatherMotion>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.683594" Rows="100.000000" Width="7"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.005004" Rows="100.000000" Width="7"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -738,7 +738,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.341797" Rows="100.000000" Width="7"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001210" Rows="100.000000" Width="7"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
@@ -477,7 +477,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8.736328" Rows="100.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.031867" Rows="100.000000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -491,7 +491,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.101562" Rows="100.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.026030" Rows="100.000000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -515,7 +515,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.878906" Rows="100.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.003318" Rows="100.000000" Width="9"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="i">
@@ -533,7 +533,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.439453" Rows="100.000000" Width="9"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001073" Rows="100.000000" Width="9"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="i">
@@ -557,7 +557,7 @@
           </dxl:RedistributeMotion>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.390625" Rows="100.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001933" Rows="100.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -575,7 +575,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.195312" Rows="100.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000935" Rows="100.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-double.mdp
@@ -456,7 +456,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.296875" Rows="100.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.030459" Rows="100.000000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -470,7 +470,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.662109" Rows="100.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.024622" Rows="100.000000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -492,7 +492,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.439453" Rows="100.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001073" Rows="100.000000" Width="9"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="i">
@@ -515,7 +515,7 @@
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.390625" Rows="100.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001933" Rows="100.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -533,7 +533,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.195312" Rows="100.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000935" Rows="100.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
@@ -355,7 +355,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.050781" Rows="100.000000" Width="6"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.022512" Rows="100.000000" Width="6"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -369,7 +369,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.757812" Rows="100.000000" Width="6"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.019818" Rows="100.000000" Width="6"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -391,7 +391,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.195312" Rows="100.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000935" Rows="100.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -414,7 +414,7 @@
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.195312" Rows="100.000000" Width="2"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001379" Rows="100.000000" Width="2"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="i">
@@ -432,7 +432,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.097656" Rows="100.000000" Width="2"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000880" Rows="100.000000" Width="2"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -986,9 +986,9 @@ OR
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="298878">
-      <dxl:Result>
+      <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="14963.550781" Rows="521.833333" Width="246"/>
+          <dxl:Cost StartupCost="0" TotalCost="9921.832259" Rows="521.833333" Width="246"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="rolname">
@@ -1109,105 +1109,24 @@ OR
             <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:Filter>
+        <dxl:Filter/>
+        <dxl:JoinFilter>
           <dxl:Or>
-            <dxl:If TypeMdid="0.16.1.0">
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Comparison>
-              <dxl:If TypeMdid="0.16.1.0">
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                  <dxl:Ident ColId="128" ColName="ColRef_0128" TypeMdid="0.20.1.0"/>
-                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
-                </dxl:Comparison>
-                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:If>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-            </dxl:If>
-            <dxl:If TypeMdid="0.16.1.0">
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                <dxl:Ident ColId="130" ColName="ColRef_0130" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Comparison>
-              <dxl:If TypeMdid="0.16.1.0">
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                  <dxl:Ident ColId="132" ColName="ColRef_0132" TypeMdid="0.20.1.0"/>
-                  <dxl:Ident ColId="130" ColName="ColRef_0130" TypeMdid="0.20.1.0"/>
-                </dxl:Comparison>
-                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:If>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-            </dxl:If>
+            <dxl:Ident ColId="133" ColName="ColRef_0133" TypeMdid="0.16.1.0"/>
+            <dxl:Ident ColId="135" ColName="ColRef_0135" TypeMdid="0.16.1.0"/>
           </dxl:Or>
-        </dxl:Filter>
-        <dxl:OneTimeFilter/>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        </dxl:JoinFilter>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+            <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
+            <dxl:Ident ColId="43" ColName="oid" TypeMdid="0.26.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="14711.826172" Rows="1.000000" Width="230"/>
+            <dxl:Cost StartupCost="0" TotalCost="8624.683750" Rows="1000.000000" Width="144"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="0"/>
-            <dxl:GroupingColumn ColId="1"/>
-            <dxl:GroupingColumn ColId="2"/>
-            <dxl:GroupingColumn ColId="3"/>
-            <dxl:GroupingColumn ColId="4"/>
-            <dxl:GroupingColumn ColId="5"/>
-            <dxl:GroupingColumn ColId="6"/>
-            <dxl:GroupingColumn ColId="7"/>
-            <dxl:GroupingColumn ColId="8"/>
-            <dxl:GroupingColumn ColId="9"/>
-            <dxl:GroupingColumn ColId="10"/>
-            <dxl:GroupingColumn ColId="11"/>
-            <dxl:GroupingColumn ColId="12"/>
-            <dxl:GroupingColumn ColId="13"/>
-            <dxl:GroupingColumn ColId="14"/>
-            <dxl:GroupingColumn ColId="15"/>
-            <dxl:GroupingColumn ColId="16"/>
-            <dxl:GroupingColumn ColId="17"/>
-            <dxl:GroupingColumn ColId="24"/>
-            <dxl:GroupingColumn ColId="25"/>
-            <dxl:GroupingColumn ColId="26"/>
-            <dxl:GroupingColumn ColId="27"/>
-            <dxl:GroupingColumn ColId="28"/>
-            <dxl:GroupingColumn ColId="29"/>
-            <dxl:GroupingColumn ColId="30"/>
-            <dxl:GroupingColumn ColId="31"/>
-            <dxl:GroupingColumn ColId="32"/>
-            <dxl:GroupingColumn ColId="33"/>
-            <dxl:GroupingColumn ColId="34"/>
-            <dxl:GroupingColumn ColId="35"/>
-            <dxl:GroupingColumn ColId="36"/>
-            <dxl:GroupingColumn ColId="37"/>
-            <dxl:GroupingColumn ColId="38"/>
-            <dxl:GroupingColumn ColId="39"/>
-            <dxl:GroupingColumn ColId="40"/>
-            <dxl:GroupingColumn ColId="41"/>
-            <dxl:GroupingColumn ColId="42"/>
-            <dxl:GroupingColumn ColId="49"/>
-            <dxl:GroupingColumn ColId="50"/>
-            <dxl:GroupingColumn ColId="51"/>
-            <dxl:GroupingColumn ColId="52"/>
-            <dxl:GroupingColumn ColId="53"/>
-            <dxl:GroupingColumn ColId="54"/>
-            <dxl:GroupingColumn ColId="55"/>
-            <dxl:GroupingColumn ColId="62"/>
-            <dxl:GroupingColumn ColId="126"/>
-            <dxl:GroupingColumn ColId="128"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="130" Alias="ColRef_0130">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
-                <dxl:Ident ColId="129" ColName="ColRef_0129" TypeMdid="0.16.1.0"/>
-              </dxl:AggFunc>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="132" Alias="ColRef_0132">
-              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                <dxl:Ident ColId="131" ColName="ColRef_0131" TypeMdid="0.23.1.0"/>
-              </dxl:AggFunc>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="rolname">
               <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
@@ -1259,56 +1178,8 @@ OR
             <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
               <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="25" Alias="rolname">
-              <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="26" Alias="rolsuper">
-              <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="27" Alias="rolinherit">
-              <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-              <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-              <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-              <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-              <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-              <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="33" Alias="rolpassword">
-              <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-              <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="35" Alias="rolconfig">
-              <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="36" Alias="rolresqueue">
-              <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-              <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-              <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-              <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-              <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-              <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="oid">
+              <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="50" Alias="fdwname">
               <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
@@ -1325,50 +1196,91 @@ OR
             <dxl:ProjElem ColId="54" Alias="fdwoptions">
               <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="126" Alias="ColRef_0126">
-              <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="128" Alias="ColRef_0128">
-              <dxl:Ident ColId="128" ColName="ColRef_0128" TypeMdid="0.20.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="ctid">
-              <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-              <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="42" Alias="ctid">
-              <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-              <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="55" Alias="ctid">
-              <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-              <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="133" Alias="ColRef_0133">
+              <dxl:Ident ColId="133" ColName="ColRef_0133" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="14709.890625" Rows="1.000000" Width="249"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.521514" Rows="1000.000000" Width="112"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="131" Alias="ColRef_0131">
-                <dxl:If TypeMdid="0.23.1.0">
-                  <dxl:IsNull>
+              <dxl:ProjElem ColId="133" Alias="ColRef_0133">
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                  <dxl:TestExpr>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                      <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
+                      <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
                       <dxl:Cast TypeMdid="0.19.1.0" FuncId="0.1400.1.0">
-                        <dxl:Ident ColId="114" ColName="role_name" TypeMdid="0.10689.1.0"/>
+                        <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
                       </dxl:Cast>
                     </dxl:Comparison>
-                  </dxl:IsNull>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                </dxl:If>
+                  </dxl:TestExpr>
+                  <dxl:ParamList/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000240" Rows="1.000000" Width="9"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="88" Alias="role_name">
+                        <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000240" Rows="1.000000" Width="9"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="88" Alias="role_name">
+                          <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
+                            <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
+                              <dxl:Ident ColId="63" ColName="rolname" TypeMdid="0.19.1.0"/>
+                            </dxl:FuncExpr>
+                          </dxl:CoerceToDomain>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="134" Alias="ColRef_0134">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000231" Rows="1.000000" Width="64"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="63" Alias="rolname">
+                            <dxl:Ident ColId="63" ColName="rolname" TypeMdid="0.19.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                            <dxl:Ident ColId="81" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
+                          </dxl:FuncExpr>
+                        </dxl:Filter>
+                        <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid" ExecuteAsUser="10">
+                          <dxl:Columns>
+                            <dxl:Column ColId="63" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                            <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="81" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="82" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="83" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="84" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="85" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="86" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="87" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:SubPlan>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="0" Alias="rolname">
                 <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
@@ -1421,105 +1333,15 @@ OR
               <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
                 <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="ctid">
-                <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="25" Alias="rolname">
-                <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="26" Alias="rolsuper">
-                <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="27" Alias="rolinherit">
-                <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="33" Alias="rolpassword">
-                <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="35" Alias="rolconfig">
-                <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="42" Alias="ctid">
-                <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="50" Alias="fdwname">
-                <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="51" Alias="fdwowner">
-                <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="53" Alias="fdwacl">
-                <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="55" Alias="ctid">
-                <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="126" Alias="ColRef_0126">
-                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="128" Alias="ColRef_0128">
-                <dxl:Ident ColId="128" ColName="ColRef_0128" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="129" Alias="ColRef_0129">
-                <dxl:Ident ColId="129" ColName="ColRef_0129" TypeMdid="0.16.1.0"/>
+              <dxl:ProjElem ColId="18" Alias="oid">
+                <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="14708.404297" Rows="1.000000" Width="253"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.409514" Rows="1000.000000" Width="112"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="rolname">
@@ -1573,1345 +1395,311 @@ OR
                 <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
                   <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="ctid">
-                  <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                  <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="25" Alias="rolname">
-                  <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="26" Alias="rolsuper">
-                  <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="27" Alias="rolinherit">
-                  <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                  <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                  <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                  <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                  <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                  <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="33" Alias="rolpassword">
-                  <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                  <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="35" Alias="rolconfig">
-                  <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                  <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                  <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                  <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                  <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                  <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                  <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="ctid">
-                  <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                  <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="50" Alias="fdwname">
-                  <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="51" Alias="fdwowner">
-                  <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                  <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="53" Alias="fdwacl">
-                  <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                  <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="55" Alias="ctid">
-                  <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                  <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="114" Alias="role_name">
-                  <dxl:Ident ColId="114" ColName="role_name" TypeMdid="0.10689.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="126" Alias="ColRef_0126">
-                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="128" Alias="ColRef_0128">
-                  <dxl:Ident ColId="128" ColName="ColRef_0128" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="129" Alias="ColRef_0129">
-                  <dxl:Ident ColId="129" ColName="ColRef_0129" TypeMdid="0.16.1.0"/>
+                <dxl:ProjElem ColId="18" Alias="oid">
+                  <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:IsNotFalse>
+              <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="rolsuper" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="rolinherit" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="4" Attno="5" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="5" Attno="6" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="6" Attno="7" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="7" Attno="8" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="8" Attno="9" ColName="rolpassword" TypeMdid="0.25.1.0"/>
+                  <dxl:Column ColId="9" Attno="10" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
+                  <dxl:Column ColId="10" Attno="11" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
+                  <dxl:Column ColId="11" Attno="12" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="12" Attno="13" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="13" Attno="14" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="14" Attno="15" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="15" Attno="16" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="16" Attno="17" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="18" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="32"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="50" Alias="fdwname">
+                <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="51" Alias="fdwowner">
+                <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="52" Alias="fdwvalidator">
+                <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="53" Alias="fdwacl">
+                <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="54" Alias="fdwoptions">
+                <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.2898.1.1" TableName="pg_foreign_data_wrapper">
+              <dxl:Columns>
+                <dxl:Column ColId="50" Attno="1" ColName="fdwname" TypeMdid="0.19.1.0"/>
+                <dxl:Column ColId="51" Attno="2" ColName="fdwowner" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="52" Attno="3" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="53" Attno="4" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
+                <dxl:Column ColId="54" Attno="5" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
+                <dxl:Column ColId="55" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="56" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="57" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="58" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="59" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="60" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="61" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="62" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:NestedLoopJoin>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1293.521514" Rows="1000.000000" Width="112"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="135" Alias="ColRef_0135">
+              <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                <dxl:TestExpr>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
                     <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
                     <dxl:Cast TypeMdid="0.19.1.0" FuncId="0.1400.1.0">
                       <dxl:Ident ColId="114" ColName="role_name" TypeMdid="0.10689.1.0"/>
                     </dxl:Cast>
                   </dxl:Comparison>
-                </dxl:IsNotFalse>
-              </dxl:JoinFilter>
-              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="10313.191406" Rows="1.000000" Width="244"/>
-                </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="0"/>
-                  <dxl:GroupingColumn ColId="1"/>
-                  <dxl:GroupingColumn ColId="2"/>
-                  <dxl:GroupingColumn ColId="3"/>
-                  <dxl:GroupingColumn ColId="4"/>
-                  <dxl:GroupingColumn ColId="5"/>
-                  <dxl:GroupingColumn ColId="6"/>
-                  <dxl:GroupingColumn ColId="7"/>
-                  <dxl:GroupingColumn ColId="8"/>
-                  <dxl:GroupingColumn ColId="9"/>
-                  <dxl:GroupingColumn ColId="10"/>
-                  <dxl:GroupingColumn ColId="11"/>
-                  <dxl:GroupingColumn ColId="12"/>
-                  <dxl:GroupingColumn ColId="13"/>
-                  <dxl:GroupingColumn ColId="14"/>
-                  <dxl:GroupingColumn ColId="15"/>
-                  <dxl:GroupingColumn ColId="16"/>
-                  <dxl:GroupingColumn ColId="17"/>
-                  <dxl:GroupingColumn ColId="24"/>
-                  <dxl:GroupingColumn ColId="25"/>
-                  <dxl:GroupingColumn ColId="26"/>
-                  <dxl:GroupingColumn ColId="27"/>
-                  <dxl:GroupingColumn ColId="28"/>
-                  <dxl:GroupingColumn ColId="29"/>
-                  <dxl:GroupingColumn ColId="30"/>
-                  <dxl:GroupingColumn ColId="31"/>
-                  <dxl:GroupingColumn ColId="32"/>
-                  <dxl:GroupingColumn ColId="33"/>
-                  <dxl:GroupingColumn ColId="34"/>
-                  <dxl:GroupingColumn ColId="35"/>
-                  <dxl:GroupingColumn ColId="36"/>
-                  <dxl:GroupingColumn ColId="37"/>
-                  <dxl:GroupingColumn ColId="38"/>
-                  <dxl:GroupingColumn ColId="39"/>
-                  <dxl:GroupingColumn ColId="40"/>
-                  <dxl:GroupingColumn ColId="41"/>
-                  <dxl:GroupingColumn ColId="42"/>
-                  <dxl:GroupingColumn ColId="49"/>
-                  <dxl:GroupingColumn ColId="50"/>
-                  <dxl:GroupingColumn ColId="51"/>
-                  <dxl:GroupingColumn ColId="52"/>
-                  <dxl:GroupingColumn ColId="53"/>
-                  <dxl:GroupingColumn ColId="54"/>
-                  <dxl:GroupingColumn ColId="55"/>
-                  <dxl:GroupingColumn ColId="62"/>
-                </dxl:GroupingColumns>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="126" Alias="ColRef_0126">
-                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
-                      <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.16.1.0"/>
-                    </dxl:AggFunc>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="128" Alias="ColRef_0128">
-                    <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                      <dxl:Ident ColId="127" ColName="ColRef_0127" TypeMdid="0.23.1.0"/>
-                    </dxl:AggFunc>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="0" Alias="rolname">
-                    <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="rolsuper">
-                    <dxl:Ident ColId="1" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="rolinherit">
-                    <dxl:Ident ColId="2" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="rolcreaterole">
-                    <dxl:Ident ColId="3" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="4" Alias="rolcreatedb">
-                    <dxl:Ident ColId="4" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="5" Alias="rolcatupdate">
-                    <dxl:Ident ColId="5" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="6" Alias="rolcanlogin">
-                    <dxl:Ident ColId="6" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="7" Alias="rolconnlimit">
-                    <dxl:Ident ColId="7" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="rolpassword">
-                    <dxl:Ident ColId="8" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="rolvaliduntil">
-                    <dxl:Ident ColId="9" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="rolconfig">
-                    <dxl:Ident ColId="10" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="11" Alias="rolresqueue">
-                    <dxl:Ident ColId="11" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="12" Alias="rolcreaterextgpfd">
-                    <dxl:Ident ColId="12" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="13" Alias="rolcreaterexthttp">
-                    <dxl:Ident ColId="13" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="14" Alias="rolcreatewextgpfd">
-                    <dxl:Ident ColId="14" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="15" Alias="rolcreaterexthdfs">
-                    <dxl:Ident ColId="15" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
-                    <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="17" Alias="ctid">
-                    <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                    <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="25" Alias="rolname">
-                    <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="rolsuper">
-                    <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="27" Alias="rolinherit">
-                    <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                    <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                    <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                    <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                    <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                    <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="33" Alias="rolpassword">
-                    <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                    <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="35" Alias="rolconfig">
-                    <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                    <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                    <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                    <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                    <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                    <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                    <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="42" Alias="ctid">
-                    <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                    <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="50" Alias="fdwname">
-                    <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="51" Alias="fdwowner">
-                    <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                    <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="53" Alias="fdwacl">
-                    <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                    <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="55" Alias="ctid">
-                    <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                    <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
+                </dxl:TestExpr>
+                <dxl:ParamList/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="10311.259766" Rows="1.000000" Width="233"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000240" Rows="1.000000" Width="9"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="127" Alias="ColRef_0127">
-                      <dxl:If TypeMdid="0.23.1.0">
-                        <dxl:IsNull>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                            <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                            <dxl:Cast TypeMdid="0.19.1.0" FuncId="0.1400.1.0">
-                              <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
-                            </dxl:Cast>
-                          </dxl:Comparison>
-                        </dxl:IsNull>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                      </dxl:If>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="0" Alias="rolname">
-                      <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="rolsuper">
-                      <dxl:Ident ColId="1" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="rolinherit">
-                      <dxl:Ident ColId="2" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="rolcreaterole">
-                      <dxl:Ident ColId="3" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="4" Alias="rolcreatedb">
-                      <dxl:Ident ColId="4" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="5" Alias="rolcatupdate">
-                      <dxl:Ident ColId="5" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="6" Alias="rolcanlogin">
-                      <dxl:Ident ColId="6" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="rolconnlimit">
-                      <dxl:Ident ColId="7" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="rolpassword">
-                      <dxl:Ident ColId="8" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="rolvaliduntil">
-                      <dxl:Ident ColId="9" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="10" Alias="rolconfig">
-                      <dxl:Ident ColId="10" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="11" Alias="rolresqueue">
-                      <dxl:Ident ColId="11" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="12" Alias="rolcreaterextgpfd">
-                      <dxl:Ident ColId="12" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="13" Alias="rolcreaterexthttp">
-                      <dxl:Ident ColId="13" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="14" Alias="rolcreatewextgpfd">
-                      <dxl:Ident ColId="14" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="15" Alias="rolcreaterexthdfs">
-                      <dxl:Ident ColId="15" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
-                      <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="17" Alias="ctid">
-                      <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                      <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="rolname">
-                      <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="rolsuper">
-                      <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="27" Alias="rolinherit">
-                      <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                      <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                      <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                      <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                      <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                      <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="33" Alias="rolpassword">
-                      <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                      <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="35" Alias="rolconfig">
-                      <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                      <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                      <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                      <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                      <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                      <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                      <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="42" Alias="ctid">
-                      <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                      <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="50" Alias="fdwname">
-                      <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="fdwowner">
-                      <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                      <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="53" Alias="fdwacl">
-                      <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                      <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="55" Alias="ctid">
-                      <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                      <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="125" Alias="ColRef_0125">
-                      <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.16.1.0"/>
+                    <dxl:ProjElem ColId="114" Alias="role_name">
+                      <dxl:Ident ColId="114" ColName="role_name" TypeMdid="0.10689.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="10309.804688" Rows="1.000000" Width="237"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000240" Rows="1.000000" Width="9"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="rolname">
-                        <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
+                      <dxl:ProjElem ColId="114" Alias="role_name">
+                        <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
+                          <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
+                            <dxl:Ident ColId="89" ColName="rolname" TypeMdid="0.19.1.0"/>
+                          </dxl:FuncExpr>
+                        </dxl:CoerceToDomain>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="rolsuper">
-                        <dxl:Ident ColId="1" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="rolinherit">
-                        <dxl:Ident ColId="2" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="3" Alias="rolcreaterole">
-                        <dxl:Ident ColId="3" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="4" Alias="rolcreatedb">
-                        <dxl:Ident ColId="4" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="rolcatupdate">
-                        <dxl:Ident ColId="5" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="rolcanlogin">
-                        <dxl:Ident ColId="6" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="rolconnlimit">
-                        <dxl:Ident ColId="7" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="rolpassword">
-                        <dxl:Ident ColId="8" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="rolvaliduntil">
-                        <dxl:Ident ColId="9" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="rolconfig">
-                        <dxl:Ident ColId="10" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="rolresqueue">
-                        <dxl:Ident ColId="11" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="12" Alias="rolcreaterextgpfd">
-                        <dxl:Ident ColId="12" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="13" Alias="rolcreaterexthttp">
-                        <dxl:Ident ColId="13" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="14" Alias="rolcreatewextgpfd">
-                        <dxl:Ident ColId="14" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="15" Alias="rolcreaterexthdfs">
-                        <dxl:Ident ColId="15" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
-                        <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="17" Alias="ctid">
-                        <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                        <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="25" Alias="rolname">
-                        <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="26" Alias="rolsuper">
-                        <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="27" Alias="rolinherit">
-                        <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                        <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                        <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                        <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                        <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                        <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="33" Alias="rolpassword">
-                        <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                        <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="35" Alias="rolconfig">
-                        <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                        <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                        <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                        <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                        <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                        <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                        <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="42" Alias="ctid">
-                        <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                        <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="50" Alias="fdwname">
-                        <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="51" Alias="fdwowner">
-                        <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                        <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="53" Alias="fdwacl">
-                        <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                        <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="55" Alias="ctid">
-                        <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                        <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="88" Alias="role_name">
-                        <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="125" Alias="ColRef_0125">
-                        <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.16.1.0"/>
+                      <dxl:ProjElem ColId="136" Alias="ColRef_0136">
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="2" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="3" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="4" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="5" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="6" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="8" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="9" SortOperatorMdid="0.1322.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="10" SortOperatorMdid="0.1072.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="11" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="12" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="13" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="14" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="15" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="16" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="17" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="24" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="25" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="26" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="27" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="28" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="29" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="31" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="33" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="34" SortOperatorMdid="0.1322.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="35" SortOperatorMdid="0.1072.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="36" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="37" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="38" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="39" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="40" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="42" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="49" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="50" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="51" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="52" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="53" SortOperatorMdid="0.1072.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="54" SortOperatorMdid="0.1072.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="55" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="62" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:HashJoin JoinType="Inner">
+                    <dxl:OneTimeFilter/>
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="10308.804688" Rows="1.000000" Width="237"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000231" Rows="1.000000" Width="64"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="rolname">
-                          <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="rolsuper">
-                          <dxl:Ident ColId="1" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="rolinherit">
-                          <dxl:Ident ColId="2" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="rolcreaterole">
-                          <dxl:Ident ColId="3" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="4" Alias="rolcreatedb">
-                          <dxl:Ident ColId="4" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="5" Alias="rolcatupdate">
-                          <dxl:Ident ColId="5" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="6" Alias="rolcanlogin">
-                          <dxl:Ident ColId="6" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="rolconnlimit">
-                          <dxl:Ident ColId="7" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="rolpassword">
-                          <dxl:Ident ColId="8" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="9" Alias="rolvaliduntil">
-                          <dxl:Ident ColId="9" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="10" Alias="rolconfig">
-                          <dxl:Ident ColId="10" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="rolresqueue">
-                          <dxl:Ident ColId="11" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="12" Alias="rolcreaterextgpfd">
-                          <dxl:Ident ColId="12" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="13" Alias="rolcreaterexthttp">
-                          <dxl:Ident ColId="13" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="14" Alias="rolcreatewextgpfd">
-                          <dxl:Ident ColId="14" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="15" Alias="rolcreaterexthdfs">
-                          <dxl:Ident ColId="15" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
-                          <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="17" Alias="ctid">
-                          <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                          <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="25" Alias="rolname">
-                          <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="26" Alias="rolsuper">
-                          <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="27" Alias="rolinherit">
-                          <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                          <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                          <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                          <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                          <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                          <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="rolpassword">
-                          <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                          <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="35" Alias="rolconfig">
-                          <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                          <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                          <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                          <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                          <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                          <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                          <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="42" Alias="ctid">
-                          <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                          <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="50" Alias="fdwname">
-                          <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="51" Alias="fdwowner">
-                          <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                          <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="53" Alias="fdwacl">
-                          <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                          <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="55" Alias="ctid">
-                          <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                          <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="88" Alias="role_name">
-                          <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="125" Alias="ColRef_0125">
-                          <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.16.1.0"/>
+                        <dxl:ProjElem ColId="89" Alias="rolname">
+                          <dxl:Ident ColId="89" ColName="rolname" TypeMdid="0.19.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:JoinFilter/>
-                      <dxl:HashCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                          <dxl:Ident ColId="43" ColName="oid" TypeMdid="0.26.1.0"/>
-                          <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:HashCondList>
-                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="8485.139648" Rows="1.000000" Width="143"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="25" Alias="rolname">
-                            <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="26" Alias="rolsuper">
-                            <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="27" Alias="rolinherit">
-                            <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                            <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                            <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                            <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                            <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                            <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="rolpassword">
-                            <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                            <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="35" Alias="rolconfig">
-                            <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                            <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                            <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                            <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                            <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                            <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                            <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="42" Alias="ctid">
-                            <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="43" Alias="oid">
-                            <dxl:Ident ColId="43" ColName="oid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                            <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="50" Alias="fdwname">
-                            <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="51" Alias="fdwowner">
-                            <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                            <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="53" Alias="fdwacl">
-                            <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                            <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="55" Alias="ctid">
-                            <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                            <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:JoinFilter>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.098633" Rows="1.000000" Width="101"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="25" Alias="rolname">
-                              <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="26" Alias="rolsuper">
-                              <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="27" Alias="rolinherit">
-                              <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="28" Alias="rolcreaterole">
-                              <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="29" Alias="rolcreatedb">
-                              <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="30" Alias="rolcatupdate">
-                              <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="31" Alias="rolcanlogin">
-                              <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="32" Alias="rolconnlimit">
-                              <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="33" Alias="rolpassword">
-                              <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
-                              <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="35" Alias="rolconfig">
-                              <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="36" Alias="rolresqueue">
-                              <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
-                              <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
-                              <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
-                              <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
-                              <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
-                              <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="42" Alias="ctid">
-                              <dxl:Ident ColId="42" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="43" Alias="oid">
-                              <dxl:Ident ColId="43" ColName="oid" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="49" Alias="gp_segment_id">
-                              <dxl:Ident ColId="49" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
-                            <dxl:Columns>
-                              <dxl:Column ColId="25" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                              <dxl:Column ColId="26" Attno="2" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="27" Attno="3" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="28" Attno="4" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="29" Attno="5" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="30" Attno="6" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="31" Attno="7" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="32" Attno="8" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="33" Attno="9" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                              <dxl:Column ColId="34" Attno="10" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                              <dxl:Column ColId="35" Attno="11" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                              <dxl:Column ColId="36" Attno="12" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="37" Attno="13" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="38" Attno="14" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="39" Attno="15" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="40" Attno="16" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="41" Attno="17" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="42" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="43" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="44" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="45" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="46" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="47" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="48" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="49" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.041016" Rows="1.000000" Width="42"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="50" Alias="fdwname">
-                              <dxl:Ident ColId="50" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="51" Alias="fdwowner">
-                              <dxl:Ident ColId="51" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="52" Alias="fdwvalidator">
-                              <dxl:Ident ColId="52" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="53" Alias="fdwacl">
-                              <dxl:Ident ColId="53" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="54" Alias="fdwoptions">
-                              <dxl:Ident ColId="54" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="55" Alias="ctid">
-                              <dxl:Ident ColId="55" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="62" Alias="gp_segment_id">
-                              <dxl:Ident ColId="62" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.2898.1.1" TableName="pg_foreign_data_wrapper">
-                            <dxl:Columns>
-                              <dxl:Column ColId="50" Attno="1" ColName="fdwname" TypeMdid="0.19.1.0"/>
-                              <dxl:Column ColId="51" Attno="2" ColName="fdwowner" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="52" Attno="3" ColName="fdwvalidator" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="53" Attno="4" ColName="fdwacl" TypeMdid="0.1034.1.0"/>
-                              <dxl:Column ColId="54" Attno="5" ColName="fdwoptions" TypeMdid="0.1009.1.0"/>
-                              <dxl:Column ColId="55" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="56" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="57" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="58" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="59" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="60" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="61" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="62" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:NestedLoopJoin>
-                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1821.311523" Rows="1.000000" Width="110"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="rolname">
-                            <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="rolsuper">
-                            <dxl:Ident ColId="1" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="rolinherit">
-                            <dxl:Ident ColId="2" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="3" Alias="rolcreaterole">
-                            <dxl:Ident ColId="3" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="4" Alias="rolcreatedb">
-                            <dxl:Ident ColId="4" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="5" Alias="rolcatupdate">
-                            <dxl:Ident ColId="5" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="6" Alias="rolcanlogin">
-                            <dxl:Ident ColId="6" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="7" Alias="rolconnlimit">
-                            <dxl:Ident ColId="7" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="rolpassword">
-                            <dxl:Ident ColId="8" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="9" Alias="rolvaliduntil">
-                            <dxl:Ident ColId="9" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="10" Alias="rolconfig">
-                            <dxl:Ident ColId="10" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="11" Alias="rolresqueue">
-                            <dxl:Ident ColId="11" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="12" Alias="rolcreaterextgpfd">
-                            <dxl:Ident ColId="12" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="13" Alias="rolcreaterexthttp">
-                            <dxl:Ident ColId="13" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="14" Alias="rolcreatewextgpfd">
-                            <dxl:Ident ColId="14" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="15" Alias="rolcreaterexthdfs">
-                            <dxl:Ident ColId="15" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
-                            <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="17" Alias="ctid">
-                            <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="18" Alias="oid">
-                            <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                            <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="88" Alias="role_name">
-                            <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="125" Alias="ColRef_0125">
-                            <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:IsNotFalse>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                              <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                              <dxl:Cast TypeMdid="0.19.1.0" FuncId="0.1400.1.0">
-                                <dxl:Ident ColId="88" ColName="role_name" TypeMdid="0.10689.1.0"/>
-                              </dxl:Cast>
-                            </dxl:Comparison>
-                          </dxl:IsNotFalse>
-                        </dxl:JoinFilter>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.098633" Rows="1.000000" Width="101"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="0" Alias="rolname">
-                              <dxl:Ident ColId="0" ColName="rolname" TypeMdid="0.19.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="rolsuper">
-                              <dxl:Ident ColId="1" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="rolinherit">
-                              <dxl:Ident ColId="2" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="3" Alias="rolcreaterole">
-                              <dxl:Ident ColId="3" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="4" Alias="rolcreatedb">
-                              <dxl:Ident ColId="4" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="5" Alias="rolcatupdate">
-                              <dxl:Ident ColId="5" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="6" Alias="rolcanlogin">
-                              <dxl:Ident ColId="6" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="7" Alias="rolconnlimit">
-                              <dxl:Ident ColId="7" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="8" Alias="rolpassword">
-                              <dxl:Ident ColId="8" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="9" Alias="rolvaliduntil">
-                              <dxl:Ident ColId="9" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="10" Alias="rolconfig">
-                              <dxl:Ident ColId="10" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="11" Alias="rolresqueue">
-                              <dxl:Ident ColId="11" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="12" Alias="rolcreaterextgpfd">
-                              <dxl:Ident ColId="12" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="13" Alias="rolcreaterexthttp">
-                              <dxl:Ident ColId="13" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="14" Alias="rolcreatewextgpfd">
-                              <dxl:Ident ColId="14" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="15" Alias="rolcreaterexthdfs">
-                              <dxl:Ident ColId="15" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="16" Alias="rolcreatewexthdfs">
-                              <dxl:Ident ColId="16" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="17" Alias="ctid">
-                              <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="18" Alias="oid">
-                              <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="24" Alias="gp_segment_id">
-                              <dxl:Ident ColId="24" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
-                            <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="rolsuper" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="2" Attno="3" ColName="rolinherit" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="3" Attno="4" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="4" Attno="5" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="5" Attno="6" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="6" Attno="7" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="7" Attno="8" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="8" Attno="9" ColName="rolpassword" TypeMdid="0.25.1.0"/>
-                              <dxl:Column ColId="9" Attno="10" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
-                              <dxl:Column ColId="10" Attno="11" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
-                              <dxl:Column ColId="11" Attno="12" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="12" Attno="13" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="13" Attno="14" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="14" Attno="15" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="15" Attno="16" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="16" Attno="17" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
-                              <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="18" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.212891" Rows="1.000000" Width="9"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="125" Alias="ColRef_0125">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="88" Alias="role_name">
-                              <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
-                                <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
-                                  <dxl:Ident ColId="63" ColName="rolname" TypeMdid="0.19.1.0"/>
-                                </dxl:FuncExpr>
-                              </dxl:CoerceToDomain>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.195312" Rows="1.000000" Width="64"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="63" Alias="rolname">
-                                <dxl:Ident ColId="63" ColName="rolname" TypeMdid="0.19.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                                <dxl:Ident ColId="81" ColName="oid" TypeMdid="0.26.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
-                              </dxl:FuncExpr>
-                            </dxl:Filter>
-                            <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid" ExecuteAsUser="10">
-                              <dxl:Columns>
-                                <dxl:Column ColId="63" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                                <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="81" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="82" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="83" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="84" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="85" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="86" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="87" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:Result>
-                      </dxl:NestedLoopJoin>
-                    </dxl:HashJoin>
-                  </dxl:Sort>
+                      <dxl:Filter>
+                        <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                          <dxl:Ident ColId="107" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
+                        </dxl:FuncExpr>
+                      </dxl:Filter>
+                      <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid" ExecuteAsUser="10">
+                        <dxl:Columns>
+                          <dxl:Column ColId="89" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                          <dxl:Column ColId="106" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="107" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="108" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="109" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="110" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="111" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="112" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="113" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Result>
                 </dxl:Result>
-              </dxl:Aggregate>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.212891" Rows="1.000000" Width="9"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="129" Alias="ColRef_0129">
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="114" Alias="role_name">
-                    <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
-                      <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
-                        <dxl:Ident ColId="89" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      </dxl:FuncExpr>
-                    </dxl:CoerceToDomain>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.195312" Rows="1.000000" Width="64"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="89" Alias="rolname">
-                      <dxl:Ident ColId="89" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="107" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
-                    </dxl:FuncExpr>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid" ExecuteAsUser="10">
-                    <dxl:Columns>
-                      <dxl:Column ColId="89" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="106" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="107" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="108" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="109" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="110" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="111" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="112" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="113" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
-            </dxl:NestedLoopJoin>
-          </dxl:Result>
-        </dxl:Aggregate>
-      </dxl:Result>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="25" Alias="rolname">
+              <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="26" Alias="rolsuper">
+              <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="27" Alias="rolinherit">
+              <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="28" Alias="rolcreaterole">
+              <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="29" Alias="rolcreatedb">
+              <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="30" Alias="rolcatupdate">
+              <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="31" Alias="rolcanlogin">
+              <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="32" Alias="rolconnlimit">
+              <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="33" Alias="rolpassword">
+              <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
+              <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="35" Alias="rolconfig">
+              <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="36" Alias="rolresqueue">
+              <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
+              <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
+              <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
+              <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
+              <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
+              <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="43" Alias="oid">
+              <dxl:Ident ColId="43" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.409514" Rows="1000.000000" Width="112"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="25" Alias="rolname">
+                <dxl:Ident ColId="25" ColName="rolname" TypeMdid="0.19.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="26" Alias="rolsuper">
+                <dxl:Ident ColId="26" ColName="rolsuper" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="27" Alias="rolinherit">
+                <dxl:Ident ColId="27" ColName="rolinherit" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="28" Alias="rolcreaterole">
+                <dxl:Ident ColId="28" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="29" Alias="rolcreatedb">
+                <dxl:Ident ColId="29" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="30" Alias="rolcatupdate">
+                <dxl:Ident ColId="30" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="rolcanlogin">
+                <dxl:Ident ColId="31" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="rolconnlimit">
+                <dxl:Ident ColId="32" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="33" Alias="rolpassword">
+                <dxl:Ident ColId="33" ColName="rolpassword" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="34" Alias="rolvaliduntil">
+                <dxl:Ident ColId="34" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="35" Alias="rolconfig">
+                <dxl:Ident ColId="35" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="36" Alias="rolresqueue">
+                <dxl:Ident ColId="36" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="37" Alias="rolcreaterextgpfd">
+                <dxl:Ident ColId="37" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="38" Alias="rolcreaterexthttp">
+                <dxl:Ident ColId="38" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="39" Alias="rolcreatewextgpfd">
+                <dxl:Ident ColId="39" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="40" Alias="rolcreaterexthdfs">
+                <dxl:Ident ColId="40" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="rolcreatewexthdfs">
+                <dxl:Ident ColId="41" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="43" Alias="oid">
+                <dxl:Ident ColId="43" ColName="oid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
+              <dxl:Columns>
+                <dxl:Column ColId="25" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                <dxl:Column ColId="26" Attno="2" ColName="rolsuper" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="27" Attno="3" ColName="rolinherit" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="28" Attno="4" ColName="rolcreaterole" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="29" Attno="5" ColName="rolcreatedb" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="30" Attno="6" ColName="rolcatupdate" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="31" Attno="7" ColName="rolcanlogin" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="32" Attno="8" ColName="rolconnlimit" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="33" Attno="9" ColName="rolpassword" TypeMdid="0.25.1.0"/>
+                <dxl:Column ColId="34" Attno="10" ColName="rolvaliduntil" TypeMdid="0.1184.1.0"/>
+                <dxl:Column ColId="35" Attno="11" ColName="rolconfig" TypeMdid="0.1009.1.0"/>
+                <dxl:Column ColId="36" Attno="12" ColName="rolresqueue" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="37" Attno="13" ColName="rolcreaterextgpfd" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="38" Attno="14" ColName="rolcreaterexthttp" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="39" Attno="15" ColName="rolcreatewextgpfd" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="40" Attno="16" ColName="rolcreaterexthdfs" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="41" Attno="17" ColName="rolcreatewexthdfs" TypeMdid="0.16.1.0"/>
+                <dxl:Column ColId="42" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="43" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="44" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="45" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="46" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="47" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="48" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="49" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Join-INDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-INDF.mdp
@@ -347,7 +347,7 @@ select * from foo, foo2 where foo.a is not distinct from foo2.a;
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.402344" Rows="9.999994" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.003542" Rows="9.999994" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -364,7 +364,7 @@ select * from foo, foo2 where foo.a is not distinct from foo2.a;
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.343750" Rows="9.999994" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.003003" Rows="9.999994" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -389,7 +389,7 @@ select * from foo, foo2 where foo.a is not distinct from foo2.a;
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.085938" Rows="22.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000230" Rows="22.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -416,7 +416,7 @@ select * from foo, foo2 where foo.a is not distinct from foo2.a;
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="4.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="4.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3832,10 +3832,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="433116">
+    <dxl:Plan Id="0" SpaceSize="431278">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="654544318.346447" Rows="19136.250000" Width="31"/>
+          <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="year">
@@ -3855,7 +3855,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="654544027.686413" Rows="19136.250000" Width="31"/>
+            <dxl:Cost StartupCost="0" TotalCost="3422676.865496" Rows="19136.250000" Width="31"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="year">
@@ -3875,7 +3875,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="654544027.686413" Rows="19136.250000" Width="31"/>
+              <dxl:Cost StartupCost="0" TotalCost="3422676.865496" Rows="19136.250000" Width="31"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -3905,7 +3905,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="654542176.599743" Rows="19136.250000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="3422671.973515" Rows="19136.250000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="year">
@@ -3942,7 +3942,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="654541857.908092" Rows="19136.250000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3422670.955275" Rows="19136.250000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="year">
@@ -3965,7 +3965,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="654541857.908092" Rows="19136.250000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="3422670.955275" Rows="19136.250000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="27"/>
@@ -3995,7 +3995,7 @@
                   <dxl:Filter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="344652958.259605" Rows="5288759693.059181" Width="30"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2087869.893271" Rows="5288759693.059181" Width="30"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="6" Alias="sales">
@@ -4032,7 +4032,7 @@
                     </dxl:HashCondList>
                     <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="201428659.370418" Rows="5288759693.059181" Width="15"/>
+                        <dxl:Cost StartupCost="0" TotalCost="865037.759215" Rows="5288759693.059181" Width="15"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="sales_date">
@@ -4059,7 +4059,7 @@
                       </dxl:HashCondList>
                       <dxl:DynamicTableScan PartIndexId="1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="67142457.040790" Rows="5288759693.059181" Width="26"/>
+                          <dxl:Cost StartupCost="0" TotalCost="96421.988429" Rows="5288759693.059181" Width="26"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="sales_date">
@@ -4091,7 +4091,7 @@
                       </dxl:DynamicTableScan>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="168.771484" Rows="20824.000000" Width="11"/>
+                          <dxl:Cost StartupCost="0" TotalCost="435.650572" Rows="20824.000000" Width="11"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="10" Alias="prod_code">
@@ -4102,7 +4102,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="55.923828" Rows="10412.000000" Width="11"/>
+                            <dxl:Cost StartupCost="0" TotalCost="432.546182" Rows="10412.000000" Width="11"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="10" Alias="prod_code">
@@ -4166,7 +4166,7 @@
                       </dxl:PrintableFilter>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="65645401.072891" Rows="607744.000000" Width="30"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1552.578227" Rows="607744.000000" Width="30"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4189,7 +4189,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="65636497.572891" Rows="303872.000000" Width="30"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1313.962739" Rows="303872.000000" Width="30"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4214,7 +4214,7 @@
                           </dxl:JoinFilter>
                           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="3.636719" Rows="200.000000" Width="18"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.062429" Rows="200.000000" Width="18"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="38" Alias="shop_code">
@@ -4228,7 +4228,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:TableScan>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.878906" Rows="100.000000" Width="18"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.013640" Rows="100.000000" Width="18"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="38" Alias="shop_code">
@@ -4256,7 +4256,7 @@
                           </dxl:BroadcastMotion>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="140.936172" Rows="3038.720000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.551944" Rows="3038.720000" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="26" Alias="ymd">

--- a/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
@@ -541,7 +541,7 @@ where e < 10;
     <dxl:Plan Id="0" SpaceSize="78">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="67985.085817" Rows="324.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="8620.170543" Rows="324.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="c">
@@ -567,7 +567,7 @@ where e < 10;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="67979.656130" Rows="324.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="8620.129810" Rows="324.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="c">
@@ -593,58 +593,9 @@ where e < 10;
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.158203" Rows="18.000000" Width="12"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="20" Alias="a">
-                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="b">
-                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="d">
-                <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.052734" Rows="9.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="20" Alias="a">
-                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="b">
-                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="d">
-                  <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.19556034.1.1" TableName="t">
-                <dxl:Columns>
-                  <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="22" Attno="3" ColName="d" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5769.497927" Rows="36.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.008577" Rows="36.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="c">
@@ -666,7 +617,7 @@ where e < 10;
             <dxl:OneTimeFilter/>
             <dxl:Window PartitionColumns="0">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5767.935427" Rows="90.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.007096" Rows="90.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="19" Alias="e">
@@ -690,7 +641,7 @@ where e < 10;
               <dxl:Filter/>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="5765.529177" Rows="90.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.006376" Rows="90.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -712,7 +663,7 @@ where e < 10;
                 </dxl:JoinFilter>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.255739" Rows="9.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000614" Rows="9.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -731,7 +682,7 @@ where e < 10;
                   <dxl:LimitOffset/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.035156" Rows="9.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000104" Rows="9.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -757,9 +708,9 @@ where e < 10;
                     </dxl:TableDescriptor>
                   </dxl:TableScan>
                 </dxl:Sort>
-                <dxl:Materialize Eager="true">
+                <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.273438" Rows="20.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.002353" Rows="20.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="c">
@@ -772,7 +723,7 @@ where e < 10;
                   <dxl:Filter/>
                   <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.117188" Rows="20.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.002273" Rows="20.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="c">
@@ -786,7 +737,7 @@ where e < 10;
                     <dxl:SortingColumnList/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="c">
@@ -823,6 +774,72 @@ where e < 10;
               </dxl:WindowKeyList>
             </dxl:Window>
           </dxl:Result>
+          <dxl:Materialize Eager="true">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.003139" Rows="18.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="d">
+                <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.003031" Rows="18.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="20" Alias="a">
+                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="b">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="d">
+                  <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000104" Rows="9.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="20" Alias="a">
+                    <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="b">
+                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="22" Alias="d">
+                    <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.19556034.1.1" TableName="t">
+                  <dxl:Columns>
+                    <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="22" Attno="3" ColName="d" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
@@ -786,7 +786,7 @@
     <dxl:Plan Id="0" SpaceSize="29572">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="768948417.867188" Rows="10000000.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="10867.964640" Rows="10000000.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -806,7 +806,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="768870291.867188" Rows="10000000.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="10149.564640" Rows="10000000.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -834,7 +834,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="48870251.804688" Rows="2000.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="969.632979" Rows="2000.000000" Width="9"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -851,7 +851,7 @@
             <dxl:SortingColumnList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="48870242.015625" Rows="1000.000000" Width="9"/>
+                <dxl:Cost StartupCost="0" TotalCost="969.397404" Rows="1000.000000" Width="9"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -868,7 +868,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="48870242.015625" Rows="1000.000000" Width="9"/>
+                  <dxl:Cost StartupCost="0" TotalCost="969.397404" Rows="1000.000000" Width="9"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="ColRef_0027">
@@ -882,7 +882,7 @@
                       <dxl:ParamList/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -893,7 +893,7 @@
                         <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="28" Alias="ColRef_0028">
@@ -905,9 +905,9 @@
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="4.082031" Rows="2.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000076" Rows="2.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="19"/>
@@ -918,9 +918,9 @@
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:Append IsTarget="false" IsZapped="false">
+                            <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="3.035156" Rows="2.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000063" Rows="2.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="19" Alias="?column?">
@@ -928,55 +928,71 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:Result>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:Append IsTarget="false" IsZapped="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="2.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="19" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                    <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
-                                    <dxl:ProjElem ColId="18" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    <dxl:ProjElem ColId="19" Alias="?column?">
+                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
                                   <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="18" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
                                 </dxl:Result>
-                              </dxl:Result>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="21" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
-                                    <dxl:ProjElem ColId="20" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    <dxl:ProjElem ColId="21" Alias="?column?">
+                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
                                   <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="20" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
                                 </dxl:Result>
-                              </dxl:Result>
-                            </dxl:Append>
+                              </dxl:Append>
+                            </dxl:Sort>
                           </dxl:Aggregate>
                         </dxl:Result>
                       </dxl:Result>
@@ -993,7 +1009,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="48870232.226562" Rows="1000.000000" Width="9"/>
+                    <dxl:Cost StartupCost="0" TotalCost="969.392904" Rows="1000.000000" Width="9"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -1023,7 +1039,7 @@
           </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="39.062500" Rows="10000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
@@ -812,7 +812,7 @@
     <dxl:Plan Id="0" SpaceSize="234125728">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="130674387.565104" Rows="520834.333333" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="9312.745178" Rows="520834.333333" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -832,7 +832,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="130670317.546875" Rows="520834.333333" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="9275.328440" Rows="520834.333333" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -855,290 +855,100 @@
               <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.16.1.0"/>
             </dxl:Or>
           </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="48870251.804688" Rows="2000.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="969.397404" Rows="1000.000000" Width="9"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="i">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="j">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="36" Alias="ColRef_0036">
-                <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="48870242.015625" Rows="1000.000000" Width="9"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="i">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="36" Alias="ColRef_0036">
-                  <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="48870242.015625" Rows="1000.000000" Width="9"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="36" Alias="ColRef_0036">
-                    <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-                      <dxl:TestExpr>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                  <dxl:TestExpr>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:TestExpr>
+                  <dxl:ParamList/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="?column?">
+                        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="37" Alias="ColRef_0037">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="19" Alias="?column?">
                           <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:TestExpr>
-                      <dxl:ParamList/>
-                      <dxl:Result>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000076" Rows="2.000000" Width="4"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="19"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="19" Alias="?column?">
                             <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Result>
+                        <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000063" Rows="2.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="37" Alias="ColRef_0037">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="19" Alias="?column?">
                               <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:Append IsTarget="false" IsZapped="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="4.082031" Rows="2.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="2.000000" Width="4"/>
                             </dxl:Properties>
-                            <dxl:GroupingColumns>
-                              <dxl:GroupingColumn ColId="19"/>
-                            </dxl:GroupingColumns>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="19" Alias="?column?">
                                 <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:Append IsTarget="false" IsZapped="false">
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="3.035156" Rows="2.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="19" Alias="?column?">
-                                  <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="19" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:Result>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="18" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
-                              </dxl:Result>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="21" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:Result>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="20" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
-                              </dxl:Result>
-                            </dxl:Append>
-                          </dxl:Aggregate>
-                        </dxl:Result>
-                      </dxl:Result>
-                    </dxl:SubPlan>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="0" Alias="i">
-                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="j">
-                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="48870232.226562" Rows="1000.000000" Width="9"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="i">
-                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="j">
-                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.27319.1.1" TableName="x">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
-            </dxl:Result>
-          </dxl:BroadcastMotion>
-          <dxl:Materialize Eager="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="800064.742188" Rows="1000.000000" Width="9"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="38" Alias="ColRef_0038">
-                <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="i">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="j">
-                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="800054.953125" Rows="1000.000000" Width="9"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="38" Alias="ColRef_0038">
-                  <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-                    <dxl:TestExpr>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:TestExpr>
-                    <dxl:ParamList/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="23" Alias="?column?">
-                          <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="23" Alias="?column?">
-                            <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.082031" Rows="2.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="23"/>
-                          </dxl:GroupingColumns>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="23" Alias="?column?">
-                              <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:Append IsTarget="false" IsZapped="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="3.035156" Rows="2.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="23" Alias="?column?">
-                                <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="23" Alias="?column?">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
                               <dxl:OneTimeFilter/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="22" Alias="">
+                                  <dxl:ProjElem ColId="18" Alias="">
                                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
@@ -1148,21 +958,21 @@
                             </dxl:Result>
                             <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="25" Alias="?column?">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                                <dxl:ProjElem ColId="21" Alias="?column?">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
                               <dxl:OneTimeFilter/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="24" Alias="">
+                                  <dxl:ProjElem ColId="20" Alias="">
                                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
@@ -1171,23 +981,85 @@
                               </dxl:Result>
                             </dxl:Result>
                           </dxl:Append>
-                        </dxl:Aggregate>
-                      </dxl:Result>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
                     </dxl:Result>
-                  </dxl:SubPlan>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="j">
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="969.392904" Rows="1000.000000" Width="9"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="j">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.27319.1.1" TableName="x">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="864.027321" Rows="2000.000000" Width="9"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="i">
+                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="j">
+                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="864.018321" Rows="2000.000000" Width="9"/>
+              </dxl:Properties>
+              <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
                   <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="j">
                   <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                  <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="800045.164062" Rows="1000.000000" Width="9"/>
+                  <dxl:Cost StartupCost="0" TotalCost="863.782746" Rows="1000.000000" Width="9"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="i">
@@ -1196,23 +1068,183 @@
                   <dxl:ProjElem ColId="10" Alias="j">
                     <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                    <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.16.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:Result>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="863.782746" Rows="1000.000000" Width="9"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                      <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                        <dxl:TestExpr>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:TestExpr>
+                        <dxl:ParamList/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="23" Alias="?column?">
+                              <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="23" Alias="?column?">
+                                <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000076" Rows="2.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="23"/>
+                              </dxl:GroupingColumns>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="23" Alias="?column?">
+                                  <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:Sort SortDiscardDuplicates="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000063" Rows="2.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="23" Alias="?column?">
+                                    <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList>
+                                  <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                </dxl:SortingColumnList>
+                                <dxl:LimitCount/>
+                                <dxl:LimitOffset/>
+                                <dxl:Append IsTarget="false" IsZapped="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="2.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="23" Alias="?column?">
+                                      <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="23" Alias="?column?">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="22" Alias="">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                    </dxl:Result>
+                                  </dxl:Result>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="25" Alias="?column?">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="24" Alias="">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                    </dxl:Result>
+                                  </dxl:Result>
+                                </dxl:Append>
+                              </dxl:Sort>
+                            </dxl:Aggregate>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:SubPlan>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="j">
+                      <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="863.778246" Rows="1000.000000" Width="9"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="i">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="j">
+                        <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
+                      <dxl:Columns>
+                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:BroadcastMotion>
           </dxl:Materialize>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -11702,7 +11702,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="56112323.212557" Rows="4424643.209483" Width="856"/>
+          <dxl:Cost StartupCost="0" TotalCost="88162.264340" Rows="4424643.209483" Width="856"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -11888,9 +11888,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="Inner">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="54262959.621094" Rows="4424643.209483" Width="856"/>
+            <dxl:Cost StartupCost="0" TotalCost="71156.413643" Rows="4424643.209483" Width="856"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -12075,16 +12075,230 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
+          <dxl:JoinFilter>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="13" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="41" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
-          </dxl:HashCondList>
+          </dxl:JoinFilter>
+          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.044508" Rows="2.000000" Width="655"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="41" Alias="web_site_sk">
+                <dxl:Ident ColId="41" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="web_site_id">
+                <dxl:Ident ColId="42" ColName="web_site_id" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="43" Alias="web_rec_start_date">
+                <dxl:Ident ColId="43" ColName="web_rec_start_date" TypeMdid="0.1082.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="44" Alias="web_rec_end_date">
+                <dxl:Ident ColId="44" ColName="web_rec_end_date" TypeMdid="0.1082.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="45" Alias="web_name">
+                <dxl:Ident ColId="45" ColName="web_name" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="46" Alias="web_open_date_sk">
+                <dxl:Ident ColId="46" ColName="web_open_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="47" Alias="web_close_date_sk">
+                <dxl:Ident ColId="47" ColName="web_close_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="48" Alias="web_class">
+                <dxl:Ident ColId="48" ColName="web_class" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="49" Alias="web_manager">
+                <dxl:Ident ColId="49" ColName="web_manager" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="50" Alias="web_mkt_id">
+                <dxl:Ident ColId="50" ColName="web_mkt_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="51" Alias="web_mkt_class">
+                <dxl:Ident ColId="51" ColName="web_mkt_class" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="52" Alias="web_mkt_desc">
+                <dxl:Ident ColId="52" ColName="web_mkt_desc" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="53" Alias="web_market_manager">
+                <dxl:Ident ColId="53" ColName="web_market_manager" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="54" Alias="web_company_id">
+                <dxl:Ident ColId="54" ColName="web_company_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="55" Alias="web_company_name">
+                <dxl:Ident ColId="55" ColName="web_company_name" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="56" Alias="web_street_number">
+                <dxl:Ident ColId="56" ColName="web_street_number" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="57" Alias="web_street_name">
+                <dxl:Ident ColId="57" ColName="web_street_name" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="58" Alias="web_street_type">
+                <dxl:Ident ColId="58" ColName="web_street_type" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="59" Alias="web_suite_number">
+                <dxl:Ident ColId="59" ColName="web_suite_number" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="60" Alias="web_city">
+                <dxl:Ident ColId="60" ColName="web_city" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="61" Alias="web_county">
+                <dxl:Ident ColId="61" ColName="web_county" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="62" Alias="web_state">
+                <dxl:Ident ColId="62" ColName="web_state" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="63" Alias="web_zip">
+                <dxl:Ident ColId="63" ColName="web_zip" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="64" Alias="web_country">
+                <dxl:Ident ColId="64" ColName="web_country" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="65" Alias="web_gmt_offset">
+                <dxl:Ident ColId="65" ColName="web_gmt_offset" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="66" Alias="web_tax_percentage">
+                <dxl:Ident ColId="66" ColName="web_tax_percentage" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.010219" Rows="1.000000" Width="655"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="41" Alias="web_site_sk">
+                  <dxl:Ident ColId="41" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="web_site_id">
+                  <dxl:Ident ColId="42" ColName="web_site_id" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="43" Alias="web_rec_start_date">
+                  <dxl:Ident ColId="43" ColName="web_rec_start_date" TypeMdid="0.1082.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="44" Alias="web_rec_end_date">
+                  <dxl:Ident ColId="44" ColName="web_rec_end_date" TypeMdid="0.1082.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="45" Alias="web_name">
+                  <dxl:Ident ColId="45" ColName="web_name" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="46" Alias="web_open_date_sk">
+                  <dxl:Ident ColId="46" ColName="web_open_date_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="47" Alias="web_close_date_sk">
+                  <dxl:Ident ColId="47" ColName="web_close_date_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="48" Alias="web_class">
+                  <dxl:Ident ColId="48" ColName="web_class" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="49" Alias="web_manager">
+                  <dxl:Ident ColId="49" ColName="web_manager" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="50" Alias="web_mkt_id">
+                  <dxl:Ident ColId="50" ColName="web_mkt_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="51" Alias="web_mkt_class">
+                  <dxl:Ident ColId="51" ColName="web_mkt_class" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="52" Alias="web_mkt_desc">
+                  <dxl:Ident ColId="52" ColName="web_mkt_desc" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="53" Alias="web_market_manager">
+                  <dxl:Ident ColId="53" ColName="web_market_manager" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="54" Alias="web_company_id">
+                  <dxl:Ident ColId="54" ColName="web_company_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="55" Alias="web_company_name">
+                  <dxl:Ident ColId="55" ColName="web_company_name" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="56" Alias="web_street_number">
+                  <dxl:Ident ColId="56" ColName="web_street_number" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="57" Alias="web_street_name">
+                  <dxl:Ident ColId="57" ColName="web_street_name" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="58" Alias="web_street_type">
+                  <dxl:Ident ColId="58" ColName="web_street_type" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="59" Alias="web_suite_number">
+                  <dxl:Ident ColId="59" ColName="web_suite_number" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="60" Alias="web_city">
+                  <dxl:Ident ColId="60" ColName="web_city" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="61" Alias="web_county">
+                  <dxl:Ident ColId="61" ColName="web_county" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="62" Alias="web_state">
+                  <dxl:Ident ColId="62" ColName="web_state" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="63" Alias="web_zip">
+                  <dxl:Ident ColId="63" ColName="web_zip" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="64" Alias="web_country">
+                  <dxl:Ident ColId="64" ColName="web_country" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="65" Alias="web_gmt_offset">
+                  <dxl:Ident ColId="65" ColName="web_gmt_offset" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="66" Alias="web_tax_percentage">
+                  <dxl:Ident ColId="66" ColName="web_tax_percentage" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                  <dxl:Ident ColId="55" ColName="web_company_name" TypeMdid="0.1042.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAAB3ByaQ==" LintValue="650191652"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.641665.1.1" TableName="web_site">
+                <dxl:Columns>
+                  <dxl:Column ColId="41" Attno="1" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="42" Attno="2" ColName="web_site_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="43" Attno="3" ColName="web_rec_start_date" TypeMdid="0.1082.1.0"/>
+                  <dxl:Column ColId="44" Attno="4" ColName="web_rec_end_date" TypeMdid="0.1082.1.0"/>
+                  <dxl:Column ColId="45" Attno="5" ColName="web_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="46" Attno="6" ColName="web_open_date_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="47" Attno="7" ColName="web_close_date_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="48" Attno="8" ColName="web_class" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="49" Attno="9" ColName="web_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
+                  <dxl:Column ColId="50" Attno="10" ColName="web_mkt_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="51" Attno="11" ColName="web_mkt_class" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="52" Attno="12" ColName="web_mkt_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
+                  <dxl:Column ColId="53" Attno="13" ColName="web_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
+                  <dxl:Column ColId="54" Attno="14" ColName="web_company_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="55" Attno="15" ColName="web_company_name" TypeMdid="0.1042.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="56" Attno="16" ColName="web_street_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="57" Attno="17" ColName="web_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                  <dxl:Column ColId="58" Attno="18" ColName="web_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
+                  <dxl:Column ColId="59" Attno="19" ColName="web_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="60" Attno="20" ColName="web_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                  <dxl:Column ColId="61" Attno="21" ColName="web_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="62" Attno="22" ColName="web_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                  <dxl:Column ColId="63" Attno="23" ColName="web_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="64" Attno="24" ColName="web_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
+                  <dxl:Column ColId="65" Attno="25" ColName="web_gmt_offset" TypeMdid="0.1700.1.0"/>
+                  <dxl:Column ColId="66" Attno="26" ColName="web_tax_percentage" TypeMdid="0.1700.1.0"/>
+                  <dxl:Column ColId="67" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="68" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="69" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="70" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="71" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="72" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="73" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="18087644.531250" Rows="184296000.000000" Width="201"/>
+              <dxl:Cost StartupCost="0" TotalCost="12138.403400" Rows="184296000.000000" Width="201"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -12237,222 +12451,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="18.630859" Rows="2.000000" Width="655"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="41" Alias="web_site_sk">
-                <dxl:Ident ColId="41" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="42" Alias="web_site_id">
-                <dxl:Ident ColId="42" ColName="web_site_id" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="43" Alias="web_rec_start_date">
-                <dxl:Ident ColId="43" ColName="web_rec_start_date" TypeMdid="0.1082.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="44" Alias="web_rec_end_date">
-                <dxl:Ident ColId="44" ColName="web_rec_end_date" TypeMdid="0.1082.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="45" Alias="web_name">
-                <dxl:Ident ColId="45" ColName="web_name" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="46" Alias="web_open_date_sk">
-                <dxl:Ident ColId="46" ColName="web_open_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="47" Alias="web_close_date_sk">
-                <dxl:Ident ColId="47" ColName="web_close_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="48" Alias="web_class">
-                <dxl:Ident ColId="48" ColName="web_class" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="49" Alias="web_manager">
-                <dxl:Ident ColId="49" ColName="web_manager" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="50" Alias="web_mkt_id">
-                <dxl:Ident ColId="50" ColName="web_mkt_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="51" Alias="web_mkt_class">
-                <dxl:Ident ColId="51" ColName="web_mkt_class" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="52" Alias="web_mkt_desc">
-                <dxl:Ident ColId="52" ColName="web_mkt_desc" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="53" Alias="web_market_manager">
-                <dxl:Ident ColId="53" ColName="web_market_manager" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="54" Alias="web_company_id">
-                <dxl:Ident ColId="54" ColName="web_company_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="55" Alias="web_company_name">
-                <dxl:Ident ColId="55" ColName="web_company_name" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="56" Alias="web_street_number">
-                <dxl:Ident ColId="56" ColName="web_street_number" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="57" Alias="web_street_name">
-                <dxl:Ident ColId="57" ColName="web_street_name" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="58" Alias="web_street_type">
-                <dxl:Ident ColId="58" ColName="web_street_type" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="59" Alias="web_suite_number">
-                <dxl:Ident ColId="59" ColName="web_suite_number" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="60" Alias="web_city">
-                <dxl:Ident ColId="60" ColName="web_city" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="61" Alias="web_county">
-                <dxl:Ident ColId="61" ColName="web_county" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="62" Alias="web_state">
-                <dxl:Ident ColId="62" ColName="web_state" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="63" Alias="web_zip">
-                <dxl:Ident ColId="63" ColName="web_zip" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="64" Alias="web_country">
-                <dxl:Ident ColId="64" ColName="web_country" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="65" Alias="web_gmt_offset">
-                <dxl:Ident ColId="65" ColName="web_gmt_offset" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="66" Alias="web_tax_percentage">
-                <dxl:Ident ColId="66" ColName="web_tax_percentage" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="16.351562" Rows="1.000000" Width="655"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="41" Alias="web_site_sk">
-                  <dxl:Ident ColId="41" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="web_site_id">
-                  <dxl:Ident ColId="42" ColName="web_site_id" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="web_rec_start_date">
-                  <dxl:Ident ColId="43" ColName="web_rec_start_date" TypeMdid="0.1082.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="44" Alias="web_rec_end_date">
-                  <dxl:Ident ColId="44" ColName="web_rec_end_date" TypeMdid="0.1082.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="45" Alias="web_name">
-                  <dxl:Ident ColId="45" ColName="web_name" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="46" Alias="web_open_date_sk">
-                  <dxl:Ident ColId="46" ColName="web_open_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="47" Alias="web_close_date_sk">
-                  <dxl:Ident ColId="47" ColName="web_close_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="48" Alias="web_class">
-                  <dxl:Ident ColId="48" ColName="web_class" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="49" Alias="web_manager">
-                  <dxl:Ident ColId="49" ColName="web_manager" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="50" Alias="web_mkt_id">
-                  <dxl:Ident ColId="50" ColName="web_mkt_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="51" Alias="web_mkt_class">
-                  <dxl:Ident ColId="51" ColName="web_mkt_class" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="web_mkt_desc">
-                  <dxl:Ident ColId="52" ColName="web_mkt_desc" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="53" Alias="web_market_manager">
-                  <dxl:Ident ColId="53" ColName="web_market_manager" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="54" Alias="web_company_id">
-                  <dxl:Ident ColId="54" ColName="web_company_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="55" Alias="web_company_name">
-                  <dxl:Ident ColId="55" ColName="web_company_name" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="56" Alias="web_street_number">
-                  <dxl:Ident ColId="56" ColName="web_street_number" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="57" Alias="web_street_name">
-                  <dxl:Ident ColId="57" ColName="web_street_name" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="58" Alias="web_street_type">
-                  <dxl:Ident ColId="58" ColName="web_street_type" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="59" Alias="web_suite_number">
-                  <dxl:Ident ColId="59" ColName="web_suite_number" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="60" Alias="web_city">
-                  <dxl:Ident ColId="60" ColName="web_city" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="61" Alias="web_county">
-                  <dxl:Ident ColId="61" ColName="web_county" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="62" Alias="web_state">
-                  <dxl:Ident ColId="62" ColName="web_state" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="63" Alias="web_zip">
-                  <dxl:Ident ColId="63" ColName="web_zip" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="64" Alias="web_country">
-                  <dxl:Ident ColId="64" ColName="web_country" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="65" Alias="web_gmt_offset">
-                  <dxl:Ident ColId="65" ColName="web_gmt_offset" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="66" Alias="web_tax_percentage">
-                  <dxl:Ident ColId="66" ColName="web_tax_percentage" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                  <dxl:Ident ColId="55" ColName="web_company_name" TypeMdid="0.1042.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAAB3ByaQ==" LintValue="650191652"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.641665.1.1" TableName="web_site">
-                <dxl:Columns>
-                  <dxl:Column ColId="41" Attno="1" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="42" Attno="2" ColName="web_site_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="43" Attno="3" ColName="web_rec_start_date" TypeMdid="0.1082.1.0"/>
-                  <dxl:Column ColId="44" Attno="4" ColName="web_rec_end_date" TypeMdid="0.1082.1.0"/>
-                  <dxl:Column ColId="45" Attno="5" ColName="web_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                  <dxl:Column ColId="46" Attno="6" ColName="web_open_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="47" Attno="7" ColName="web_close_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="48" Attno="8" ColName="web_class" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                  <dxl:Column ColId="49" Attno="9" ColName="web_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                  <dxl:Column ColId="50" Attno="10" ColName="web_mkt_id" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="51" Attno="11" ColName="web_mkt_class" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                  <dxl:Column ColId="52" Attno="12" ColName="web_mkt_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                  <dxl:Column ColId="53" Attno="13" ColName="web_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                  <dxl:Column ColId="54" Attno="14" ColName="web_company_id" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="55" Attno="15" ColName="web_company_name" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                  <dxl:Column ColId="56" Attno="16" ColName="web_street_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                  <dxl:Column ColId="57" Attno="17" ColName="web_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                  <dxl:Column ColId="58" Attno="18" ColName="web_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
-                  <dxl:Column ColId="59" Attno="19" ColName="web_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                  <dxl:Column ColId="60" Attno="20" ColName="web_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                  <dxl:Column ColId="61" Attno="21" ColName="web_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
-                  <dxl:Column ColId="62" Attno="22" ColName="web_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                  <dxl:Column ColId="63" Attno="23" ColName="web_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                  <dxl:Column ColId="64" Attno="24" ColName="web_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                  <dxl:Column ColId="65" Attno="25" ColName="web_gmt_offset" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="66" Attno="26" ColName="web_tax_percentage" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="67" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="68" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="69" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="70" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="71" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="72" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="73" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
-        </dxl:HashJoin>
+        </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
@@ -272,111 +272,79 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="235">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="10.055664" Rows="3.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000327" Rows="3.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="mrs_t1">
-            <dxl:Ident ColId="9" ColName="mrs_t1" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9.049805" Rows="3.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000315" Rows="3.000000" Width="1"/>
           </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="9" Alias="mrs_t1">
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
+          <dxl:ProjList/>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.038086" Rows="3.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
             </dxl:Properties>
-            <dxl:GroupingColumns>
-              <dxl:GroupingColumn ColId="0"/>
-            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="">
-                <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:OneTimeFilter/>
+          </dxl:Result>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000295" Rows="4.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="7.027344" Rows="4.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000291" Rows="4.000000" Width="1"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
+              <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.025391" Rows="4.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000273" Rows="4.000000" Width="1"/>
                 </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="">
-                    <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="4.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      <dxl:Ident ColId="1" ColName="x" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.509062.1.1" TableName="mrs_t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="1" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:NestedLoopJoin>
-            </dxl:RedistributeMotion>
-          </dxl:Aggregate>
-        </dxl:Result>
-      </dxl:GatherMotion>
+                <dxl:ProjList/>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:Ident ColId="1" ColName="x" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.509062.1.1" TableName="mrs_t1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="1" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:GatherMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-Empty.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-Empty.mdp
@@ -1015,7 +1015,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="309.226562" Rows="800.000000" Width="143"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.759648" Rows="800.000000" Width="143"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -1050,7 +1050,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="252.367188" Rows="800.000000" Width="143"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.245992" Rows="800.000000" Width="143"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">

--- a/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-green-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-green-2.mdp
@@ -1015,7 +1015,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="309.226562" Rows="800.000000" Width="143"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.759648" Rows="800.000000" Width="143"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -1050,7 +1050,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="252.367188" Rows="800.000000" Width="143"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.245992" Rows="800.000000" Width="143"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">

--- a/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-green.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-green.mdp
@@ -1015,7 +1015,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="309.226562" Rows="800.000000" Width="143"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.759648" Rows="800.000000" Width="143"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -1050,7 +1050,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="252.367188" Rows="800.000000" Width="143"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.245992" Rows="800.000000" Width="143"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -389,7 +389,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2474.828730" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="919.567476" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -409,7 +409,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2474.828134" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="919.566880" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -458,7 +458,7 @@
           </dxl:TableScan>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2043.827104" Rows="0.100000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="488.565850" Rows="0.100000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -491,7 +491,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2043.827104" Rows="0.100000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="488.565850" Rows="0.100000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -396,7 +396,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2474.829059" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="919.567805" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -416,7 +416,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2474.828463" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="919.567209" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -465,7 +465,7 @@
           </dxl:TableScan>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2043.828141" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="488.566887" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -501,7 +501,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2043.828141" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="488.566887" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
@@ -412,7 +412,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="505.129504" Rows="3.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="828.356949" Rows="3.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -438,7 +438,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="505.128967" Rows="3.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="828.356412" Rows="3.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -588,7 +588,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
           </dxl:RedistributeMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.128140" Rows="0.500000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.355585" Rows="0.500000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -291,7 +291,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.127819" Rows="2.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.295778" Rows="2.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -311,7 +311,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.127700" Rows="2.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.295658" Rows="2.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -389,7 +389,7 @@
           </dxl:RedistributeMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
@@ -276,7 +276,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.127794" Rows="2.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="822.295752" Rows="2.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -296,7 +296,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.127675" Rows="2.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="822.295633" Rows="2.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -345,7 +345,7 @@
           </dxl:TableScan>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127597" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IsNullPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IsNullPred.mdp
@@ -12162,7 +12162,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1980639.835413" Rows="2818278.671879" Width="251"/>
+          <dxl:Cost StartupCost="0" TotalCost="8890.464428" Rows="2818278.671879" Width="251"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -12299,7 +12299,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1635234.564592" Rows="2818278.671879" Width="251"/>
+            <dxl:Cost StartupCost="0" TotalCost="5714.292547" Rows="2818278.671879" Width="251"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -12440,7 +12440,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="944425.022949" Rows="6352219.549592" Width="251"/>
+              <dxl:Cost StartupCost="0" TotalCost="5609.798536" Rows="6352219.549592" Width="251"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -12581,9 +12581,9 @@
                 <dxl:Ident ColId="39" ColName="sr_ticket_number" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="189863.723145" Rows="2880303.000000" Width="135"/>
+                <dxl:Cost StartupCost="0" TotalCost="1531.851807" Rows="2880303.000000" Width="135"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -12657,44 +12657,127 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1962051.1.1" TableName="store_sales">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="4" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="5" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="6" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="7" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="8" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="9" Attno="10" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="10" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="12" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="13" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="14" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="15" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="16" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="17" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="18" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="19" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="20" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="21" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="22" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                  <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="9" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="561.693749" Rows="2880303.000000" Width="135"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
+                    <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="ss_sold_time_sk">
+                    <dxl:Ident ColId="1" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="ss_item_sk">
+                    <dxl:Ident ColId="2" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="3" Alias="ss_customer_sk">
+                    <dxl:Ident ColId="3" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="4" Alias="ss_cdemo_sk">
+                    <dxl:Ident ColId="4" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="5" Alias="ss_hdemo_sk">
+                    <dxl:Ident ColId="5" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="6" Alias="ss_addr_sk">
+                    <dxl:Ident ColId="6" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="7" Alias="ss_store_sk">
+                    <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="ss_promo_sk">
+                    <dxl:Ident ColId="8" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="9" Alias="ss_ticket_number">
+                    <dxl:Ident ColId="9" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="ss_quantity">
+                    <dxl:Ident ColId="10" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="ss_wholesale_cost">
+                    <dxl:Ident ColId="11" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="ss_list_price">
+                    <dxl:Ident ColId="12" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="13" Alias="ss_sales_price">
+                    <dxl:Ident ColId="13" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="14" Alias="ss_ext_discount_amt">
+                    <dxl:Ident ColId="14" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="15" Alias="ss_ext_sales_price">
+                    <dxl:Ident ColId="15" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="16" Alias="ss_ext_wholesale_cost">
+                    <dxl:Ident ColId="16" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="17" Alias="ss_ext_list_price">
+                    <dxl:Ident ColId="17" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="18" Alias="ss_ext_tax">
+                    <dxl:Ident ColId="18" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="19" Alias="ss_coupon_amt">
+                    <dxl:Ident ColId="19" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="20" Alias="ss_net_paid">
+                    <dxl:Ident ColId="20" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="ss_net_paid_inc_tax">
+                    <dxl:Ident ColId="21" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="22" Alias="ss_net_profit">
+                    <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.1962051.1.1" TableName="store_sales">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="4" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="5" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="6" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="7" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="8" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="9" Attno="10" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="12" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="13" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="14" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="15" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="16" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="17" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="18" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="19" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="20" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="21" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="22" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:RedistributeMotion>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="48892.111328" Rows="575454.000000" Width="116"/>
+                <dxl:Cost StartupCost="0" TotalCost="525.826187" Rows="287727.000000" Width="116"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="sr_returned_date_sk">
@@ -12760,9 +12843,14 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="39" ColName="sr_ticket_number" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="16297.037109" Rows="287727.000000" Width="116"/>
+                  <dxl:Cost StartupCost="0" TotalCost="442.552239" Rows="287727.000000" Width="116"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="30" Alias="sr_returned_date_sk">
@@ -12859,7 +12947,7 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:BroadcastMotion>
+            </dxl:RedistributeMotion>
           </dxl:HashJoin>
         </dxl:Result>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/LOJWithFalsePred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJWithFalsePred.mdp
@@ -176,9 +176,9 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.009766" Rows="2.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000121" Rows="2.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="?column?">
@@ -197,7 +197,7 @@
         </dxl:JoinFilter>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="?column?">
@@ -208,7 +208,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="">
@@ -225,31 +225,31 @@
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="i">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="3" Alias="j">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="4" Alias="ctid">
-              <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true" IsByValue="false"/>
+              <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="5" Alias="xmin">
-              <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="6" Alias="cmin">
-              <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="7" Alias="xmax">
-              <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="8" Alias="cmax">
-              <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="tableoid">
-              <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="gp_segment_id">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/Lead-Lag-WinFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Lead-Lag-WinFuncs.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="2"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647"/>
       <dxl:TraceFlags Value="103027,101001,101013,103001"/>
     </dxl:OptimizerConfig>
@@ -232,7 +232,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.919955" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.001265" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="lead">
@@ -246,7 +246,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.919955" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.001265" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="lead">
@@ -264,7 +264,7 @@
           <dxl:Filter/>
           <dxl:Window PartitionColumns="">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.685580" Rows="10.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001145" Rows="10.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="lead">
@@ -279,7 +279,7 @@
             <dxl:Filter/>
             <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.529330" Rows="10.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001065" Rows="10.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -292,7 +292,7 @@
               </dxl:SortingColumnList>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.490268" Rows="10.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000706" Rows="10.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -307,7 +307,7 @@
                 <dxl:LimitOffset/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -2113,7 +2113,7 @@
     <dxl:Plan Id="0" SpaceSize="680">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="40173678.932290" Rows="896.720000" Width="238"/>
+          <dxl:Cost StartupCost="0" TotalCost="69956.106522" Rows="896.720000" Width="238"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="36" Alias="tableoid">
@@ -2145,7 +2145,7 @@
               </dxl:ParamList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="114.285313" Rows="1.000000" Width="64"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.059266" Rows="1.000000" Width="64"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="74" Alias="rolname">
@@ -2156,7 +2156,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="114.285313" Rows="1.000000" Width="64"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.059266" Rows="1.000000" Width="64"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="99" Alias="rolpassword">
@@ -2170,7 +2170,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="113.160313" Rows="1.000000" Width="64"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.059202" Rows="1.000000" Width="64"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="74" Alias="rolname">
@@ -2236,7 +2236,7 @@
               </dxl:ParamList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="126.140625" Rows="1.000000" Width="64"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.131851" Rows="1.000000" Width="64"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="102" Alias="spcname">
@@ -2276,7 +2276,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="361895.471665" Rows="896.720000" Width="145"/>
+            <dxl:Cost StartupCost="0" TotalCost="69955.893103" Rows="1000.000000" Width="241"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="relname">
@@ -2342,7 +2342,7 @@
           <dxl:LimitOffset/>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="712.465820" Rows="896.720000" Width="145"/>
+              <dxl:Cost StartupCost="0" TotalCost="1295.838652" Rows="896.720000" Width="145"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="relname">
@@ -2423,7 +2423,7 @@
             </dxl:HashCondList>
             <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="48.243164" Rows="1.000000" Width="137"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.051129" Rows="1.000000" Width="137"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="relname">
@@ -2485,7 +2485,7 @@
               </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="46.622070" Rows="2.000000" Width="137"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.049779" Rows="2.000000" Width="137"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="relname">
@@ -2577,7 +2577,7 @@
               </dxl:TableScan>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="53" Alias="parchildrelid">
@@ -2602,7 +2602,7 @@
             </dxl:HashJoin>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="225.298828" Rows="2240.800000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.642269" Rows="2240.800000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="38" Alias="classid">

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.265625" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001150" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -277,7 +277,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.250000" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001007" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -308,7 +308,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -335,7 +335,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000116" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp
@@ -397,7 +397,7 @@
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.582031" Rows="15.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.008993" Rows="15.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -411,7 +411,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.523438" Rows="15.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.008454" Rows="15.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -435,7 +435,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.406250" Rows="44.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.007730" Rows="44.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -458,7 +458,7 @@
             </dxl:HashCondList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="20.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000209" Rows="20.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -481,7 +481,7 @@
             </dxl:TableScan>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.117188" Rows="30.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000314" Rows="30.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11631,10 +11631,10 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="174532">
+    <dxl:Plan Id="0" SpaceSize="176644">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="139746685.873548" Rows="5.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="7462.922002" Rows="5.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11646,7 +11646,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="139746684.795423" Rows="5.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="7462.921962" Rows="5.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11660,7 +11660,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
           <dxl:SortingColumnList/>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="139746683.775892" Rows="5.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="7462.921782" Rows="5.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11672,7 +11672,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
             </dxl:ProjList>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="139746682.736829" Rows="34588120.393257" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="7462.921762" Rows="34588120.393257" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11684,7 +11684,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="2" Columns="190">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="53.374023" Rows="17877.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="434.143134" Rows="17877.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="190" Alias="i_item_sk">
@@ -11693,7 +11693,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                 </dxl:ProjList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="34.916016" Rows="17877.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="434.067693" Rows="17877.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="190" Alias="i_item_sk">
@@ -11738,7 +11738,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
               </dxl:CTEProducer>
               <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="139476408.672234" Rows="34579006.805802" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6890.426146" Rows="34579006.805802" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11750,7 +11750,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                 </dxl:ProjList>
                 <dxl:CTEProducer CTEId="3" Columns="247,248">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="138462666.906256" Rows="34571856.005802" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2714.983600" Rows="34571856.005802" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="247" Alias="i_item_sk">
@@ -11760,9 +11760,9 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                       <dxl:Ident ColId="248" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:HashJoin JoinType="Inner">
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="138428904.328125" Rows="34571856.005802" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2697.697672" Rows="34571856.005802" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="247" Alias="i_item_sk">
@@ -11773,36 +11773,113 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="248" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="138293052.947266" Rows="34571856.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1303.011659" Rows="2880988.000483" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="247" Alias="i_item_sk">
+                          <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="248" Alias="ss_item_sk">
                           <dxl:Ident ColId="248" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:JoinFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:JoinFilter>
+                      <dxl:JoinFilter/>
+                      <dxl:HashCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="248" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:HashCondList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="561.724831" Rows="2880988.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="248" Alias="ss_item_sk">
+                            <dxl:Ident ColId="248" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.15668460.1.1" TableName="store_sales">
+                          <dxl:Columns>
+                            <dxl:Column ColId="249" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="250" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="248" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="251" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="252" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="253" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="254" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="255" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="256" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="257" Attno="10" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="258" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="259" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="260" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="261" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="262" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="263" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="264" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="265" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="266" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="267" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="268" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="269" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="270" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="271" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="272" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="273" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="274" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="275" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="276" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="277" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="24.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="432.957889" Rows="35754.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="247" Alias="i_item_sk">
+                            <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:CTEConsumer CTEId="2" Columns="247">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.086167" Rows="17877.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="247" Alias="i_item_sk">
+                              <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                        </dxl:CTEConsumer>
+                      </dxl:BroadcastMotion>
+                    </dxl:HashJoin>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.002855" Rows="24.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.002843" Rows="24.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="12.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.002518" Rows="12.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
@@ -11848,79 +11925,12 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
                       </dxl:BroadcastMotion>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5626.929688" Rows="2880988.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="248" Alias="ss_item_sk">
-                            <dxl:Ident ColId="248" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.15668460.1.1" TableName="store_sales">
-                          <dxl:Columns>
-                            <dxl:Column ColId="249" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="250" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="248" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="251" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="252" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="253" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="254" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="255" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="256" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="257" Attno="10" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="258" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="259" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="260" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="261" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="262" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="263" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="264" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="265" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="266" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="267" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="268" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="269" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="270" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="271" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="272" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="273" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="274" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="275" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="276" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="277" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:NestedLoopJoin>
-                    <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="105.748047" Rows="35754.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="247" Alias="i_item_sk">
-                          <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:CTEConsumer CTEId="2" Columns="247">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="34.916016" Rows="17877.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="247" Alias="i_item_sk">
-                            <dxl:Ident ColId="247" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:BroadcastMotion>
-                  </dxl:HashJoin>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
                 </dxl:CTEProducer>
                 <dxl:Append IsTarget="false" IsZapped="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="743592.275308" Rows="34579006.805802" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="4037.126519" Rows="34579006.805802" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11933,7 +11943,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                   <dxl:Filter/>
                   <dxl:CTEConsumer CTEId="3" Columns="95,124">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="135046.312523" Rows="34571856.005802" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="764.272692" Rows="34571856.005802" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="95" Alias="i_item_sk">
@@ -11946,7 +11956,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                   </dxl:CTEConsumer>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="338396.472115" Rows="7150.800000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="3134.537800" Rows="7150.800000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="342" Alias="i_item_sk">
@@ -11960,7 +11970,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                     <dxl:OneTimeFilter/>
                     <dxl:HashJoin JoinType="LeftAntiSemiJoin">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="338339.606490" Rows="7150.800000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="3134.509197" Rows="7150.800000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="342" Alias="i_item_sk">
@@ -11979,7 +11989,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                       </dxl:HashCondList>
                       <dxl:CTEConsumer CTEId="2" Columns="342">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="34.916016" Rows="17877.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.086167" Rows="17877.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="342" Alias="i_item_sk">
@@ -11989,7 +11999,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                       </dxl:CTEConsumer>
                       <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="337910.133634" Rows="16574.710197" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="2700.216462" Rows="16574.710197" Width="4"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="343"/>
@@ -12002,7 +12012,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                         <dxl:Filter/>
                         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="337714.898749" Rows="16574.710197" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="2699.199669" Rows="16574.710197" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="343" Alias="i_item_sk">
@@ -12018,7 +12028,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                           </dxl:HashExprList>
                           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="337681.526268" Rows="16574.710197" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="2699.095912" Rows="16574.710197" Width="4"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="343"/>
@@ -12031,7 +12041,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                             <dxl:Filter/>
                             <dxl:CTEConsumer CTEId="3" Columns="343,344">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="67523.156261" Rows="34571856.005802" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="597.636346" Rows="34571856.005802" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="343" Alias="i_item_sk">

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
@@ -30,6 +30,14 @@ and ei.entity_id  = i.ad_id;
       <dxl:TraceFlags Value="103027,102024,102025,102045,102046,102115,102116,102117,102119,102121,103017"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.17279045.1.1.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.17279045.1.1.8" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.17279045.1.1.1" Name="entity_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
@@ -293,10 +301,10 @@ and ei.entity_id  = i.ad_id;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3472">
+    <dxl:Plan Id="0" SpaceSize="5008">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="11.008789" Rows="2.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.003103" Rows="2.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="user_id">
@@ -313,7 +321,7 @@ and ei.entity_id  = i.ad_id;
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9.985352" Rows="2.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.002887" Rows="2.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="user_id">
@@ -328,7 +336,7 @@ and ei.entity_id  = i.ad_id;
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="19,20,21,22,23,24,25,26,27,28">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.025391" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="user_id">
@@ -364,7 +372,7 @@ and ei.entity_id  = i.ad_id;
             </dxl:ProjList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.024414" Rows="1.000000" Width="50"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="19" Alias="user_id">
@@ -417,7 +425,7 @@ and ei.entity_id  = i.ad_id;
           </dxl:CTEProducer>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7.913086" Rows="2.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.002803" Rows="2.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="user_id">
@@ -432,7 +440,7 @@ and ei.entity_id  = i.ad_id;
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="1" Columns="29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.641602" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.002018" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="29" Alias="user_id">
@@ -495,7 +503,7 @@ and ei.entity_id  = i.ad_id;
               </dxl:ProjList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.640625" Rows="1.000000" Width="96"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.002017" Rows="1.000000" Width="96"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="29" Alias="user_id">
@@ -570,7 +578,7 @@ and ei.entity_id  = i.ad_id;
                 </dxl:HashCondList>
                 <dxl:CTEConsumer CTEId="0" Columns="29,30,31,32,33,34,35,36,37,38">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.048828" Rows="1.000000" Width="50"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000120" Rows="1.000000" Width="50"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="29" Alias="user_id">
@@ -607,7 +615,7 @@ and ei.entity_id  = i.ad_id;
                 </dxl:CTEConsumer>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.044922" Rows="1.000000" Width="46"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="46"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="39" Alias="user_id">
@@ -657,7 +665,7 @@ and ei.entity_id  = i.ad_id;
             </dxl:CTEProducer>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.232422" Rows="2.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000766" Rows="2.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="user_id">
@@ -673,7 +681,7 @@ and ei.entity_id  = i.ad_id;
               <dxl:Filter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="user_id">
@@ -690,7 +698,7 @@ and ei.entity_id  = i.ad_id;
                 <dxl:OneTimeFilter/>
                 <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="1.000000" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="user_id">
@@ -755,7 +763,7 @@ and ei.entity_id  = i.ad_id;
               </dxl:Result>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.173828" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000697" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="48" Alias="user_id">
@@ -765,14 +773,14 @@ and ei.entity_id  = i.ad_id;
                     <dxl:Ident ColId="50" ColName="event_time" TypeMdid="0.1114.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="78" Alias="ad_id">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
                 <dxl:HashJoin JoinType="LeftAntiSemiJoin">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.134766" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000677" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="48" Alias="user_id">
@@ -800,7 +808,7 @@ and ei.entity_id  = i.ad_id;
                   </dxl:HashCondList>
                   <dxl:CTEConsumer CTEId="0" Columns="48,49,50,51,52,53,54,55,56,57">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="1.000000" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="48" Alias="user_id">
@@ -835,9 +843,9 @@ and ei.entity_id  = i.ad_id;
                       </dxl:ProjElem>
                     </dxl:ProjList>
                   </dxl:CTEConsumer>
-                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.037109" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="58"/>
@@ -852,9 +860,9 @@ and ei.entity_id  = i.ad_id;
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:CTEConsumer CTEId="1" Columns="58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="58" Alias="user_id">
@@ -915,7 +923,78 @@ and ei.entity_id  = i.ad_id;
                           <dxl:Ident ColId="76" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                    </dxl:CTEConsumer>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="58" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="59" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:CTEConsumer CTEId="1" Columns="58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="58" Alias="user_id">
+                            <dxl:Ident ColId="58" ColName="user_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="59" Alias="entity_id">
+                            <dxl:Ident ColId="59" ColName="entity_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="60" Alias="event_time">
+                            <dxl:Ident ColId="60" ColName="event_time" TypeMdid="0.1114.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="61" Alias="ctid">
+                            <dxl:Ident ColId="61" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="62" Alias="xmin">
+                            <dxl:Ident ColId="62" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="63" Alias="cmin">
+                            <dxl:Ident ColId="63" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="64" Alias="xmax">
+                            <dxl:Ident ColId="64" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="65" Alias="cmax">
+                            <dxl:Ident ColId="65" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="66" Alias="tableoid">
+                            <dxl:Ident ColId="66" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="67" Alias="gp_segment_id">
+                            <dxl:Ident ColId="67" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="68" Alias="user_id">
+                            <dxl:Ident ColId="68" ColName="user_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="69" Alias="ad_id">
+                            <dxl:Ident ColId="69" ColName="ad_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="70" Alias="ctid">
+                            <dxl:Ident ColId="70" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="71" Alias="xmin">
+                            <dxl:Ident ColId="71" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="72" Alias="cmin">
+                            <dxl:Ident ColId="72" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="73" Alias="xmax">
+                            <dxl:Ident ColId="73" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="74" Alias="cmax">
+                            <dxl:Ident ColId="74" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="75" Alias="tableoid">
+                            <dxl:Ident ColId="75" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="76" Alias="gp_segment_id">
+                            <dxl:Ident ColId="76" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Sort>
                   </dxl:Aggregate>
                 </dxl:HashJoin>
               </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/LikePredStatsNotComparable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LikePredStatsNotComparable.mdp
@@ -313,7 +313,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.519531" Rows="400.000000" Width="7"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.041801" Rows="400.000000" Width="7"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.152344" Rows="400.000000" Width="7"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.029229" Rows="400.000000" Width="7"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
@@ -333,7 +333,7 @@
     <dxl:Plan Id="0" SpaceSize="101">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="52812.751912" Rows="5.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="585.939124" Rows="5.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="c">
@@ -353,83 +353,81 @@
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Sort SortDiscardDuplicates="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="52811.683553" Rows="5.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="585.938495" Rows="5.000000" Width="28"/>
           </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="2"/>
+          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="count">
-              <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
+                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+              </dxl:AggFunc>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="11" Alias="sum">
-              <dxl:Ident ColId="11" ColName="sum" TypeMdid="0.20.1.0"/>
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+              </dxl:AggFunc>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="12" Alias="avg">
-              <dxl:Ident ColId="12" ColName="avg" TypeMdid="0.1700.1.0"/>
+              <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final">
+                <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.17.1.0"/>
+              </dxl:AggFunc>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList>
-            <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-          </dxl:SortingColumnList>
-          <dxl:LimitCount/>
-          <dxl:LimitOffset/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="52805.623047" Rows="5.000000" Width="28"/>
+              <dxl:Cost StartupCost="0" TotalCost="585.938366" Rows="11.250000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="2"/>
+              <dxl:GroupingColumn ColId="13"/>
             </dxl:GroupingColumns>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="15" Alias="ColRef_0015">
+                <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Intermediate">
+                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.17.1.0"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="count">
-                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
-                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
-                </dxl:AggFunc>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="sum">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
-                </dxl:AggFunc>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="avg">
-                <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final">
-                  <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.17.1.0"/>
-                </dxl:AggFunc>
+              <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="52804.134766" Rows="11.250000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="585.938226" Rows="11.250000" Width="16"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="2"/>
-                <dxl:GroupingColumn ColId="13"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="15" Alias="ColRef_0015">
-                  <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Intermediate">
-                    <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.17.1.0"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="c">
                   <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="13" Alias="ColRef_0013">
                   <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.17.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="13" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="52802.607422" Rows="11.250000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="585.936954" Rows="11.250000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="c">
@@ -451,7 +449,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="52801.519531" Rows="11.250000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="585.936672" Rows="11.250000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="c">
@@ -468,7 +466,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="52801.519531" Rows="11.250000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="585.936672" Rows="11.250000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="2"/>
@@ -493,7 +491,7 @@
                     <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="21511.843750" Rows="1001232.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="461.747835" Rows="1001232.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="13" Alias="ColRef_0013">
@@ -516,7 +514,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5866.593750" Rows="1001232.000000" Width="12"/>
+                          <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="12"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">
@@ -549,9 +547,9 @@
                   </dxl:Aggregate>
                 </dxl:Result>
               </dxl:RedistributeMotion>
-            </dxl:Aggregate>
+            </dxl:Sort>
           </dxl:Aggregate>
-        </dxl:Sort>
+        </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Minidump.xml
+++ b/src/backend/gporca/data/dxl/minidump/Minidump.xml
@@ -12,7 +12,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="3"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
       <dxl:TraceFlags Value="103027,0,101000,101001"/>
     </dxl:OptimizerConfig>
     <dxl:Query>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
@@ -9,6 +9,22 @@
       <dxl:TraceFlags Value="103027,103001,103002"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.2799.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.27.1.0"/>
+        <dxl:RightType Mdid="0.27.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.2800.1.0"/>
+        <dxl:InverseOp Mdid="0.2802.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -707,9 +723,9 @@
       </dxl:LogicalSelect>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="49">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="78355635.599609" Rows="1000.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1818691.526596" Rows="1000.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -719,11 +735,278 @@
             <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:TableScan>
+        <dxl:Filter>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+            <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:FuncExpr>
+            <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+              <dxl:TestExpr/>
+              <dxl:ParamList>
+                <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ParamList>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1817829.141818" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="28" Alias="sum">
+                    <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1817829.141369" Rows="1001.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1817829.075503" Rows="1001.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="i">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                        <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:FuncExpr>
+                        <dxl:Ident ColId="27" ColName="sum" TypeMdid="0.20.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1817763.209703" Rows="1001.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="9"/>
+                        <dxl:GroupingColumn ColId="11"/>
+                        <dxl:GroupingColumn ColId="17"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="27" Alias="sum">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="i">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="ctid">
+                          <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                          <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="1817583.040983" Rows="10008999.000000" Width="18"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="i">
+                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="11" Alias="ctid">
+                            <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                            <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="18" Alias="i">
+                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:JoinFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:JoinFilter>
+                        <dxl:Materialize Eager="true">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.457797" Rows="1001.000000" Width="14"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="i">
+                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="11" Alias="ctid">
+                              <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                              <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.443783" Rows="1001.000000" Width="14"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="9" Alias="i">
+                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="11" Alias="ctid">
+                                <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                                <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="11" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:Sort SortDiscardDuplicates="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.380860" Rows="1001.000000" Width="14"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="i">
+                                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="11" Alias="ctid">
+                                  <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                                  <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="11" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.011562" Rows="1001.000000" Width="14"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="i">
+                                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="11" Alias="ctid">
+                                    <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.40994.1.1" TableName="y">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:Sort>
+                          </dxl:GatherMotion>
+                        </dxl:Materialize>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="659089.361300" Rows="9999.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="18" Alias="i">
+                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter>
+                            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:Filter>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Materialize Eager="true">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.361300" Rows="10000.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="18" Alias="i">
+                                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.321300" Rows="10000.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="18" Alias="i">
+                                  <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="18" Alias="i">
+                                    <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.761868.1.1" TableName="z">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:GatherMotion>
+                          </dxl:Materialize>
+                        </dxl:Result>
+                      </dxl:NestedLoopJoin>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:Result>
+              </dxl:Aggregate>
+            </dxl:SubPlan>
+          </dxl:Comparison>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="78355628.740234" Rows="1000.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.076590" Rows="1000.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -733,212 +1016,37 @@
               <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-              <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.011550" Rows="1000.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:FuncExpr>
-              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList>
-                  <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ParamList>
-                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="78259621.880859" Rows="2.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:GroupingColumns/>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="28" Alias="sum">
-                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="78259613.044922" Rows="2002.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="9" Alias="i">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="78259604.224609" Rows="2000.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="9" Alias="i">
-                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                          <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
-                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:FuncExpr>
-                          <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                            <dxl:TestExpr/>
-                            <dxl:ParamList>
-                              <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:ParamList>
-                            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="78195523.539062" Rows="2.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:GroupingColumns/>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="27" Alias="sum">
-                                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                                    <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                  </dxl:AggFunc>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="78195444.406250" Rows="19998.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="18" Alias="i">
-                                    <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter>
-                                  <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                                    <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                                  </dxl:Comparison>
-                                </dxl:Filter>
-                                <dxl:OneTimeFilter/>
-                                <dxl:Materialize Eager="true">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="138.718750" Rows="20000.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="18" Alias="i">
-                                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="59.593750" Rows="20000.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="18" Alias="i">
-                                        <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:SortingColumnList/>
-                                    <dxl:TableScan>
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="19.531250" Rows="10000.000000" Width="4"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="18" Alias="i">
-                                          <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:TableDescriptor Mdid="0.761868.1.1" TableName="z">
-                                        <dxl:Columns>
-                                          <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                          <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                          <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                          <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                          <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                          <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                          <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                          <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                        </dxl:Columns>
-                                      </dxl:TableDescriptor>
-                                    </dxl:TableScan>
-                                  </dxl:BroadcastMotion>
-                                </dxl:Materialize>
-                              </dxl:Result>
-                            </dxl:Aggregate>
-                          </dxl:SubPlan>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Materialize Eager="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="15.685547" Rows="2002.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="9" Alias="i">
-                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="6.865234" Rows="2002.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="9" Alias="i">
-                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.955078" Rows="1001.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="9" Alias="i">
-                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.40994.1.1" TableName="y">
-                              <dxl:Columns>
-                                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                      </dxl:Materialize>
-                    </dxl:Result>
-                  </dxl:Result>
-                </dxl:Aggregate>
-              </dxl:SubPlan>
-            </dxl:Comparison>
-          </dxl:Filter>
-          <dxl:TableDescriptor Mdid="0.40971.1.1" TableName="x">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="1" Attno="2" ColName="bi" TypeMdid="0.20.1.0"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:TableScan>
-      </dxl:GatherMotion>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="bi">
+                <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.40971.1.1" TableName="x">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="bi" TypeMdid="0.20.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -689,7 +689,7 @@
     <dxl:Plan Id="0" SpaceSize="4866">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="244.269531" Rows="999.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1294.489763" Rows="999.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -703,7 +703,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="237.416016" Rows="999.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1294.435937" Rows="999.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -723,7 +723,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.859375" Rows="1000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.011550" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -748,9 +748,9 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:HashJoin JoinType="In">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="199.287109" Rows="1001.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="863.206198" Rows="1001.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -761,50 +761,13 @@
             <dxl:JoinFilter/>
             <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                 <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="137.718750" Rows="10000.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="18"/>
-              </dxl:GroupingColumns>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="i">
-                  <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="19.531250" Rows="10000.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="18" Alias="i">
-                    <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.761868.1.1" TableName="z">
-                  <dxl:Columns>
-                    <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:Aggregate>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.955078" Rows="1001.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011562" Rows="1001.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -822,6 +785,29 @@
                   <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
                   <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
                   <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="i">
+                  <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.761868.1.1" TableName="z">
+                <dxl:Columns>
+                  <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevelDecorrelationWithSemiJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevelDecorrelationWithSemiJoins.mdp
@@ -407,10 +407,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="56">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="50.335938" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.001153" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -427,7 +427,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">
@@ -438,7 +438,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="c1">
@@ -462,7 +462,7 @@
         </dxl:GatherMotion>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="48.226562" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.000560" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="8" Alias="c2">
@@ -477,7 +477,7 @@
               </dxl:ParamList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="30.210938" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000419" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="48" Alias="ColRef_0048">
@@ -488,7 +488,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="30.210938" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000419" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -504,7 +504,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="29.208984" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000386" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -518,12 +518,12 @@
                               <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
                               <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                             </dxl:Comparison>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:IsNull>
                                 <dxl:Ident ColId="8" ColName="c2" TypeMdid="0.23.1.0"/>
                               </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                               <dxl:If TypeMdid="0.16.1.0">
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                   <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
@@ -541,7 +541,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="28.207031" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000385" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
@@ -559,7 +559,7 @@
                       <dxl:Filter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="27.160156" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.000381" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="37" Alias="ColRef_0037">
@@ -586,7 +586,7 @@
                         <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="26.144531" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.000373" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="16" Alias="c3">
@@ -602,7 +602,7 @@
                               </dxl:ParamList>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="7.113281" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000225" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="47" Alias="ColRef_0047">
@@ -613,7 +613,7 @@
                                 <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="7.113281" Rows="1.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000225" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="46" Alias="ColRef_0046">
@@ -629,7 +629,7 @@
                                   <dxl:OneTimeFilter/>
                                   <dxl:Result>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="6.111328" Rows="1.000000" Width="1"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000192" Rows="1.000000" Width="1"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="46" Alias="ColRef_0046">
@@ -643,12 +643,12 @@
                                               <dxl:Ident ColId="45" ColName="ColRef_0045" TypeMdid="0.20.1.0"/>
                                               <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                                             </dxl:Comparison>
-                                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                                             <dxl:If TypeMdid="0.16.1.0">
                                               <dxl:IsNull>
                                                 <dxl:Ident ColId="16" ColName="c3" TypeMdid="0.23.1.0"/>
                                               </dxl:IsNull>
-                                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                                               <dxl:If TypeMdid="0.16.1.0">
                                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                                   <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
@@ -666,7 +666,7 @@
                                     <dxl:OneTimeFilter/>
                                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="5.109375" Rows="1.000000" Width="16"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="1.000000" Width="16"/>
                                       </dxl:Properties>
                                       <dxl:GroupingColumns/>
                                       <dxl:ProjList>
@@ -684,7 +684,7 @@
                                       <dxl:Filter/>
                                       <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="4.062500" Rows="1.000000" Width="8"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000187" Rows="1.000000" Width="8"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="42" Alias="ColRef_0042">
@@ -711,7 +711,7 @@
                                         <dxl:OneTimeFilter/>
                                         <dxl:Result>
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="8"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000179" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="24" Alias="c4">
@@ -727,7 +727,7 @@
                                           <dxl:OneTimeFilter/>
                                           <dxl:Materialize Eager="true">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="8"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="8"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
                                               <dxl:ProjElem ColId="24" Alias="c4">
@@ -737,7 +737,7 @@
                                             <dxl:Filter/>
                                             <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="8"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="24" Alias="c4">
@@ -748,7 +748,7 @@
                                               <dxl:SortingColumnList/>
                                               <dxl:TableScan>
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
                                                   <dxl:ProjElem ColId="24" Alias="c4">
@@ -782,7 +782,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:Materialize Eager="true">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="16" Alias="c3">
@@ -792,7 +792,7 @@
                             <dxl:Filter/>
                             <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="16" Alias="c3">
@@ -803,7 +803,7 @@
                               <dxl:SortingColumnList/>
                               <dxl:TableScan>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="16" Alias="c3">
@@ -837,7 +837,7 @@
           <dxl:OneTimeFilter/>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="c2">
@@ -848,7 +848,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="c2">

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-ArrayCmp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-ArrayCmp.mdp
@@ -278,7 +278,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.222656" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000856" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -298,7 +298,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.210938" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000748" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -324,7 +324,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -360,7 +360,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
@@ -255,7 +255,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.126953" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000614" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="t1">
@@ -269,7 +269,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.121094" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000561" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="t1">
@@ -289,7 +289,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="t1">
@@ -316,7 +316,7 @@
           </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="t2">
@@ -332,7 +332,7 @@
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="t2">

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-NullInner.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-NullInner.mdp
@@ -296,10 +296,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.130859" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000709" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="t1">
@@ -310,10 +310,16 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="10" ColName="s2" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.125000" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="t1">
@@ -324,16 +330,10 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="10" ColName="s2" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
+          <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="t1">
@@ -358,9 +358,21 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+        </dxl:GatherMotion>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="s2">
+              <dxl:Ident ColId="10" ColName="s2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="s2">
@@ -368,34 +380,22 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="s2">
-                  <dxl:Ident ColId="10" ColName="s2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.53023.1.1" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="s1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="s2" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
-        </dxl:HashJoin>
-      </dxl:GatherMotion>
+            <dxl:TableDescriptor Mdid="0.53023.1.1" TableName="s">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="s1" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="10" Attno="2" ColName="s2" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-NullOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-NullOuter.mdp
@@ -296,10 +296,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.130859" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000709" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="s1">
@@ -310,10 +310,16 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="s1" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.125000" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="s1">
@@ -324,16 +330,10 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="s1" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
+          <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="s1">
@@ -358,9 +358,21 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+        </dxl:GatherMotion>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="t2">
+              <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="t2">
@@ -368,34 +380,22 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="t2">
-                  <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.53000.1.1" TableName="t">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:BroadcastMotion>
-        </dxl:HashJoin>
-      </dxl:GatherMotion>
+            <dxl:TableDescriptor Mdid="0.53000.1.1" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="10" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
@@ -172,7 +172,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
         </dxl:PartConstraint>
       </dxl:Index>
       <dxl:RelationStatistics Mdid="2.41880825.1.1" Name="tt_p" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.41880825.1.0" Name="tt_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,8,2" PartitionColumns="0">
+      <dxl:Relation Mdid="0.41880825.1.0" Name="tt_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,8,2" PartitionColumns="0"  PartitionTypes="r" NumberLeafPartitions="2">
         <dxl:Columns>
           <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -232,7 +232,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Relation Mdid="0.41880825.1.1" Name="tt_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,8,2" PartitionColumns="0">
+      <dxl:Relation Mdid="0.41880825.1.1" Name="tt_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,8,2" PartitionColumns="0" PartitionTypes="r" NumberLeafPartitions="2">
         <dxl:Columns>
           <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -326,7 +326,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
         </dxl:PartConstraint>
       </dxl:Index>
       <dxl:RelationStatistics Mdid="2.41880987.1.1" Name="z_p" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.41880987.1.0" Name="z_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="0">
+      <dxl:Relation Mdid="0.41880987.1.0" Name="z_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="0" PartitionTypes="r" NumberLeafPartitions="2">
         <dxl:Columns>
           <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -389,7 +389,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Relation Mdid="0.41880987.1.1" Name="z_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="0">
+      <dxl:Relation Mdid="0.41880987.1.1" Name="z_p" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="0" PartitionTypes="r" NumberLeafPartitions="2">
         <dxl:Columns>
           <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Or-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Or-Predicates.mdp
@@ -676,7 +676,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.800781" Rows="1.000000" Width="410"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.002376" Rows="1.000000" Width="410"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="hcs_key">
@@ -879,7 +879,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.600586" Rows="1.000000" Width="410"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="1.000000" Width="410"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="hcs_key">

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -9,6 +9,22 @@
       <dxl:TraceFlags Value="103027,102016,103001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.664.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.740.1.0"/>
+        <dxl:Commutator Mdid="0.666.1.0"/>
+        <dxl:InverseOp Mdid="0.667.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -581,10 +597,10 @@
         </dxl:LogicalProject>
       </dxl:Difference>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1425697200">
+    <dxl:Plan Id="0" SpaceSize="1423008000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="537.771973" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="department">
@@ -596,9 +612,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="536.766113" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="2592.974188" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="13"/>
@@ -613,9 +629,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="535.707520" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="2592.974172" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="13" Alias="name">
@@ -626,28 +642,15 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Not>
-                <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
-                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                    <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
-                  </dxl:Cast>
-                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                    <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
-                  </dxl:Cast>
-                </dxl:IsDistinctFrom>
-              </dxl:Not>
-              <dxl:Not>
-                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="21" ColName="emp_id" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="65" ColName="emp_id" TypeMdid="0.23.1.0"/>
-                </dxl:IsDistinctFrom>
-              </dxl:Not>
-            </dxl:HashCondList>
-            <dxl:Append IsTarget="false" IsZapped="false">
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="13" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="21" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:HashJoin JoinType="LeftAntiSemiJoin">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="357.393555" Rows="2.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="2592.974172" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="name">
@@ -658,65 +661,83 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Result>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                      <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
+                    </dxl:Cast>
+                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                      <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
+                    </dxl:Cast>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="21" ColName="emp_id" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="65" ColName="emp_id" TypeMdid="0.23.1.0"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
+              </dxl:HashCondList>
+              <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="178.173340" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1728.648662" Rows="2.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="13" Alias="name">
                     <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="21" Alias="emp_id">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:Ident ColId="21" ColName="emp_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="177.149902" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="864.324319" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="13"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="13" Alias="name">
                       <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="emp_id">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="176.103027" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="864.324307" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="13"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="13" Alias="name">
                         <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="175.099121" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="13"/>
-                      </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="13" Alias="name">
                           <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:HashJoin JoinType="Inner">
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="13" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="17.825684" Rows="10001.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="13" Alias="name">
@@ -724,150 +745,168 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:JoinFilter/>
-                        <dxl:HashCondList>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="1" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="12" ColName="deptno" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:HashCondList>
-                        <dxl:TableScan>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.883301" Rows="10001.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="864.324279" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="13"/>
+                          </dxl:GroupingColumns>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="1" Alias="deptno">
-                              <dxl:Ident ColId="1" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.1637457.1.1" TableName="emp">
-                            <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="empid" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="deptno" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="2.000000" Width="12"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="12" Alias="deptno">
-                              <dxl:Ident ColId="12" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="13" Alias="name">
                               <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
+                          <dxl:HashJoin JoinType="Inner">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="1.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="863.708516" Rows="10001.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="12" Alias="deptno">
-                                <dxl:Ident ColId="12" ColName="deptno" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="13" Alias="name">
                                 <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                                  <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
-                                </dxl:Cast>
-                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVNhbGVz" LintValue="422208302"/>
+                            <dxl:Filter/>
+                            <dxl:JoinFilter/>
+                            <dxl:HashCondList>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="12" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="1" ColName="deptno" TypeMdid="0.23.1.0"/>
                               </dxl:Comparison>
-                            </dxl:Filter>
-                            <dxl:TableDescriptor Mdid="0.1637500.1.1" TableName="dept">
-                              <dxl:Columns>
-                                <dxl:Column ColId="12" Attno="1" ColName="deptno" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="13" Attno="2" ColName="name" TypeMdid="0.1043.1.0" ColWidth="255"/>
-                                <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                      </dxl:HashJoin>
-                    </dxl:Aggregate>
-                  </dxl:RedistributeMotion>
-                </dxl:Aggregate>
-              </dxl:Result>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="178.173340" Rows="1.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="35" Alias="name">
-                    <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="43" Alias="emp_id">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                            </dxl:HashCondList>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000214" Rows="1.000000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="12" Alias="deptno">
+                                  <dxl:Ident ColId="12" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="13" Alias="name">
+                                  <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                    <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVNhbGVz" LintValue="422208302"/>
+                                </dxl:Comparison>
+                              </dxl:Filter>
+                              <dxl:TableDescriptor Mdid="0.1637500.1.1" TableName="dept">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="12" Attno="1" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="13" Attno="2" ColName="name" TypeMdid="0.1043.1.0" ColWidth="255"/>
+                                  <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.954545" Rows="10001.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="1" Alias="deptno">
+                                  <dxl:Ident ColId="1" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:HashExprList>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="1" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                              </dxl:HashExprList>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.929593" Rows="10001.000000" Width="1"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="1" Alias="deptno">
+                                    <dxl:Ident ColId="1" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.1637457.1.1" TableName="emp">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="0" Attno="1" ColName="empid" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="1" Attno="2" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:RedistributeMotion>
+                          </dxl:HashJoin>
+                        </dxl:Aggregate>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Result>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="177.149902" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="864.324319" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="35"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="35" Alias="name">
                       <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="43" Alias="emp_id">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="176.103027" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="864.324307" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="35"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="35" Alias="name">
                         <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="175.099121" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="35"/>
-                      </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="35" Alias="name">
                           <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:HashJoin JoinType="Inner">
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="35" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="17.825684" Rows="10001.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="35" Alias="name">
@@ -875,151 +914,169 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:JoinFilter/>
-                        <dxl:HashCondList>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="23" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="34" ColName="deptno" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:HashCondList>
-                        <dxl:TableScan>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.883301" Rows="10001.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="864.324279" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="35"/>
+                          </dxl:GroupingColumns>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="23" Alias="deptno">
-                              <dxl:Ident ColId="23" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.1637457.1.1" TableName="emp">
-                            <dxl:Columns>
-                              <dxl:Column ColId="22" Attno="1" ColName="empid" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="23" Attno="2" ColName="deptno" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="27" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="28" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="29" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="30" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="31" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="32" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="33" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="2.000000" Width="12"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="34" Alias="deptno">
-                              <dxl:Ident ColId="34" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="35" Alias="name">
                               <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
+                          <dxl:HashJoin JoinType="Inner">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="1.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="863.708516" Rows="10001.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="34" Alias="deptno">
-                                <dxl:Ident ColId="34" ColName="deptno" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="35" Alias="name">
                                 <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                                  <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
-                                </dxl:Cast>
-                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVNhbGVz" LintValue="422208302"/>
+                            <dxl:Filter/>
+                            <dxl:JoinFilter/>
+                            <dxl:HashCondList>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="34" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="23" ColName="deptno" TypeMdid="0.23.1.0"/>
                               </dxl:Comparison>
-                            </dxl:Filter>
-                            <dxl:TableDescriptor Mdid="0.1637500.1.1" TableName="dept">
-                              <dxl:Columns>
-                                <dxl:Column ColId="34" Attno="1" ColName="deptno" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="35" Attno="2" ColName="name" TypeMdid="0.1043.1.0" ColWidth="255"/>
-                                <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="37" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="38" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="39" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="40" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="41" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="42" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                      </dxl:HashJoin>
-                    </dxl:Aggregate>
-                  </dxl:RedistributeMotion>
-                </dxl:Aggregate>
-              </dxl:Result>
-            </dxl:Append>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="177.149902" Rows="1.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="65" Alias="emp_id">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="57" Alias="name">
-                  <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                            </dxl:HashCondList>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000214" Rows="1.000000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="34" Alias="deptno">
+                                  <dxl:Ident ColId="34" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="35" Alias="name">
+                                  <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                    <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVNhbGVz" LintValue="422208302"/>
+                                </dxl:Comparison>
+                              </dxl:Filter>
+                              <dxl:TableDescriptor Mdid="0.1637500.1.1" TableName="dept">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="34" Attno="1" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="35" Attno="2" ColName="name" TypeMdid="0.1043.1.0" ColWidth="255"/>
+                                  <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="37" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="38" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="39" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="40" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="41" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="42" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.954545" Rows="10001.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="23" Alias="deptno">
+                                  <dxl:Ident ColId="23" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:HashExprList>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="23" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                              </dxl:HashExprList>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.929593" Rows="10001.000000" Width="1"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="23" Alias="deptno">
+                                    <dxl:Ident ColId="23" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.1637457.1.1" TableName="emp">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="22" Attno="1" ColName="empid" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="23" Attno="2" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="27" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="28" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="29" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="30" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="31" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="32" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="33" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:RedistributeMotion>
+                          </dxl:HashJoin>
+                        </dxl:Aggregate>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:Append>
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="176.126465" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="864.324286" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="57"/>
-                </dxl:GroupingColumns>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="65" Alias="emp_id">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="57" Alias="name">
                     <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:OneTimeFilter/>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="175.079590" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="864.324274" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="57"/>
+                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="57" Alias="name">
                       <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                  <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="174.075684" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="864.324262" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="57"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="57" Alias="name">
                         <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:HashJoin JoinType="Inner">
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="57" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="16.802246" Rows="10001.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="864.324262" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="57" Alias="name">
@@ -1027,85 +1084,118 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:JoinFilter/>
-                      <dxl:HashCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="45" ColName="deptno" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="56" ColName="deptno" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:HashCondList>
-                      <dxl:TableScan>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="4.883301" Rows="10001.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="864.324246" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="57"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="45" Alias="deptno">
-                            <dxl:Ident ColId="45" ColName="deptno" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.1637457.1.1" TableName="emp">
-                          <dxl:Columns>
-                            <dxl:Column ColId="44" Attno="1" ColName="empid" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="45" Attno="2" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="50" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="51" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="52" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="53" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="54" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="55" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="2.000000" Width="12"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="56" Alias="deptno">
-                            <dxl:Ident ColId="56" ColName="deptno" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="57" Alias="name">
                             <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:HashJoin JoinType="Inner">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+                            <dxl:Cost StartupCost="0" TotalCost="863.708483" Rows="10001.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="56" Alias="deptno">
-                              <dxl:Ident ColId="56" ColName="deptno" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="57" Alias="name">
                               <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.1637500.1.1" TableName="dept">
-                            <dxl:Columns>
-                              <dxl:Column ColId="56" Attno="1" ColName="deptno" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="57" Attno="2" ColName="name" TypeMdid="0.1043.1.0" ColWidth="255"/>
-                              <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:BroadcastMotion>
-                    </dxl:HashJoin>
-                  </dxl:Aggregate>
-                </dxl:RedistributeMotion>
-              </dxl:Aggregate>
-            </dxl:Result>
-          </dxl:HashJoin>
+                          <dxl:JoinFilter/>
+                          <dxl:HashCondList>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="56" ColName="deptno" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="45" ColName="deptno" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:HashCondList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000159" Rows="1.000000" Width="12"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="56" Alias="deptno">
+                                <dxl:Ident ColId="56" ColName="deptno" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="57" Alias="name">
+                                <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.1637500.1.1" TableName="dept">
+                              <dxl:Columns>
+                                <dxl:Column ColId="56" Attno="1" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="57" Attno="2" ColName="name" TypeMdid="0.1043.1.0" ColWidth="255"/>
+                                <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.954545" Rows="10001.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="45" Alias="deptno">
+                                <dxl:Ident ColId="45" ColName="deptno" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:HashExprList>
+                              <dxl:HashExpr>
+                                <dxl:Ident ColId="45" ColName="deptno" TypeMdid="0.23.1.0"/>
+                              </dxl:HashExpr>
+                            </dxl:HashExprList>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.929593" Rows="10001.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="45" Alias="deptno">
+                                  <dxl:Ident ColId="45" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.1637457.1.1" TableName="emp">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="44" Attno="1" ColName="empid" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="45" Attno="2" ColName="deptno" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="50" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="51" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="52" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="53" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="54" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="55" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:RedistributeMotion>
+                        </dxl:HashJoin>
+                      </dxl:Aggregate>
+                    </dxl:RedistributeMotion>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:Result>
+            </dxl:HashJoin>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops.mdp
@@ -341,10 +341,10 @@
         </dxl:LogicalGet>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="108">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.339844" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000549" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -356,9 +356,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.332031" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000478" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -373,9 +373,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Append IsTarget="false" IsZapped="false">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.128906" Rows="3.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000457" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -386,9 +386,15 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableScan>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000457" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -399,75 +405,165 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.17005.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="11" Alias="a">
-                  <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="12" Alias="b">
-                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.25307.1.1" TableName="h">
-                <dxl:Columns>
-                  <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="20" Alias="c">
-                  <dxl:Ident ColId="20" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="d">
-                  <dxl:Ident ColId="21" ColName="d" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.17041.1.1" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="20" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="21" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Append>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000426" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="0"/>
+                  <dxl:GroupingColumn ColId="1"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000397" Rows="3.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000318" Rows="3.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Append IsTarget="false" IsZapped="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000186" Rows="3.000000" Width="16"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.17005.1.1" TableName="r">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="a">
+                            <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="b">
+                            <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.25307.1.1" TableName="h">
+                          <dxl:Columns>
+                            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="c">
+                            <dxl:Ident ColId="20" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="21" Alias="d">
+                            <dxl:Ident ColId="21" ColName="d" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.17041.1.1" TableName="s">
+                          <dxl:Columns>
+                            <dxl:Column ColId="20" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="21" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Append>
+                  </dxl:RandomMotion>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:RedistributeMotion>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/NestedProjectCountStarWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedProjectCountStarWithOuterRefs.mdp
@@ -772,7 +772,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="771.863300" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="4335.234155" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="22" Alias="?column?">
@@ -783,7 +783,7 @@
               </dxl:ParamList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="128.667988" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3473.190806" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="21" Alias="?column?">
@@ -796,7 +796,7 @@
                         </dxl:ParamList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="110.650410" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="437.254813" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="20" Alias="?column?">
@@ -810,7 +810,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="109.634785" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="437.254805" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns/>
                             <dxl:ProjList>
@@ -821,7 +821,7 @@
                             <dxl:Filter/>
                             <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="108.617205" Rows="1.000889" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="437.254805" Rows="1.000889" Width="1"/>
                               </dxl:Properties>
                               <dxl:ProjList/>
                               <dxl:Filter>
@@ -833,7 +833,7 @@
                               <dxl:OneTimeFilter/>
                               <dxl:Materialize Eager="true">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="107.597656" Rows="9011.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.325567" Rows="9011.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="11" Alias="j">
@@ -843,7 +843,7 @@
                                 <dxl:Filter/>
                                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="36.199219" Rows="9011.000000" Width="4"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.289523" Rows="9011.000000" Width="4"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="11" Alias="j">
@@ -854,7 +854,7 @@
                                   <dxl:SortingColumnList/>
                                   <dxl:TableScan>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="17.599609" Rows="9011.000000" Width="4"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="4"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="11" Alias="j">
@@ -889,7 +889,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="">
@@ -907,7 +907,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="10.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="10.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="j">
@@ -918,7 +918,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="j">

--- a/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred-2.mdp
@@ -259,7 +259,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.234375" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001222" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -279,7 +279,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.218750" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001078" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -313,7 +313,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -340,7 +340,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred.mdp
@@ -337,7 +337,7 @@
     <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="196.066406" Rows="1.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000954" Rows="1.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="i">
@@ -362,7 +362,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="195.052734" Rows="1.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000828" Rows="1.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="i">
@@ -389,7 +389,7 @@
           <dxl:LimitOffset/>
           <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="194.052734" Rows="1.000000" Width="28"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000828" Rows="1.000000" Width="28"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="i">
@@ -422,49 +422,7 @@
             </dxl:JoinFilter>
             <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="2.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="i">
-                  <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="j">
-                  <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="10" Alias="i">
-                    <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="11" Alias="j">
-                    <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.49189.1.1" TableName="case2_tbl">
-                  <dxl:Columns>
-                    <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:BroadcastMotion>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000338" Rows="2.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="i">
@@ -475,18 +433,60 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.49165.1.1" TableName="case_tbl">
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="i">
+                    <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="f">
+                    <dxl:Ident ColId="2" ColName="f" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.49165.1.1" TableName="case_tbl">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="dummy" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="f" TypeMdid="0.701.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="i">
+                  <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="j">
+                  <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.49189.1.1" TableName="case2_tbl">
                 <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="dummy" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="f" TypeMdid="0.701.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/NotExists-SuperfluousEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NotExists-SuperfluousEquality.mdp
@@ -391,7 +391,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="14.890625" Rows="400.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.070466" Rows="400.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -405,7 +405,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="11.546875" Rows="400.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.048914" Rows="400.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/NullConstant-INDF-Col.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NullConstant-INDF-Col.mdp
@@ -268,7 +268,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.371094" Rows="30.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.003230" Rows="30.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -279,7 +279,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.312500" Rows="30.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002692" Rows="30.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -290,7 +290,7 @@
             <dxl:Not>
               <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:IsDistinctFrom>
             </dxl:Not>
           </dxl:Filter>
@@ -310,7 +310,7 @@
       </dxl:GatherMotion>
       <dxl:DirectDispatchInfo>
         <dxl:KeyValue>
-          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
         </dxl:KeyValue>
       </dxl:DirectDispatchInfo>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/NullIf-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NullIf-With-Subquery.mdp
@@ -425,7 +425,7 @@ FROM x
     <dxl:Plan Id="0" SpaceSize="55">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.191406" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.004152" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="nullif">
@@ -439,7 +439,7 @@ FROM x
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.152344" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.003793" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="nullif">
@@ -462,7 +462,7 @@ FROM x
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.074219" Rows="10.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.003753" Rows="10.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="ColRef_0021">
@@ -479,7 +479,7 @@ FROM x
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.917969" Rows="10.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.003673" Rows="10.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -502,7 +502,7 @@ FROM x
               </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -527,9 +527,9 @@ FROM x
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.214844" Rows="10.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000459" Rows="10.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="9"/>
@@ -543,9 +543,9 @@ FROM x
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableScan>
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000405" Rows="10.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="i">
@@ -553,19 +553,35 @@ FROM x
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.32802.1.1" TableName="y">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="i">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.32802.1.1" TableName="y">
+                      <dxl:Columns>
+                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:Sort>
               </dxl:Aggregate>
             </dxl:HashJoin>
           </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/OR.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OR.mdp
@@ -1020,7 +1020,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="16123.176758" Rows="2.000000" Width="165"/>
+          <dxl:Cost StartupCost="0" TotalCost="444.968210" Rows="2.000000" Width="165"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -1055,7 +1055,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="16122.015625" Rows="2.000000" Width="165"/>
+            <dxl:Cost StartupCost="0" TotalCost="444.966728" Rows="2.000000" Width="165"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">

--- a/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
@@ -730,10 +730,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2388">
+    <dxl:Plan Id="0" SpaceSize="3513">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="209596.144137" Rows="400.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="14873.784860" Rows="400.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -745,9 +745,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:TableScan>
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="209592.800387" Rows="400.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="14873.763308" Rows="400.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -762,27 +762,153 @@
               <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:FuncExpr>
-              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList>
-                  <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ParamList>
-                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:Ident ColId="28" ColName="sum" TypeMdid="0.20.1.0"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="14873.730408" Rows="1000.000000" Width="20"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="0"/>
+              <dxl:GroupingColumn ColId="1"/>
+              <dxl:GroupingColumn ColId="2"/>
+              <dxl:GroupingColumn ColId="8"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="28" Alias="sum">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="bi">
+                <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="ctid">
+                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="14868.524803" Rows="399999.600000" Width="26"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="bi">
+                  <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="ctid">
+                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="i">
+                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:JoinFilter>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.591206" Rows="1000.000000" Width="22"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="i">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="bi">
+                    <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="ctid">
+                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="113585.941012" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.011550" Rows="1000.000000" Width="22"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="28" Alias="sum">
-                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="0" Alias="i">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="bi">
+                      <dxl:Ident ColId="1" ColName="bi" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="ctid">
+                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.40971.1.1" TableName="x">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="bi" TypeMdid="0.20.1.0"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Sort>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="2077.718575" Rows="800.800000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="i">
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="2077.716974" Rows="800.800000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="113581.800391" Rows="799.999200" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2077.675052" Rows="400.400000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="i">
@@ -790,166 +916,172 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                        <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:FuncExpr>
+                        <dxl:Ident ColId="27" ColName="sum" TypeMdid="0.20.1.0"/>
                       </dxl:Comparison>
                     </dxl:Filter>
                     <dxl:OneTimeFilter/>
-                    <dxl:Materialize Eager="false">
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="110455.803516" Rows="800.800000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2077.642119" Rows="1001.000000" Width="12"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="9"/>
+                        <dxl:GroupingColumn ColId="11"/>
+                        <dxl:GroupingColumn ColId="17"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="27" Alias="sum">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="9" Alias="i">
                           <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="ctid">
+                          <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                          <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="110451.675391" Rows="800.800000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1987.557759" Rows="10008999.000000" Width="18"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
                             <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="11" Alias="ctid">
+                            <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                            <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="18" Alias="i">
+                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:JoinFilter>
+                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:JoinFilter>
+                        <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="110449.111328" Rows="400.400000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.380860" Rows="1001.000000" Width="14"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="9" Alias="i">
                               <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="11" Alias="ctid">
+                              <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                              <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                              <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.011562" Rows="1001.000000" Width="14"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="9" Alias="i">
                                 <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:FuncExpr>
-                              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                                <dxl:TestExpr/>
-                                <dxl:ParamList>
-                                  <dxl:Param ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                </dxl:ParamList>
-                                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="78414.156250" Rows="2.000000" Width="8"/>
-                                  </dxl:Properties>
-                                  <dxl:GroupingColumns/>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="27" Alias="sum">
-                                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                                        <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                      </dxl:AggFunc>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:Result>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="78335.023438" Rows="19998.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="18" Alias="i">
-                                        <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                                        <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                      </dxl:Comparison>
-                                    </dxl:Filter>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:Materialize Eager="false">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="138.718750" Rows="20000.000000" Width="4"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="18" Alias="i">
-                                          <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                                        <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="59.593750" Rows="20000.000000" Width="4"/>
-                                        </dxl:Properties>
-                                        <dxl:ProjList>
-                                          <dxl:ProjElem ColId="18" Alias="i">
-                                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                        </dxl:ProjList>
-                                        <dxl:Filter/>
-                                        <dxl:SortingColumnList/>
-                                        <dxl:TableScan>
-                                          <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="19.531250" Rows="10000.000000" Width="4"/>
-                                          </dxl:Properties>
-                                          <dxl:ProjList>
-                                            <dxl:ProjElem ColId="18" Alias="i">
-                                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                            </dxl:ProjElem>
-                                          </dxl:ProjList>
-                                          <dxl:Filter/>
-                                          <dxl:TableDescriptor Mdid="0.761868.1.1" TableName="z">
-                                            <dxl:Columns>
-                                              <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                              <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                              <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                              <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                              <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                              <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                              <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                              <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                            </dxl:Columns>
-                                          </dxl:TableDescriptor>
-                                        </dxl:TableScan>
-                                      </dxl:BroadcastMotion>
-                                    </dxl:Materialize>
-                                  </dxl:Result>
-                                </dxl:Aggregate>
-                              </dxl:SubPlan>
-                            </dxl:Comparison>
-                          </dxl:Filter>
-                          <dxl:TableDescriptor Mdid="0.40994.1.1" TableName="y">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:BroadcastMotion>
-                    </dxl:Materialize>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="11" Alias="ctid">
+                                <dxl:Ident ColId="11" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                                <dxl:Ident ColId="17" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.40994.1.1" TableName="y">
+                              <dxl:Columns>
+                                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:Sort>
+                        <dxl:Materialize Eager="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="432.228700" Rows="20000.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="18" Alias="i">
+                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="432.188700" Rows="20000.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="18" Alias="i">
+                                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="18" Alias="i">
+                                  <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.761868.1.1" TableName="z">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:BroadcastMotion>
+                        </dxl:Materialize>
+                      </dxl:NestedLoopJoin>
+                    </dxl:Aggregate>
                   </dxl:Result>
-                </dxl:Aggregate>
-              </dxl:SubPlan>
-            </dxl:Comparison>
-          </dxl:Filter>
-          <dxl:TableDescriptor Mdid="0.40971.1.1" TableName="x">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="1" Attno="2" ColName="bi" TypeMdid="0.20.1.0"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:TableScan>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Aggregate>
+        </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/OptimizerConfigWithSegmentsForCosting.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OptimizerConfigWithSegmentsForCosting.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="100"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="100"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
@@ -372,7 +372,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.156250" Rows="1000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.018324" Rows="1000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -386,7 +386,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.078125" Rows="1000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000209" Rows="1000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/OrderByOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderByOuterRef.mdp
@@ -306,7 +306,7 @@
     <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="33.136719" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000372" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@
             </dxl:ParamList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="7.113281" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000169" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="ColRef_0023">
@@ -335,7 +335,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="7.113281" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000169" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -351,7 +351,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.111328" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -365,12 +365,12 @@
                             <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                             <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                           <dxl:If TypeMdid="0.16.1.0">
                             <dxl:IsNull>
                               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                 <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
@@ -388,7 +388,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="5.109375" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000135" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -406,7 +406,7 @@
                     <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="4.062500" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000132" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="ColRef_0018">
@@ -433,7 +433,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:Limit>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000124" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
@@ -442,7 +442,7 @@
                         </dxl:ProjList>
                         <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000116" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="9" Alias="i">
@@ -452,7 +452,7 @@
                           <dxl:Filter/>
                           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="i">
@@ -463,7 +463,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:TableScan>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="9" Alias="i">
@@ -505,7 +505,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -519,7 +519,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/OuterJoin-With-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OuterJoin-With-OuterRefs.mdp
@@ -551,7 +551,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3910416.085938" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="432737.770661" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="?column?">
@@ -562,7 +562,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3910413.132812" Rows="1000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="432737.752701" Rows="1000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="?column?">
@@ -573,7 +573,7 @@
                 </dxl:ParamList>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3200005.273438" Rows="88.800000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431875.675753" Rows="88.800000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="i">
@@ -592,7 +592,7 @@
                   </dxl:JoinFilter>
                   <dxl:Materialize Eager="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.136719" Rows="20.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001229" Rows="20.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="i">
@@ -602,7 +602,7 @@
                     <dxl:Filter/>
                     <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.058594" Rows="20.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001189" Rows="20.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="i">
@@ -613,7 +613,7 @@
                       <dxl:SortingColumnList/>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
@@ -638,7 +638,7 @@
                   </dxl:Materialize>
                   <dxl:Materialize Eager="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.136719" Rows="20.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001229" Rows="20.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="i">
@@ -648,7 +648,7 @@
                     <dxl:Filter/>
                     <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.058594" Rows="20.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001189" Rows="20.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="i">
@@ -659,7 +659,7 @@
                       <dxl:SortingColumnList/>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="18" Alias="i">
@@ -690,7 +690,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3910408.226562" Rows="1000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="432737.750701" Rows="1000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
@@ -3306,7 +3306,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.106825" Rows="1201.003300" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.057038" Rows="1201.003300" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -3329,7 +3329,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.035213" Rows="1201.003300" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="430.960341" Rows="1201.003300" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -3397,9 +3397,9 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
               </dxl:And>
             </dxl:PrintableFilter>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicBitmapTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.035213" Rows="1201.003300" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="430.960341" Rows="1201.003300" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -3418,7 +3418,8 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
                 <dxl:Ident ColId="4" ColName="region" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
+            <dxl:Filter/>
+            <dxl:RecheckCond>
               <dxl:And>
                 <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                   <dxl:Ident ColId="2" ColName="month" TypeMdid="0.23.1.0"/>
@@ -3429,7 +3430,20 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                 </dxl:Comparison>
               </dxl:And>
-            </dxl:Filter>
+            </dxl:RecheckCond>
+            <dxl:BitmapIndexProbe>
+              <dxl:IndexCondList>
+                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                  <dxl:Ident ColId="2" ColName="month" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                  <dxl:Ident ColId="2" ColName="month" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                </dxl:Comparison>
+              </dxl:IndexCondList>
+              <dxl:IndexDescriptor Mdid="0.3749921.1.0" IndexName="date_parts_ind_1_prt_outlying_years_2_prt_q1_3_prt_other_days"/>
+            </dxl:BitmapIndexProbe>
             <dxl:TableDescriptor Mdid="0.3748460.1.0" TableName="date_parts">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
@@ -3446,7 +3460,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
                 <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
-          </dxl:DynamicTableScan>
+          </dxl:DynamicBitmapTableScan>
         </dxl:Sequence>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
@@ -2243,7 +2243,7 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="204.393208" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="397.983325" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -2266,7 +2266,7 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="204.392403" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="397.982520" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -2354,7 +2354,7 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
           </dxl:PartitionSelector>
           <dxl:DynamicBitmapTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="204.392403" Rows="10.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="397.982520" Rows="10.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
@@ -257,7 +257,7 @@ WHERE b in (1,2);
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.070312" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000159" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -277,7 +277,7 @@ WHERE b in (1,2);
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -385,7 +385,7 @@ WHERE b in (1,2);
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AsymmetricRangePredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AsymmetricRangePredicate.mdp
@@ -261,7 +261,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -275,7 +275,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -317,7 +317,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-NonPartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-NonPartKey.mdp
@@ -316,7 +316,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="233.123047" Rows="1.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000693" Rows="1.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="numcol">
@@ -336,7 +336,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="232.109375" Rows="1.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000567" Rows="1.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="numcol">
@@ -363,7 +363,7 @@
                 </dxl:ParamList>
                 <dxl:Limit>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.068359" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000325" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="?column?">
@@ -372,7 +372,7 @@
                   </dxl:ProjList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="5.052734" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000317" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="22" Alias="?column?">
@@ -386,7 +386,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="4.037109" Rows="2.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="2.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter>
@@ -398,7 +398,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:Materialize Eager="true">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="3.035156" Rows="2.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000244" Rows="2.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="11" Alias="numcol">
@@ -408,7 +408,7 @@
                         <dxl:Filter/>
                         <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.019531" Rows="2.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000236" Rows="2.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="11" Alias="numcol">
@@ -419,7 +419,7 @@
                           <dxl:SortingColumnList/>
                           <dxl:Sequence>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="11" Alias="numcol">
@@ -449,7 +449,7 @@
                             </dxl:PartitionSelector>
                             <dxl:DynamicTableScan PartIndexId="2">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="11" Alias="numcol">
@@ -490,7 +490,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.013672" Rows="1.000000" Width="28"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="28"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="numcol">
@@ -529,7 +529,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.013672" Rows="1.000000" Width="28"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="28"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="numcol">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-PartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-PartKey.mdp
@@ -316,7 +316,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="521.126953" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000747" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="numcol">
@@ -343,7 +343,7 @@
               </dxl:ParamList>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.064453" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000152" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="?column?">
@@ -352,7 +352,7 @@
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.048828" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000144" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="?column?">
@@ -366,7 +366,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4.033203" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter>
@@ -378,7 +378,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Materialize Eager="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.031250" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="13" Alias="ptcol">
@@ -388,7 +388,7 @@
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000062" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="13" Alias="ptcol">
@@ -399,7 +399,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:Sequence>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="13" Alias="ptcol">
@@ -457,7 +457,7 @@
                           </dxl:PartitionSelector>
                           <dxl:DynamicTableScan PartIndexId="2">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="13" Alias="ptcol">
@@ -497,7 +497,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.062500" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000204" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="numcol">
@@ -517,7 +517,7 @@
           <dxl:SortingColumnList/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="numcol">
@@ -556,7 +556,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="numcol">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -485,7 +485,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.058594" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -502,7 +502,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -565,7 +565,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-NoDefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-NoDefaultPart.mdp
@@ -234,7 +234,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -248,7 +248,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -314,7 +314,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -533,10 +533,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1109">
+    <dxl:Plan Id="0" SpaceSize="1155">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8.859375" Rows="100.000000" Width="14"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.020930" Rows="100.000000" Width="14"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist">
@@ -559,7 +559,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.175781" Rows="100.000000" Width="14"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.014644" Rows="100.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist">
@@ -588,7 +588,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.683594" Rows="100.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001210" Rows="100.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="dist">
@@ -654,7 +654,7 @@
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.031250" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000276" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="tid">
@@ -665,7 +665,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.023438" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="13" Alias="tid">
@@ -676,7 +676,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.023438" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="23" Alias="?column?">
@@ -690,7 +690,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="13" Alias="tid">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
@@ -490,7 +490,7 @@
     <dxl:Plan Id="0" SpaceSize="68">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="11.828125" Rows="100.000000" Width="46"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.043086" Rows="100.000000" Width="46"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist">
@@ -525,7 +525,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.582031" Rows="100.000000" Width="46"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.022432" Rows="100.000000" Width="46"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist">
@@ -566,7 +566,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.683594" Rows="100.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001210" Rows="100.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="dist">
@@ -641,7 +641,7 @@
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.156250" Rows="2.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001895" Rows="2.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="dist">
@@ -661,7 +661,7 @@
               <dxl:SortingColumnList/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.093750" Rows="1.000000" Width="32"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000220" Rows="1.000000" Width="32"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="dist">
@@ -679,7 +679,7 @@
                 </dxl:ProjList>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="32"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000188" Rows="1.000000" Width="32"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="12" Alias="dist">
@@ -701,7 +701,7 @@
                   </dxl:SortingColumnList>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="32"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="32"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="12" Alias="dist">
@@ -725,7 +725,7 @@
                     <dxl:LimitOffset/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="32"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="32"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="12" Alias="dist">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
@@ -686,7 +686,7 @@
     <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="10323.538987" Rows="10000.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="880.893213" Rows="10000.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -706,7 +706,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="10224.882737" Rows="10000.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="879.995213" Rows="10000.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">
@@ -732,7 +732,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="39.062500" Rows="10000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -792,7 +792,7 @@
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="8230.695237" Rows="20000.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="442.780953" Rows="20000.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -809,7 +809,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="7917.195237" Rows="10000.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="434.404953" Rows="10000.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -826,7 +826,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Window PartitionColumns="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="7917.195237" Rows="10000.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="434.404953" Rows="10000.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="count">
@@ -842,7 +842,7 @@
                   <dxl:Filter/>
                   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7759.945237" Rows="10000.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="434.324953" Rows="10000.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -858,7 +858,7 @@
                     </dxl:SortingColumnList>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="7719.882737" Rows="10000.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="433.965753" Rows="10000.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">
@@ -876,7 +876,7 @@
                       <dxl:LimitOffset/>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="39.062500" Rows="10000.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE.mdp
@@ -310,7 +310,7 @@
     <dxl:Plan Id="7" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1924.220703" Rows="8.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.002909" Rows="8.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -339,7 +339,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1923.095703" Rows="8.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001759" Rows="8.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -373,7 +373,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="2.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000565" Rows="2.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -393,7 +393,7 @@
             <dxl:SortingColumnList/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.009766" Rows="1.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -432,7 +432,7 @@
               </dxl:PartitionSelector>
               <dxl:DynamicTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.009766" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -469,7 +469,7 @@
           </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.046875" Rows="8.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DateTime.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DateTime.mdp
@@ -350,7 +350,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.306641" Rows="1.000000" Width="157"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000980" Rows="1.000000" Width="157"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -406,7 +406,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.076660" Rows="1.000000" Width="157"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="157"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -481,7 +481,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.076660" Rows="1.000000" Width="157"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="157"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="l_orderkey">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelection.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelection.mdp
@@ -220,7 +220,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -234,7 +234,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -267,7 +267,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
@@ -596,7 +596,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="23.693359" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.112395" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -616,7 +616,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="22.683594" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.112305" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -642,7 +642,7 @@
           </dxl:HashCondList>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.906250" Rows="1000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -675,7 +675,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.906250" Rows="1000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -703,7 +703,7 @@
           </dxl:Sequence>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.035156" Rows="2.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000671" Rows="2.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -717,7 +717,7 @@
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Disjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Disjunction.mdp
@@ -260,7 +260,7 @@ WHERE b = 1 or b = 2;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.070312" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000159" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -280,7 +280,7 @@ WHERE b = 1 or b = 2;
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -388,7 +388,7 @@ WHERE b = 1 or b = 2;
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
@@ -217,9 +217,9 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="17">
-      <dxl:HashJoin JoinType="Inner">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.226562" Rows="1.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000851" Rows="1.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -236,18 +236,18 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000725" Rows="1.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="a">
               <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
@@ -256,10 +256,16 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:Sequence>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -269,30 +275,16 @@
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartitionSelector RelationMdid="0.1017416.1.1" PartitionLevels="1" ScanId="2">
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartEqFilters>
-              <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartFilters>
-              <dxl:ResidualFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:ResidualFilter>
-              <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-              </dxl:PropagationExpression>
-              <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PrintableFilter>
-            </dxl:PartitionSelector>
-            <dxl:DynamicTableScan PartIndexId="2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -302,40 +294,59 @@
                   <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1017416.1.1" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:DynamicTableScan>
-          </dxl:Sequence>
-        </dxl:GatherMotion>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.046875" Rows="1.000000" Width="12"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
+              <dxl:PartitionSelector RelationMdid="0.1017416.1.1" PartitionLevels="1" ScanId="2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:PartEqFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PartEqFilters>
+                <dxl:PartFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PartFilters>
+                <dxl:ResidualFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ResidualFilter>
+                <dxl:PropagationExpression>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                </dxl:PropagationExpression>
+                <dxl:PrintableFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PrintableFilter>
+              </dxl:PartitionSelector>
+              <dxl:DynamicTableScan PartIndexId="2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="a">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="b">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.1017416.1.1" TableName="s">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:DynamicTableScan>
+            </dxl:Sequence>
+          </dxl:RedistributeMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -368,7 +379,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -394,8 +405,8 @@
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:Sequence>
-        </dxl:GatherMotion>
-      </dxl:HashJoin>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
@@ -273,7 +273,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.148438" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000643" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -287,7 +287,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.140625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000571" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -307,7 +307,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -357,7 +357,7 @@
             </dxl:PrintableFilter>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="a">
@@ -387,7 +387,7 @@
               </dxl:PartitionSelector>
               <dxl:DynamicTableScan PartIndexId="2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
@@ -294,7 +294,7 @@ select * from s,t where s.b=t.a and t.b=35;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.335938" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001717" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -314,7 +314,7 @@ select * from s,t where s.b=t.a and t.b=35;
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.320312" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001573" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -340,7 +340,7 @@ select * from s,t where s.b=t.a and t.b=35;
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -397,7 +397,7 @@ select * from s,t where s.b=t.a and t.b=35;
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.109375" Rows="2.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000921" Rows="2.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -411,7 +411,7 @@ select * from s,t where s.b=t.a and t.b=35;
               <dxl:SortingColumnList/>
               <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">
@@ -447,7 +447,7 @@ select * from s,t where s.b=t.a and t.b=35;
                 </dxl:PartitionSelector>
                 <dxl:DynamicTableScan PartIndexId="2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1232,7 +1232,7 @@
     <dxl:Plan Id="0" SpaceSize="33">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="10.193655" Rows="101.010101" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.027662" Rows="101.010101" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1255,7 +1255,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.009943" Rows="101.010101" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.016777" Rows="101.010101" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1284,7 +1284,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.591856" Rows="101.010101" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001167" Rows="101.010101" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1345,7 +1345,7 @@
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.093750" Rows="2.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000710" Rows="2.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
@@ -1359,7 +1359,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.070312" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">
@@ -1371,9 +1371,9 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3.070312" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="10"/>
@@ -1389,9 +1389,9 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Sequence>
+                  <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -1401,33 +1401,15 @@
                         <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:PartitionSelector RelationMdid="0.325915.1.1" PartitionLevels="1" ScanId="2">
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:Sequence>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:PartEqFilters>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                      </dxl:PartEqFilters>
-                      <dxl:PartFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartFilters>
-                      <dxl:ResidualFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ResidualFilter>
-                      <dxl:PropagationExpression>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                      </dxl:PropagationExpression>
-                      <dxl:PrintableFilter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                        </dxl:Comparison>
-                      </dxl:PrintableFilter>
-                    </dxl:PartitionSelector>
-                    <dxl:DynamicTableScan PartIndexId="2">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="a">
@@ -1437,27 +1419,64 @@
                           <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
+                      <dxl:PartitionSelector RelationMdid="0.325915.1.1" PartitionLevels="1" ScanId="2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:PartEqFilters>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:TableDescriptor Mdid="0.325915.1.1" TableName="p2">
-                        <dxl:Columns>
-                          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="12" Attno="3" ColName="pk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:DynamicTableScan>
-                  </dxl:Sequence>
+                        </dxl:PartEqFilters>
+                        <dxl:PartFilters>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:PartFilters>
+                        <dxl:ResidualFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ResidualFilter>
+                        <dxl:PropagationExpression>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                        </dxl:PropagationExpression>
+                        <dxl:PrintableFilter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          </dxl:Comparison>
+                        </dxl:PrintableFilter>
+                      </dxl:PartitionSelector>
+                      <dxl:DynamicTableScan PartIndexId="2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="10" Alias="a">
+                            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="pk">
+                            <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="12" ColName="pk" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          </dxl:Comparison>
+                        </dxl:Filter>
+                        <dxl:TableDescriptor Mdid="0.325915.1.1" TableName="p2">
+                          <dxl:Columns>
+                            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="12" Attno="3" ColName="pk" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:DynamicTableScan>
+                    </dxl:Sequence>
+                  </dxl:Sort>
                 </dxl:Aggregate>
               </dxl:Result>
             </dxl:BroadcastMotion>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
@@ -298,7 +298,7 @@
     <dxl:Plan Id="0" SpaceSize="62">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.390625" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001279" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -318,7 +318,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.375000" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001135" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -348,7 +348,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -403,9 +403,9 @@
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:PrintableFilter>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.140625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="9"/>
@@ -420,9 +420,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sequence>
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">
@@ -432,30 +432,16 @@
                     <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:PartitionSelector RelationMdid="0.325276.1.1" PartitionLevels="1" ScanId="2">
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:PartEqFilters>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PartEqFilters>
-                  <dxl:PartFilters>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PartFilters>
-                  <dxl:ResidualFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:ResidualFilter>
-                  <dxl:PropagationExpression>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:PropagationExpression>
-                  <dxl:PrintableFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PrintableFilter>
-                </dxl:PartitionSelector>
-                <dxl:DynamicTableScan PartIndexId="2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="a">
@@ -465,22 +451,56 @@
                       <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.325276.1.1" TableName="s">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:DynamicTableScan>
-              </dxl:Sequence>
+                  <dxl:PartitionSelector RelationMdid="0.325276.1.1" PartitionLevels="1" ScanId="2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:PartEqFilters>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PartEqFilters>
+                    <dxl:PartFilters>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PartFilters>
+                    <dxl:ResidualFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ResidualFilter>
+                    <dxl:PropagationExpression>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:PropagationExpression>
+                    <dxl:PrintableFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PrintableFilter>
+                  </dxl:PartitionSelector>
+                  <dxl:DynamicTableScan PartIndexId="2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="a">
+                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="b">
+                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.325276.1.1" TableName="s">
+                      <dxl:Columns>
+                        <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:DynamicTableScan>
+                </dxl:Sequence>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:PartitionSelector>
         </dxl:HashJoin>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
@@ -637,104 +637,110 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="11.285156" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.061573" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="count">
-            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+              <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
+            </dxl:AggFunc>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9.878906" Rows="200.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.061572" Rows="1.000000" Width="8"/>
           </dxl:Properties>
-          <dxl:ProjList/>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+              <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.781250" Rows="200.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.061536" Rows="1.000000" Width="8"/>
             </dxl:Properties>
-            <dxl:ProjList/>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:Sequence>
+            <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.976562" Rows="500.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.061536" Rows="200.000000" Width="1"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="2" Alias="k">
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:PartitionSelector RelationMdid="0.259515.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartEqFilters>
-                <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartFilters>
-                <dxl:ResidualFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ResidualFilter>
-                <dxl:PropagationExpression>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:PropagationExpression>
-                <dxl:PrintableFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PrintableFilter>
-              </dxl:PartitionSelector>
-              <dxl:DynamicTableScan PartIndexId="1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.976562" Rows="500.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.007975" Rows="500.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="k">
                     <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.259515.1.1" TableName="foo3_p">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:DynamicTableScan>
-            </dxl:Sequence>
-            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.117188" Rows="40.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="i">
-                  <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
+                <dxl:PartitionSelector RelationMdid="0.259515.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.007975" Rows="500.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="2" Alias="k">
+                      <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.259515.1.1" TableName="foo3_p">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="20.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.002476" Rows="40.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="i">
@@ -742,21 +748,33 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.259490.1.1" TableName="foo2">
-                  <dxl:Columns>
-                    <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:BroadcastMotion>
-          </dxl:HashJoin>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000308" Rows="20.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="i">
+                      <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.259490.1.1" TableName="foo2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+            </dxl:HashJoin>
+          </dxl:Aggregate>
         </dxl:GatherMotion>
       </dxl:Aggregate>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -1352,7 +1352,7 @@
     <dxl:Plan Id="0" SpaceSize="1137">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4005245.452411" Rows="12277684.984863" Width="246"/>
+          <dxl:Cost StartupCost="0" TotalCost="23519.811673" Rows="12277684.984863" Width="246"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -1513,7 +1513,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2530483.463018" Rows="12277684.984863" Width="246"/>
+            <dxl:Cost StartupCost="0" TotalCost="9958.617500" Rows="12277684.984863" Width="246"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -1680,7 +1680,7 @@
           </dxl:HashCondList>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="833299.908641" Rows="12277684.984863" Width="139"/>
+              <dxl:Cost StartupCost="0" TotalCost="1001.605410" Rows="12277684.984863" Width="139"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -1899,7 +1899,7 @@
             </dxl:PrintableFilter>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="30543.603625" Rows="60.823481" Width="107"/>
+                <dxl:Cost StartupCost="0" TotalCost="497.662223" Rows="60.823481" Width="107"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -1991,7 +1991,7 @@
               <dxl:SortingColumnList/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="30536.248047" Rows="30.411740" Width="107"/>
+                  <dxl:Cost StartupCost="0" TotalCost="497.491873" Rows="30.411740" Width="107"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2089,7 +2089,7 @@
                 </dxl:HashCondList>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="15268.099609" Rows="73049.000000" Width="107"/>
+                    <dxl:Cost StartupCost="0" TotalCost="480.024280" Rows="73049.000000" Width="107"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2181,7 +2181,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:Sequence>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3816.524902" Rows="73049.000000" Width="107"/>
+                      <dxl:Cost StartupCost="0" TotalCost="433.752121" Rows="73049.000000" Width="107"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2292,7 +2292,7 @@
                     </dxl:PartitionSelector>
                     <dxl:DynamicTableScan PartIndexId="2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3816.524902" Rows="73049.000000" Width="107"/>
+                        <dxl:Cost StartupCost="0" TotalCost="433.752121" Rows="73049.000000" Width="107"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2425,7 +2425,7 @@
                 </dxl:GatherMotion>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="66" Alias="bla">
@@ -2436,7 +2436,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="65" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -3255,10 +3255,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="47573">
+    <dxl:Plan Id="0" SpaceSize="47588">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1140973220.554819" Rows="371185706.953630" Width="355"/>
+          <dxl:Cost StartupCost="0" TotalCost="1784762.484108" Rows="371185706.953630" Width="355"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3484,109 +3484,13 @@
         </dxl:JoinFilter>
         <dxl:HashCondList>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
             <dxl:Ident ColId="15" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
           </dxl:Comparison>
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="366902.000000" Rows="11740800.000000" Width="16"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="41" Alias="inv_date_sk">
-              <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="42" Alias="inv_item_sk">
-              <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
-              <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
-              <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:Sequence>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="91725.000000" Rows="11740800.000000" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="41" Alias="inv_date_sk">
-                <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="42" Alias="inv_item_sk">
-                <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
-                <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
-                <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:PartitionSelector RelationMdid="0.810176.1.1" PartitionLevels="1" ScanId="2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartEqFilters>
-              <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartFilters>
-              <dxl:ResidualFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:ResidualFilter>
-              <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-              </dxl:PropagationExpression>
-              <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PrintableFilter>
-            </dxl:PartitionSelector>
-            <dxl:DynamicTableScan PartIndexId="2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="91725.000000" Rows="11740800.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="41" Alias="inv_date_sk">
-                  <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="inv_item_sk">
-                  <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
-                  <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
-                  <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.810176.1.1" TableName="inventory">
-                <dxl:Columns>
-                  <dxl:Column ColId="41" Attno="1" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="42" Attno="2" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="43" Attno="3" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="44" Attno="4" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:DynamicTableScan>
-          </dxl:Sequence>
-        </dxl:GatherMotion>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1138451773.032026" Rows="539984.658212" Width="339"/>
+            <dxl:Cost StartupCost="0" TotalCost="1313165.628414" Rows="539984.658212" Width="339"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3795,7 +3699,7 @@
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1138362389.805886" Rows="539984.658212" Width="339"/>
+              <dxl:Cost StartupCost="0" TotalCost="1312343.712366" Rows="539984.658212" Width="339"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -4008,9 +3912,9 @@
                 <dxl:Ident ColId="64" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1138239261.044233" Rows="539984.658212" Width="232"/>
+                <dxl:Cost StartupCost="0" TotalCost="1311504.590863" Rows="539984.658212" Width="232"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -4132,16 +4036,83 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
+              <dxl:JoinFilter>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="5" ColName="cs_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
-              </dxl:HashCondList>
+              </dxl:JoinFilter>
+              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.240955" Rows="2.000000" Width="32"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
+                    <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
+                    <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
+                    <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="55" Alias="hd_dep_count">
+                    <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
+                    <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.239280" Rows="1.000000" Width="32"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
+                      <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
+                      <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
+                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="55" Alias="hd_dep_count">
+                      <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
+                      <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACj4xMDAwMA==" LintValue="266732324"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.810130.1.1" TableName="household_demographics">
+                    <dxl:Columns>
+                      <dxl:Column ColId="52" Attno="1" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="53" Attno="2" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="54" Attno="3" ColName="hd_buy_potential" TypeMdid="0.1042.1.0" ColWidth="15"/>
+                      <dxl:Column ColId="55" Attno="4" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="56" Attno="5" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
               <dxl:DynamicTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="379413048.368911" Rows="3885189615.297647" Width="200"/>
+                  <dxl:Cost StartupCost="0" TotalCost="246169.243168" Rows="3885189615.297647" Width="200"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -4294,75 +4265,7 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:DynamicTableScan>
-              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="114.625000" Rows="2.000000" Width="32"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
-                    <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
-                    <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
-                    <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="55" Alias="hd_dep_count">
-                    <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
-                    <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="113.562500" Rows="1.000000" Width="32"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
-                      <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
-                      <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
-                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="55" Alias="hd_dep_count">
-                      <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
-                      <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACj4xMDAwMA==" LintValue="266732324"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.810130.1.1" TableName="household_demographics">
-                    <dxl:Columns>
-                      <dxl:Column ColId="52" Attno="1" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="53" Attno="2" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="54" Attno="3" ColName="hd_buy_potential" TypeMdid="0.1042.1.0" ColWidth="15"/>
-                      <dxl:Column ColId="55" Attno="4" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="56" Attno="5" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
-            </dxl:HashJoin>
+            </dxl:NestedLoopJoin>
             <dxl:PartitionSelector RelationMdid="0.802597.1.1" PartitionLevels="1" ScanId="1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
@@ -4473,7 +4376,7 @@
               </dxl:PrintableFilter>
               <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="179.916538" Rows="967.490176" Width="107"/>
+                  <dxl:Cost StartupCost="0" TotalCost="432.429157" Rows="967.490176" Width="107"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -4565,7 +4468,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="128.368956" Rows="483.745088" Width="107"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.074320" Rows="483.745088" Width="107"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -4679,7 +4582,7 @@
                   </dxl:PartitionSelector>
                   <dxl:DynamicTableScan PartIndexId="3">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="128.368956" Rows="483.745088" Width="107"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.074320" Rows="483.745088" Width="107"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -4817,6 +4720,102 @@
               </dxl:BroadcastMotion>
             </dxl:PartitionSelector>
           </dxl:HashJoin>
+        </dxl:GatherMotion>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1691.609696" Rows="11740800.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="41" Alias="inv_date_sk">
+              <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="42" Alias="inv_item_sk">
+              <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
+              <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
+              <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="579.521120" Rows="11740800.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="41" Alias="inv_date_sk">
+                <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="inv_item_sk">
+                <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
+                <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
+                <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.810176.1.1" PartitionLevels="1" ScanId="2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicTableScan PartIndexId="2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="579.521120" Rows="11740800.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="41" Alias="inv_date_sk">
+                  <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="inv_item_sk">
+                  <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
+                  <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
+                  <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.810176.1.1" TableName="inventory">
+                <dxl:Columns>
+                  <dxl:Column ColId="41" Attno="1" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="42" Attno="2" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="43" Attno="3" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="44" Attno="4" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:Sequence>
         </dxl:GatherMotion>
       </dxl:HashJoin>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -483,7 +483,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.058594" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -500,7 +500,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -559,7 +559,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.048828" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NonConstSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NonConstSelect.mdp
@@ -338,64 +338,34 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.030273" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="?column?">
-            <dxl:Ident ColId="23" ColName="?column?" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.028320" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="1.000000" Width="1"/>
           </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="23" Alias="?column?">
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
+          <dxl:ProjList/>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Sequence>
+          <dxl:SortingColumnList/>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.024414" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="1"/>
             </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="10" Alias="l_shipdate">
-                <dxl:Ident ColId="10" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="l_commitdate">
-                <dxl:Ident ColId="11" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:PartitionSelector RelationMdid="0.29434.1.1" PartitionLevels="1" ScanId="1">
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartEqFilters>
-              <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartFilters>
-              <dxl:ResidualFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:ResidualFilter>
-              <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-              </dxl:PropagationExpression>
-              <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PrintableFilter>
-            </dxl:PartitionSelector>
-            <dxl:DynamicTableScan PartIndexId="1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.024414" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="l_shipdate">
@@ -405,30 +375,64 @@
                   <dxl:Ident ColId="11" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
-                  <dxl:Ident ColId="10" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:Ident ColId="11" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.29434.1.1" TableName="lineitem">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="10" Attno="11" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:Column ColId="11" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:DynamicTableScan>
-          </dxl:Sequence>
-        </dxl:Result>
-      </dxl:GatherMotion>
+              <dxl:PartitionSelector RelationMdid="0.29434.1.1" PartitionLevels="1" ScanId="1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:PartEqFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PartEqFilters>
+                <dxl:PartFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PartFilters>
+                <dxl:ResidualFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ResidualFilter>
+                <dxl:PropagationExpression>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:PropagationExpression>
+                <dxl:PrintableFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PrintableFilter>
+              </dxl:PartitionSelector>
+              <dxl:DynamicTableScan PartIndexId="1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="l_shipdate">
+                    <dxl:Ident ColId="10" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="l_commitdate">
+                    <dxl:Ident ColId="11" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
+                    <dxl:Ident ColId="10" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
+                    <dxl:Ident ColId="11" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.29434.1.1" TableName="lineitem">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="11" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
+                    <dxl:Column ColId="11" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                    <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:DynamicTableScan>
+            </dxl:Sequence>
+          </dxl:Result>
+        </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
@@ -258,7 +258,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.070312" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="month_id">
@@ -275,7 +275,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="month_id">
@@ -316,7 +316,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="month_id">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Range.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Range.mdp
@@ -299,7 +299,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.070312" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="month_id">
@@ -316,7 +316,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="month_id">
@@ -384,7 +384,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="month_id">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQAll.mdp
@@ -347,7 +347,7 @@
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="43.191406" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000518" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -365,7 +365,7 @@
             </dxl:ParamList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="8.128906" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000237" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="ColRef_0023">
@@ -376,7 +376,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="8.128906" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000237" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -392,7 +392,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="7.126953" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000204" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -406,12 +406,12 @@
                             <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                             <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                           <dxl:If TypeMdid="0.16.1.0">
                             <dxl:IsNull>
                               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                 <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
@@ -429,7 +429,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6.125000" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000203" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -447,7 +447,7 @@
                     <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5.078125" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000200" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="ColRef_0018">
@@ -474,7 +474,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="4.062500" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000192" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
@@ -490,7 +490,7 @@
                         <dxl:OneTimeFilter/>
                         <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000126" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="9" Alias="i">
@@ -500,7 +500,7 @@
                           <dxl:Filter/>
                           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="i">
@@ -511,7 +511,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:Sequence>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="9" Alias="i">
@@ -541,7 +541,7 @@
                               </dxl:PartitionSelector>
                               <dxl:DynamicTableScan PartIndexId="2">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="9" Alias="i">
@@ -577,7 +577,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.062500" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000213" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -591,7 +591,7 @@
           <dxl:SortingColumnList/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -624,7 +624,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQAny.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQAny.mdp
@@ -4,6 +4,14 @@
     <dxl:Stacktrace/>
     <dxl:TraceFlags Value="103027,101000,101001,103001"/>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.1095.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.1082.1.0"/>
+        <dxl:RightType Mdid="0.1082.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1087.1.0"/>
+        <dxl:Commutator Mdid="0.1097.1.0"/>
+        <dxl:InverseOp Mdid="0.1098.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:EqualityOp Mdid="0.410.1.0"/>
         <dxl:InequalityOp Mdid="0.411.1.0"/>
@@ -346,7 +354,7 @@
     <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.382812" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001046" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -360,7 +368,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.375000" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000974" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -385,7 +393,7 @@
           </dxl:HashCondList>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -418,7 +426,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -444,9 +452,9 @@
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:Sequence>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.140625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="9"/>
@@ -464,9 +472,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Sequence>
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -476,30 +484,16 @@
                   <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:PartitionSelector RelationMdid="0.24756.1.1" PartitionLevels="1" ScanId="2">
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="10" SortOperatorMdid="0.1095.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartEqFilters>
-                <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartFilters>
-                <dxl:ResidualFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ResidualFilter>
-                <dxl:PropagationExpression>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                </dxl:PropagationExpression>
-                <dxl:PrintableFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PrintableFilter>
-              </dxl:PartitionSelector>
-              <dxl:DynamicTableScan PartIndexId="2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="i">
@@ -509,22 +503,56 @@
                     <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.24756.1.1" TableName="smallt2_part">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:DynamicTableScan>
-            </dxl:Sequence>
+                <dxl:PartitionSelector RelationMdid="0.24756.1.1" PartitionLevels="1" ScanId="2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="d">
+                      <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.24756.1.1" TableName="smallt2_part">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Sort>
           </dxl:Aggregate>
         </dxl:HashJoin>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
@@ -312,7 +312,7 @@
     <dxl:Plan Id="0" SpaceSize="90">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.187500" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000680" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -326,7 +326,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.179688" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000608" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -346,7 +346,7 @@
           </dxl:HashCondList>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -379,7 +379,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -407,7 +407,7 @@
           </dxl:Sequence>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -437,7 +437,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
@@ -306,7 +306,7 @@
     <dxl:Plan Id="0" SpaceSize="33">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.187500" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000680" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -320,7 +320,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="LeftAntiSemiJoin">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.179688" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000608" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -340,7 +340,7 @@
           </dxl:HashCondList>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -373,7 +373,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -401,7 +401,7 @@
           </dxl:Sequence>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">
@@ -431,7 +431,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
@@ -317,7 +317,7 @@
     <dxl:Plan Id="0" SpaceSize="71">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.281250" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000922" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -331,7 +331,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.273438" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000850" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -355,7 +355,7 @@
           </dxl:HashCondList>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -388,7 +388,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -414,9 +414,9 @@
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:Sequence>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="9"/>
@@ -432,61 +432,77 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Sequence>
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
                   <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:PartitionSelector RelationMdid="0.24756.1.1" PartitionLevels="1" ScanId="2">
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartEqFilters>
-                <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartFilters>
-                <dxl:ResidualFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ResidualFilter>
-                <dxl:PropagationExpression>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                </dxl:PropagationExpression>
-                <dxl:PrintableFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PrintableFilter>
-              </dxl:PartitionSelector>
-              <dxl:DynamicTableScan PartIndexId="2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="i">
                     <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.24756.1.1" TableName="smallt2_part">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:DynamicTableScan>
-            </dxl:Sequence>
+                <dxl:PartitionSelector RelationMdid="0.24756.1.1" PartitionLevels="1" ScanId="2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.24756.1.1" TableName="smallt2_part">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Sort>
           </dxl:Aggregate>
         </dxl:HashJoin>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-VolatileFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-VolatileFunc.mdp
@@ -227,7 +227,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -241,7 +241,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -274,7 +274,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -686,7 +686,7 @@
     <dxl:Plan Id="0" SpaceSize="9">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="116561.907440" Rows="10000.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="953.336726" Rows="10000.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -712,7 +712,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="79.125000" Rows="10000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.538100" Rows="10000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="a">
@@ -726,7 +726,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="39.062500" Rows="10000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -754,7 +754,7 @@
         </dxl:GatherMotion>
         <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="100699.126190" Rows="100009.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="472.987738" Rows="100009.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="count">
@@ -770,7 +770,7 @@
           <dxl:Filter/>
           <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="99135.485565" Rows="100009.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="472.187666" Rows="100009.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -786,7 +786,7 @@
             </dxl:SortingColumnList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="98743.825409" Rows="100009.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="468.595342" Rows="100009.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -804,7 +804,7 @@
               <dxl:LimitOffset/>
               <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="390.660156" Rows="100009.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -837,7 +837,7 @@
                 </dxl:PartitionSelector>
                 <dxl:DynamicTableScan PartIndexId="1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="390.660156" Rows="100009.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PredStatsNotComparable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredStatsNotComparable.mdp
@@ -314,7 +314,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.519531" Rows="400.000000" Width="7"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.041801" Rows="400.000000" Width="7"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -325,7 +325,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.152344" Rows="400.000000" Width="7"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.029229" Rows="400.000000" Width="7"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc1.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.171875" Rows="1.000000" Width="40"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000261" Rows="1.000000" Width="40"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -288,7 +288,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.093750" Rows="1.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000229" Rows="1.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="rank">
@@ -313,7 +313,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.031250" Rows="1.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="sum">
@@ -340,7 +340,7 @@
             <dxl:LimitOffset/>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="sum">
@@ -364,7 +364,7 @@
               <dxl:Filter/>
               <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -381,7 +381,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc2.mdp
@@ -258,7 +258,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.171875" Rows="1.000000" Width="40"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000261" Rows="1.000000" Width="40"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -289,7 +289,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.093750" Rows="1.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000229" Rows="1.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="rank">
@@ -314,7 +314,7 @@
           <dxl:Filter/>
           <dxl:Window PartitionColumns="0">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.031250" Rows="1.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="row_number">
@@ -336,7 +336,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.031250" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="sum">
@@ -360,7 +360,7 @@
               <dxl:LimitOffset/>
               <dxl:Window PartitionColumns="">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.031250" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="sum">
@@ -381,7 +381,7 @@
                 <dxl:Filter/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -398,7 +398,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc3.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.091797" Rows="1.000000" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000261" Rows="1.000000" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -283,7 +283,7 @@
         <dxl:SortingColumnList/>
         <dxl:Window PartitionColumns="0">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.074219" Rows="1.000000" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000100" Rows="1.000000" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -308,7 +308,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.046875" Rows="1.000000" Width="28"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="28"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="sum">
@@ -336,7 +336,7 @@
             <dxl:LimitOffset/>
             <dxl:Window PartitionColumns="0">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="28"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="28"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="sum">
@@ -360,7 +360,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.046875" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -381,7 +381,7 @@
                 <dxl:LimitOffset/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc4.mdp
@@ -263,7 +263,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.154297" Rows="1.000000" Width="44"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000360" Rows="1.000000" Width="44"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -289,7 +289,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.132812" Rows="1.000000" Width="44"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="1.000000" Width="44"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -326,7 +326,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Window PartitionColumns="0">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.089844" Rows="1.000000" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="1.000000" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="12" Alias="rank">
@@ -351,7 +351,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.019531" Rows="1.000000" Width="36"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="36"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="sum">
@@ -379,7 +379,7 @@
               <dxl:LimitOffset/>
               <dxl:Window PartitionColumns="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.019531" Rows="1.000000" Width="36"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="36"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="sum">
@@ -403,7 +403,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.019531" Rows="1.000000" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -424,7 +424,7 @@
                   <dxl:LimitOffset/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="1.000000" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc5.mdp
@@ -263,7 +263,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.148438" Rows="1.000000" Width="40"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000305" Rows="1.000000" Width="40"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -289,7 +289,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.128906" Rows="1.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000126" Rows="1.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -320,7 +320,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Window PartitionColumns="0">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.089844" Rows="1.000000" Width="40"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000109" Rows="1.000000" Width="40"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="12" Alias="rank">
@@ -345,7 +345,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.058594" Rows="1.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="sum">
@@ -373,7 +373,7 @@
               <dxl:LimitOffset/>
               <dxl:Window PartitionColumns="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.058594" Rows="1.000000" Width="32"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="32"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="sum">
@@ -397,7 +397,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="1.000000" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -418,7 +418,7 @@
                   <dxl:LimitOffset/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.058594" Rows="1.000000" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/ProjectCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectCountStar.mdp
@@ -736,7 +736,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
     <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="103.716309" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.104136" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="?column?">
@@ -747,7 +747,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="102.677246" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103776" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="?column?">
@@ -758,7 +758,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="101.599121" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.103736" Rows="20.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="?column?">
@@ -775,7 +775,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="100.442871" Rows="20.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="21" Alias="ColRef_0021">
@@ -786,7 +786,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="99.286621" Rows="20.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
@@ -799,7 +799,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                 </dxl:JoinFilter>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.004883" Rows="10.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
@@ -818,7 +818,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                 </dxl:TableScan>
                 <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="18.281738" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="count">
@@ -828,7 +828,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                   <dxl:Filter/>
                   <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="17.266113" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
@@ -839,7 +839,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                     <dxl:SortingColumnList/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="16.250488" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
@@ -852,7 +852,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="15.219238" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -863,7 +863,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                         <dxl:SortingColumnList/>
                         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="14.215332" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns/>
                           <dxl:ProjList>
@@ -874,7 +874,7 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                           <dxl:Filter/>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="4.399902" Rows="9011.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/ProjectOutsideCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectOutsideCountStar.mdp
@@ -726,7 +726,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="101.403809" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.104056" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -737,120 +737,146 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="100.364746" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103696" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="?column?">
               <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                  <dxl:TestExpr/>
-                  <dxl:ParamList/>
-                  <dxl:Materialize Eager="false">
+                <dxl:Coalesce TypeMdid="0.20.1.0">
+                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:Coalesce>
+              </dxl:OpExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="count">
+                  <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="count">
+                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="count">
+                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="18.281738" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="17.266113" Rows="2.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="count">
-                          <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="16.250488" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns/>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="18" Alias="count">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
-                              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                            </dxl:AggFunc>
+                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="15.219238" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
                           </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
+                          <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="14.215332" Rows="1.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:GroupingColumns/>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="4.399902" Rows="9011.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:Aggregate>
-                        </dxl:GatherMotion>
+                          <dxl:TableDescriptor Mdid="0.3373352.1.1" TableName="x">
+                            <dxl:Columns>
+                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
                       </dxl:Aggregate>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:SubPlan>
-              </dxl:OpExpr>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="99.286621" Rows="1000.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.3373378.1.1" TableName="y">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/ProjectRepeatedColumn1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectRepeatedColumn1.mdp
@@ -209,7 +209,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.234375" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -226,7 +226,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.234375" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="?column?">
@@ -243,7 +243,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.078125" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000209" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ProjectRepeatedColumn2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectRepeatedColumn2.mdp
@@ -210,7 +210,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.234375" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -230,7 +230,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.234375" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000438" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="?column?">
@@ -247,7 +247,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.078125" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000209" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ProjectUnderSubq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectUnderSubq.mdp
@@ -735,31 +735,31 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="24">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="81033.761719" Rows="10000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1300.232119" Rows="10000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="?column?">
-            <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.25.1.0"/>
+            <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="80993.699219" Rows="10000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1300.152119" Rows="1000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="20" Alias="?column?">
+            <dxl:ProjElem ColId="19" Alias="?column?">
               <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
+          <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="80914.574219" Rows="1000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1300.116199" Rows="1000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="?column?">
@@ -772,7 +772,7 @@
                         <dxl:ParamList/>
                         <dxl:Materialize Eager="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="899.878906" Rows="2.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="437.951914" Rows="2.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="18" Alias="count">
@@ -782,7 +782,7 @@
                           <dxl:Filter/>
                           <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="898.863281" Rows="2.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="437.951906" Rows="2.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="18" Alias="count">
@@ -793,7 +793,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="897.847656" Rows="1.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="437.951487" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns/>
                               <dxl:ProjList>
@@ -806,7 +806,7 @@
                               <dxl:Filter/>
                               <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="896.816406" Rows="1.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="437.951486" Rows="1.000000" Width="8"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -817,7 +817,7 @@
                                 <dxl:SortingColumnList/>
                                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="895.812500" Rows="1.000000" Width="8"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="437.951450" Rows="1.000000" Width="8"/>
                                   </dxl:Properties>
                                   <dxl:GroupingColumns/>
                                   <dxl:ProjList>
@@ -828,7 +828,7 @@
                                   <dxl:Filter/>
                                   <dxl:TableScan>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="298.265625" Rows="610848.000000" Width="1"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="1"/>
                                     </dxl:Properties>
                                     <dxl:ProjList/>
                                     <dxl:Filter/>
@@ -861,7 +861,7 @@
             <dxl:OneTimeFilter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="80905.761719" Rows="1000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1300.112199" Rows="1000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
@@ -879,8 +879,8 @@
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
+        </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ProjectWithConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectWithConstant.mdp
@@ -387,7 +387,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2976.640625" Rows="101432.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.672316" Rows="101432.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -401,7 +401,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2579.421875" Rows="101432.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="435.028879" Rows="101432.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -414,7 +414,7 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1784.984375" Rows="101432.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="434.623151" Rows="101432.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -433,7 +433,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="991.546875" Rows="101432.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="432.954595" Rows="101432.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="g">
@@ -447,7 +447,7 @@
               <dxl:OneTimeFilter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="198.109375" Rows="101432.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="432.171540" Rows="101432.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -472,7 +472,7 @@
           </dxl:Result>
           <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.000000" Rows="0.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="a">
@@ -504,31 +504,31 @@
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="a">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="21" Alias="g">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="14" Alias="ctid">
-                    <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true" IsByValue="false"/>
+                    <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="15" Alias="xmin">
-                    <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="16" Alias="cmin">
-                    <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="17" Alias="xmax">
-                    <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="18" Alias="cmax">
-                    <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="19" Alias="tableoid">
-                    <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="20" Alias="gp_segment_id">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/ProjectWithTextConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectWithTextConstant.mdp
@@ -1891,7 +1891,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="36092.076172" Rows="998707.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1074.205091" Rows="998707.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="25" Alias="sale_type">
@@ -1902,7 +1902,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="32189.876953" Rows="998707.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1038.331535" Rows="998707.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="25" Alias="sale_type">
@@ -1912,7 +1912,7 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="16094.430664" Rows="998706.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="517.168354" Rows="998706.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="25" Alias="sale_type">
@@ -1928,7 +1928,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="8291.040039" Rows="998706.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="500.739640" Rows="998706.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="25" Alias="sale_type">
@@ -1939,7 +1939,7 @@
               <dxl:OneTimeFilter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="487.649414" Rows="998706.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="495.816019" Rows="998706.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
@@ -1960,7 +1960,7 @@
           </dxl:Result>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8292.047852" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="517.168354" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="51" Alias="sale_type">
@@ -1976,7 +1976,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="8291.040039" Rows="998706.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="500.739640" Rows="998706.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="sale_type">
@@ -1987,7 +1987,7 @@
               <dxl:OneTimeFilter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="487.649414" Rows="998706.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="495.816019" Rows="998706.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -9,6 +9,14 @@
       <dxl:TraceFlags Value="103027,102146,101013,102053,103001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
@@ -378,10 +386,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="210080">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="32360">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="67.375000" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.002899" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="c9596">
@@ -389,38 +397,46 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="66.373047" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.002899" Rows="1.000000" Width="4"/>
           </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="20"/>
+            <dxl:GroupingColumn ColId="17"/>
+          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="?column?">
               <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="max">
+              <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="66.373047" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="3017.002889" Rows="1.000000" Width="8"/>
             </dxl:Properties>
-            <dxl:GroupingColumns>
-              <dxl:GroupingColumn ColId="20"/>
-              <dxl:GroupingColumn ColId="17"/>
-            </dxl:GroupingColumns>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="20" Alias="?column?">
-                <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="17" Alias="max">
                 <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="?column?">
+                <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="65.337891" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="3017.002889" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="17" Alias="max">
@@ -431,41 +447,55 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="64.333984" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="17" Alias="max">
-                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="20" Alias="?column?">
-                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
+              <dxl:JoinFilter>
+                <dxl:And>
                   <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
                     <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
                     <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0">
                       <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:FuncExpr>
                   </dxl:Comparison>
-                </dxl:JoinFilter>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:JoinFilter>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000270" Rows="1.000000" Width="20"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="c504">
+                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="16" Alias="avg">
+                    <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="17" Alias="max">
+                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="12.326172" Rows="2.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="c504">
+                      <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="16" Alias="avg">
                       <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
                     </dxl:ProjElem>
@@ -473,269 +503,262 @@
                       <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashJoin JoinType="Inner">
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="11.302734" Rows="1.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="8"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="16" Alias="avg">
-                        <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal">
+                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="17" Alias="max">
-                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
+                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="c504">
+                        <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:JoinFilter>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="4.136719" Rows="1.000000" Width="20"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="8" Alias="c504">
                           <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="16" Alias="avg">
-                          <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="17" Alias="max">
-                          <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="3.117188" Rows="1.000000" Width="20"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="8" Alias="c504">
                             <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="16" Alias="avg">
-                            <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="17" Alias="max">
-                            <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="20"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="8"/>
-                          </dxl:GroupingColumns>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="16" Alias="avg">
-                              <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal">
-                                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="17" Alias="max">
-                              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
-                                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="8" Alias="c504">
                               <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="8" Alias="c504">
-                                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:HashExprList>
-                              <dxl:HashExpr>
-                                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                            </dxl:HashExprList>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="8" Alias="c504">
-                                  <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.131046.1.1" TableName="t39">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:RedistributeMotion>
-                        </dxl:Aggregate>
-                      </dxl:Result>
-                    </dxl:GatherMotion>
+                          <dxl:TableDescriptor Mdid="0.131046.1.1" TableName="t39">
+                            <dxl:Columns>
+                              <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:GatherMotion>
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="2586.001485" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="?column?">
+                    <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="min">
+                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="20" Alias="?column?">
+                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000186" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="?column?">
+                      <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="min">
+                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Limit>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000120" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="1" Alias="?column?">
+                        <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="min">
+                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.087891" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000112" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="?column?">
+                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="2" Alias="min">
                           <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
                       </dxl:Filter>
                       <dxl:OneTimeFilter/>
-                      <dxl:Limit>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.080078" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="1"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
+                          <dxl:ProjElem ColId="2" Alias="min">
+                            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal">
+                              <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="1" Alias="?column?">
                             <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="min">
-                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Result>
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.064453" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="1" Alias="?column?">
                               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="min">
-                              <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:And>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:Comparison>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                              </dxl:Comparison>
-                            </dxl:And>
-                          </dxl:Filter>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="3.048828" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
-                            <dxl:GroupingColumns>
-                              <dxl:GroupingColumn ColId="1"/>
-                            </dxl:GroupingColumns>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="2" Alias="min">
-                                <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal">
-                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                </dxl:AggFunc>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="1" Alias="?column?">
                                 <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
                             <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2.017578" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="1" Alias="?column?">
-                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
-                              <dxl:Filter>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                </dxl:Comparison>
-                              </dxl:Filter>
+                              <dxl:Filter/>
                               <dxl:OneTimeFilter/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="1" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  <dxl:ProjElem ColId="0" Alias="">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:OneTimeFilter/>
-                                <dxl:Result>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="0" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
                               </dxl:Result>
                             </dxl:Result>
-                          </dxl:Aggregate>
-                        </dxl:Result>
-                        <dxl:LimitCount>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="3613"/>
-                        </dxl:LimitCount>
-                        <dxl:LimitOffset>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:LimitOffset>
-                      </dxl:Limit>
+                          </dxl:Result>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
                     </dxl:Result>
-                  </dxl:HashJoin>
-                </dxl:BroadcastMotion>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="3613"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3.007812" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -744,47 +767,24 @@
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="true">
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.003906" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
-                    <dxl:ProjList/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="">
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.002930" Rows="1.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList/>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="19" Alias="">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                        </dxl:Result>
-                      </dxl:Result>
-                    </dxl:RandomMotion>
-                  </dxl:Materialize>
+                    <dxl:OneTimeFilter/>
+                  </dxl:Result>
                 </dxl:Result>
               </dxl:NestedLoopJoin>
-            </dxl:RedistributeMotion>
-          </dxl:Aggregate>
-        </dxl:Result>
-      </dxl:GatherMotion>
+            </dxl:HashJoin>
+          </dxl:Sort>
+        </dxl:Aggregate>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
@@ -17,6 +17,14 @@
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
       </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -686,10 +694,10 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4854">
+    <dxl:Plan Id="0" SpaceSize="17398">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7590.830078" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="908.045287" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="b">
@@ -698,9 +706,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7588.824219" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="908.045269" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
@@ -711,9 +719,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Append IsTarget="false" IsZapped="false">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7587.785156" Rows="2.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="908.045264" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="one">
@@ -721,159 +729,266 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="126.099609" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="908.045264" Rows="1.000000" Width="4"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="9"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="one">
                   <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="125.076172" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="908.045256" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="9"/>
+                </dxl:GroupingColumns>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="one">
                     <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="124.074219" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="908.045251" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="9"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="one">
                       <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Result>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="44.945312" Rows="10000.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="908.045251" Rows="2.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="one">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:TableScan>
+                    <dxl:SortingColumnList/>
+                    <dxl:Append IsTarget="false" IsZapped="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="4.882812" Rows="10000.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="908.045229" Rows="2.000000" Width="4"/>
                       </dxl:Properties>
-                      <dxl:ProjList/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="one">
+                          <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.57356.1.1" TableName="a">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:Result>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
-            </dxl:Aggregate>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="7460.669922" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="19"/>
-              </dxl:GroupingColumns>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="19" Alias="one">
-                  <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="7459.646484" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="one">
-                    <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="7458.644531" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="19"/>
-                  </dxl:GroupingColumns>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="19" Alias="one">
-                      <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2685.390625" Rows="610848.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="one">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="298.265625" Rows="610848.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.27319.1.1" TableName="x">
-                        <dxl:Columns>
-                          <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:Result>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
-            </dxl:Aggregate>
-          </dxl:Append>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.741665" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="9"/>
+                        </dxl:GroupingColumns>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="one">
+                            <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.741658" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="one">
+                              <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.741658" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="9" Alias="one">
+                                <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:HashExprList>
+                              <dxl:HashExpr>
+                                <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                              </dxl:HashExpr>
+                            </dxl:HashExprList>
+                            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.741651" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="9"/>
+                              </dxl:GroupingColumns>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="one">
+                                  <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:Result>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.133800" Rows="10000.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="one">
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList/>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.57356.1.1" TableName="a">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:Result>
+                            </dxl:Aggregate>
+                          </dxl:RedistributeMotion>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="476.303557" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="19"/>
+                        </dxl:GroupingColumns>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="one">
+                            <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="476.303550" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="19" Alias="one">
+                              <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="476.303550" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="19" Alias="one">
+                                <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:HashExprList>
+                              <dxl:HashExpr>
+                                <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
+                              </dxl:HashExpr>
+                            </dxl:HashExprList>
+                            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="476.303542" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="19"/>
+                              </dxl:GroupingColumns>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="19" Alias="one">
+                                  <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:Result>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="439.173146" Rows="610848.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="19" Alias="one">
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList/>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.27319.1.1" TableName="x">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:Result>
+                            </dxl:Aggregate>
+                          </dxl:RedistributeMotion>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:Append>
+                  </dxl:RandomMotion>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:RedistributeMotion>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
@@ -17,6 +17,14 @@
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
       </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBFunc Mdid="0.65.1.0" Name="int4eq" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.16.1.0"/>
       </dxl:GPDBFunc>
@@ -204,7 +212,7 @@
     <dxl:Plan Id="0" SpaceSize="988020">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="14.421875" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.001436" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -217,7 +225,7 @@
         <dxl:Filter/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="13.390625" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.001435" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="field_1">
@@ -225,9 +233,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:HashJoin JoinType="In">
+          <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.187500" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000714" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="field_1">
@@ -238,13 +246,126 @@
             <dxl:JoinFilter/>
             <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="field_1" TypeMdid="0.23.1.0"/>
                 <dxl:Ident ColId="5" ColName="field_1" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="field_1" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000151" Rows="2.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="5"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="5" Alias="field_1">
+                  <dxl:Ident ColId="5" ColName="field_1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000135" Rows="3.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="5" Alias="field_1">
+                    <dxl:Ident ColId="5" ColName="field_1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="5" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:Append IsTarget="false" IsZapped="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000027" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="5" Alias="field_1">
+                      <dxl:Ident ColId="5" ColName="field_1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="5" Alias="field_1">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="4" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="7" Alias="field_1">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="6" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="field_1">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="8" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:Append>
+              </dxl:Sort>
+            </dxl:Aggregate>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="field_1">
@@ -255,7 +376,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="">
@@ -266,93 +387,10 @@
                 <dxl:OneTimeFilter/>
               </dxl:Result>
             </dxl:Result>
-            <dxl:Append IsTarget="false" IsZapped="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.052734" Rows="3.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="5" Alias="field_1">
-                  <dxl:Ident ColId="5" ColName="field_1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="5" Alias="field_1">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="4" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="7" Alias="field_1">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="6" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="field_1">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="8" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:Append>
           </dxl:HashJoin>
-          <dxl:HashJoin JoinType="In">
+          <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.187500" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000714" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="field_1">
@@ -363,13 +401,126 @@
             <dxl:JoinFilter/>
             <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="3" ColName="field_1" TypeMdid="0.23.1.0"/>
                 <dxl:Ident ColId="12" ColName="field_1" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="3" ColName="field_1" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000151" Rows="2.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="12"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="12" Alias="field_1">
+                  <dxl:Ident ColId="12" ColName="field_1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000135" Rows="3.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="12" Alias="field_1">
+                    <dxl:Ident ColId="12" ColName="field_1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:Append IsTarget="false" IsZapped="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000027" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="12" Alias="field_1">
+                      <dxl:Ident ColId="12" ColName="field_1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="12" Alias="field_1">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="14" Alias="field_1">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="13" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="16" Alias="field_1">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="15" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:Append>
+              </dxl:Sort>
+            </dxl:Aggregate>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="field_1">
@@ -380,7 +531,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="">
@@ -391,89 +542,6 @@
                 <dxl:OneTimeFilter/>
               </dxl:Result>
             </dxl:Result>
-            <dxl:Append IsTarget="false" IsZapped="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.052734" Rows="3.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="12" Alias="field_1">
-                  <dxl:Ident ColId="12" ColName="field_1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="12" Alias="field_1">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="11" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="14" Alias="field_1">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="13" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="16" Alias="field_1">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="15" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:Append>
           </dxl:HashJoin>
         </dxl:Append>
       </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -4984,7 +4984,7 @@
     <dxl:Plan Id="0" SpaceSize="55602">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4212763332.381836" Rows="60175000.000000" Width="14"/>
+          <dxl:Cost StartupCost="0" TotalCost="25985.808128" Rows="60175000.000000" Width="14"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="15" Alias="l_shipmode">
@@ -4998,7 +4998,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4212351978.842773" Rows="60175000.000000" Width="14"/>
+            <dxl:Cost StartupCost="0" TotalCost="22203.207628" Rows="60175000.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="15" Alias="l_shipmode">
@@ -5018,186 +5018,9 @@
               </dxl:Comparison>
             </dxl:Or>
           </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="100742.785156" Rows="2000.000000" Width="5"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="34" Alias="month_number">
-                <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="57" Alias="ColRef_0057">
-                <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="100736.902344" Rows="1000.000000" Width="5"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="34" Alias="month_number">
-                  <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="57" Alias="ColRef_0057">
-                  <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="100736.902344" Rows="1000.000000" Width="5"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="57" Alias="ColRef_0057">
-                    <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-                      <dxl:TestExpr>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:TestExpr>
-                      <dxl:ParamList/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="49" Alias="?column?">
-                            <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="5.101562" Rows="2.000000" Width="5"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="58" Alias="ColRef_0058">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="49" Alias="?column?">
-                              <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="4.082031" Rows="2.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:GroupingColumns>
-                              <dxl:GroupingColumn ColId="49"/>
-                            </dxl:GroupingColumns>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="49" Alias="?column?">
-                                <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:Append IsTarget="false" IsZapped="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="3.035156" Rows="2.000000" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="49" Alias="?column?">
-                                  <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="49" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:Result>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="48" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
-                              </dxl:Result>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="51" Alias="?column?">
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:Result>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="50" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
-                              </dxl:Result>
-                            </dxl:Append>
-                          </dxl:Aggregate>
-                        </dxl:Result>
-                      </dxl:Result>
-                    </dxl:SubPlan>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="34" Alias="month_number">
-                    <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="100731.019531" Rows="1000.000000" Width="5"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="34" Alias="month_number">
-                      <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.738647.1.1" TableName="times">
-                    <dxl:Columns>
-                      <dxl:Column ColId="25" Attno="2" ColName="date_id" TypeMdid="0.1082.1.0"/>
-                      <dxl:Column ColId="34" Attno="11" ColName="month_number" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
-            </dxl:Result>
-          </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="411.352539" Rows="60175.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="433.846277" Rows="60175.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="13" Alias="l_receiptdate">
@@ -5230,7 +5053,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="411.352539" Rows="60175.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="433.846277" Rows="60175.000000" Width="14"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="l_receiptdate">
@@ -5258,6 +5081,213 @@
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:Sequence>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.665817" Rows="2000.000000" Width="5"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="34" Alias="month_number">
+                <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.660817" Rows="2000.000000" Width="5"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="34" Alias="month_number">
+                  <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                  <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.529942" Rows="1000.000000" Width="5"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="34" Alias="month_number">
+                    <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                    <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.16.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.529942" Rows="1000.000000" Width="5"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                      <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                        <dxl:TestExpr>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:TestExpr>
+                        <dxl:ParamList/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="49" Alias="?column?">
+                              <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000086" Rows="2.000000" Width="5"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="49" Alias="?column?">
+                                <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000076" Rows="2.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="49"/>
+                              </dxl:GroupingColumns>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="49" Alias="?column?">
+                                  <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:Sort SortDiscardDuplicates="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000063" Rows="2.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="49" Alias="?column?">
+                                    <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList>
+                                  <dxl:SortingColumn ColId="49" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                </dxl:SortingColumnList>
+                                <dxl:LimitCount/>
+                                <dxl:LimitOffset/>
+                                <dxl:Append IsTarget="false" IsZapped="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="2.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="49" Alias="?column?">
+                                      <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="49" Alias="?column?">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="48" Alias="">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                    </dxl:Result>
+                                  </dxl:Result>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="51" Alias="?column?">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="50" Alias="">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                    </dxl:Result>
+                                  </dxl:Result>
+                                </dxl:Append>
+                              </dxl:Sort>
+                            </dxl:Aggregate>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:SubPlan>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="34" Alias="month_number">
+                      <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="862.527442" Rows="1000.000000" Width="5"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="34" Alias="month_number">
+                        <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.738647.1.1" TableName="times">
+                      <dxl:Columns>
+                        <dxl:Column ColId="25" Attno="2" ColName="date_id" TypeMdid="0.1082.1.0"/>
+                        <dxl:Column ColId="34" Attno="11" ColName="month_number" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/RollupNoAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RollupNoAgg.mdp
@@ -228,10 +228,10 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="52">
+    <dxl:Plan Id="0" SpaceSize="68">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8.175781" Rows="3.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000147" Rows="3.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -243,38 +243,38 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:OneTimeFilter/>
-        <dxl:Sequence>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.128906" Rows="3.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000123" Rows="3.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">
               <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:CTEProducer CTEId="0" Columns="0">
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.011719" Rows="2.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000069" Rows="3.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+            <dxl:CTEProducer CTEId="0" Columns="0">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="2.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="2.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -295,74 +295,114 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:GatherMotion>
-          </dxl:CTEProducer>
-          <dxl:Append IsTarget="false" IsZapped="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.093750" Rows="3.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="a">
-                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            </dxl:CTEProducer>
+            <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.054688" Rows="2.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000034" Rows="3.000000" Width="4"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="9"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
                   <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:CTEConsumer CTEId="0" Columns="9">
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="9"/>
+                </dxl:GroupingColumns>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">
                     <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-              </dxl:CTEConsumer>
-            </dxl:Aggregate>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="27" Alias="a">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:GroupingColumns/>
-                <dxl:ProjList/>
                 <dxl:Filter/>
-                <dxl:CTEConsumer CTEId="0" Columns="18">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="2.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="a">
-                      <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="9" Alias="a">
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                </dxl:CTEConsumer>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:CTEConsumer CTEId="0" Columns="9">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="2.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="a">
+                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Sort>
               </dxl:Aggregate>
-            </dxl:Result>
-          </dxl:Append>
-        </dxl:Sequence>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="27" Alias="a">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000002" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:CTEConsumer CTEId="0" Columns="18">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000002" Rows="2.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="18" Alias="a">
+                              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                        </dxl:CTEConsumer>
+                      </dxl:Aggregate>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:RandomMotion>
+              </dxl:Result>
+            </dxl:Append>
+          </dxl:Sequence>
+        </dxl:GatherMotion>
       </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Select-Over-CTEAnchor.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Over-CTEAnchor.mdp
@@ -463,7 +463,7 @@
     <dxl:Plan Id="0" SpaceSize="1820">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1291.686523" Rows="3.333333" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="10344.016560" Rows="3.333333" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -489,7 +489,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1289.569336" Rows="3.333333" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="10344.016201" Rows="3.333333" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">
@@ -520,7 +520,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.530273" Rows="2.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.003172" Rows="2.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="36" Alias="c">
@@ -540,7 +540,7 @@
             <dxl:SortingColumnList/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="7.514648" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.002753" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="36" Alias="c">
@@ -558,7 +558,7 @@
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="1" Columns="18,19,27,28">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.299805" Rows="3.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001871" Rows="3.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="c">
@@ -576,7 +576,7 @@
                 </dxl:ProjList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.296875" Rows="3.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.001870" Rows="3.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="c">
@@ -602,7 +602,7 @@
                   </dxl:HashCondList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="c">
@@ -629,7 +629,7 @@
                   </dxl:TableScan>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.062500" Rows="3.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000291" Rows="3.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="27" Alias="a">
@@ -663,7 +663,7 @@
               </dxl:CTEProducer>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.199219" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000874" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="36" Alias="c">
@@ -689,7 +689,7 @@
                 </dxl:HashCondList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="3.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000157" Rows="3.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="36" Alias="c">
@@ -714,7 +714,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:CTEConsumer CTEId="1" Columns="36,37,38,39">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.023438" Rows="3.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="3.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="36" Alias="c">
@@ -734,7 +734,7 @@
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="3.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="54" Alias="c">
@@ -750,7 +750,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:CTEConsumer CTEId="1" Columns="54,55,56,57">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.011719" Rows="3.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="3.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="54" Alias="c">
@@ -773,7 +773,7 @@
           </dxl:BroadcastMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Select-Over-PartTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Over-PartTbl.mdp
@@ -2612,7 +2612,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="348946322.694889" Rows="190108557.331236" Width="138"/>
+          <dxl:Cost StartupCost="0" TotalCost="238860.008541" Rows="190108557.331236" Width="138"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -2668,7 +2668,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="336136272.421592" Rows="190108557.331236" Width="138"/>
+            <dxl:Cost StartupCost="0" TotalCost="121064.944248" Rows="190108557.331236" Width="138"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -2743,7 +2743,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="336136272.421592" Rows="190108557.331236" Width="138"/>
+              <dxl:Cost StartupCost="0" TotalCost="121064.944248" Rows="190108557.331236" Width="138"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="l_orderkey">

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -889,10 +889,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19316">
-      <dxl:Sort SortDiscardDuplicates="false">
+    <dxl:Plan Id="0" SpaceSize="72144">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="281618.935587" Rows="3009.000000" Width="64"/>
+          <dxl:Cost StartupCost="0" TotalCost="891.087839" Rows="3009.000000" Width="64"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="proname">
@@ -903,11 +903,9 @@
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:LimitCount/>
-        <dxl:LimitOffset/>
-        <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3464.329271" Rows="3009.000000" Width="64"/>
+            <dxl:Cost StartupCost="0" TotalCost="890.223173" Rows="3009.000000" Width="64"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="proname">
@@ -915,16 +913,14 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-              <dxl:Ident ColId="0" ColName="proname" TypeMdid="0.19.1.0"/>
-              <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="603.289635" Rows="3009.000000" Width="64"/>
+              <dxl:Cost StartupCost="0" TotalCost="884.460602" Rows="3009.000000" Width="64"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="proname">
@@ -939,9 +935,9 @@
                 <dxl:Ident ColId="35" ColName="oid" TypeMdid="0.26.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="199.816406" Rows="3009.000000" Width="68"/>
+                <dxl:Cost StartupCost="0" TotalCost="877.795162" Rows="3009.000000" Width="68"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="proname">
@@ -952,24 +948,176 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1255.1.1" TableName="pg_proc">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="proname" TypeMdid="0.19.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="pronamespace" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="24" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="877.236572" Rows="3009.000000" Width="68"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="proname">
+                    <dxl:Ident ColId="0" ColName="proname" TypeMdid="0.19.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="pronamespace">
+                    <dxl:Ident ColId="1" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                    <dxl:Ident ColId="0" ColName="proname" TypeMdid="0.19.1.0"/>
+                    <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.557718" Rows="3009.000000" Width="68"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="proname">
+                      <dxl:Ident ColId="0" ColName="proname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="pronamespace">
+                      <dxl:Ident ColId="1" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.1255.1.1" TableName="pg_proc">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="proname" TypeMdid="0.19.1.0"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="24" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="439.262185" Rows="3009.000000" Width="64"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="42" Alias="proname">
+                      <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                      <dxl:Ident ColId="43" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                      <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.557718" Rows="3009.000000" Width="68"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="42" Alias="proname">
+                        <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="43" Alias="pronamespace">
+                        <dxl:Ident ColId="43" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.1255.1.1" TableName="pg_proc">
+                      <dxl:Columns>
+                        <dxl:Column ColId="42" Attno="1" ColName="proname" TypeMdid="0.19.1.0"/>
+                        <dxl:Column ColId="43" Attno="2" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="66" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="67" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="68" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="69" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="70" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="71" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="72" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:Assert ErrorCode="P0003">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="6.002018" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="77" Alias="oid">
+                        <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:AssertConstraintList>
+                      <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                          <dxl:Ident ColId="89" ColName="row_number" TypeMdid="0.20.1.0"/>
+                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:Cast>
+                        </dxl:Comparison>
+                      </dxl:AssertConstraint>
+                    </dxl:AssertConstraintList>
+                    <dxl:Window PartitionColumns="">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="6.002010" Rows="2.800000" Width="16"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="89" Alias="row_number">
+                          <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="77" Alias="oid">
+                          <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:IndexScan IndexScanDirection="Forward">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="6.001968" Rows="2.800000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="77" Alias="oid">
+                            <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                            <dxl:Ident ColId="73" ColName="nspname" TypeMdid="0.19.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="cGdfY2F0YWxvZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          </dxl:Comparison>
+                        </dxl:IndexCondList>
+                        <dxl:IndexDescriptor Mdid="0.2684.1.0" IndexName="pg_namespace_nspname_index"/>
+                        <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace">
+                          <dxl:Columns>
+                            <dxl:Column ColId="73" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
+                            <dxl:Column ColId="76" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="77" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="78" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="79" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="80" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="81" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="82" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="83" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:IndexScan>
+                      <dxl:WindowKeyList>
+                        <dxl:WindowKey>
+                          <dxl:SortingColumnList/>
+                        </dxl:WindowKey>
+                      </dxl:WindowKeyList>
+                    </dxl:Window>
+                  </dxl:Assert>
+                </dxl:HashJoin>
+              </dxl:HashJoin>
+            </dxl:RandomMotion>
             <dxl:Assert ErrorCode="P0003">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.762292" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.004363" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="35" Alias="oid">
@@ -986,176 +1134,90 @@
                   </dxl:Comparison>
                 </dxl:AssertConstraint>
               </dxl:AssertConstraintList>
-              <dxl:Window PartitionColumns="">
+              <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.746667" Rows="2.800000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.004355" Rows="5.600000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="90" Alias="row_number">
-                    <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="35" Alias="oid">
                     <dxl:Ident ColId="35" ColName="oid" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="90" Alias="row_number">
+                    <dxl:Ident ColId="90" ColName="row_number" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:IndexScan IndexScanDirection="Forward">
+                <dxl:SortingColumnList/>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.746667" Rows="2.800000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6.002010" Rows="2.800000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="35" Alias="oid">
                       <dxl:Ident ColId="35" ColName="oid" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:IndexCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                      <dxl:Ident ColId="31" ColName="nspname" TypeMdid="0.19.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGlkeWNhdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                    </dxl:Comparison>
-                  </dxl:IndexCondList>
-                  <dxl:IndexDescriptor Mdid="0.2684.1.0" IndexName="pg_namespace_nspname_index"/>
-                  <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace">
-                    <dxl:Columns>
-                      <dxl:Column ColId="31" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="35" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="36" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="37" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="38" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="39" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="40" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="41" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:IndexScan>
-                <dxl:WindowKeyList>
-                  <dxl:WindowKey>
-                    <dxl:SortingColumnList/>
-                  </dxl:WindowKey>
-                </dxl:WindowKeyList>
-              </dxl:Window>
-            </dxl:Assert>
-          </dxl:HashJoin>
-          <dxl:HashJoin JoinType="Inner">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="603.289635" Rows="3009.000000" Width="64"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="42" Alias="proname">
-                <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="43" ColName="pronamespace" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="199.816406" Rows="3009.000000" Width="68"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="42" Alias="proname">
-                  <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="pronamespace">
-                  <dxl:Ident ColId="43" ColName="pronamespace" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1255.1.1" TableName="pg_proc">
-                <dxl:Columns>
-                  <dxl:Column ColId="42" Attno="1" ColName="proname" TypeMdid="0.19.1.0"/>
-                  <dxl:Column ColId="43" Attno="2" ColName="pronamespace" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="66" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="67" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="68" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="69" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="70" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="71" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="72" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:Assert ErrorCode="P0003">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.762292" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="77" Alias="oid">
-                  <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:AssertConstraintList>
-                <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                    <dxl:Ident ColId="89" ColName="row_number" TypeMdid="0.20.1.0"/>
-                    <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:Cast>
-                  </dxl:Comparison>
-                </dxl:AssertConstraint>
-              </dxl:AssertConstraintList>
-              <dxl:Window PartitionColumns="">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.746667" Rows="2.800000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="89" Alias="row_number">
-                    <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="77" Alias="oid">
-                    <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:IndexScan IndexScanDirection="Forward">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.746667" Rows="2.800000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="77" Alias="oid">
-                      <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                    <dxl:ProjElem ColId="90" Alias="row_number">
+                      <dxl:Ident ColId="90" ColName="row_number" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:IndexCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                      <dxl:Ident ColId="73" ColName="nspname" TypeMdid="0.19.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.19.1.0" Value="cGdfY2F0YWxvZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                    </dxl:Comparison>
-                  </dxl:IndexCondList>
-                  <dxl:IndexDescriptor Mdid="0.2684.1.0" IndexName="pg_namespace_nspname_index"/>
-                  <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace">
-                    <dxl:Columns>
-                      <dxl:Column ColId="73" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="76" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="77" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="78" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="79" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="80" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="81" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="82" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="83" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:IndexScan>
-                <dxl:WindowKeyList>
-                  <dxl:WindowKey>
-                    <dxl:SortingColumnList/>
-                  </dxl:WindowKey>
-                </dxl:WindowKeyList>
-              </dxl:Window>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Window PartitionColumns="">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="6.002010" Rows="2.800000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="90" Alias="row_number">
+                        <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="35" Alias="oid">
+                        <dxl:Ident ColId="35" ColName="oid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:IndexScan IndexScanDirection="Forward">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="6.001968" Rows="2.800000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="35" Alias="oid">
+                          <dxl:Ident ColId="35" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:IndexCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                          <dxl:Ident ColId="31" ColName="nspname" TypeMdid="0.19.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGlkeWNhdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                        </dxl:Comparison>
+                      </dxl:IndexCondList>
+                      <dxl:IndexDescriptor Mdid="0.2684.1.0" IndexName="pg_namespace_nspname_index"/>
+                      <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace">
+                        <dxl:Columns>
+                          <dxl:Column ColId="31" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
+                          <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="35" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="36" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="37" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="38" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="39" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="40" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="41" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:IndexScan>
+                    <dxl:WindowKeyList>
+                      <dxl:WindowKey>
+                        <dxl:SortingColumnList/>
+                      </dxl:WindowKey>
+                    </dxl:WindowKeyList>
+                  </dxl:Window>
+                </dxl:Result>
+              </dxl:BroadcastMotion>
             </dxl:Assert>
           </dxl:HashJoin>
-        </dxl:HashJoin>
-      </dxl:Sort>
+        </dxl:Sort>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SelectOnBpchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectOnBpchar.mdp
@@ -1330,7 +1330,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3689.988281" Rows="1.000000" Width="125"/>
+          <dxl:Cost StartupCost="0" TotalCost="434.570048" Rows="1.000000" Width="125"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -1386,7 +1386,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3688.927246" Rows="1.000000" Width="125"/>
+            <dxl:Cost StartupCost="0" TotalCost="434.569487" Rows="1.000000" Width="125"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="l_orderkey">

--- a/src/backend/gporca/data/dxl/minidump/SelectOnCastedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectOnCastedCol.mdp
@@ -2069,7 +2069,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="24717.486528" Rows="48656.716292" Width="258"/>
+          <dxl:Cost StartupCost="0" TotalCost="503.926109" Rows="48656.716292" Width="258"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ca_address_sk">
@@ -2116,7 +2116,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="18586.880667" Rows="48656.716292" Width="258"/>
+            <dxl:Cost StartupCost="0" TotalCost="447.561196" Rows="48656.716292" Width="258"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ca_address_sk">

--- a/src/backend/gporca/data/dxl/minidump/Self-Comparison-Nullable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Self-Comparison-Nullable.mdp
@@ -192,7 +192,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8.250000" Rows="400.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.062472" Rows="400.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -206,7 +206,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.468750" Rows="400.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.055288" Rows="400.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Self-Comparison.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Self-Comparison.mdp
@@ -215,7 +215,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -229,7 +229,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2InnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2InnerJoin.mdp
@@ -531,7 +531,7 @@
     <dxl:Plan Id="0" SpaceSize="69">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="123.457031" Rows="4.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="863.943229" Rows="4.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -542,7 +542,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="122.449219" Rows="4.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="863.943157" Rows="4.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -553,7 +553,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="122.449219" Rows="4.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="863.943157" Rows="4.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -574,7 +574,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="121.378906" Rows="4.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="863.943124" Rows="4.000000" Width="14"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -596,7 +596,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="119.613281" Rows="4.000000" Width="14"/>
+                  <dxl:Cost StartupCost="0" TotalCost="863.942966" Rows="4.000000" Width="14"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -621,7 +621,7 @@
                 </dxl:HashExprList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="118.585938" Rows="4.000000" Width="14"/>
+                    <dxl:Cost StartupCost="0" TotalCost="863.942878" Rows="4.000000" Width="14"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -649,7 +649,7 @@
                   </dxl:HashCondList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="39.066406" Rows="10001.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.104510" Rows="10001.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="c">
@@ -676,7 +676,7 @@
                   </dxl:TableScan>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.035156" Rows="4.000000" Width="18"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="4.000000" Width="18"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-1.mdp
@@ -277,7 +277,7 @@
     <dxl:Plan Id="0" SpaceSize="118">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3216.576172" Rows="200.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.057274" Rows="200.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -291,7 +291,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3214.013672" Rows="200.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.042906" Rows="200.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -307,7 +307,7 @@
           </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.031250" Rows="200.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.024651" Rows="200.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -339,48 +339,60 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.982422" Rows="2.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.011439" Rows="2.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.980469" Rows="2.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011438" Rows="2.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.978516" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.011386" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.976562" Rows="1000.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.011385" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
-                  <dxl:TableScan>
+                  <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.488281" Rows="1000.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.011380" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
-                      <dxl:Columns>
-                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
                 </dxl:GatherMotion>
                 <dxl:LimitCount>
                   <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-2.mdp
@@ -277,7 +277,7 @@
     <dxl:Plan Id="0" SpaceSize="118">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2414.427734" Rows="200.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.043069" Rows="200.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -291,7 +291,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2412.255859" Rows="200.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.032293" Rows="200.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -307,7 +307,7 @@
           </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.273438" Rows="200.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.015682" Rows="200.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -339,48 +339,60 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.982422" Rows="2.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.011439" Rows="2.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.980469" Rows="2.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011438" Rows="2.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.978516" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.011386" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.976562" Rows="1000.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.011385" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
-                  <dxl:TableScan>
+                  <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.488281" Rows="1000.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.011380" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
-                      <dxl:Columns>
-                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
                 </dxl:GatherMotion>
                 <dxl:LimitCount>
                   <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp
@@ -296,9 +296,9 @@ explain select * from x where x.i in (select x.y from y);
       </dxl:LogicalSelect>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="16">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="25621.500000" Rows="500.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.088746" Rows="500.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -308,11 +308,113 @@ explain select * from x where x.i in (select x.y from y);
             <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:TableScan>
+        <dxl:Filter>
+          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+            <dxl:TestExpr/>
+            <dxl:ParamList/>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.011458" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.011458" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                    <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                    <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.011425" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.011424" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.011416" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.011380" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
+                            <dxl:Columns>
+                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:Aggregate>
+                    </dxl:GatherMotion>
+                  </dxl:Materialize>
+                </dxl:Aggregate>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:SubPlan>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="25616.593750" Rows="500.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.039019" Rows="200.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -322,142 +424,42 @@ explain select * from x where x.i in (select x.y from y);
               <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter>
-            <dxl:And>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.024651" Rows="200.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="j">
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
-              <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="7.562500" Rows="2.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7.562500" Rows="2.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                        <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.546875" Rows="2.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                          <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.531250" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                            <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                            <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.515625" Rows="1.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns/>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
-                                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="3.484375" Rows="1.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2.480469" Rows="1.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:GroupingColumns/>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.488281" Rows="1000.000000" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.40972.1.1" TableName="y">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Aggregate>
-                          </dxl:GatherMotion>
-                        </dxl:Aggregate>
-                      </dxl:Result>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
-              </dxl:SubPlan>
-            </dxl:And>
-          </dxl:Filter>
-          <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:TableScan>
-      </dxl:GatherMotion>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
@@ -105,7 +105,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:Sort SortDiscardDuplicates="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="32341.075290" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.256156" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -120,7 +120,7 @@
         <dxl:LimitOffset/>
         <dxl:TableValuedFunction FuncId="0.516381.1.0" Name="myfunc" TypeMdid="0.23.1.0">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.812500" Rows="1000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.004000" Rows="1000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -132,7 +132,7 @@
             <dxl:ParamList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="11.019531" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="ColRef_0004">
@@ -141,9 +141,9 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="10.011719" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="?column?">
@@ -156,7 +156,7 @@
                 </dxl:JoinFilter>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="ColRef_0003">
@@ -168,7 +168,7 @@
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="12" Alias="?column?">
@@ -179,7 +179,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127907" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="391.295609" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -274,7 +274,7 @@
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127855" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="391.295557" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/SortOverStreamAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SortOverStreamAgg.mdp
@@ -2067,7 +2067,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="896.996522" Rows="2.000000" Width="15"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.985181" Rows="2.000000" Width="15"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="id">
@@ -2083,7 +2083,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="895.981874" Rows="2.000000" Width="15"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.985046" Rows="2.000000" Width="15"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="year_id">
@@ -2101,7 +2101,7 @@
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="894.981874" Rows="2.000000" Width="15"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.985046" Rows="2.000000" Width="15"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="19"/>
@@ -2119,7 +2119,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="893.923280" Rows="2.000000" Width="15"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.985023" Rows="2.000000" Width="15"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="19"/>
@@ -2139,7 +2139,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="884.339296" Rows="730.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.980634" Rows="730.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="19" Alias="year_id">
@@ -2157,7 +2157,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="9.554688" Rows="730.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.769248" Rows="730.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="year_id">
@@ -2176,7 +2176,7 @@
                   </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4.277344" Rows="730.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.747392" Rows="730.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="19" Alias="year_id">

--- a/src/backend/gporca/data/dxl/minidump/Stats-For-Select-With-Outer-Refs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stats-For-Select-With-Outer-Refs.mdp
@@ -731,7 +731,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1906.107428" Rows="2585.000000" Width="83"/>
+          <dxl:Cost StartupCost="0" TotalCost="5177.936329" Rows="2585.000000" Width="83"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="attname">
@@ -753,7 +753,7 @@
               </dxl:ParamList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.101569" Rows="0.000387" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.425377" Rows="0.000387" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="37" Alias="substring">
@@ -771,7 +771,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.101562" Rows="0.000387" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.425377" Rows="0.000387" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="25" Alias="adrelid">
@@ -798,7 +798,7 @@
                   </dxl:OneTimeFilter>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.070312" Rows="1.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000145" Rows="1.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="25" Alias="adrelid">
@@ -850,7 +850,7 @@
         <dxl:OneTimeFilter/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1486.054694" Rows="1000.000000" Width="83"/>
+            <dxl:Cost StartupCost="0" TotalCost="5177.721774" Rows="1000.000000" Width="83"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="attrelid">

--- a/src/backend/gporca/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
@@ -420,7 +420,7 @@
     <dxl:Plan Id="0" SpaceSize="117">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="39.099609" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.000818" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -431,7 +431,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="38.097656" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000800" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -442,7 +442,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="38.097656" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000800" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -462,7 +462,7 @@
                   </dxl:ParamList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="5.093750" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000648" Rows="2.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="j">
@@ -478,7 +478,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Materialize Eager="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="4.085938" Rows="2.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000582" Rows="2.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="j">
@@ -488,7 +488,7 @@
                       <dxl:Filter/>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="3.078125" Rows="2.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="862.000578" Rows="2.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="10" Alias="j">
@@ -499,7 +499,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:HashJoin JoinType="In">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.074219" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="862.000473" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="10" Alias="j">
@@ -520,7 +520,7 @@
                           </dxl:HashCondList>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="i">
@@ -547,7 +547,7 @@
                           </dxl:TableScan>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="18" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Subq-NoParams.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-NoParams.mdp
@@ -387,7 +387,7 @@
     <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="325.106771" Rows="3.333333" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001824" Rows="3.333333" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -399,9 +399,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:TableScan>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="324.093750" Rows="3.333333" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001704" Rows="3.333333" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -411,25 +411,76 @@
               <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList/>
-                <dxl:Materialize Eager="false">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:Assert ErrorCode="P0003">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000927" Rows="2.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:AssertConstraintList>
+              <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                  <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+                  <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Cast>
+                </dxl:Comparison>
+              </dxl:AssertConstraint>
+            </dxl:AssertConstraintList>
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000923" Rows="2.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="row_number">
+                  <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000294" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="b">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="18" Alias="row_number">
+                    <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Window PartitionColumns="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3.054688" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000294" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="row_number">
+                      <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="10" Alias="b">
                       <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.046875" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000294" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="b">
@@ -440,7 +491,7 @@
                     <dxl:SortingColumnList/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.042969" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000276" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="b">
@@ -467,25 +518,44 @@
                         </dxl:Columns>
                       </dxl:TableDescriptor>
                     </dxl:TableScan>
-                  </dxl:BroadcastMotion>
-                </dxl:Materialize>
-              </dxl:SubPlan>
-            </dxl:Comparison>
-          </dxl:Filter>
-          <dxl:TableDescriptor Mdid="0.409260.1.1" TableName="x">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:TableScan>
+                  </dxl:GatherMotion>
+                  <dxl:WindowKeyList>
+                    <dxl:WindowKey>
+                      <dxl:SortingColumnList/>
+                    </dxl:WindowKey>
+                  </dxl:WindowKeyList>
+                </dxl:Window>
+              </dxl:Result>
+            </dxl:BroadcastMotion>
+          </dxl:Assert>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="j">
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.409260.1.1" TableName="x">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Subq-On-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-On-OuterRef.mdp
@@ -265,7 +265,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2.117188" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000632" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -279,7 +279,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.109375" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000560" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -299,7 +299,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -322,7 +322,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="x">

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-Limit1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-Limit1.mdp
@@ -325,9 +325,9 @@
       </dxl:LogicalSelect>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="12">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="26.111328" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000299" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -337,11 +337,194 @@
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:TableScan>
+        <dxl:Filter>
+          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+            <dxl:TestExpr/>
+            <dxl:ParamList>
+              <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ParamList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.16.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.16.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                      <dxl:If TypeMdid="0.16.1.0">
+                        <dxl:IsNull>
+                          <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                        </dxl:IsNull>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        <dxl:If TypeMdid="0.16.1.0">
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:Comparison>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                          <dxl:If TypeMdid="0.16.1.0">
+                            <dxl:IsNull>
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:IsNull>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                            <dxl:If TypeMdid="0.16.1.0">
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                              </dxl:Comparison>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                            </dxl:If>
+                          </dxl:If>
+                        </dxl:If>
+                      </dxl:If>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                          <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                          <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000080" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+                          <dxl:If TypeMdid="0.23.1.0">
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                          </dxl:If>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                          <dxl:If TypeMdid="0.23.1.0">
+                            <dxl:IsNull>
+                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:IsNull>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                          </dxl:If>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Limit>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="i">
+                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Materialize Eager="true">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="i">
+                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="9" Alias="i">
+                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="i">
+                                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.1623088.1.1" TableName="s">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:GatherMotion>
+                        </dxl:Materialize>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
+                    </dxl:Result>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:SubPlan>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="25.107422" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -351,217 +534,37 @@
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter>
-            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ParamList>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="8.099609" Rows="2.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="8.099609" Rows="2.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                      <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                      <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.16.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7.095703" Rows="2.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                        <dxl:If TypeMdid="0.16.1.0">
-                          <dxl:IsNull>
-                            <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-                          </dxl:IsNull>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          <dxl:If TypeMdid="0.16.1.0">
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                            </dxl:Comparison>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                            <dxl:If TypeMdid="0.16.1.0">
-                              <dxl:IsNull>
-                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                              <dxl:If TypeMdid="0.16.1.0">
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                                </dxl:Comparison>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                              </dxl:If>
-                            </dxl:If>
-                          </dxl:If>
-                        </dxl:If>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.093750" Rows="2.000000" Width="16"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                            <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                            <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.046875" Rows="2.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-                            <dxl:If TypeMdid="0.23.1.0">
-                              <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:Comparison>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                            </dxl:If>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                            <dxl:If TypeMdid="0.23.1.0">
-                              <dxl:IsNull>
-                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                            </dxl:If>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Materialize Eager="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.031250" Rows="2.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="9" Alias="i">
-                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="3.023438" Rows="2.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="9" Alias="i">
-                                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Limit>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2.015625" Rows="1.000000" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="9" Alias="i">
-                                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="9" Alias="i">
-                                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:TableScan>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="9" Alias="i">
-                                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:TableDescriptor Mdid="0.1623088.1.1" TableName="s">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                              </dxl:GatherMotion>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:Result>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:SubPlan>
-          </dxl:Filter>
-          <dxl:TableDescriptor Mdid="0.1623062.1.1" TableName="t">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:TableScan>
-      </dxl:GatherMotion>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.1623062.1.1" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-To-ScalarSubq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-To-ScalarSubq.mdp
@@ -366,13 +366,13 @@
       </dxl:LogicalLimit>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="22">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="36.136719" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000355" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="six">
-            <dxl:Ident ColId="21" ColName="six" TypeMdid="0.705.1.0"/>
+            <dxl:ConstValue TypeMdid="0.705.1.0" Value="AA=="/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="0" Alias="Correlated Field">
             <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
@@ -382,18 +382,12 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList>
-          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-          <dxl:SortingColumn ColId="2" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-        </dxl:SortingColumnList>
+        <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="35.126953" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000335" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="21" Alias="six">
-              <dxl:ConstValue TypeMdid="0.705.1.0" Value="AA=="/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="f1">
               <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
@@ -401,11 +395,205 @@
               <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
+          <dxl:Filter>
+            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+              <dxl:TestExpr/>
+              <dxl:ParamList>
+                <dxl:Param ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
+                <dxl:Param ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
+              </dxl:ParamList>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+                      <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.16.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                      <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.16.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+                        <dxl:If TypeMdid="0.16.1.0">
+                          <dxl:IsNull>
+                            <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
+                          </dxl:IsNull>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          <dxl:If TypeMdid="0.16.1.0">
+                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                              <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                            </dxl:Comparison>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                            <dxl:If TypeMdid="0.16.1.0">
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
+                              </dxl:IsNull>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                              <dxl:If TypeMdid="0.16.1.0">
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                                  <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:Comparison>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                              </dxl:If>
+                            </dxl:If>
+                          </dxl:If>
+                        </dxl:If>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="16"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                            <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="25" Alias="ColRef_0025">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                            <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                            <dxl:If TypeMdid="0.23.1.0">
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.670.1.0">
+                                <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
+                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                  <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                </dxl:Cast>
+                              </dxl:Comparison>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                            </dxl:If>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                            <dxl:If TypeMdid="0.23.1.0">
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                              </dxl:IsNull>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                            </dxl:If>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="?column?">
+                              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                                <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
+                              </dxl:OpExpr>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Materialize Eager="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="11" Alias="f2">
+                                <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="11" Alias="f2">
+                                  <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="11" Alias="f2">
+                                    <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
+                                    <dxl:FuncExpr FuncId="0.317.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                      <dxl:Ident ColId="12" ColName="f3" TypeMdid="0.701.1.0"/>
+                                    </dxl:FuncExpr>
+                                  </dxl:Comparison>
+                                </dxl:Filter>
+                                <dxl:TableDescriptor Mdid="0.734133.1.1" TableName="subselect_tbl">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="10" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="11" Attno="2" ColName="f2" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="12" Attno="3" ColName="f3" TypeMdid="0.701.1.0"/>
+                                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:GatherMotion>
+                          </dxl:Materialize>
+                        </dxl:Result>
+                      </dxl:Result>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:SubPlan>
+          </dxl:Filter>
           <dxl:OneTimeFilter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="34.107422" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="f1">
@@ -422,9 +610,9 @@
             </dxl:SortingColumnList>
             <dxl:LimitCount/>
             <dxl:LimitOffset/>
-            <dxl:TableScan>
+            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="33.107422" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="f1">
@@ -434,218 +622,39 @@
                   <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
-                  <dxl:TestExpr/>
-                  <dxl:ParamList>
-                    <dxl:Param ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
-                    <dxl:Param ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
-                  </dxl:ParamList>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="8.095703" Rows="2.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="27" Alias="ColRef_0027">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="8.095703" Rows="2.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="26" Alias="ColRef_0026">
-                          <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                          <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.16.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="7.093750" Rows="2.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="26" Alias="ColRef_0026">
-                            <dxl:If TypeMdid="0.16.1.0">
-                              <dxl:IsNull>
-                                <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
-                              </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                              <dxl:If TypeMdid="0.16.1.0">
-                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                                  <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                                </dxl:Comparison>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                                <dxl:If TypeMdid="0.16.1.0">
-                                  <dxl:IsNull>
-                                    <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
-                                  </dxl:IsNull>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                                  <dxl:If TypeMdid="0.16.1.0">
-                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                                      <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
-                                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                                    </dxl:Comparison>
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                                  </dxl:If>
-                                </dxl:If>
-                              </dxl:If>
-                            </dxl:If>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="6.091797" Rows="2.000000" Width="16"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns/>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-                              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="25" Alias="ColRef_0025">
-                              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:Result>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="5.044922" Rows="2.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                                <dxl:If TypeMdid="0.23.1.0">
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.670.1.0">
-                                    <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
-                                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                    </dxl:Cast>
-                                  </dxl:Comparison>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                </dxl:If>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                                <dxl:If TypeMdid="0.23.1.0">
-                                  <dxl:IsNull>
-                                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                  </dxl:IsNull>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                </dxl:If>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="4.029297" Rows="2.000000" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="20" Alias="?column?">
-                                  <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                                    <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
-                                  </dxl:OpExpr>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="3.021484" Rows="2.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="11" Alias="f2">
-                                    <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="2.013672" Rows="2.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="11" Alias="f2">
-                                      <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="11" Alias="f2">
-                                        <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter>
-                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                        <dxl:Ident ColId="11" ColName="f2" TypeMdid="0.23.1.0"/>
-                                        <dxl:FuncExpr FuncId="0.317.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                                          <dxl:Ident ColId="12" ColName="f3" TypeMdid="0.701.1.0"/>
-                                        </dxl:FuncExpr>
-                                      </dxl:Comparison>
-                                    </dxl:Filter>
-                                    <dxl:TableDescriptor Mdid="0.734133.1.1" TableName="subselect_tbl">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="10" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
-                                        <dxl:Column ColId="11" Attno="2" ColName="f2" TypeMdid="0.23.1.0"/>
-                                        <dxl:Column ColId="12" Attno="3" ColName="f3" TypeMdid="0.701.1.0"/>
-                                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
-                          </dxl:Result>
-                        </dxl:Aggregate>
-                      </dxl:Result>
-                    </dxl:Result>
-                  </dxl:Result>
-                </dxl:SubPlan>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.734133.1.1" TableName="subselect_tbl">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="f3" TypeMdid="0.701.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="f1">
+                    <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="f3">
+                    <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.734133.1.1" TableName="subselect_tbl">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="f3" TypeMdid="0.701.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:GatherMotion>
           </dxl:Sort>
         </dxl:Result>
-      </dxl:GatherMotion>
+      </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,10 +456,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1235275">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="62302">
+      <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.230469" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -470,10 +470,16 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="Inner">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.226562" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -484,16 +490,10 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
+          <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -518,22 +518,38 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        </dxl:GatherMotion>
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000967" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="27"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="27" Alias="i">
+              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7.164062" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
             </dxl:Properties>
-            <dxl:GroupingColumns>
-              <dxl:GroupingColumn ColId="27"/>
-            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="27" Alias="i">
                 <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5.132812" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="i">
@@ -548,9 +564,9 @@
                   <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:TableScan>
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="i">
@@ -560,31 +576,46 @@
                     <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-                    <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                  <dxl:Columns>
-                    <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="27" Alias="i">
+                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="28" Alias="j">
+                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                      </dxl:Array>
+                    </dxl:ArrayComp>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                    <dxl:Columns>
+                      <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:GatherMotion>
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.054688" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000437" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="19" Alias="j">
@@ -595,7 +626,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.050781" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000419" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="j">
@@ -612,7 +643,7 @@
                   </dxl:HashCondList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="j">
@@ -636,7 +667,7 @@
                   </dxl:TableScan>
                   <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.005859" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="19" Alias="j">
@@ -647,7 +678,7 @@
                     <dxl:SortingColumnList/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="j">
@@ -671,11 +702,11 @@
                     </dxl:TableScan>
                   </dxl:BroadcastMotion>
                 </dxl:HashJoin>
-              </dxl:BroadcastMotion>
+              </dxl:GatherMotion>
             </dxl:HashJoin>
-          </dxl:Aggregate>
-        </dxl:HashJoin>
-      </dxl:GatherMotion>
+          </dxl:Sort>
+        </dxl:Aggregate>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,10 +431,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="340829">
+    <dxl:Plan Id="0" SpaceSize="384581">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="18.187988" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -448,7 +448,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="17.184082" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="12930.008037" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -464,7 +464,7 @@
           </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -491,32 +491,32 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.180176" Rows="2.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001304" Rows="2.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="7.178223" Rows="2.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001303" Rows="2.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.176270" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.001251" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.174316" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.001250" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4.173828" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.001245" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
@@ -529,7 +529,7 @@
                     </dxl:HashCondList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="j">
@@ -553,7 +553,7 @@
                     </dxl:TableScan>
                     <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.128906" Rows="2.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000950" Rows="2.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="j">
@@ -564,7 +564,7 @@
                       <dxl:SortingColumnList/>
                       <dxl:HashJoin JoinType="In">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2.125000" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="862.000846" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="19" Alias="j">
@@ -585,7 +585,7 @@
                         </dxl:HashCondList>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="18" Alias="i">
@@ -612,7 +612,7 @@
                         </dxl:TableScan>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="27" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Switch-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Switch-With-Subquery.mdp
@@ -404,7 +404,7 @@
     <dxl:Plan Id="0" SpaceSize="134">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.788583" Rows="10.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002549" Rows="10.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="c">
@@ -417,7 +417,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.769051" Rows="10.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002369" Rows="10.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="c">
@@ -432,7 +432,7 @@
           <dxl:LimitOffset/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.406250" Rows="10.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.002106" Rows="10.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="c">
@@ -453,7 +453,7 @@
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.367188" Rows="10.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.002086" Rows="10.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -473,7 +473,7 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.078125" Rows="10.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000304" Rows="10.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -492,7 +492,7 @@
                 </dxl:HashExprList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -518,17 +518,17 @@
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
               </dxl:RedistributeMotion>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.132812" Rows="2.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000467" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="10"/>
                 </dxl:GroupingColumns>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="max">
-                    <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
-                      <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final">
+                      <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
                     </dxl:AggFunc>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="10" Alias="j">
@@ -536,47 +536,119 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="10.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000455" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="j">
                       <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                      <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:TableScan>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000455" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="j">
                         <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                        <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.32802.1.1" TableName="y">
-                      <dxl:Columns>
-                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:RedistributeMotion>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000429" Rows="2.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="10" Alias="j">
+                          <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                          <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000429" Rows="2.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="10"/>
+                        </dxl:GroupingColumns>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial">
+                              <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="j">
+                            <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000405" Rows="10.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="10" Alias="j">
+                              <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="10" Alias="j">
+                                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.32802.1.1" TableName="y">
+                              <dxl:Columns>
+                                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:Result>
+                  </dxl:RedistributeMotion>
+                </dxl:Sort>
               </dxl:Aggregate>
             </dxl:HashJoin>
           </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -2651,7 +2651,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="544733.504140" Rows="11530621.000000" Width="123"/>
+          <dxl:Cost StartupCost="0" TotalCost="9093.143836" Rows="11530621.000000" Width="123"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="inv_date_sk">
@@ -2761,7 +2761,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="180166.953125" Rows="11530621.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1576.797809" Rows="11530621.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="inv_date_sk">
@@ -2781,7 +2781,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="90082.976562" Rows="11530621.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="576.862356" Rows="11530621.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="inv_date_sk">
@@ -2817,7 +2817,7 @@
         </dxl:GatherMotion>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3867.264637" Rows="350.629208" Width="107"/>
+            <dxl:Cost StartupCost="0" TotalCost="435.150680" Rows="350.629208" Width="107"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="d_date_sk">
@@ -2909,7 +2909,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3847.945630" Rows="350.629208" Width="107"/>
+              <dxl:Cost StartupCost="0" TotalCost="434.982227" Rows="350.629208" Width="107"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="d_date_sk">

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -3673,10 +3673,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1154464">
+    <dxl:Plan Id="0" SpaceSize="1253539">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="865342008.829724" Rows="10325183.250315" Width="697"/>
+          <dxl:Cost StartupCost="0" TotalCost="2449307.347267" Rows="10325183.250315" Width="697"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -3795,7 +3795,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="861828017.241116" Rows="10325183.250315" Width="697"/>
+            <dxl:Cost StartupCost="0" TotalCost="2416994.376530" Rows="10325183.250315" Width="697"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -3917,14 +3917,10 @@
               <dxl:Ident ColId="32" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="16" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="54" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="16" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="854074911.201895" Rows="10325183.250323" Width="500"/>
+              <dxl:Cost StartupCost="0" TotalCost="2386370.844305" Rows="10325183.250323" Width="500"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -4027,7 +4023,7 @@
             </dxl:HashExprList>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="851554113.509922" Rows="10325183.250323" Width="500"/>
+                <dxl:Cost StartupCost="0" TotalCost="2378291.388412" Rows="10325183.250323" Width="500"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -4128,18 +4124,10 @@
                   <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="0" ColName="p_partkey" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="32" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="54" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="53" ColName="ps_partkey" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="414013491.500000" Rows="1536050048.000000" Width="138"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2305315.183208" Rows="24060859.229183" Width="357"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="30" Alias="l_orderkey">
@@ -4190,17 +4178,37 @@
                   <dxl:ProjElem ColId="45" Alias="l_comment">
                     <dxl:Ident ColId="45" ColName="l_comment" TypeMdid="0.1043.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="53" Alias="ps_partkey">
+                    <dxl:Ident ColId="53" ColName="ps_partkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="54" Alias="ps_suppkey">
+                    <dxl:Ident ColId="54" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="55" Alias="ps_availqty">
+                    <dxl:Ident ColId="55" ColName="ps_availqty" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="56" Alias="ps_supplycost">
+                    <dxl:Ident ColId="56" ColName="ps_supplycost" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="57" Alias="ps_comment">
+                    <dxl:Ident ColId="57" ColName="ps_comment" TypeMdid="0.1043.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="32" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="54" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Sequence>
+                    <dxl:Ident ColId="53" ColName="ps_partkey" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="103503372.375000" Rows="1536050048.000000" Width="138"/>
+                    <dxl:Cost StartupCost="0" TotalCost="706261.357556" Rows="1536050048.000000" Width="138"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="30" Alias="l_orderkey">
@@ -4252,30 +4260,16 @@
                       <dxl:Ident ColId="45" ColName="l_comment" TypeMdid="0.1043.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="0.93299.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Sequence>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:DynamicTableScan PartIndexId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="103503372.375000" Rows="1536050048.000000" Width="138"/>
+                      <dxl:Cost StartupCost="0" TotalCost="71396.512218" Rows="1536050048.000000" Width="138"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="30" Alias="l_orderkey">
@@ -4327,96 +4321,115 @@
                         <dxl:Ident ColId="45" ColName="l_comment" TypeMdid="0.1043.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.93299.1.1" TableName="lineitem">
-                      <dxl:Columns>
-                        <dxl:Column ColId="30" Attno="1" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="31" Attno="2" ColName="l_partkey" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="32" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="33" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="34" Attno="5" ColName="l_quantity" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="35" Attno="6" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="36" Attno="7" ColName="l_discount" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="37" Attno="8" ColName="l_tax" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="38" Attno="9" ColName="l_returnflag" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="39" Attno="10" ColName="l_linestatus" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="40" Attno="11" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                        <dxl:Column ColId="41" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-                        <dxl:Column ColId="42" Attno="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
-                        <dxl:Column ColId="43" Attno="14" ColName="l_shipinstruct" TypeMdid="0.1042.1.0" ColWidth="25"/>
-                        <dxl:Column ColId="44" Attno="15" ColName="l_shipmode" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                        <dxl:Column ColId="45" Attno="16" ColName="l_comment" TypeMdid="0.1043.1.0" ColWidth="44"/>
-                        <dxl:Column ColId="46" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="47" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="48" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="49" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="50" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="51" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="52" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicTableScan>
-                </dxl:Sequence>
-              </dxl:RedistributeMotion>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="86495679.324219" Rows="81489013.073017" Width="362"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="p_partkey">
-                    <dxl:Ident ColId="0" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="p_name">
-                    <dxl:Ident ColId="1" ColName="p_name" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="p_mfgr">
-                    <dxl:Ident ColId="2" ColName="p_mfgr" TypeMdid="0.1042.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="p_brand">
-                    <dxl:Ident ColId="3" ColName="p_brand" TypeMdid="0.1042.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="4" Alias="p_type">
-                    <dxl:Ident ColId="4" ColName="p_type" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="5" Alias="p_size">
-                    <dxl:Ident ColId="5" ColName="p_size" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="6" Alias="p_container">
-                    <dxl:Ident ColId="6" ColName="p_container" TypeMdid="0.1042.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="7" Alias="p_retailprice">
-                    <dxl:Ident ColId="7" ColName="p_retailprice" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="p_comment">
-                    <dxl:Ident ColId="8" ColName="p_comment" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="53" Alias="ps_partkey">
-                    <dxl:Ident ColId="53" ColName="ps_partkey" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="54" Alias="ps_suppkey">
-                    <dxl:Ident ColId="54" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="55" Alias="ps_availqty">
-                    <dxl:Ident ColId="55" ColName="ps_availqty" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="56" Alias="ps_supplycost">
-                    <dxl:Ident ColId="56" ColName="ps_supplycost" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="57" Alias="ps_comment">
-                    <dxl:Ident ColId="57" ColName="ps_comment" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="53" ColName="ps_partkey" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="0" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
+                    <dxl:PartitionSelector RelationMdid="0.93299.1.1" PartitionLevels="1" ScanId="1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:PartEqFilters>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:PartEqFilters>
+                      <dxl:PartFilters>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:PartFilters>
+                      <dxl:ResidualFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:ResidualFilter>
+                      <dxl:PropagationExpression>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:PropagationExpression>
+                      <dxl:PrintableFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:PrintableFilter>
+                    </dxl:PartitionSelector>
+                    <dxl:DynamicTableScan PartIndexId="1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="71396.512218" Rows="1536050048.000000" Width="138"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="30" Alias="l_orderkey">
+                          <dxl:Ident ColId="30" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="31" Alias="l_partkey">
+                          <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="l_suppkey">
+                          <dxl:Ident ColId="32" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="33" Alias="l_linenumber">
+                          <dxl:Ident ColId="33" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="34" Alias="l_quantity">
+                          <dxl:Ident ColId="34" ColName="l_quantity" TypeMdid="0.1700.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="35" Alias="l_extendedprice">
+                          <dxl:Ident ColId="35" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="36" Alias="l_discount">
+                          <dxl:Ident ColId="36" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="37" Alias="l_tax">
+                          <dxl:Ident ColId="37" ColName="l_tax" TypeMdid="0.1700.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="38" Alias="l_returnflag">
+                          <dxl:Ident ColId="38" ColName="l_returnflag" TypeMdid="0.1042.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="39" Alias="l_linestatus">
+                          <dxl:Ident ColId="39" ColName="l_linestatus" TypeMdid="0.1042.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="40" Alias="l_shipdate">
+                          <dxl:Ident ColId="40" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="41" Alias="l_commitdate">
+                          <dxl:Ident ColId="41" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="42" Alias="l_receiptdate">
+                          <dxl:Ident ColId="42" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="43" Alias="l_shipinstruct">
+                          <dxl:Ident ColId="43" ColName="l_shipinstruct" TypeMdid="0.1042.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="44" Alias="l_shipmode">
+                          <dxl:Ident ColId="44" ColName="l_shipmode" TypeMdid="0.1042.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="45" Alias="l_comment">
+                          <dxl:Ident ColId="45" ColName="l_comment" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.93299.1.1" TableName="lineitem">
+                        <dxl:Columns>
+                          <dxl:Column ColId="30" Attno="1" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="31" Attno="2" ColName="l_partkey" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="32" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="33" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="34" Attno="5" ColName="l_quantity" TypeMdid="0.1700.1.0"/>
+                          <dxl:Column ColId="35" Attno="6" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                          <dxl:Column ColId="36" Attno="7" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                          <dxl:Column ColId="37" Attno="8" ColName="l_tax" TypeMdid="0.1700.1.0"/>
+                          <dxl:Column ColId="38" Attno="9" ColName="l_returnflag" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                          <dxl:Column ColId="39" Attno="10" ColName="l_linestatus" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                          <dxl:Column ColId="40" Attno="11" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
+                          <dxl:Column ColId="41" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                          <dxl:Column ColId="42" Attno="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
+                          <dxl:Column ColId="43" Attno="14" ColName="l_shipinstruct" TypeMdid="0.1042.1.0" ColWidth="25"/>
+                          <dxl:Column ColId="44" Attno="15" ColName="l_shipmode" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                          <dxl:Column ColId="45" Attno="16" ColName="l_comment" TypeMdid="0.1043.1.0" ColWidth="44"/>
+                          <dxl:Column ColId="46" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="47" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="48" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="49" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="50" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="51" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="52" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:DynamicTableScan>
+                  </dxl:Sequence>
+                </dxl:RedistributeMotion>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="21921386.718750" Rows="205000000.000000" Width="219"/>
+                    <dxl:Cost StartupCost="0" TotalCost="14468.375000" Rows="205000000.000000" Width="219"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="53" Alias="ps_partkey">
@@ -4453,74 +4466,74 @@
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6433920.121094" Rows="20476560.000000" Width="143"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="p_partkey">
-                      <dxl:Ident ColId="0" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="p_name">
-                      <dxl:Ident ColId="1" ColName="p_name" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="p_mfgr">
-                      <dxl:Ident ColId="2" ColName="p_mfgr" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="p_brand">
-                      <dxl:Ident ColId="3" ColName="p_brand" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="4" Alias="p_type">
-                      <dxl:Ident ColId="4" ColName="p_type" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="5" Alias="p_size">
-                      <dxl:Ident ColId="5" ColName="p_size" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="6" Alias="p_container">
-                      <dxl:Ident ColId="6" ColName="p_container" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="p_retailprice">
-                      <dxl:Ident ColId="7" ColName="p_retailprice" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="p_comment">
-                      <dxl:Ident ColId="8" ColName="p_comment" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1209.1.0">
-                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                        <dxl:Ident ColId="1" ColName="p_name" TypeMdid="0.1043.1.0"/>
-                      </dxl:Cast>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAADSUlZ3JlZW4lJQ==" LintValue="295215918"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.99274.1.1" TableName="part">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="p_name" TypeMdid="0.1043.1.0" ColWidth="55"/>
-                      <dxl:Column ColId="2" Attno="3" ColName="p_mfgr" TypeMdid="0.1042.1.0" ColWidth="25"/>
-                      <dxl:Column ColId="3" Attno="4" ColName="p_brand" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                      <dxl:Column ColId="4" Attno="5" ColName="p_type" TypeMdid="0.1043.1.0" ColWidth="25"/>
-                      <dxl:Column ColId="5" Attno="6" ColName="p_size" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="6" Attno="7" ColName="p_container" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                      <dxl:Column ColId="7" Attno="8" ColName="p_retailprice" TypeMdid="0.1700.1.0"/>
-                      <dxl:Column ColId="8" Attno="9" ColName="p_comment" TypeMdid="0.1043.1.0" ColWidth="23"/>
-                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
               </dxl:HashJoin>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="6727.337434" Rows="20476560.000000" Width="143"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="p_partkey">
+                    <dxl:Ident ColId="0" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="p_name">
+                    <dxl:Ident ColId="1" ColName="p_name" TypeMdid="0.1043.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="p_mfgr">
+                    <dxl:Ident ColId="2" ColName="p_mfgr" TypeMdid="0.1042.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="3" Alias="p_brand">
+                    <dxl:Ident ColId="3" ColName="p_brand" TypeMdid="0.1042.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="4" Alias="p_type">
+                    <dxl:Ident ColId="4" ColName="p_type" TypeMdid="0.1043.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="5" Alias="p_size">
+                    <dxl:Ident ColId="5" ColName="p_size" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="6" Alias="p_container">
+                    <dxl:Ident ColId="6" ColName="p_container" TypeMdid="0.1042.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="7" Alias="p_retailprice">
+                    <dxl:Ident ColId="7" ColName="p_retailprice" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="p_comment">
+                    <dxl:Ident ColId="8" ColName="p_comment" TypeMdid="0.1043.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1209.1.0">
+                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                      <dxl:Ident ColId="1" ColName="p_name" TypeMdid="0.1043.1.0"/>
+                    </dxl:Cast>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAADSUlZ3JlZW4lJQ==" LintValue="295215918"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.99274.1.1" TableName="part">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="p_name" TypeMdid="0.1043.1.0" ColWidth="55"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="p_mfgr" TypeMdid="0.1042.1.0" ColWidth="25"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="p_brand" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                    <dxl:Column ColId="4" Attno="5" ColName="p_type" TypeMdid="0.1043.1.0" ColWidth="25"/>
+                    <dxl:Column ColId="5" Attno="6" ColName="p_size" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="6" Attno="7" ColName="p_container" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                    <dxl:Column ColId="7" Attno="8" ColName="p_retailprice" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="8" Attno="9" ColName="p_comment" TypeMdid="0.1043.1.0" ColWidth="23"/>
+                    <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
             </dxl:HashJoin>
           </dxl:RedistributeMotion>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="246501.059570" Rows="2562610.000000" Width="197"/>
+              <dxl:Cost StartupCost="0" TotalCost="590.970929" Rows="2562610.000000" Width="197"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="16" Alias="s_suppkey">

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
@@ -6497,10 +6497,10 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16918566576">
+    <dxl:Plan Id="0" SpaceSize="18318938624">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5607982245.179001" Rows="25.000000" Width="34"/>
+          <dxl:Cost StartupCost="0" TotalCost="9730008.262386" Rows="25.000000" Width="34"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="69" Alias="n_name">
@@ -6516,7 +6516,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5607982243.763962" Rows="25.000000" Width="34"/>
+            <dxl:Cost StartupCost="0" TotalCost="9730008.258569" Rows="25.000000" Width="34"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="69" Alias="n_name">
@@ -6534,7 +6534,7 @@
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5607982139.924661" Rows="25.000000" Width="34"/>
+              <dxl:Cost StartupCost="0" TotalCost="9730008.249788" Rows="25.000000" Width="34"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="69"/>
@@ -6544,112 +6544,169 @@
                 <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="89" Alias="revenue">
-                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.1700.1.0"/>
+                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Normal">
+                  <dxl:OpExpr OperatorName="*" OperatorMdid="0.1760.1.0" OperatorType="0.1700.1.0">
+                    <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                    <dxl:OpExpr OperatorName="-" OperatorMdid="0.1759.1.0" OperatorType="0.1700.1.0">
+                      <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
+                      <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                    </dxl:OpExpr>
+                  </dxl:OpExpr>
                 </dxl:AggFunc>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5607982136.434426" Rows="25.000000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="5552671.849226" Rows="67480880077.599854" Width="42"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="36" Alias="l_extendedprice">
+                  <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="37" Alias="l_discount">
+                  <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="69" Alias="n_name">
                   <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:Result>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="54" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="57" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="5607982135.019387" Rows="25.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="558820.299523" Rows="168702200.193471" Width="50"/>
                 </dxl:Properties>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="3" Alias="c_nationkey">
+                    <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="33" Alias="l_suppkey">
+                    <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="36" Alias="l_extendedprice">
+                    <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="37" Alias="l_discount">
+                    <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="69" Alias="n_name">
                     <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                    <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5607982135.019387" Rows="25.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="545619.352358" Rows="168702200.193471" Width="50"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="69"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="90" Alias="ColRef_0090">
-                      <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                        <dxl:OpExpr OperatorName="*" OperatorMdid="0.1760.1.0" OperatorType="0.1700.1.0">
-                          <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
-                          <dxl:OpExpr OperatorName="-" OperatorMdid="0.1759.1.0" OperatorType="0.1700.1.0">
-                            <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
-                            <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
-                          </dxl:OpExpr>
-                        </dxl:OpExpr>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="3" Alias="c_nationkey">
+                      <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="33" Alias="l_suppkey">
+                      <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="36" Alias="l_extendedprice">
+                      <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="37" Alias="l_discount">
+                      <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="69" Alias="n_name">
                       <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:HashJoin JoinType="Inner">
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="31" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="72441189.323697" Rows="67480880077.599854" Width="42"/>
+                      <dxl:Cost StartupCost="0" TotalCost="71397.896000" Rows="1536080000.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="31" Alias="l_orderkey">
+                        <dxl:Ident ColId="31" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="33" Alias="l_suppkey">
+                        <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="36" Alias="l_extendedprice">
                         <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="37" Alias="l_discount">
                         <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
                       </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.447748.1.1" TableName="lineitem">
+                      <dxl:Columns>
+                        <dxl:Column ColId="31" Attno="1" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="33" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="36" Attno="6" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
+                        <dxl:Column ColId="37" Attno="7" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                        <dxl:Column ColId="47" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="48" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="49" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="50" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="51" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="52" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="53" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="56242.898849" Rows="21392620.717043" Width="34"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="3" Alias="c_nationkey">
+                        <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="o_orderkey">
+                        <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="69" Alias="n_name">
                         <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="54" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="57" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
                     <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="63974439.150187" Rows="168702200.193471" Width="50"/>
+                        <dxl:Cost StartupCost="0" TotalCost="55104.597500" Rows="21392620.717043" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="3" Alias="c_nationkey">
                           <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="l_suppkey">
-                          <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="36" Alias="l_extendedprice">
-                          <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="37" Alias="l_discount">
-                          <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
+                        <dxl:ProjElem ColId="15" Alias="o_orderkey">
+                          <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="69" Alias="n_name">
                           <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
@@ -6659,159 +6716,81 @@
                       <dxl:JoinFilter/>
                       <dxl:HashCondList>
                         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="31" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="0" ColName="c_custkey" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                         </dxl:Comparison>
                       </dxl:HashCondList>
-                      <dxl:TableScan>
+                      <dxl:HashJoin JoinType="Inner">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="18000937.500000" Rows="1536080000.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="8139.402806" Rows="7681740.000000" Width="34"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="31" Alias="l_orderkey">
-                            <dxl:Ident ColId="31" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="0" Alias="c_custkey">
+                            <dxl:Ident ColId="0" ColName="c_custkey" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="l_suppkey">
-                            <dxl:Ident ColId="33" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="36" Alias="l_extendedprice">
-                            <dxl:Ident ColId="36" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="37" Alias="l_discount">
-                            <dxl:Ident ColId="37" ColName="l_discount" TypeMdid="0.1700.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.447748.1.1" TableName="lineitem">
-                          <dxl:Columns>
-                            <dxl:Column ColId="31" Attno="1" ColName="l_orderkey" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="33" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="36" Attno="6" ColName="l_extendedprice" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="37" Attno="7" ColName="l_discount" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="47" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="48" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="49" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="50" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="51" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="52" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="53" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="6420116.351459" Rows="21392620.717043" Width="34"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
                           <dxl:ProjElem ColId="3" Alias="c_nationkey">
                             <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="15" Alias="o_orderkey">
-                            <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="69" Alias="n_name">
                             <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:HashJoin JoinType="Inner">
+                        <dxl:JoinFilter/>
+                        <dxl:HashCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="68" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:HashCondList>
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="6064964.421587" Rows="21392620.717043" Width="34"/>
+                            <dxl:Cost StartupCost="0" TotalCost="3103.285302" Rows="38408700.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="c_custkey">
+                              <dxl:Ident ColId="0" ColName="c_custkey" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="3" Alias="c_nationkey">
                               <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="15" Alias="o_orderkey">
-                              <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.447514.1.1" TableName="customer">
+                            <dxl:Columns>
+                              <dxl:Column ColId="0" Attno="1" ColName="c_custkey" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="3" Attno="4" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="8" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="9" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="10" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="11" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="12" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="862.009717" Rows="10.000000" Width="30"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="68" Alias="n_nationkey">
+                              <dxl:Ident ColId="68" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="69" Alias="n_name">
                               <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:JoinFilter/>
-                          <dxl:HashCondList>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                              <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
-                              <dxl:Ident ColId="0" ColName="c_custkey" TypeMdid="0.23.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:HashCondList>
-                          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="3503915.370139" Rows="106963103.585235" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="15" Alias="o_orderkey">
-                                <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="16" Alias="o_custkey">
-                                <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:HashExprList>
-                              <dxl:HashExpr>
-                                <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                            </dxl:HashExprList>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="3086089.746760" Rows="106963103.585235" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="15" Alias="o_orderkey">
-                                  <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="16" Alias="o_custkey">
-                                  <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter>
-                                <dxl:And>
-                                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
-                                    <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
-                                  </dxl:Comparison>
-                                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2345.1.0">
-                                    <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.1114.1.0" Value="AEDFJYNw//8=" DoubleValue="-157766400000000.000000"/>
-                                  </dxl:Comparison>
-                                </dxl:And>
-                              </dxl:Filter>
-                              <dxl:TableDescriptor Mdid="0.447800.1.1" TableName="orders">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="15" Attno="1" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="16" Attno="2" ColName="o_custkey" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="19" Attno="5" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                                  <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:RedistributeMotion>
+                          <dxl:SortingColumnList/>
                           <dxl:HashJoin JoinType="Inner">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="450109.937500" Rows="7681740.000000" Width="34"/>
+                              <dxl:Cost StartupCost="0" TotalCost="862.005791" Rows="5.000000" Width="30"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="c_custkey">
-                                <dxl:Ident ColId="0" ColName="c_custkey" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="3" Alias="c_nationkey">
-                                <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="68" Alias="n_nationkey">
+                                <dxl:Ident ColId="68" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="69" Alias="n_name">
                                 <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
@@ -6821,40 +6800,13 @@
                             <dxl:JoinFilter/>
                             <dxl:HashCondList>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
-                                <dxl:Ident ColId="68" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="70" ColName="n_regionkey" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="79" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
                               </dxl:Comparison>
                             </dxl:HashCondList>
                             <dxl:TableScan>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="150033.984375" Rows="38408700.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="c_custkey">
-                                  <dxl:Ident ColId="0" ColName="c_custkey" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="3" Alias="c_nationkey">
-                                  <dxl:Ident ColId="3" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.447514.1.1" TableName="customer">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="0" Attno="1" ColName="c_custkey" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="3" Attno="4" ColName="c_nationkey" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="8" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="9" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="10" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="11" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="12" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="5.519531" Rows="10.000000" Width="30"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.001478" Rows="25.000000" Width="34"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="68" Alias="n_nationkey">
@@ -6863,153 +6815,176 @@
                                 <dxl:ProjElem ColId="69" Alias="n_name">
                                   <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                                 </dxl:ProjElem>
+                                <dxl:ProjElem ColId="70" Alias="n_regionkey">
+                                  <dxl:Ident ColId="70" ColName="n_regionkey" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.447774.1.1" TableName="nation">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="68" Attno="1" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="69" Attno="2" ColName="n_name" TypeMdid="0.1042.1.0" ColWidth="25"/>
+                                  <dxl:Column ColId="70" Attno="3" ColName="n_regionkey" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="72" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="73" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="74" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="75" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="76" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="77" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="78" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000638" Rows="2.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="79" Alias="r_regionkey">
+                                  <dxl:Ident ColId="79" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
-                              <dxl:HashJoin JoinType="Inner">
+                              <dxl:TableScan>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="4.373047" Rows="5.000000" Width="30"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000428" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="68" Alias="n_nationkey">
-                                    <dxl:Ident ColId="68" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="69" Alias="n_name">
-                                    <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
+                                  <dxl:ProjElem ColId="79" Alias="r_regionkey">
+                                    <dxl:Ident ColId="79" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:JoinFilter/>
-                                <dxl:HashCondList>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                    <dxl:Ident ColId="70" ColName="n_regionkey" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="79" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
+                                <dxl:Filter>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                                    <dxl:Ident ColId="80" ColName="r_name" TypeMdid="0.1042.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACEFTSUE=" LintValue="451683180"/>
                                   </dxl:Comparison>
-                                </dxl:HashCondList>
-                                <dxl:TableScan>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.415039" Rows="25.000000" Width="34"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="68" Alias="n_nationkey">
-                                      <dxl:Ident ColId="68" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="69" Alias="n_name">
-                                      <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="70" Alias="n_regionkey">
-                                      <dxl:Ident ColId="70" ColName="n_regionkey" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:TableDescriptor Mdid="0.447774.1.1" TableName="nation">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="68" Attno="1" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
-                                      <dxl:Column ColId="69" Attno="2" ColName="n_name" TypeMdid="0.1042.1.0" ColWidth="25"/>
-                                      <dxl:Column ColId="70" Attno="3" ColName="n_regionkey" TypeMdid="0.23.1.0"/>
-                                      <dxl:Column ColId="72" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                      <dxl:Column ColId="73" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="74" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="75" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="76" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="77" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                      <dxl:Column ColId="78" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                                <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="2.088867" Rows="2.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="79" Alias="r_regionkey">
-                                      <dxl:Ident ColId="79" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1.081055" Rows="1.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="79" Alias="r_regionkey">
-                                        <dxl:Ident ColId="79" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter>
-                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                                        <dxl:Ident ColId="80" ColName="r_name" TypeMdid="0.1042.1.0"/>
-                                        <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACEFTSUE=" LintValue="451683180"/>
-                                      </dxl:Comparison>
-                                    </dxl:Filter>
-                                    <dxl:TableDescriptor Mdid="0.447878.1.1" TableName="region">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="79" Attno="1" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
-                                        <dxl:Column ColId="80" Attno="2" ColName="r_name" TypeMdid="0.1042.1.0" ColWidth="25"/>
-                                        <dxl:Column ColId="82" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                        <dxl:Column ColId="83" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="84" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="85" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="86" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="87" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                        <dxl:Column ColId="88" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:BroadcastMotion>
-                              </dxl:HashJoin>
+                                </dxl:Filter>
+                                <dxl:TableDescriptor Mdid="0.447878.1.1" TableName="region">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="79" Attno="1" ColName="r_regionkey" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="80" Attno="2" ColName="r_name" TypeMdid="0.1042.1.0" ColWidth="25"/>
+                                    <dxl:Column ColId="82" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="83" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="84" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="85" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="86" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="87" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="88" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
                             </dxl:BroadcastMotion>
                           </dxl:HashJoin>
-                        </dxl:HashJoin>
-                      </dxl:RedistributeMotion>
-                    </dxl:HashJoin>
-                    <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="29914.398438" Rows="5105220.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="54" Alias="s_suppkey">
-                          <dxl:Ident ColId="54" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="57" Alias="s_nationkey">
-                          <dxl:Ident ColId="57" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:HashJoin>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="9971.132812" Rows="2552610.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="26814.944290" Rows="106963103.585235" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="54" Alias="s_suppkey">
-                            <dxl:Ident ColId="54" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="15" Alias="o_orderkey">
+                            <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="57" Alias="s_nationkey">
-                            <dxl:Ident ColId="57" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="16" Alias="o_custkey">
+                            <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.447904.1.1" TableName="supplier">
-                          <dxl:Columns>
-                            <dxl:Column ColId="54" Attno="1" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="57" Attno="4" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="62" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="63" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="64" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="65" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="66" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="67" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:BroadcastMotion>
-                  </dxl:HashJoin>
-                </dxl:Aggregate>
-              </dxl:Result>
-            </dxl:RedistributeMotion>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="25475.766233" Rows="106963103.585235" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="15" Alias="o_orderkey">
+                              <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="16" Alias="o_custkey">
+                              <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter>
+                            <dxl:And>
+                              <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
+                                <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
+                              </dxl:Comparison>
+                              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2345.1.0">
+                                <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.1114.1.0" Value="AEDFJYNw//8=" DoubleValue="-157766400000000.000000"/>
+                              </dxl:Comparison>
+                            </dxl:And>
+                          </dxl:Filter>
+                          <dxl:TableDescriptor Mdid="0.447800.1.1" TableName="orders">
+                            <dxl:Columns>
+                              <dxl:Column ColId="15" Attno="1" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="16" Attno="2" ColName="o_custkey" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="19" Attno="5" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
+                              <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                    </dxl:HashJoin>
+                  </dxl:RedistributeMotion>
+                </dxl:HashJoin>
+              </dxl:RedistributeMotion>
+              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1143.854632" Rows="5105220.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="54" Alias="s_suppkey">
+                    <dxl:Ident ColId="54" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="57" Alias="s_nationkey">
+                    <dxl:Ident ColId="57" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="590.346679" Rows="2552610.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="54" Alias="s_suppkey">
+                      <dxl:Ident ColId="54" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="57" Alias="s_nationkey">
+                      <dxl:Ident ColId="57" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.447904.1.1" TableName="supplier">
+                    <dxl:Columns>
+                      <dxl:Column ColId="54" Attno="1" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="57" Attno="4" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="62" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="63" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="64" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="65" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="66" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="67" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+            </dxl:HashJoin>
           </dxl:Aggregate>
         </dxl:Sort>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
@@ -279,7 +279,7 @@ SELECT generate_series((
     <dxl:Plan Id="0" SpaceSize="126">
       <dxl:TableValuedFunction FuncId="0.1068.1.0" Name="generate_series" TypeMdid="0.20.1.0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="15.625000" Rows="1000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="generate_series">
@@ -291,7 +291,7 @@ SELECT generate_series((
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="282.199219" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -302,7 +302,7 @@ SELECT generate_series((
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="282.199219" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -325,7 +325,7 @@ SELECT generate_series((
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="281.167969" Rows="4.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6896.001783" Rows="4.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="76" Alias="ColRef_0076">
@@ -339,7 +339,7 @@ SELECT generate_series((
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="280.042969" Rows="4.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6896.001719" Rows="4.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="count">
@@ -355,7 +355,7 @@ SELECT generate_series((
                   </dxl:JoinFilter>
                   <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="20.022461" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000110" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="count">
@@ -368,7 +368,7 @@ SELECT generate_series((
                     </dxl:JoinFilter>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="53" Alias="ColRef_0023">
@@ -380,7 +380,7 @@ SELECT generate_series((
                     </dxl:Result>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.020508" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
@@ -391,20 +391,20 @@ SELECT generate_series((
                       <dxl:Filter/>
                       <dxl:Materialize Eager="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2.002930" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1.000977" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:Filter/>
@@ -429,7 +429,7 @@ SELECT generate_series((
                   </dxl:NestedLoopJoin>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3.020508" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -440,20 +440,20 @@ SELECT generate_series((
                     <dxl:Filter/>
                     <dxl:Materialize Eager="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.002930" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.000977" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
@@ -486,7 +486,7 @@ SELECT generate_series((
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="282.199219" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="52" Alias="ColRef_0025">
@@ -497,7 +497,7 @@ SELECT generate_series((
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="282.199219" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -520,7 +520,7 @@ SELECT generate_series((
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="281.167969" Rows="4.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6896.001783" Rows="4.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="76" Alias="ColRef_0076">
@@ -534,7 +534,7 @@ SELECT generate_series((
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="280.042969" Rows="4.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6896.001719" Rows="4.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="count">
@@ -550,7 +550,7 @@ SELECT generate_series((
                   </dxl:JoinFilter>
                   <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="20.022461" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000110" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="count">
@@ -563,7 +563,7 @@ SELECT generate_series((
                     </dxl:JoinFilter>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="53" Alias="ColRef_0023">
@@ -575,7 +575,7 @@ SELECT generate_series((
                     </dxl:Result>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.020508" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
@@ -586,20 +586,20 @@ SELECT generate_series((
                       <dxl:Filter/>
                       <dxl:Materialize Eager="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2.002930" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1.000977" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:Filter/>
@@ -624,7 +624,7 @@ SELECT generate_series((
                   </dxl:NestedLoopJoin>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3.020508" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -635,20 +635,20 @@ SELECT generate_series((
                     <dxl:Filter/>
                     <dxl:Materialize Eager="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.002930" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.000977" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/TVF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVF.mdp
@@ -93,7 +93,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="46.875000" Rows="1000.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.024000" Rows="1000.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="name">
@@ -110,7 +110,7 @@
         <dxl:OneTimeFilter/>
         <dxl:TableValuedFunction FuncId="0.2510.1.0" Name="pg_prepared_statement" TypeMdid="0.2249.1.0">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="46.875000" Rows="1000.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.024000" Rows="1000.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="name">

--- a/src/backend/gporca/data/dxl/minidump/TVFAnyelement.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFAnyelement.mdp
@@ -62,7 +62,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:TableValuedFunction FuncId="0.973889.1.0" Name="unnest1" TypeMdid="0.23.1.0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.812500" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.004000" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="unnest1">

--- a/src/backend/gporca/data/dxl/minidump/TVFCorrelatedExecution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFCorrelatedExecution.mdp
@@ -94,7 +94,7 @@
     <dxl:Plan Id="0" SpaceSize="48">
       <dxl:TableValuedFunction FuncId="0.65639.1.0" Name="myfunc" TypeMdid="0.2249.1.0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="15.625000" Rows="1000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -109,7 +109,7 @@
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="77.037109" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -120,7 +120,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="77.037109" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -132,9 +132,9 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="76.021484" Rows="4.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="4.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="?column?">
@@ -148,9 +148,9 @@
                 <dxl:JoinFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:JoinFilter>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="10.011719" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -163,7 +163,7 @@
                   </dxl:JoinFilter>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="ColRef_0006">
@@ -175,7 +175,7 @@
                   </dxl:Result>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="20" Alias="?column?">
@@ -186,7 +186,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="">
@@ -200,7 +200,7 @@
                 </dxl:NestedLoopJoin>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="?column?">
@@ -211,7 +211,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="21" Alias="">
@@ -231,7 +231,7 @@
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="77.037109" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="17" Alias="ColRef_0008">
@@ -242,7 +242,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="77.037109" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -254,9 +254,9 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="76.021484" Rows="4.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="4.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="?column?">
@@ -270,9 +270,9 @@
                 <dxl:JoinFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:JoinFilter>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="10.011719" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -285,7 +285,7 @@
                   </dxl:JoinFilter>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="ColRef_0006">
@@ -297,7 +297,7 @@
                   </dxl:Result>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="20" Alias="?column?">
@@ -308,7 +308,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="">
@@ -322,7 +322,7 @@
                 </dxl:NestedLoopJoin>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="?column?">
@@ -333,7 +333,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="21" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/TVFGenerateSeries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFGenerateSeries.mdp
@@ -59,7 +59,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:TableValuedFunction FuncId="0.1067.1.0" Name="generate_series" TypeMdid="0.23.1.0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.812500" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.004000" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/TVFRandom.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFRandom.mdp
@@ -57,7 +57,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:TableValuedFunction FuncId="0.1598.1.0" Name="random" TypeMdid="0.701.1.0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000008" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="random">

--- a/src/backend/gporca/data/dxl/minidump/TVFVolatileJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFVolatileJoin.mdp
@@ -403,10 +403,10 @@
         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="67.042969" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000150" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="random">
@@ -420,15 +420,24 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+        <dxl:JoinFilter>
+          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+        </dxl:JoinFilter>
+        <dxl:TableValuedFunction FuncId="0.1598.1.0" Name="random" TypeMdid="0.701.1.0">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="66.035156" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000008" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="random">
               <dxl:Ident ColId="0" ColName="random" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
+          </dxl:ProjList>
+        </dxl:TableValuedFunction>
+        <dxl:Materialize Eager="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000062" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
@@ -437,34 +446,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
-          <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="2.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="random">
-                <dxl:Ident ColId="0" ColName="random" TypeMdid="0.701.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableValuedFunction FuncId="0.1598.1.0" Name="random" TypeMdid="0.701.1.0">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="random">
-                  <dxl:Ident ColId="0" ColName="random" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-            </dxl:TableValuedFunction>
-          </dxl:BroadcastMotion>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
@@ -475,22 +459,37 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.85930.1.1" TableName="foo">
-              <dxl:Columns>
-                <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:NestedLoopJoin>
-      </dxl:GatherMotion>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a">
+                  <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="b">
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.85930.1.1" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:Materialize>
+      </dxl:NestedLoopJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
@@ -269,7 +269,7 @@
     <dxl:Plan Id="0" SpaceSize="39">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="29339.586914" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="579.912290" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -280,7 +280,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29338.571289" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="579.912146" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -289,9 +289,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="29338.571289" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="579.912146" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -307,9 +307,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="29337.364258" Rows="11.250000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="579.912092" Rows="11.250000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -324,9 +324,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="29336.100586" Rows="11.250000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="579.912022" Rows="11.250000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -337,20 +337,16 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="29335.056641" Rows="11.250000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="579.911386" Rows="11.250000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="1"/>
-                    <dxl:GroupingColumn ColId="11"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -360,57 +356,81 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Result>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="13689.718750" Rows="1001232.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="579.911246" Rows="11.250000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="11"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                        <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:OpExpr>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="b">
                         <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                        <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:TableScan>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5866.593750" Rows="1001232.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="457.742907" Rows="1001232.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                          <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:OpExpr>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="1" Alias="b">
                           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="c">
-                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:Result>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
+                      <dxl:OneTimeFilter/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="c">
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Result>
+                  </dxl:Aggregate>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
@@ -259,7 +259,7 @@
     <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="19560.587891" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="572.182101" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -270,7 +270,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="19559.572266" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="572.181958" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -279,9 +279,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="19559.572266" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="572.181958" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -297,9 +297,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="19558.470703" Rows="4.500000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="572.181931" Rows="4.500000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -314,9 +314,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="19557.365234" Rows="4.500000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="572.181903" Rows="4.500000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -327,20 +327,16 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19556.347656" Rows="4.500000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="572.181783" Rows="4.500000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="1"/>
-                    <dxl:GroupingColumn ColId="0"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -350,10 +346,20 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3911.062500" Rows="1001232.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="572.181727" Rows="4.500000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="0"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -363,22 +369,36 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Aggregate>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
@@ -259,7 +259,7 @@
     <dxl:Plan Id="0" SpaceSize="25">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9782.804688" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="507.148946" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -270,7 +270,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9781.789062" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="507.148802" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -279,9 +279,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="9781.789062" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="507.148802" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -297,9 +297,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="9780.726562" Rows="4.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="507.148785" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -310,9 +310,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="9779.679688" Rows="4.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="507.148772" Rows="4.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -320,51 +320,67 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="9778.671875" Rows="4.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="507.148727" Rows="4.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="1"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1955.531250" Rows="1001232.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="507.148702" Rows="4.000000" Width="4"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="1"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="b">
                         <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Aggregate>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbMultipleCol-DistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbMultipleCol-DistinctOnDistrCol.mdp
@@ -260,7 +260,7 @@
     <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="29338.957520" Rows="11.250000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="637.665082" Rows="11.250000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -271,7 +271,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29337.913574" Rows="11.250000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="637.664678" Rows="11.250000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -280,9 +280,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="29337.913574" Rows="11.250000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="637.664678" Rows="11.250000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -302,9 +302,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="29336.562012" Rows="11.250000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="637.664585" Rows="11.250000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -323,9 +323,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="29335.166504" Rows="11.250000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="637.664480" Rows="11.250000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -339,24 +339,17 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="29334.100586" Rows="11.250000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="637.663526" Rows="11.250000" Width="12"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="1"/>
-                    <dxl:GroupingColumn ColId="2"/>
-                    <dxl:GroupingColumn ColId="0"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -369,10 +362,24 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="5866.593750" Rows="1001232.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="637.663315" Rows="11.250000" Width="12"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="2"/>
+                      <dxl:GroupingColumn ColId="0"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -385,23 +392,40 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="c">
+                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Aggregate>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
@@ -259,7 +259,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="302067.597758" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="663.259999" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -270,7 +270,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="302066.589946" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="663.259928" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -281,7 +281,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="302066.589946" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="663.259928" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -299,7 +299,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="298154.511821" Rows="1001232.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="661.257459" Rows="1001232.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -314,7 +314,7 @@
               <dxl:LimitOffset/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1955.531250" Rows="1001232.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctComputedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctComputedCol.mdp
@@ -259,7 +259,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="13693.769531" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="458.507885" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -272,7 +272,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="13692.738281" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="458.507884" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="ColRef_0012">
@@ -283,7 +283,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="13691.734375" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="458.507848" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -296,7 +296,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="9779.656250" Rows="1001232.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="458.283572" Rows="1001232.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -312,7 +312,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="7823.125000" Rows="1001232.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="452.015860" Rows="1001232.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -326,7 +326,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3911.062500" Rows="1001232.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctDistrCol.mdp
@@ -249,7 +249,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5869.644531" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="446.513125" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -262,7 +262,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5868.613281" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="446.513125" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -273,7 +273,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5867.609375" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="446.513089" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -286,7 +286,7 @@
             <dxl:Filter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1955.531250" Rows="1001232.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctNonDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctNonDistrCol.mdp
@@ -257,7 +257,7 @@
     <dxl:Plan Id="0" SpaceSize="19">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7826.175781" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="452.780838" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -270,7 +270,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7825.144531" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="452.780837" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -281,7 +281,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7824.140625" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="452.780801" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -294,7 +294,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3912.062500" Rows="1001232.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="452.556525" Rows="1001232.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -310,7 +310,7 @@
               </dxl:HashExprList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1955.531250" Rows="1001232.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg.mdp
@@ -259,7 +259,7 @@
     <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="19560.930664" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="572.182779" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -270,7 +270,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="19559.915039" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="572.182635" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -279,9 +279,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="19559.915039" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="572.182635" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -297,9 +297,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="19558.708008" Rows="11.250000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="572.182581" Rows="11.250000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -314,9 +314,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="19557.444336" Rows="11.250000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="572.182511" Rows="11.250000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -327,20 +327,16 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19556.400391" Rows="11.250000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="572.181875" Rows="11.250000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="1"/>
-                    <dxl:GroupingColumn ColId="2"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -350,10 +346,20 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3911.062500" Rows="1001232.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="572.181734" Rows="11.250000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="2"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="b">
                         <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -363,23 +369,37 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Aggregate>
-              </dxl:RedistributeMotion>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="442.564230" Rows="1001232.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="c">
+                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.359750.1.1" TableName="r">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Aggregate>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/TimeStamp-Date-HashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TimeStamp-Date-HashJoin.mdp
@@ -294,7 +294,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.218750" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000955" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -322,7 +322,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -336,7 +336,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -364,7 +364,7 @@
         </dxl:GatherMotion>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.015625" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="i">
@@ -378,7 +378,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -52,7 +52,7 @@ with results as
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="32"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="32"/>
       <dxl:TraceFlags Value="103027,102146,102120,103001,103014,103015,103022,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
@@ -14870,7 +14870,7 @@ with results as
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2783469.528536" Rows="20.062500" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="21559.317591" Rows="20.062500" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="842" Alias="total_sum">
@@ -14893,7 +14893,7 @@ with results as
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2783469.528536" Rows="20.062500" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="21559.317591" Rows="20.062500" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="842" Alias="sum">
@@ -14923,7 +14923,7 @@ with results as
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2783468.501597" Rows="20.062500" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="21559.315523" Rows="20.062500" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="842" Alias="sum">
@@ -14955,7 +14955,7 @@ with results as
             <dxl:LimitOffset/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2783467.501597" Rows="20.062500" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="21559.315523" Rows="20.062500" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="842" Alias="sum">
@@ -14979,7 +14979,7 @@ with results as
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="0" Columns="204,89,88,205,206">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2783445.524920" Rows="14.062500" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="20266.314944" Rows="14.062500" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="204" Alias="sum">
@@ -15000,7 +15000,7 @@ with results as
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2783444.524062" Rows="14.062500" Width="32"/>
+                    <dxl:Cost StartupCost="0" TotalCost="20266.314943" Rows="14.062500" Width="32"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="204" Alias="sum">
@@ -15021,9 +15021,9 @@ with results as
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2783443.496596" Rows="14.062500" Width="26"/>
+                      <dxl:Cost StartupCost="0" TotalCost="20266.314929" Rows="14.062500" Width="26"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="89"/>
@@ -15043,9 +15043,9 @@ with results as
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2783442.372718" Rows="14.062500" Width="26"/>
+                        <dxl:Cost StartupCost="0" TotalCost="20266.314897" Rows="14.062500" Width="26"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15059,18 +15059,15 @@ with results as
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                        </dxl:HashExpr>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:Result>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="89" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="88" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2783441.361560" Rows="14.062500" Width="26"/>
+                          <dxl:Cost StartupCost="0" TotalCost="20266.314897" Rows="14.062500" Width="26"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15084,36 +15081,45 @@ with results as
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                          </dxl:HashExpr>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2783441.361560" Rows="14.062500" Width="26"/>
+                            <dxl:Cost StartupCost="0" TotalCost="20266.314849" Rows="14.062500" Width="26"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="89"/>
-                            <dxl:GroupingColumn ColId="88"/>
-                          </dxl:GroupingColumns>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
-                              <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="88" Alias="s_county">
                               <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="89" Alias="s_state">
                               <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
+                              <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:HashJoin JoinType="Inner">
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="2589406.916609" Rows="61135453.777721" Width="26"/>
+                              <dxl:Cost StartupCost="0" TotalCost="20266.314849" Rows="14.062500" Width="26"/>
                             </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="89"/>
+                              <dxl:GroupingColumn ColId="88"/>
+                            </dxl:GroupingColumns>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="22" Alias="ss_net_profit">
-                                <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                              <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
+                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                  <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                </dxl:AggFunc>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="88" Alias="s_county">
                                 <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
@@ -15123,115 +15129,13 @@ with results as
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:JoinFilter/>
-                            <dxl:HashCondList>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                              </dxl:Comparison>
-                            </dxl:HashCondList>
                             <dxl:HashJoin JoinType="Inner">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1080113.288623" Rows="152838634.444302" Width="12"/>
+                                <dxl:Cost StartupCost="0" TotalCost="19782.739138" Rows="61135453.777721" Width="26"/>
                               </dxl:Properties>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="7" Alias="ss_store_sk">
-                                  <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
                                 <dxl:ProjElem ColId="22" Alias="ss_net_profit">
                                   <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:JoinFilter/>
-                              <dxl:HashCondList>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:HashCondList>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="360025.375000" Rows="737331968.000000" Width="16"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
-                                    <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="7" Alias="ss_store_sk">
-                                    <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="22" Alias="ss_net_profit">
-                                    <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="0" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="2" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="7" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="9" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
-                                    <dxl:Column ColId="22" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="21.402588" Rows="12092.239264" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="30" Alias="d_date_sk">
-                                    <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:TableScan>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="18.926485" Rows="377.882477" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="30" Alias="d_date_sk">
-                                      <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                      <dxl:Ident ColId="36" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2000"/>
-                                    </dxl:Comparison>
-                                  </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="30" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                      <dxl:Column ColId="36" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                      <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                      <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                      <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                              </dxl:BroadcastMotion>
-                            </dxl:HashJoin>
-                            <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1397322.425024" Rows="4147.200000" Width="22"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="65" Alias="s_store_sk">
-                                  <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="88" Alias="s_county">
                                   <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
@@ -15241,10 +15145,111 @@ with results as
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:HashJoin JoinType="In">
+                              <dxl:JoinFilter/>
+                              <dxl:HashCondList>
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                  <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:HashCondList>
+                              <dxl:HashJoin JoinType="Inner">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1397318.640649" Rows="129.600000" Width="22"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="8119.513997" Rows="152838634.444302" Width="12"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="7" Alias="ss_store_sk">
+                                    <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="22" Alias="ss_net_profit">
+                                    <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:JoinFilter/>
+                                <dxl:HashCondList>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:HashCondList>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="2572.718951" Rows="737331968.000000" Width="16"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
+                                      <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="7" Alias="ss_store_sk">
+                                      <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="22" Alias="ss_net_profit">
+                                      <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="0" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="2" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="7" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="9" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
+                                      <dxl:Column ColId="22" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                                <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.251673" Rows="12092.239264" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="30" Alias="d_date_sk">
+                                      <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.247287" Rows="377.882477" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="30" Alias="d_date_sk">
+                                        <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="36" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2000"/>
+                                      </dxl:Comparison>
+                                    </dxl:Filter>
+                                    <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="30" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="36" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                        <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:BroadcastMotion>
+                              </dxl:HashJoin>
+                              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="10624.284156" Rows="4147.200000" Width="22"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="65" Alias="s_store_sk">
@@ -15258,16 +15263,10 @@ with results as
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:JoinFilter/>
-                                <dxl:HashCondList>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                                    <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                    <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                  </dxl:Comparison>
-                                </dxl:HashCondList>
-                                <dxl:TableScan>
+                                <dxl:SortingColumnList/>
+                                <dxl:HashJoin JoinType="In">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.217529" Rows="324.000000" Width="22"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="10624.275883" Rows="129.600000" Width="22"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="65" Alias="s_store_sk">
@@ -15281,123 +15280,127 @@ with results as
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="65" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                      <dxl:Column ColId="88" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
-                                      <dxl:Column ColId="89" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                                      <dxl:Column ColId="94" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                      <dxl:Column ColId="95" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="96" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="97" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="98" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="99" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                      <dxl:Column ColId="100" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                                <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1397316.929468" Rows="64.000000" Width="3"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="155" Alias="s_state">
+                                  <dxl:JoinFilter/>
+                                  <dxl:HashCondList>
+                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                                      <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                       <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:Result>
+                                    </dxl:Comparison>
+                                  </dxl:HashCondList>
+                                  <dxl:TableScan>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1397315.835718" Rows="2.000000" Width="3"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.004243" Rows="324.000000" Width="22"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="65" Alias="s_store_sk">
+                                        <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="88" Alias="s_county">
+                                        <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="89" Alias="s_state">
+                                        <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="65" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="88" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                        <dxl:Column ColId="89" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                                        <dxl:Column ColId="94" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        <dxl:Column ColId="95" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="96" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="97" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="98" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="99" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                        <dxl:Column ColId="100" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="10193.268682" Rows="64.000000" Width="3"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="155" Alias="s_state">
                                         <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
-                                    <dxl:Filter>
-                                      <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.420.1.0">
-                                        <dxl:Ident ColId="203" ColName="ranking" TypeMdid="0.20.1.0"/>
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                                      </dxl:Comparison>
-                                    </dxl:Filter>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:Window PartitionColumns="155">
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="1397314.829858" Rows="5.000000" Width="11"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="10193.268404" Rows="2.000000" Width="3"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
-                                        <dxl:ProjElem ColId="203" Alias="ranking">
-                                          <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                                        </dxl:ProjElem>
                                         <dxl:ProjElem ColId="155" Alias="s_state">
                                           <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                         </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="202" Alias="att_2">
-                                          <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
-                                        </dxl:ProjElem>
                                       </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:Sort SortDiscardDuplicates="false">
+                                      <dxl:Filter>
+                                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.420.1.0">
+                                          <dxl:Ident ColId="203" ColName="ranking" TypeMdid="0.20.1.0"/>
+                                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                                        </dxl:Comparison>
+                                      </dxl:Filter>
+                                      <dxl:OneTimeFilter/>
+                                      <dxl:Window PartitionColumns="155">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="1397313.808374" Rows="5.000000" Width="11"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="10193.268371" Rows="5.000000" Width="11"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
-                                          <dxl:ProjElem ColId="202" Alias="att_2">
-                                            <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
+                                          <dxl:ProjElem ColId="203" Alias="ranking">
+                                            <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
                                           </dxl:ProjElem>
                                           <dxl:ProjElem ColId="155" Alias="s_state">
                                             <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                           </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="202" Alias="att_2">
+                                            <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:SortingColumnList>
-                                          <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                          <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-                                        </dxl:SortingColumnList>
-                                        <dxl:LimitCount/>
-                                        <dxl:LimitOffset/>
-                                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                                        <dxl:Sort SortDiscardDuplicates="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="1397312.808374" Rows="5.000000" Width="11"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="10193.268360" Rows="5.000000" Width="11"/>
                                           </dxl:Properties>
-                                          <dxl:GroupingColumns>
-                                            <dxl:GroupingColumn ColId="155"/>
-                                          </dxl:GroupingColumns>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="202" Alias="att_2">
-                                              <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                                                <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
-                                              </dxl:AggFunc>
+                                              <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
                                             </dxl:ProjElem>
                                             <dxl:ProjElem ColId="155" Alias="s_state">
                                               <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
-                                          <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                          <dxl:SortingColumnList>
+                                            <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                            <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+                                          </dxl:SortingColumnList>
+                                          <dxl:LimitCount/>
+                                          <dxl:LimitOffset/>
+                                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="1397311.743921" Rows="5.000000" Width="11"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="10193.268360" Rows="5.000000" Width="11"/>
                                             </dxl:Properties>
+                                            <dxl:GroupingColumns>
+                                              <dxl:GroupingColumn ColId="155"/>
+                                            </dxl:GroupingColumns>
                                             <dxl:ProjList>
+                                              <dxl:ProjElem ColId="202" Alias="att_2">
+                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                                                  <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                </dxl:AggFunc>
+                                              </dxl:ProjElem>
                                               <dxl:ProjElem ColId="155" Alias="s_state">
                                                 <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                               </dxl:ProjElem>
-                                              <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
-                                                <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
-                                              </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:SortingColumnList/>
-                                            <dxl:HashExprList>
-                                              <dxl:HashExpr>
-                                                <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                              </dxl:HashExpr>
-                                            </dxl:HashExprList>
-                                            <dxl:Result>
+                                            <dxl:Sort SortDiscardDuplicates="false">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="1397310.742242" Rows="5.000000" Width="11"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="10193.268342" Rows="5.000000" Width="11"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15408,210 +15411,249 @@ with results as
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
                                               <dxl:Filter/>
-                                              <dxl:OneTimeFilter/>
-                                              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                                              <dxl:SortingColumnList>
+                                                <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                              </dxl:SortingColumnList>
+                                              <dxl:LimitCount/>
+                                              <dxl:LimitOffset/>
+                                              <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="1397310.742242" Rows="5.000000" Width="11"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="10193.268342" Rows="5.000000" Width="11"/>
                                                 </dxl:Properties>
-                                                <dxl:GroupingColumns>
-                                                  <dxl:GroupingColumn ColId="155"/>
-                                                </dxl:GroupingColumns>
                                                 <dxl:ProjList>
-                                                  <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
-                                                    <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                                      <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                    </dxl:AggFunc>
-                                                  </dxl:ProjElem>
                                                   <dxl:ProjElem ColId="155" Alias="s_state">
                                                     <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                   </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                    <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                  </dxl:ProjElem>
                                                 </dxl:ProjList>
                                                 <dxl:Filter/>
-                                                <dxl:HashJoin JoinType="Inner">
+                                                <dxl:SortingColumnList/>
+                                                <dxl:HashExprList>
+                                                  <dxl:HashExpr>
+                                                    <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                  </dxl:HashExpr>
+                                                </dxl:HashExprList>
+                                                <dxl:Result>
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="1192082.080330" Rows="152838634.444302" Width="11"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="10193.268330" Rows="5.000000" Width="11"/>
                                                   </dxl:Properties>
                                                   <dxl:ProjList>
-                                                    <dxl:ProjElem ColId="123" Alias="ss_net_profit">
-                                                      <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                    </dxl:ProjElem>
                                                     <dxl:ProjElem ColId="155" Alias="s_state">
                                                       <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                     </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                      <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:ProjElem>
                                                   </dxl:ProjList>
                                                   <dxl:Filter/>
-                                                  <dxl:JoinFilter/>
-                                                  <dxl:HashCondList>
-                                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                                      <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                      <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                                    </dxl:Comparison>
-                                                  </dxl:HashCondList>
-                                                  <dxl:HashJoin JoinType="Inner">
+                                                  <dxl:OneTimeFilter/>
+                                                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                                     <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="1080113.288623" Rows="152838634.444302" Width="12"/>
+                                                      <dxl:Cost StartupCost="0" TotalCost="10193.268330" Rows="5.000000" Width="11"/>
                                                     </dxl:Properties>
+                                                    <dxl:GroupingColumns>
+                                                      <dxl:GroupingColumn ColId="155"/>
+                                                    </dxl:GroupingColumns>
                                                     <dxl:ProjList>
-                                                      <dxl:ProjElem ColId="108" Alias="ss_store_sk">
-                                                        <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                      </dxl:ProjElem>
-                                                      <dxl:ProjElem ColId="123" Alias="ss_net_profit">
-                                                        <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                      </dxl:ProjElem>
-                                                    </dxl:ProjList>
-                                                    <dxl:Filter/>
-                                                    <dxl:JoinFilter/>
-                                                    <dxl:HashCondList>
-                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                                        <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                                        <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                      </dxl:Comparison>
-                                                    </dxl:HashCondList>
-                                                    <dxl:TableScan>
-                                                      <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="360025.375000" Rows="737331968.000000" Width="16"/>
-                                                      </dxl:Properties>
-                                                      <dxl:ProjList>
-                                                        <dxl:ProjElem ColId="101" Alias="ss_sold_date_sk">
-                                                          <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                        <dxl:ProjElem ColId="108" Alias="ss_store_sk">
-                                                          <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                        <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                      <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                        <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
                                                           <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                        </dxl:ProjElem>
-                                                      </dxl:ProjList>
-                                                      <dxl:Filter/>
-                                                      <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
-                                                        <dxl:Columns>
-                                                          <dxl:Column ColId="101" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="103" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="108" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="110" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
-                                                          <dxl:Column ColId="123" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="124" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                                          <dxl:Column ColId="125" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="126" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="127" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="128" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="129" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                                          <dxl:Column ColId="130" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                                        </dxl:Columns>
-                                                      </dxl:TableDescriptor>
-                                                    </dxl:TableScan>
-                                                    <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                                      <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="21.402588" Rows="12092.239264" Width="4"/>
-                                                      </dxl:Properties>
-                                                      <dxl:ProjList>
-                                                        <dxl:ProjElem ColId="167" Alias="d_date_sk">
-                                                          <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                      </dxl:ProjList>
-                                                      <dxl:Filter/>
-                                                      <dxl:SortingColumnList/>
-                                                      <dxl:TableScan>
-                                                        <dxl:Properties>
-                                                          <dxl:Cost StartupCost="0" TotalCost="18.926485" Rows="377.882477" Width="4"/>
-                                                        </dxl:Properties>
-                                                        <dxl:ProjList>
-                                                          <dxl:ProjElem ColId="167" Alias="d_date_sk">
-                                                            <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                          </dxl:ProjElem>
-                                                        </dxl:ProjList>
-                                                        <dxl:Filter>
-                                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                                            <dxl:Ident ColId="173" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2000"/>
-                                                          </dxl:Comparison>
-                                                        </dxl:Filter>
-                                                        <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
-                                                          <dxl:Columns>
-                                                            <dxl:Column ColId="167" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="173" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="195" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                                            <dxl:Column ColId="196" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                                            <dxl:Column ColId="197" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                                            <dxl:Column ColId="198" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                                            <dxl:Column ColId="199" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                                            <dxl:Column ColId="200" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                                            <dxl:Column ColId="201" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                                          </dxl:Columns>
-                                                        </dxl:TableDescriptor>
-                                                      </dxl:TableScan>
-                                                    </dxl:BroadcastMotion>
-                                                  </dxl:HashJoin>
-                                                  <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                                    <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="3.284058" Rows="10368.000000" Width="7"/>
-                                                    </dxl:Properties>
-                                                    <dxl:ProjList>
-                                                      <dxl:ProjElem ColId="131" Alias="s_store_sk">
-                                                        <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                        </dxl:AggFunc>
                                                       </dxl:ProjElem>
                                                       <dxl:ProjElem ColId="155" Alias="s_state">
                                                         <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                       </dxl:ProjElem>
                                                     </dxl:ProjList>
                                                     <dxl:Filter/>
-                                                    <dxl:SortingColumnList/>
-                                                    <dxl:TableScan>
+                                                    <dxl:HashJoin JoinType="Inner">
                                                       <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="0.069214" Rows="324.000000" Width="7"/>
+                                                        <dxl:Cost StartupCost="0" TotalCost="9599.502175" Rows="152838634.444302" Width="11"/>
                                                       </dxl:Properties>
                                                       <dxl:ProjList>
-                                                        <dxl:ProjElem ColId="131" Alias="s_store_sk">
-                                                          <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                        <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                          <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
                                                         </dxl:ProjElem>
                                                         <dxl:ProjElem ColId="155" Alias="s_state">
                                                           <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                         </dxl:ProjElem>
                                                       </dxl:ProjList>
                                                       <dxl:Filter/>
-                                                      <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
-                                                        <dxl:Columns>
-                                                          <dxl:Column ColId="131" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="155" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                                                          <dxl:Column ColId="160" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                                          <dxl:Column ColId="161" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="162" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="163" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="164" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="165" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                                          <dxl:Column ColId="166" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                                        </dxl:Columns>
-                                                      </dxl:TableDescriptor>
-                                                    </dxl:TableScan>
-                                                  </dxl:BroadcastMotion>
-                                                </dxl:HashJoin>
-                                              </dxl:Aggregate>
-                                            </dxl:Result>
-                                          </dxl:RedistributeMotion>
-                                        </dxl:Aggregate>
-                                      </dxl:Sort>
-                                      <dxl:WindowKeyList>
-                                        <dxl:WindowKey>
-                                          <dxl:SortingColumnList>
-                                            <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-                                          </dxl:SortingColumnList>
-                                        </dxl:WindowKey>
-                                      </dxl:WindowKeyList>
-                                    </dxl:Window>
-                                  </dxl:Result>
-                                </dxl:BroadcastMotion>
-                              </dxl:HashJoin>
-                            </dxl:BroadcastMotion>
-                          </dxl:HashJoin>
-                        </dxl:Aggregate>
-                      </dxl:Result>
-                    </dxl:RedistributeMotion>
+                                                      <dxl:JoinFilter/>
+                                                      <dxl:HashCondList>
+                                                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                          <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                          <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                        </dxl:Comparison>
+                                                      </dxl:HashCondList>
+                                                      <dxl:HashJoin JoinType="Inner">
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="8119.513997" Rows="152838634.444302" Width="12"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="108" Alias="ss_store_sk">
+                                                            <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                            <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:JoinFilter/>
+                                                        <dxl:HashCondList>
+                                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                            <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                          </dxl:Comparison>
+                                                        </dxl:HashCondList>
+                                                        <dxl:TableScan>
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="2572.718951" Rows="737331968.000000" Width="16"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="101" Alias="ss_sold_date_sk">
+                                                              <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="108" Alias="ss_store_sk">
+                                                              <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                              <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
+                                                            <dxl:Columns>
+                                                              <dxl:Column ColId="101" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="103" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="108" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="110" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
+                                                              <dxl:Column ColId="123" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="124" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                              <dxl:Column ColId="125" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="126" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="127" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="128" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="129" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                              <dxl:Column ColId="130" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                          </dxl:TableDescriptor>
+                                                        </dxl:TableScan>
+                                                        <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.251673" Rows="12092.239264" Width="4"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="167" Alias="d_date_sk">
+                                                              <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:SortingColumnList/>
+                                                          <dxl:TableScan>
+                                                            <dxl:Properties>
+                                                              <dxl:Cost StartupCost="0" TotalCost="431.247287" Rows="377.882477" Width="4"/>
+                                                            </dxl:Properties>
+                                                            <dxl:ProjList>
+                                                              <dxl:ProjElem ColId="167" Alias="d_date_sk">
+                                                                <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                              </dxl:ProjElem>
+                                                            </dxl:ProjList>
+                                                            <dxl:Filter>
+                                                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                                <dxl:Ident ColId="173" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2000"/>
+                                                              </dxl:Comparison>
+                                                            </dxl:Filter>
+                                                            <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
+                                                              <dxl:Columns>
+                                                                <dxl:Column ColId="167" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="173" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="195" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                                <dxl:Column ColId="196" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                                <dxl:Column ColId="197" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                                <dxl:Column ColId="198" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                                <dxl:Column ColId="199" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                                <dxl:Column ColId="200" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                                <dxl:Column ColId="201" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                              </dxl:Columns>
+                                                            </dxl:TableDescriptor>
+                                                          </dxl:TableScan>
+                                                        </dxl:BroadcastMotion>
+                                                      </dxl:HashJoin>
+                                                      <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="431.010956" Rows="10368.000000" Width="7"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="131" Alias="s_store_sk">
+                                                            <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="155" Alias="s_state">
+                                                            <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:SortingColumnList/>
+                                                        <dxl:TableScan>
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.004243" Rows="324.000000" Width="7"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="131" Alias="s_store_sk">
+                                                              <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="155" Alias="s_state">
+                                                              <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
+                                                            <dxl:Columns>
+                                                              <dxl:Column ColId="131" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="155" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                                                              <dxl:Column ColId="160" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                              <dxl:Column ColId="161" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="162" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="163" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="164" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="165" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                              <dxl:Column ColId="166" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                          </dxl:TableDescriptor>
+                                                        </dxl:TableScan>
+                                                      </dxl:BroadcastMotion>
+                                                    </dxl:HashJoin>
+                                                  </dxl:Aggregate>
+                                                </dxl:Result>
+                                              </dxl:RedistributeMotion>
+                                            </dxl:Sort>
+                                          </dxl:Aggregate>
+                                        </dxl:Sort>
+                                        <dxl:WindowKeyList>
+                                          <dxl:WindowKey>
+                                            <dxl:SortingColumnList>
+                                              <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+                                            </dxl:SortingColumnList>
+                                          </dxl:WindowKey>
+                                        </dxl:WindowKeyList>
+                                      </dxl:Window>
+                                    </dxl:Result>
+                                  </dxl:BroadcastMotion>
+                                </dxl:HashJoin>
+                              </dxl:BroadcastMotion>
+                            </dxl:HashJoin>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
                   </dxl:Aggregate>
                 </dxl:Result>
               </dxl:CTEProducer>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="19.868919" Rows="20.062500" Width="44"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000552" Rows="20.062500" Width="44"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="842" Alias="sum">
@@ -15644,7 +15686,7 @@ with results as
                 <dxl:OneTimeFilter/>
                 <dxl:Window PartitionColumns="847,1477">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="18.815041" Rows="20.062500" Width="31"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000524" Rows="20.062500" Width="31"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1478" Alias="rank">
@@ -15669,7 +15711,7 @@ with results as
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="17.777081" Rows="20.062500" Width="31"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="842" Alias="sum">
@@ -15698,7 +15740,7 @@ with results as
                     <dxl:LimitOffset/>
                     <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="16.777081" Rows="20.062500" Width="31"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="842" Alias="sum">
@@ -15729,7 +15771,7 @@ with results as
                       </dxl:HashExprList>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="15.758101" Rows="20.062500" Width="31"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="842" Alias="sum">
@@ -15752,7 +15794,7 @@ with results as
                         <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="15.758101" Rows="20.062500" Width="31"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="1477" Alias="?column?">
@@ -15780,9 +15822,9 @@ with results as
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="14.720140" Rows="20.062500" Width="34"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.000424" Rows="20.062500" Width="34"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="842"/>
@@ -15813,9 +15855,9 @@ with results as
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                            <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="13.530069" Rows="20.062500" Width="38"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="842" Alias="sum">
@@ -15838,39 +15880,20 @@ with results as
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:HashExprList>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                              </dxl:HashExprList>
-                              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="843" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="844" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="845" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="846" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="12.506804" Rows="20.062500" Width="38"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
                                 </dxl:Properties>
-                                <dxl:GroupingColumns>
-                                  <dxl:GroupingColumn ColId="842"/>
-                                  <dxl:GroupingColumn ColId="843"/>
-                                  <dxl:GroupingColumn ColId="844"/>
-                                  <dxl:GroupingColumn ColId="845"/>
-                                  <dxl:GroupingColumn ColId="846"/>
-                                  <dxl:GroupingColumn ColId="847"/>
-                                </dxl:GroupingColumns>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="842" Alias="sum">
                                     <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
@@ -15892,10 +15915,39 @@ with results as
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:Append IsTarget="false" IsZapped="false">
+                                <dxl:SortingColumnList/>
+                                <dxl:HashExprList>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                </dxl:HashExprList>
+                                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="11.367208" Rows="20.062500" Width="38"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="1293.000289" Rows="20.062500" Width="38"/>
                                   </dxl:Properties>
+                                  <dxl:GroupingColumns>
+                                    <dxl:GroupingColumn ColId="842"/>
+                                    <dxl:GroupingColumn ColId="843"/>
+                                    <dxl:GroupingColumn ColId="844"/>
+                                    <dxl:GroupingColumn ColId="845"/>
+                                    <dxl:GroupingColumn ColId="846"/>
+                                    <dxl:GroupingColumn ColId="847"/>
+                                  </dxl:GroupingColumns>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="842" Alias="sum">
                                       <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
@@ -15917,9 +15969,9 @@ with results as
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:Result>
+                                  <dxl:Sort SortDiscardDuplicates="false">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1.099609" Rows="14.062500" Width="38"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="842" Alias="sum">
@@ -15932,20 +15984,29 @@ with results as
                                         <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                                       </dxl:ProjElem>
                                       <dxl:ProjElem ColId="845" Alias="g_state">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                        <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                       <dxl:ProjElem ColId="846" Alias="g_county">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                        <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                       <dxl:ProjElem ColId="847" Alias="lochierarchy">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                        <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:CTEConsumer CTEId="0" Columns="842,843,844,848,849">
+                                    <dxl:SortingColumnList>
+                                      <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="843" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="844" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="845" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="846" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    </dxl:SortingColumnList>
+                                    <dxl:LimitCount/>
+                                    <dxl:LimitOffset/>
+                                    <dxl:Append IsTarget="false" IsZapped="false">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="0.025391" Rows="14.062500" Width="26"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="842" Alias="sum">
@@ -15957,241 +16018,341 @@ with results as
                                         <dxl:ProjElem ColId="844" Alias="s_county">
                                           <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                                         </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="848" Alias="gstate">
-                                          <dxl:Ident ColId="848" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                        <dxl:ProjElem ColId="845" Alias="g_state">
+                                          <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="849" Alias="g_county">
-                                          <dxl:Ident ColId="849" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                        <dxl:ProjElem ColId="846" Alias="g_county">
+                                          <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                    </dxl:CTEConsumer>
-                                  </dxl:Result>
-                                  <dxl:Result>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="4.153639" Rows="5.000000" Width="31"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="1259" Alias="sum">
-                                        <dxl:Ident ColId="1259" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1053" Alias="s_state">
-                                        <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1260" Alias="s_county">
-                                        <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" LintValue="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1261" Alias="g_state">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1262" Alias="g_county">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1263" Alias="lochierarchy">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="3.093092" Rows="5.000000" Width="11"/>
-                                      </dxl:Properties>
-                                      <dxl:GroupingColumns>
-                                        <dxl:GroupingColumn ColId="1053"/>
-                                      </dxl:GroupingColumns>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="1259" Alias="sum">
-                                          <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                                            <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
-                                          </dxl:AggFunc>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="1053" Alias="s_state">
-                                          <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                        <dxl:ProjElem ColId="847" Alias="lochierarchy">
+                                          <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
-                                      <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                      <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="2.028639" Rows="5.000000" Width="11"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="14.062500" Width="38"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
+                                          <dxl:ProjElem ColId="842" Alias="sum">
+                                            <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="843" Alias="s_state">
+                                            <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="844" Alias="s_county">
+                                            <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="845" Alias="g_state">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="846" Alias="g_county">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="847" Alias="lochierarchy">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:CTEConsumer CTEId="0" Columns="842,843,844,848,849">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="14.062500" Width="26"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="842" Alias="sum">
+                                              <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="843" Alias="s_state">
+                                              <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="844" Alias="s_county">
+                                              <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="848" Alias="gstate">
+                                              <dxl:Ident ColId="848" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="849" Alias="g_county">
+                                              <dxl:Ident ColId="849" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                        </dxl:CTEConsumer>
+                                      </dxl:Result>
+                                      <dxl:Result>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="5.000000" Width="31"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="1259" Alias="sum">
+                                            <dxl:Ident ColId="1259" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
                                           <dxl:ProjElem ColId="1053" Alias="s_state">
                                             <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                           </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
-                                            <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                          <dxl:ProjElem ColId="1260" Alias="s_county">
+                                            <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" LintValue="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1261" Alias="g_state">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1262" Alias="g_county">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1263" Alias="lochierarchy">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:SortingColumnList/>
-                                        <dxl:HashExprList>
-                                          <dxl:HashExpr>
-                                            <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                          </dxl:HashExpr>
-                                        </dxl:HashExprList>
-                                        <dxl:Result>
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="1.026960" Rows="5.000000" Width="11"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="5.000000" Width="11"/>
                                           </dxl:Properties>
+                                          <dxl:GroupingColumns>
+                                            <dxl:GroupingColumn ColId="1053"/>
+                                          </dxl:GroupingColumns>
                                           <dxl:ProjList>
+                                            <dxl:ProjElem ColId="1259" Alias="sum">
+                                              <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                                                <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                              </dxl:AggFunc>
+                                            </dxl:ProjElem>
                                             <dxl:ProjElem ColId="1053" Alias="s_state">
                                               <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                             </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
-                                              <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
-                                            </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
-                                          <dxl:OneTimeFilter/>
-                                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                                          <dxl:Sort SortDiscardDuplicates="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="1.026960" Rows="5.000000" Width="11"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
                                             </dxl:Properties>
-                                            <dxl:GroupingColumns>
-                                              <dxl:GroupingColumn ColId="1053"/>
-                                            </dxl:GroupingColumns>
                                             <dxl:ProjList>
-                                              <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
-                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                                  <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                                </dxl:AggFunc>
-                                              </dxl:ProjElem>
                                               <dxl:ProjElem ColId="1053" Alias="s_state">
                                                 <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                               </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                              </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:CTEConsumer CTEId="0" Columns="1052,1053,1054,1055,1056">
+                                            <dxl:SortingColumnList>
+                                              <dxl:SortingColumn ColId="1053" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                            </dxl:SortingColumnList>
+                                            <dxl:LimitCount/>
+                                            <dxl:LimitOffset/>
+                                            <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="0.004721" Rows="14.062500" Width="11"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="1052" Alias="sum">
-                                                  <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                                </dxl:ProjElem>
                                                 <dxl:ProjElem ColId="1053" Alias="s_state">
                                                   <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                 </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1054" Alias="s_county">
-                                                  <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1055" Alias="gstate">
-                                                  <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1056" Alias="g_county">
-                                                  <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                  <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
-                                            </dxl:CTEConsumer>
-                                          </dxl:Aggregate>
-                                        </dxl:Result>
-                                      </dxl:RedistributeMotion>
-                                    </dxl:Aggregate>
-                                  </dxl:Result>
-                                  <dxl:Result>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="5.067429" Rows="1.000000" Width="36"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="1471" Alias="sum">
-                                        <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1472" Alias="s_state">
-                                        <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" LintValue="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1473" Alias="s_county">
-                                        <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" LintValue="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1474" Alias="g_state">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1475" Alias="g_county">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1476" Alias="lochierarchy">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="4.065231" Rows="1.000000" Width="8"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="1471" Alias="sum">
-                                          <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:SortingColumnList/>
-                                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                              <dxl:Filter/>
+                                              <dxl:SortingColumnList/>
+                                              <dxl:HashExprList>
+                                                <dxl:HashExpr>
+                                                  <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                </dxl:HashExpr>
+                                              </dxl:HashExprList>
+                                              <dxl:Result>
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="1053" Alias="s_state">
+                                                    <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                    <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:OneTimeFilter/>
+                                                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
+                                                  </dxl:Properties>
+                                                  <dxl:GroupingColumns>
+                                                    <dxl:GroupingColumn ColId="1053"/>
+                                                  </dxl:GroupingColumns>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                      <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                                        <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                      </dxl:AggFunc>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1053" Alias="s_state">
+                                                      <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:Sort SortDiscardDuplicates="false">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="14.062500" Width="11"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="1052" Alias="sum">
+                                                        <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1053" Alias="s_state">
+                                                        <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1054" Alias="s_county">
+                                                        <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1055" Alias="gstate">
+                                                        <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1056" Alias="g_county">
+                                                        <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:SortingColumnList>
+                                                      <dxl:SortingColumn ColId="1053" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                    </dxl:SortingColumnList>
+                                                    <dxl:LimitCount/>
+                                                    <dxl:LimitOffset/>
+                                                    <dxl:CTEConsumer CTEId="0" Columns="1052,1053,1054,1055,1056">
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="14.062500" Width="11"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="1052" Alias="sum">
+                                                          <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1053" Alias="s_state">
+                                                          <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1054" Alias="s_county">
+                                                          <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1055" Alias="gstate">
+                                                          <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1056" Alias="g_county">
+                                                          <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                    </dxl:CTEConsumer>
+                                                  </dxl:Sort>
+                                                </dxl:Aggregate>
+                                              </dxl:Result>
+                                            </dxl:RedistributeMotion>
+                                          </dxl:Sort>
+                                        </dxl:Aggregate>
+                                      </dxl:Result>
+                                      <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="3.057419" Rows="1.000000" Width="8"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="36"/>
                                         </dxl:Properties>
-                                        <dxl:GroupingColumns/>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="1471" Alias="sum">
-                                            <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                                              <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
-                                            </dxl:AggFunc>
+                                            <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1472" Alias="s_state">
+                                            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" LintValue="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1473" Alias="s_county">
+                                            <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" LintValue="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1474" Alias="g_state">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1475" Alias="g_county">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1476" Alias="lochierarchy">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="2.026169" Rows="1.000000" Width="8"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
-                                            <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
-                                              <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
+                                            <dxl:ProjElem ColId="1471" Alias="sum">
+                                              <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
                                           <dxl:SortingColumnList/>
                                           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="1.025925" Rows="1.000000" Width="8"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
                                             </dxl:Properties>
                                             <dxl:GroupingColumns/>
                                             <dxl:ProjList>
-                                              <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
-                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                                  <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                              <dxl:ProjElem ColId="1471" Alias="sum">
+                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                                                  <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
                                                 </dxl:AggFunc>
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:CTEConsumer CTEId="0" Columns="1264,1265,1266,1267,1268">
+                                            <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="0.003433" Rows="14.062500" Width="8"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="1264" Alias="sum">
-                                                  <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1265" Alias="s_state">
-                                                  <dxl:Ident ColId="1265" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1266" Alias="s_county">
-                                                  <dxl:Ident ColId="1266" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1267" Alias="gstate">
-                                                  <dxl:Ident ColId="1267" ColName="gstate" TypeMdid="0.23.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1268" Alias="g_county">
-                                                  <dxl:Ident ColId="1268" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
+                                                  <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
-                                            </dxl:CTEConsumer>
+                                              <dxl:Filter/>
+                                              <dxl:SortingColumnList/>
+                                              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="8"/>
+                                                </dxl:Properties>
+                                                <dxl:GroupingColumns/>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
+                                                    <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                                      <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:AggFunc>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:CTEConsumer CTEId="0" Columns="1264,1265,1266,1267,1268">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="14.062500" Width="8"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="1264" Alias="sum">
+                                                      <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1265" Alias="s_state">
+                                                      <dxl:Ident ColId="1265" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1266" Alias="s_county">
+                                                      <dxl:Ident ColId="1266" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1267" Alias="gstate">
+                                                      <dxl:Ident ColId="1267" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1268" Alias="g_county">
+                                                      <dxl:Ident ColId="1268" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                </dxl:CTEConsumer>
+                                              </dxl:Aggregate>
+                                            </dxl:GatherMotion>
                                           </dxl:Aggregate>
-                                        </dxl:GatherMotion>
-                                      </dxl:Aggregate>
-                                    </dxl:RandomMotion>
-                                  </dxl:Result>
-                                </dxl:Append>
-                              </dxl:Aggregate>
-                            </dxl:RedistributeMotion>
+                                        </dxl:RandomMotion>
+                                      </dxl:Result>
+                                    </dxl:Append>
+                                  </dxl:Sort>
+                                </dxl:Aggregate>
+                              </dxl:RedistributeMotion>
+                            </dxl:Sort>
                           </dxl:Aggregate>
                         </dxl:Result>
                       </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/UDA-AnyArray.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UDA-AnyArray.mdp
@@ -275,7 +275,7 @@
     <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.038086" Rows="1.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000117" Rows="1.000000" Width="10"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="f3">
@@ -289,45 +289,45 @@
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.033203" Rows="1.000000" Width="10"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="10"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="2"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="f3">
               <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="myaggp20a">
-              <dxl:AggFunc AggMdid="0.2873631.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.1007.1.0">
-                <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
-              </dxl:AggFunc>
+              <dxl:Ident ColId="10" ColName="myaggp20a" TypeMdid="0.1007.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.011719" Rows="1.000000" Width="6"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="10"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="2"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="f1">
-                <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="f3">
                 <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="myaggp20a">
+                <dxl:AggFunc AggMdid="0.2873631.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.1007.1.0">
+                  <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="6"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="6"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="f1">
@@ -338,15 +338,14 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.25.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:TableScan>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="6"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="6"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="f1">
@@ -357,23 +356,43 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.2890053.1.1" TableName="t">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="f3" TypeMdid="0.25.1.0"/>
-                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:RedistributeMotion>
-          </dxl:Sort>
-        </dxl:Aggregate>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.25.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="6"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="f1">
+                      <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="f3">
+                      <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.2890053.1.1" TableName="t">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="f3" TypeMdid="0.25.1.0"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UDA-AnyElement-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UDA-AnyElement-1.mdp
@@ -404,7 +404,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.609375" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.006172" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -418,7 +418,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.867188" Rows="111.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.005973" Rows="111.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -432,7 +432,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.433594" Rows="111.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UDA-AnyElement-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UDA-AnyElement-2.mdp
@@ -403,7 +403,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.308594" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.003616" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -416,7 +416,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1.433594" Rows="111.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.003566" Rows="111.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -427,7 +427,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.216797" Rows="111.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Union-Distributed-Table-With-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Distributed-Table-With-Const-Table.mdp
@@ -338,7 +338,7 @@ Table X (int i, int j) is distributed by i
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.584961" Rows="101.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.005939" Rows="101.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -352,7 +352,7 @@ Table X (int i, int j) is distributed by i
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.190430" Rows="101.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002311" Rows="101.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -365,7 +365,7 @@ Table X (int i, int j) is distributed by i
           <dxl:Filter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.390625" Rows="100.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001155" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -392,7 +392,7 @@ Table X (int i, int j) is distributed by i
           </dxl:TableScan>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.010742" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000008" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="?column?">
@@ -406,21 +406,21 @@ Table X (int i, int j) is distributed by i
             <dxl:OneTimeFilter/>
             <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.002930" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/Union-On-HJNs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-On-HJNs.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="2"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="2147483647" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
       <dxl:TraceFlags Value="103027,102146,103001,103016,103022,104002"/>
     </dxl:OptimizerConfig>
@@ -489,7 +489,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="57.867989" Rows="2.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="5172.080244" Rows="2.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -509,7 +509,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="56.836739" Rows="2.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="5172.079957" Rows="2.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -528,7 +528,7 @@
           <dxl:Filter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="27.493028" Rows="1.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.040089" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -546,7 +546,7 @@
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="1" Columns="177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="20.937500" Rows="8.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.039369" Rows="8.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="177" Alias="a">
@@ -657,7 +657,7 @@
               </dxl:ProjList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="19.929688" Rows="8.000000" Width="152"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.039365" Rows="8.000000" Width="152"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="177" Alias="a">
@@ -770,51 +770,15 @@
                 <dxl:JoinFilter/>
                 <dxl:HashCondList>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
                     <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:HashCondList>
-                <dxl:HashJoin JoinType="Inner">
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.125000" Rows="32.000000" Width="68"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="196" Alias="d">
-                      <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="197" Alias="ctid">
-                      <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="198" Alias="xmin">
-                      <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="199" Alias="cmin">
-                      <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="200" Alias="xmax">
-                      <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="201" Alias="cmax">
-                      <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="202" Alias="tableoid">
-                      <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="203" Alias="gp_segment_id">
-                      <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="204" Alias="e">
                       <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
@@ -841,100 +805,15 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.265625" Rows="8.000000" Width="34"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="196" Alias="d">
-                        <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="197" Alias="ctid">
-                        <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="198" Alias="xmin">
-                        <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="199" Alias="cmin">
-                        <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="200" Alias="xmax">
-                        <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="201" Alias="cmax">
-                        <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="202" Alias="tableoid">
-                        <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="203" Alias="gp_segment_id">
-                        <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.132812" Rows="8.000000" Width="34"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="196" Alias="d">
-                          <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="197" Alias="ctid">
-                          <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="198" Alias="xmin">
-                          <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="199" Alias="cmin">
-                          <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="200" Alias="xmax">
-                          <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="201" Alias="cmax">
-                          <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="202" Alias="tableoid">
-                          <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="203" Alias="gp_segment_id">
-                          <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
-                        <dxl:Columns>
-                          <dxl:Column ColId="214" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="196" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="215" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="197" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="198" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="199" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="200" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="201" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="202" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="203" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.265625" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="204" Alias="e">
@@ -963,63 +842,25 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.132812" Rows="8.000000" Width="34"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="204" Alias="e">
-                          <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="205" Alias="ctid">
-                          <dxl:Ident ColId="205" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="206" Alias="xmin">
-                          <dxl:Ident ColId="206" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="207" Alias="cmin">
-                          <dxl:Ident ColId="207" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="208" Alias="xmax">
-                          <dxl:Ident ColId="208" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="209" Alias="cmax">
-                          <dxl:Ident ColId="209" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="210" Alias="tableoid">
-                          <dxl:Ident ColId="210" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="211" Alias="gp_segment_id">
-                          <dxl:Ident ColId="211" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
-                        <dxl:Columns>
-                          <dxl:Column ColId="216" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="217" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="204" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="205" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="206" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="207" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="208" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="209" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="210" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="211" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                </dxl:HashJoin>
+                    <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
+                      <dxl:Columns>
+                        <dxl:Column ColId="216" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="217" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="204" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="205" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="206" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="207" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="208" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="209" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="210" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="211" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.117188" Rows="8.000000" Width="84"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.024574" Rows="8.000000" Width="118"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="177" Alias="a">
@@ -1079,102 +920,126 @@
                     <dxl:ProjElem ColId="195" Alias="gp_segment_id">
                       <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="196" Alias="d">
+                      <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="197" Alias="ctid">
+                      <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="198" Alias="xmin">
+                      <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="199" Alias="cmin">
+                      <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="200" Alias="xmax">
+                      <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="201" Alias="cmax">
+                      <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="202" Alias="tableoid">
+                      <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                      <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:JoinFilter/>
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                       <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
                   <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.265625" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="188" Alias="c">
-                        <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="196" Alias="d">
+                        <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="189" Alias="ctid">
-                        <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:ProjElem ColId="197" Alias="ctid">
+                        <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="190" Alias="xmin">
-                        <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:ProjElem ColId="198" Alias="xmin">
+                        <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="191" Alias="cmin">
-                        <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:ProjElem ColId="199" Alias="cmin">
+                        <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="192" Alias="xmax">
-                        <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:ProjElem ColId="200" Alias="xmax">
+                        <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="193" Alias="cmax">
-                        <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:ProjElem ColId="201" Alias="cmax">
+                        <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="194" Alias="tableoid">
-                        <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:ProjElem ColId="202" Alias="tableoid">
+                        <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="195" Alias="gp_segment_id">
-                        <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                        <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
                       <dxl:HashExpr>
-                        <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.132812" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="188" Alias="c">
-                          <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="196" Alias="d">
+                          <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="189" Alias="ctid">
-                          <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:ProjElem ColId="197" Alias="ctid">
+                          <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="190" Alias="xmin">
-                          <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:ProjElem ColId="198" Alias="xmin">
+                          <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="191" Alias="cmin">
-                          <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:ProjElem ColId="199" Alias="cmin">
+                          <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="192" Alias="xmax">
-                          <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:ProjElem ColId="200" Alias="xmax">
+                          <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="193" Alias="cmax">
-                          <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:ProjElem ColId="201" Alias="cmax">
+                          <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="194" Alias="tableoid">
-                          <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:ProjElem ColId="202" Alias="tableoid">
+                          <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="195" Alias="gp_segment_id">
-                          <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                          <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
                         <dxl:Columns>
-                          <dxl:Column ColId="188" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="212" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="213" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="189" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="190" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="191" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="192" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="193" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="194" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="195" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="214" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="196" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="215" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="197" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="198" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="199" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="200" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="201" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="202" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="203" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:Columns>
                       </dxl:TableDescriptor>
                     </dxl:TableScan>
                   </dxl:RedistributeMotion>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.097656" Rows="1.000000" Width="50"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.005318" Rows="8.000000" Width="84"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="177" Alias="a">
@@ -1210,17 +1075,126 @@
                       <dxl:ProjElem ColId="187" Alias="gp_segment_id">
                         <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="188" Alias="c">
+                        <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="189" Alias="ctid">
+                        <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="190" Alias="xmin">
+                        <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="191" Alias="cmin">
+                        <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="192" Alias="xmax">
+                        <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="193" Alias="cmax">
+                        <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="194" Alias="tableoid">
+                        <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                        <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
                         <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Sequence>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.024414" Rows="1.000000" Width="50"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="188" Alias="c">
+                          <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="189" Alias="ctid">
+                          <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="190" Alias="xmin">
+                          <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="191" Alias="cmin">
+                          <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="192" Alias="xmax">
+                          <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="193" Alias="cmax">
+                          <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="194" Alias="tableoid">
+                          <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                          <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="188" Alias="c">
+                            <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="189" Alias="ctid">
+                            <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="190" Alias="xmin">
+                            <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="191" Alias="cmin">
+                            <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="192" Alias="xmax">
+                            <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="193" Alias="cmax">
+                            <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="194" Alias="tableoid">
+                            <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                            <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
+                          <dxl:Columns>
+                            <dxl:Column ColId="188" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="212" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="213" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="189" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="190" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="191" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="192" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="193" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="194" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="195" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="1.000000" Width="50"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="177" Alias="a">
@@ -1257,30 +1231,16 @@
                           <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:PartitionSelector RelationMdid="0.106508.1.1" PartitionLevels="1" ScanId="1">
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Sequence>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList/>
-                        <dxl:PartEqFilters>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:PartEqFilters>
-                        <dxl:PartFilters>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:PartFilters>
-                        <dxl:ResidualFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:ResidualFilter>
-                        <dxl:PropagationExpression>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:PropagationExpression>
-                        <dxl:PrintableFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:PrintableFilter>
-                      </dxl:PartitionSelector>
-                      <dxl:DynamicTableScan PartIndexId="1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.024414" Rows="1.000000" Width="50"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="177" Alias="a">
@@ -1317,31 +1277,92 @@
                             <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.106508.1.1" TableName="mpp_r6756">
-                          <dxl:Columns>
-                            <dxl:Column ColId="177" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="178" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="179" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="180" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="181" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="182" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="183" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="184" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="185" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="186" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="187" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:DynamicTableScan>
-                    </dxl:Sequence>
-                  </dxl:RedistributeMotion>
+                        <dxl:PartitionSelector RelationMdid="0.106508.1.1" PartitionLevels="1" ScanId="1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:PartEqFilters>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:PartEqFilters>
+                          <dxl:PartFilters>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:PartFilters>
+                          <dxl:ResidualFilter>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ResidualFilter>
+                          <dxl:PropagationExpression>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:PropagationExpression>
+                          <dxl:PrintableFilter>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:PrintableFilter>
+                        </dxl:PartitionSelector>
+                        <dxl:DynamicTableScan PartIndexId="1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="177" Alias="a">
+                              <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="178" Alias="b">
+                              <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="179" Alias="x">
+                              <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="180" Alias="y">
+                              <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="181" Alias="ctid">
+                              <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="182" Alias="xmin">
+                              <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="183" Alias="cmin">
+                              <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="184" Alias="xmax">
+                              <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="185" Alias="cmax">
+                              <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="186" Alias="tableoid">
+                              <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                              <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.106508.1.1" TableName="mpp_r6756">
+                            <dxl:Columns>
+                              <dxl:Column ColId="177" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="178" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="179" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="180" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="181" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="182" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="183" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="184" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="185" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="186" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="187" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:DynamicTableScan>
+                      </dxl:Sequence>
+                    </dxl:RedistributeMotion>
+                  </dxl:HashJoin>
                 </dxl:HashJoin>
               </dxl:HashJoin>
             </dxl:CTEProducer>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5.524278" Rows="1.000000" Width="28"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000704" Rows="1.000000" Width="28"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -1375,7 +1396,7 @@
               </dxl:HashCondList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.251726" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="0"/>
@@ -1397,7 +1418,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.187750" Rows="2.275556" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="2.275556" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -1515,7 +1536,7 @@
                   <dxl:LimitOffset/>
                   <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8,9,10,11,14,15,16,17,18,19,20,22,24,25,26,27,28,29,30,33,34,35,36,37,38,39,40">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.022222" Rows="2.275556" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="2.275556" Width="20"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -1629,7 +1650,7 @@
               </dxl:Aggregate>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.174896" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="224"/>
@@ -1651,7 +1672,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.123716" Rows="2.275556" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="2.275556" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="224" Alias="a">
@@ -1769,7 +1790,7 @@
                   <dxl:LimitOffset/>
                   <dxl:CTEConsumer CTEId="1" Columns="224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.017778" Rows="2.275556" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="2.275556" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="224" Alias="a">
@@ -1885,7 +1906,7 @@
           </dxl:Sequence>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="28.281211" Rows="1.000000" Width="28"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.039836" Rows="1.000000" Width="28"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="43" Alias="a">
@@ -1905,7 +1926,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="27.253868" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="2586.039822" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="43" Alias="a">
@@ -1920,7 +1941,7 @@
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="0" Columns="87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20.937500" Rows="8.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.039369" Rows="8.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="87" Alias="a">
@@ -2031,7 +2052,7 @@
                 </dxl:ProjList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19.929688" Rows="8.000000" Width="152"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1724.039365" Rows="8.000000" Width="152"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="87" Alias="a">
@@ -2144,51 +2165,15 @@
                   <dxl:JoinFilter/>
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
                       <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:HashJoin JoinType="Inner">
+                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="5.125000" Rows="32.000000" Width="68"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="106" Alias="d">
-                        <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="107" Alias="ctid">
-                        <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="108" Alias="xmin">
-                        <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="109" Alias="cmin">
-                        <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="110" Alias="xmax">
-                        <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="111" Alias="cmax">
-                        <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="112" Alias="tableoid">
-                        <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="113" Alias="gp_segment_id">
-                        <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="114" Alias="e">
                         <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
@@ -2215,100 +2200,15 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.265625" Rows="8.000000" Width="34"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="106" Alias="d">
-                          <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="107" Alias="ctid">
-                          <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="108" Alias="xmin">
-                          <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="109" Alias="cmin">
-                          <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="110" Alias="xmax">
-                          <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="111" Alias="cmax">
-                          <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="112" Alias="tableoid">
-                          <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="113" Alias="gp_segment_id">
-                          <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.132812" Rows="8.000000" Width="34"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="106" Alias="d">
-                            <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="107" Alias="ctid">
-                            <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="108" Alias="xmin">
-                            <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="109" Alias="cmin">
-                            <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="110" Alias="xmax">
-                            <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="111" Alias="cmax">
-                            <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="112" Alias="tableoid">
-                            <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="113" Alias="gp_segment_id">
-                            <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
-                          <dxl:Columns>
-                            <dxl:Column ColId="124" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="106" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="125" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="107" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="108" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="109" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="110" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="111" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="112" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="113" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:RedistributeMotion>
-                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.265625" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="114" Alias="e">
@@ -2337,63 +2237,25 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.132812" Rows="8.000000" Width="34"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="114" Alias="e">
-                            <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="115" Alias="ctid">
-                            <dxl:Ident ColId="115" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="116" Alias="xmin">
-                            <dxl:Ident ColId="116" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="117" Alias="cmin">
-                            <dxl:Ident ColId="117" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="118" Alias="xmax">
-                            <dxl:Ident ColId="118" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="119" Alias="cmax">
-                            <dxl:Ident ColId="119" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="120" Alias="tableoid">
-                            <dxl:Ident ColId="120" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="121" Alias="gp_segment_id">
-                            <dxl:Ident ColId="121" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
-                          <dxl:Columns>
-                            <dxl:Column ColId="126" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="127" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="114" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="115" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="116" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="117" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="118" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="119" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="120" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="121" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:RedistributeMotion>
-                  </dxl:HashJoin>
+                      <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
+                        <dxl:Columns>
+                          <dxl:Column ColId="126" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="127" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="114" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="115" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="116" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="117" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="118" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="119" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="120" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="121" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="5.117188" Rows="8.000000" Width="84"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.024574" Rows="8.000000" Width="118"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="87" Alias="a">
@@ -2453,102 +2315,126 @@
                       <dxl:ProjElem ColId="105" Alias="gp_segment_id">
                         <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="106" Alias="d">
+                        <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="107" Alias="ctid">
+                        <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="108" Alias="xmin">
+                        <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="109" Alias="cmin">
+                        <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="110" Alias="xmax">
+                        <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="111" Alias="cmax">
+                        <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="112" Alias="tableoid">
+                        <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                        <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:JoinFilter/>
                     <dxl:HashCondList>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                         <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:Comparison>
                     </dxl:HashCondList>
                     <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1.265625" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="98" Alias="c">
-                          <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="106" Alias="d">
+                          <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="99" Alias="ctid">
-                          <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:ProjElem ColId="107" Alias="ctid">
+                          <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="100" Alias="xmin">
-                          <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:ProjElem ColId="108" Alias="xmin">
+                          <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="101" Alias="cmin">
-                          <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:ProjElem ColId="109" Alias="cmin">
+                          <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="102" Alias="xmax">
-                          <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:ProjElem ColId="110" Alias="xmax">
+                          <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="103" Alias="cmax">
-                          <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:ProjElem ColId="111" Alias="cmax">
+                          <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="104" Alias="tableoid">
-                          <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:ProjElem ColId="112" Alias="tableoid">
+                          <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="105" Alias="gp_segment_id">
-                          <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                          <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
                         <dxl:HashExpr>
-                          <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.132812" Rows="8.000000" Width="34"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="98" Alias="c">
-                            <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="106" Alias="d">
+                            <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="99" Alias="ctid">
-                            <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:ProjElem ColId="107" Alias="ctid">
+                            <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="100" Alias="xmin">
-                            <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:ProjElem ColId="108" Alias="xmin">
+                            <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="101" Alias="cmin">
-                            <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:ProjElem ColId="109" Alias="cmin">
+                            <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="102" Alias="xmax">
-                            <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:ProjElem ColId="110" Alias="xmax">
+                            <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="103" Alias="cmax">
-                            <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:ProjElem ColId="111" Alias="cmax">
+                            <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="104" Alias="tableoid">
-                            <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:ProjElem ColId="112" Alias="tableoid">
+                            <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="105" Alias="gp_segment_id">
-                            <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                            <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
                           <dxl:Columns>
-                            <dxl:Column ColId="98" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="122" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="123" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="99" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="100" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="101" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="102" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="103" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="104" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="105" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="124" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="106" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="125" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="107" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="108" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="109" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="110" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="111" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="112" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="113" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:Columns>
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
                     </dxl:RedistributeMotion>
-                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.097656" Rows="1.000000" Width="50"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.005318" Rows="8.000000" Width="84"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="87" Alias="a">
@@ -2584,17 +2470,126 @@
                         <dxl:ProjElem ColId="97" Alias="gp_segment_id">
                           <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="98" Alias="c">
+                          <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="99" Alias="ctid">
+                          <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="100" Alias="xmin">
+                          <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="101" Alias="cmin">
+                          <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="102" Alias="xmax">
+                          <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="103" Alias="cmax">
+                          <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="104" Alias="tableoid">
+                          <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                          <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
+                      <dxl:JoinFilter/>
+                      <dxl:HashCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
                           <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:Sequence>
+                        </dxl:Comparison>
+                      </dxl:HashCondList>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.024414" Rows="1.000000" Width="50"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="98" Alias="c">
+                            <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="99" Alias="ctid">
+                            <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="100" Alias="xmin">
+                            <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="101" Alias="cmin">
+                            <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="102" Alias="xmax">
+                            <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="103" Alias="cmax">
+                            <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="104" Alias="tableoid">
+                            <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                            <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="98" Alias="c">
+                              <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="99" Alias="ctid">
+                              <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="100" Alias="xmin">
+                              <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="101" Alias="cmin">
+                              <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="102" Alias="xmax">
+                              <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="103" Alias="cmax">
+                              <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="104" Alias="tableoid">
+                              <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                              <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.106604.1.1" TableName="mpp_s6756">
+                            <dxl:Columns>
+                              <dxl:Column ColId="98" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="122" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="123" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="99" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="100" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="101" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="102" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="103" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="104" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="105" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="1.000000" Width="50"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="87" Alias="a">
@@ -2631,30 +2626,16 @@
                             <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:PartitionSelector RelationMdid="0.106508.1.1" PartitionLevels="1" ScanId="2">
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Sequence>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:PartEqFilters>
-                          <dxl:PartFilters>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:PartFilters>
-                          <dxl:ResidualFilter>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:ResidualFilter>
-                          <dxl:PropagationExpression>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                          </dxl:PropagationExpression>
-                          <dxl:PrintableFilter>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:PrintableFilter>
-                        </dxl:PartitionSelector>
-                        <dxl:DynamicTableScan PartIndexId="2">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.024414" Rows="1.000000" Width="50"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="87" Alias="a">
@@ -2691,31 +2672,92 @@
                               <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.106508.1.1" TableName="mpp_r6756">
-                            <dxl:Columns>
-                              <dxl:Column ColId="87" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="88" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="89" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="90" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="92" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="93" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="94" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="95" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="96" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="97" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:DynamicTableScan>
-                      </dxl:Sequence>
-                    </dxl:RedistributeMotion>
+                          <dxl:PartitionSelector RelationMdid="0.106508.1.1" PartitionLevels="1" ScanId="2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:PartEqFilters>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:PartEqFilters>
+                            <dxl:PartFilters>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:PartFilters>
+                            <dxl:ResidualFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:ResidualFilter>
+                            <dxl:PropagationExpression>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                            </dxl:PropagationExpression>
+                            <dxl:PrintableFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:PrintableFilter>
+                          </dxl:PartitionSelector>
+                          <dxl:DynamicTableScan PartIndexId="2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="87" Alias="a">
+                                <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="88" Alias="b">
+                                <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="89" Alias="x">
+                                <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="90" Alias="y">
+                                <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="91" Alias="ctid">
+                                <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="92" Alias="xmin">
+                                <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="93" Alias="cmin">
+                                <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="94" Alias="xmax">
+                                <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="95" Alias="cmax">
+                                <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="96" Alias="tableoid">
+                                <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                                <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.106508.1.1" TableName="mpp_r6756">
+                              <dxl:Columns>
+                                <dxl:Column ColId="87" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="88" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="89" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="90" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="92" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="93" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="94" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="95" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="96" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="97" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:DynamicTableScan>
+                        </dxl:Sequence>
+                      </dxl:RedistributeMotion>
+                    </dxl:HashJoin>
                   </dxl:HashJoin>
                 </dxl:HashJoin>
               </dxl:CTEProducer>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="5.292930" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000440" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="43" Alias="a">
@@ -2740,7 +2782,7 @@
                 </dxl:HashCondList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.111309" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="43"/>
@@ -2758,7 +2800,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.072923" Rows="2.275556" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="2.275556" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="43" Alias="a">
@@ -2875,7 +2917,7 @@
                     <dxl:LimitOffset/>
                     <dxl:CTEConsumer CTEId="0" Columns="43,44,45,46,47,48,49,50,51,52,53,54,57,58,59,60,61,62,63,65,67,68,69,70,71,72,73,76,77,78,79,80,81,82,83">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.013333" Rows="2.275556" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="2.275556" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="43" Alias="a">
@@ -2989,7 +3031,7 @@
                 </dxl:Aggregate>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.111309" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="134"/>
@@ -3007,7 +3049,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.072923" Rows="2.275556" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="2.275556" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="134" Alias="a">
@@ -3124,7 +3166,7 @@
                     <dxl:LimitOffset/>
                     <dxl:CTEConsumer CTEId="0" Columns="134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.013333" Rows="2.275556" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="2.275556" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="134" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Casting-Output.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Casting-Output.mdp
@@ -11,7 +11,7 @@ select * from x2 where a in (select a from y union select 1::int8);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="2"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
@@ -399,7 +399,7 @@ select * from x2 where a in (select a from y union select 1::int8);
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="173.419434" Rows="10.000000" Width="2"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.002070" Rows="10.000000" Width="2"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -408,9 +408,9 @@ select * from x2 where a in (select a from y union select 1::int8);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="172.409668" Rows="10.000000" Width="2"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001980" Rows="10.000000" Width="2"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -418,221 +418,144 @@ select * from x2 where a in (select a from y union select 1::int8);
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter>
-            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-                <dxl:TestExpr/>
-                <dxl:ParamList>
-                  <dxl:Param ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
-                </dxl:ParamList>
-                <dxl:Result>
+            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+              <dxl:TestExpr>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1862.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
+                  <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
+                </dxl:Comparison>
+              </dxl:TestExpr>
+              <dxl:ParamList>
+                <dxl:Param ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
+              </dxl:ParamList>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000187" Rows="4.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="17"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="17" Alias="a">
+                    <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="10.380371" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="4.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                      <dxl:If TypeMdid="0.20.1.0">
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:Comparison>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        <dxl:If TypeMdid="0.20.1.0">
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                            <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
-                          </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="-1"/>
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                        </dxl:If>
-                      </dxl:If>
+                    <dxl:ProjElem ColId="17" Alias="a">
+                      <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="17" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:Append IsTarget="false" IsZapped="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="9.364746" Rows="2.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="4.000000" Width="8"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
-                          <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
-                        </dxl:AggFunc>
+                      <dxl:ProjElem ColId="17" Alias="a">
+                        <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="8.325684" Rows="2.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="2.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                          <dxl:If TypeMdid="0.23.1.0">
-                            <dxl:IsNull>
-                              <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
-                            </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                          </dxl:If>
+                        <dxl:ProjElem ColId="17" Alias="a">
+                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.754.1.0">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
+                          </dxl:Cast>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="2.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.19760808.1.1" TableName="y">
+                              <dxl:Columns>
+                                <dxl:Column ColId="8" Attno="1" ColName="m" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="19" Alias="int8">
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="7.317871" Rows="2.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="17" Alias="a">
-                            <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
+                          <dxl:ProjElem ColId="18" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Or>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1862.1.0">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
-                              <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:IsNull>
-                              <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
-                            </dxl:IsNull>
-                          </dxl:Or>
-                        </dxl:Filter>
+                        <dxl:Filter/>
                         <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="6.161621" Rows="4.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="17"/>
-                          </dxl:GroupingColumns>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="17" Alias="a">
-                              <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:Append IsTarget="false" IsZapped="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="5.067871" Rows="4.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="17" Alias="a">
-                                <dxl:Ident ColId="17" ColName="a" TypeMdid="0.20.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="3.019043" Rows="2.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="17" Alias="a">
-                                  <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.754.1.0">
-                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
-                                  </dxl:Cast>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="2.003418" Rows="2.000000" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1.001465" Rows="2.000000" Width="1"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList/>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList/>
-                                    <dxl:Filter/>
-                                    <dxl:TableDescriptor Mdid="0.19760808.1.1" TableName="y">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="8" Attno="1" ColName="m" TypeMdid="0.23.1.0"/>
-                                        <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                        <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                        <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1.017578" Rows="1.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="19" Alias="int8">
-                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="18" Alias="">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                              </dxl:Result>
-                            </dxl:Result>
-                          </dxl:Append>
-                        </dxl:Aggregate>
                       </dxl:Result>
                     </dxl:Result>
-                  </dxl:Aggregate>
-                </dxl:Result>
-              </dxl:SubPlan>
-              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-            </dxl:Comparison>
+                  </dxl:Append>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:SubPlan>
           </dxl:Filter>
-          <dxl:OneTimeFilter/>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="171.390137" Rows="1000.000000" Width="10"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.21.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.21032616.1.1" TableName="x2">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.21.1.0"/>
-                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:Result>
+          <dxl:TableDescriptor Mdid="0.21032616.1.1" TableName="x2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.21.1.0"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Output.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Output.mdp
@@ -11,7 +11,7 @@ select * from x where a in (select a from y union select 1);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="2"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102116,102117,102119,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
@@ -380,7 +380,7 @@ select * from x where a in (select a from y union select 1);
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="328.122559" Rows="10.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.002092" Rows="10.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -391,7 +391,7 @@ select * from x where a in (select a from y union select 1);
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="327.103027" Rows="10.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001912" Rows="10.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -409,9 +409,9 @@ select * from x where a in (select a from y union select 1);
               <dxl:ParamList>
                 <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ParamList>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.083496" Rows="4.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="4.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="17"/>
@@ -422,9 +422,9 @@ select * from x where a in (select a from y union select 1);
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:Append IsTarget="false" IsZapped="false">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.036621" Rows="4.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="4.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="17" Alias="a">
@@ -432,77 +432,93 @@ select * from x where a in (select a from y union select 1);
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Result>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:Append IsTarget="false" IsZapped="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3.011230" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="4.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="17" Alias="a">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Materialize Eager="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.003418" Rows="2.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:Filter/>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.001465" Rows="2.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList/>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000488" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.19760808.1.1" TableName="y">
-                            <dxl:Columns>
-                              <dxl:Column ColId="8" Attno="1" ColName="m" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:BroadcastMotion>
-                    </dxl:Materialize>
-                  </dxl:Result>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000043" Rows="2.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        <dxl:ProjElem ColId="17" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="2.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.19760808.1.1" TableName="y">
+                              <dxl:Columns>
+                                <dxl:Column ColId="8" Attno="1" ColName="m" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
                     </dxl:Result>
-                  </dxl:Result>
-                </dxl:Append>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="19" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="18" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:Append>
+                </dxl:Sort>
               </dxl:Aggregate>
             </dxl:SubPlan>
           </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/Union-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Volatile-Func.mdp
@@ -9,6 +9,14 @@
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103003,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -101,9 +109,9 @@
       </dxl:Union>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="840">
-      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.074219" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000074" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -114,9 +122,9 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:Append IsTarget="false" IsZapped="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.035156" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000063" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="?column?">
@@ -124,58 +132,74 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Result>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="2.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="?column?">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-            </dxl:Result>
-          </dxl:Result>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="3" Alias="generate_series">
-                <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                <dxl:ProjElem ColId="1" Alias="?column?">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:FuncExpr>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="2" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
-        </dxl:Append>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="generate_series">
+                  <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:FuncExpr>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:Append>
+        </dxl:Sort>
       </dxl:Aggregate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
@@ -8893,7 +8893,7 @@
     <dxl:Plan Id="0" SpaceSize="25">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="38108.605469" Rows="2163263.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1773.052304" Rows="2163263.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="82" Alias="c_customer_sk">
@@ -8907,7 +8907,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29657.359375" Rows="2163263.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1695.347897" Rows="2163263.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="82" Alias="c_customer_sk">
@@ -8925,9 +8925,9 @@
               <dxl:Ident ColId="82" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="16902.492188" Rows="2163263.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1022.560577" Rows="2163263.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="cs_bill_customer_sk">
@@ -8935,15 +8935,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="3" ColName="cs_bill_customer_sk" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:Append IsTarget="false" IsZapped="false">
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="12676.369141" Rows="2163263.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="535.131196" Rows="1443660.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="cs_bill_customer_sk">
@@ -8951,9 +8945,15 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="3" ColName="cs_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2819.648438" Rows="1443660.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="520.723469" Rows="1443660.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="3" Alias="cs_bill_customer_sk">
@@ -8977,9 +8977,26 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
+            </dxl:RedistributeMotion>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="483.102855" Rows="719603.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
+                  <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1405.474609" Rows="719603.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="475.921217" Rows="719603.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
@@ -9003,11 +9020,11 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:Append>
-          </dxl:RedistributeMotion>
+            </dxl:RedistributeMotion>
+          </dxl:Append>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="391.238281" Rows="100157.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.031955" Rows="100157.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="82" Alias="c_customer_sk">

--- a/src/backend/gporca/data/dxl/minidump/UnionAllCompatibleDataType.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAllCompatibleDataType.mdp
@@ -368,7 +368,7 @@
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.150391" Rows="3.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000396" Rows="3.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="11" Alias="a">
@@ -382,7 +382,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.132812" Rows="3.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000234" Rows="3.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="a">
@@ -395,7 +395,7 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.027344" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="a">
@@ -413,7 +413,7 @@
             <dxl:OneTimeFilter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -441,7 +441,7 @@
           </dxl:Result>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="13" Alias="a">
@@ -457,7 +457,7 @@
             <dxl:OneTimeFilter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="a">
@@ -485,7 +485,7 @@
           </dxl:Result>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.031250" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="36" Alias="a">
@@ -501,7 +501,7 @@
             <dxl:OneTimeFilter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="25" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UnionAllWithTruncatedOutput.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAllWithTruncatedOutput.mdp
@@ -324,7 +324,7 @@
     <dxl:Plan Id="0" SpaceSize="72">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="133.125000" Rows="3.333333" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.001254" Rows="3.333333" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="i1">
@@ -338,7 +338,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="132.111979" Rows="3.333333" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.001135" Rows="3.333333" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="i2">
@@ -351,7 +351,7 @@
           <dxl:Filter/>
           <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="130.019531" Rows="1.333333" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000632" Rows="1.333333" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="i2">
@@ -368,45 +368,9 @@
                 <dxl:Ident ColId="9" ColName="j1" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:JoinFilter>
-            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="4.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="j1">
-                  <dxl:Ident ColId="9" ColName="j1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="2.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="j1">
-                    <dxl:Ident ColId="9" ColName="j1" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.50289.1.1" TableName="j">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="j1" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="j2" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:BroadcastMotion>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i1">
@@ -431,10 +395,57 @@
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
+            <dxl:Materialize Eager="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000246" Rows="4.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="j1">
+                  <dxl:Ident ColId="9" ColName="j1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000238" Rows="4.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="j1">
+                    <dxl:Ident ColId="9" ColName="j1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="j1">
+                      <dxl:Ident ColId="9" ColName="j1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.50289.1.1" TableName="j">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="j1" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="j2" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+            </dxl:Materialize>
           </dxl:NestedLoopJoin>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.066406" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000490" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="i2">
@@ -454,7 +465,7 @@
             </dxl:HashCondList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="i1">
@@ -481,7 +492,7 @@
             </dxl:TableScan>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="2.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="2.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="j1">

--- a/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
@@ -17,6 +17,14 @@
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
       </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
@@ -224,10 +232,10 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1905">
-      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+    <dxl:Plan Id="0" SpaceSize="16458">
+      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.111328" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="8"/>
@@ -238,9 +246,9 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:Append IsTarget="false" IsZapped="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.056641" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="8" Alias="max">
@@ -248,9 +256,14 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Result>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.031250" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000062" Rows="2.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="max">
@@ -258,82 +271,107 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.023438" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:GroupingColumns/>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="8" Alias="max">
-                  <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
-                    <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="c1">
-                    <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="c1">
-                      <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.17100.1.1" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-            </dxl:Aggregate>
-          </dxl:Result>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="11" Alias="v">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="8" Alias="max">
+                  <dxl:Ident ColId="8" ColName="max" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="max">
+                    <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final">
+                      <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                      <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial">
+                          <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="c1">
+                          <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.17100.1.1" TableName="t1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Aggregate>
+                </dxl:GatherMotion>
+              </dxl:Aggregate>
             </dxl:Result>
-          </dxl:Result>
-        </dxl:Append>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="11" Alias="v">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:Append>
+        </dxl:Sort>
       </dxl:Aggregate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -401,7 +401,7 @@
     <dxl:Plan Id="0" SpaceSize="7068">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.042969" Rows="13.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002353" Rows="13.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="count">
@@ -412,7 +412,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.992188" Rows="13.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001886" Rows="13.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="13"/>
@@ -425,7 +425,7 @@
           <dxl:Filter/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.687500" Rows="13.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001071" Rows="13.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="13" Alias="count">
@@ -435,7 +435,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.421875" Rows="12.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="12.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="count">
@@ -451,7 +451,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.375000" Rows="12.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000493" Rows="12.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="13" Alias="count">
@@ -462,7 +462,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.375000" Rows="12.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000493" Rows="12.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="0"/>
@@ -488,7 +488,7 @@
                   <dxl:Filter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.093750" Rows="12.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="12.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="cn">
@@ -526,7 +526,7 @@
             </dxl:RedistributeMotion>
             <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.164062" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000376" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="count">
@@ -542,54 +542,85 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.156250" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000351" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="count">
-                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal">
-                      <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
+                      <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
                     </dxl:AggFunc>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.046875" Rows="12.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000350" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="17" Alias="dt">
-                      <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                    <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                      <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
-                  <dxl:TableScan>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.023438" Rows="12.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000314" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="17" Alias="dt">
-                        <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                      <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial">
+                          <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.471019.1.1" TableName="sale">
-                      <dxl:Columns>
-                        <dxl:Column ColId="14" Attno="1" ColName="cn" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="15" Attno="2" ColName="vn" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="16" Attno="3" ColName="pn" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="17" Attno="4" ColName="dt" TypeMdid="0.1082.1.0"/>
-                        <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000311" Rows="12.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="17" Alias="dt">
+                          <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="12.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="17" Alias="dt">
+                            <dxl:Ident ColId="17" ColName="dt" TypeMdid="0.1082.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.471019.1.1" TableName="sale">
+                          <dxl:Columns>
+                            <dxl:Column ColId="14" Attno="1" ColName="cn" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="15" Attno="2" ColName="vn" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="16" Attno="3" ColName="pn" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="17" Attno="4" ColName="dt" TypeMdid="0.1082.1.0"/>
+                            <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                  </dxl:Aggregate>
                 </dxl:GatherMotion>
               </dxl:Aggregate>
             </dxl:RedistributeMotion>

--- a/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
@@ -729,10 +729,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1974">
+    <dxl:Plan Id="0" SpaceSize="1958">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7591.285525" Rows="14282.594514" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="929.941015" Rows="14282.594514" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -746,7 +746,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7534.494141" Rows="14282.594514" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="929.427984" Rows="14282.594514" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -766,7 +766,7 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2386.125000" Rows="610848.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.383362" Rows="610848.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -793,7 +793,7 @@
           </dxl:TableScan>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="179.806641" Rows="10000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.775240" Rows="10000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="9"/>
@@ -806,7 +806,7 @@
             <dxl:Filter/>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="61.611328" Rows="10001.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.161720" Rows="10001.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">
@@ -816,7 +816,7 @@
               <dxl:Filter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="19.531250" Rows="10000.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="i">
@@ -839,7 +839,7 @@
               </dxl:TableScan>
               <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.013672" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="19" Alias="?column?">
@@ -855,7 +855,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="?column?">
@@ -866,7 +866,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="">

--- a/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -1019,7 +1019,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="69.021875" Rows="136.148000" Width="132"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.173205" Rows="136.148000" Width="132"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="31" Alias="oid">
@@ -1042,7 +1042,7 @@
         </dxl:HashCondList>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="43.651562" Rows="134.800000" Width="72"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.067322" Rows="134.800000" Width="72"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="relname">
@@ -1078,7 +1078,7 @@
         </dxl:TableScan>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.492188" Rows="7.000000" Width="72"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000566" Rows="7.000000" Width="72"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="38" Alias="nspname">

--- a/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -274,10 +274,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.344727" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.102559" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -301,9 +301,9 @@
             <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Result>
+        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.243164" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000997" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -322,14 +322,19 @@
               <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-              <dxl:ConstValue TypeMdid="0.26.1.0" Value="229435"/>
+              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.26.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:SortingColumnList/>
+          <dxl:HashExprList>
+            <dxl:HashExpr>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:HashExpr>
+          </dxl:HashExprList>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.192383" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000855" Rows="2.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -347,17 +352,15 @@
               <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                 <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                <dxl:ConstValue TypeMdid="0.26.1.0" Value="229435"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
+            <dxl:OneTimeFilter/>
             <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.170898" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000803" Rows="2.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -378,7 +381,7 @@
               </dxl:ProjList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.127930" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000759" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -405,9 +408,9 @@
                     <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:HashCondList>
-                <dxl:TableScan>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="0">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.008789" Rows="1.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -424,23 +427,44 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.229435.1.1" TableName="r">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:SortingColumnList/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="18"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="ctid">
+                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.229435.1.1" TableName="r">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:GatherMotion>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="0">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="a">
@@ -454,7 +478,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="a">
@@ -479,11 +503,11 @@
                       </dxl:Columns>
                     </dxl:TableDescriptor>
                   </dxl:TableScan>
-                </dxl:BroadcastMotion>
+                </dxl:GatherMotion>
               </dxl:HashJoin>
             </dxl:Split>
-          </dxl:RedistributeMotion>
-        </dxl:Result>
+          </dxl:Result>
+        </dxl:RedistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
@@ -296,7 +296,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1,2,3" ActionCol="12" OidCol="13" CtidCol="4" SegmentIdCol="10" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.470703" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.133042" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -330,7 +330,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.337891" Rows="2.000000" Width="34"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000229" Rows="2.000000" Width="34"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -362,7 +362,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Assert ErrorCode="23514">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.271484" Rows="2.000000" Width="30"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000195" Rows="2.000000" Width="30"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -409,7 +409,7 @@
             </dxl:AssertConstraintList>
             <dxl:Assert ErrorCode="23502">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.212891" Rows="2.000000" Width="30"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000165" Rows="2.000000" Width="30"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -445,7 +445,7 @@
               </dxl:AssertConstraintList>
               <dxl:Split DeleteColumns="0,1,2,3" InsertColumns="0,11,2,3" ActionCol="12" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.154297" Rows="2.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000135" Rows="2.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -475,7 +475,7 @@
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.087891" Rows="1.000000" Width="30"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="1.000000" Width="30"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -504,7 +504,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.058594" Rows="1.000000" Width="30"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="30"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
@@ -272,7 +272,7 @@
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2311.371094" Rows="10000.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1880.351554" Rows="10000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -298,7 +298,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1294.746094" Rows="20000.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="864.726554" Rows="20000.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="785.933594" Rows="20000.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="864.466554" Rows="20000.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -352,7 +352,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="570.089844" Rows="20000.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="863.777954" Rows="20000.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -373,7 +373,7 @@
               </dxl:ProjList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="139.402344" Rows="10000.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="863.557954" Rows="10000.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -402,7 +402,7 @@
                 </dxl:HashCondList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="39.062500" Rows="10000.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="a">
@@ -429,7 +429,7 @@
                 </dxl:TableScan>
                 <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3.636719" Rows="200.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.049834" Rows="200.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -449,7 +449,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.878906" Rows="100.000000" Width="18"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="18"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -249,7 +249,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.324219" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.101765" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -275,7 +275,7 @@
         </dxl:TableDescriptor>
         <dxl:PartitionSelector RelationMdid="0.224805.1.1" PartitionLevels="1" ScanId="0">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.222656" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000202" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="b">
@@ -304,14 +304,14 @@
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:ResidualFilter>
           <dxl:PropagationExpression>
-            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
           </dxl:PropagationExpression>
           <dxl:PrintableFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:PrintableFilter>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.171875" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="b">
@@ -339,7 +339,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.150391" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="b">
@@ -360,7 +360,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.107422" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="b">
@@ -383,7 +383,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.085938" Rows="1.000000" Width="22"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="b">
@@ -422,7 +422,7 @@
                   </dxl:PartitionSelector>
                   <dxl:DynamicTableScan PartIndexId="1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.085938" Rows="1.000000" Width="22"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoCardinalityAssert.mdp
@@ -393,7 +393,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1" ActionCol="11" OidCol="12" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="255.976562" Rows="1000.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="532.719550" Rows="1000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -419,7 +419,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="153.414062" Rows="2000.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.157050" Rows="2000.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -445,7 +445,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="101.632812" Rows="2000.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.131050" Rows="2000.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -473,7 +473,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,10" ActionCol="11" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="79.148438" Rows="2000.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.062190" Rows="2000.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -494,7 +494,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="35.179688" Rows="1000.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.040190" Rows="1000.000000" Width="26"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -520,7 +520,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="8.789062" Rows="1000.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateNotNullCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNotNullCols.mdp
@@ -330,7 +330,7 @@
     <dxl:Plan Id="0" SpaceSize="28">
       <dxl:DMLUpdate Columns="0,1" ActionCol="19" OidCol="20" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.687500" Rows="8.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.815480" Rows="8.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -356,7 +356,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7.875000" Rows="16.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002980" Rows="16.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c">
@@ -382,7 +382,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.468750" Rows="16.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.002772" Rows="16.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="c">
@@ -410,7 +410,7 @@
             </dxl:HashExprList>
             <dxl:Assert ErrorCode="23502">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="5.296875" Rows="16.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.002221" Rows="16.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="c">
@@ -440,7 +440,7 @@
               </dxl:AssertConstraintList>
               <dxl:Split DeleteColumns="0,1" InsertColumns="18,9" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.953125" Rows="16.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.002045" Rows="16.000000" Width="26"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="c">
@@ -464,7 +464,7 @@
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.546875" Rows="8.000000" Width="26"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.001837" Rows="8.000000" Width="26"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="c">
@@ -490,7 +490,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.343750" Rows="8.000000" Width="30"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.001733" Rows="8.000000" Width="30"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c">
@@ -519,7 +519,7 @@
                     </dxl:HashCondList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.085938" Rows="8.000000" Width="22"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="8.000000" Width="22"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="c">
@@ -552,7 +552,7 @@
                     </dxl:TableScan>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
@@ -249,7 +249,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.324219" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.101765" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -275,7 +275,7 @@
         </dxl:TableDescriptor>
         <dxl:PartitionSelector RelationMdid="0.224805.1.1" PartitionLevels="1" ScanId="0">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.222656" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000202" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="b">
@@ -304,14 +304,14 @@
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:ResidualFilter>
           <dxl:PropagationExpression>
-            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
           </dxl:PropagationExpression>
           <dxl:PrintableFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:PrintableFilter>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="5.171875" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="b">
@@ -339,7 +339,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="4.150391" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="b">
@@ -360,7 +360,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3.107422" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="b">
@@ -383,7 +383,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2.085938" Rows="1.000000" Width="22"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="b">
@@ -422,7 +422,7 @@
                   </dxl:PartitionSelector>
                   <dxl:DynamicTableScan PartIndexId="1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.085938" Rows="1.000000" Width="22"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
@@ -198,7 +198,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.247070" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.101718" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -224,7 +224,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.145508" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -250,7 +250,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RoutedDistributeMotion SegmentIdCol="8" InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.094727" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000129" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -273,7 +273,7 @@
             <dxl:SortingColumnList/>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.073242" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="2.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -294,7 +294,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.030273" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -317,7 +317,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.008789" Rows="1.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -767,7 +767,7 @@
     <dxl:Plan Id="0" SpaceSize="88">
       <dxl:DMLUpdate Columns="0,1" ActionCol="23" OidCol="24" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="56.097656" Rows="100.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="872.289027" Rows="100.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -793,7 +793,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="44.941406" Rows="200.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.132777" Rows="200.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -819,7 +819,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="38.863281" Rows="200.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.130177" Rows="200.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -849,7 +849,7 @@
             </dxl:AssertConstraintList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="0,18" ActionCol="23" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="33.566406" Rows="200.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.127977" Rows="200.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -870,7 +870,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="28.269531" Rows="100.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.125777" Rows="100.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -896,7 +896,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:HashJoin JoinType="In">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="25.121094" Rows="100.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.124677" Rows="100.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -922,7 +922,7 @@
                   </dxl:HashCondList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.878906" Rows="100.000000" Width="18"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="18"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -955,7 +955,7 @@
                   </dxl:TableScan>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1.953125" Rows="1000.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint.mdp
@@ -198,7 +198,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.249023" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.101721" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -224,7 +224,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.147461" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000159" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c">
@@ -250,7 +250,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.096680" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000133" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="c">
@@ -277,7 +277,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.096680" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000133" Rows="2.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="c">
@@ -305,7 +305,7 @@
               </dxl:HashExprList>
               <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.075195" Rows="2.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="2.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="c">
@@ -326,7 +326,7 @@
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.032227" Rows="1.000000" Width="22"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="c">
@@ -349,7 +349,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.010742" Rows="1.000000" Width="22"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="22"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/UpdateVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateVolatileFunction.mdp
@@ -413,7 +413,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="252.070312" Rows="1000.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="532.717550" Rows="1000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -439,7 +439,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="149.507812" Rows="2000.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.155050" Rows="2000.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -465,7 +465,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="97.726562" Rows="2000.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.129050" Rows="2000.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -493,7 +493,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="75.242188" Rows="2000.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.060190" Rows="2000.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -514,7 +514,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="31.273438" Rows="1000.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.038190" Rows="1000.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -539,7 +539,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="8.789062" Rows="1000.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithOids.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithOids.mdp
@@ -210,7 +210,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1" ActionCol="11" OidCol="12" CtidCol="2" SegmentIdCol="9" InputSorted="false" PreserveOids="true" TupleOidCol="3">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.321289" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.117394" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -237,7 +237,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.204102" Rows="2.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000206" Rows="2.000000" Width="30"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -266,7 +266,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.145508" Rows="2.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -297,7 +297,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="11" CtidCol="2" SegmentIdCol="9" PreserveOids="true" TupleOidCol="3">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.120117" Rows="2.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="2.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -321,7 +321,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.069336" Rows="1.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="26"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -347,7 +347,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.043945" Rows="1.000000" Width="30"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="30"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithTriggers.mdp
@@ -206,7 +206,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1,2" ActionCol="11" OidCol="12" CtidCol="3" SegmentIdCol="9" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7.320312" Rows="8.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.938442" Rows="8.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -236,7 +236,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.382812" Rows="16.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000942" Rows="16.000000" Width="30"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="t1">
@@ -265,7 +265,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.914062" Rows="16.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="16.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="t1">
@@ -289,7 +289,7 @@
             </dxl:ProjList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.507812" Rows="8.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000494" Rows="8.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="t1">
@@ -315,7 +315,7 @@
               <dxl:OneTimeFilter/>
               <dxl:RowTrigger RelationMdid="0.187777.1.1" Type="19" OldColumns="0,1,2" NewColumns="0,10,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.507812" Rows="8.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000494" Rows="8.000000" Width="26"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="t1">
@@ -339,7 +339,7 @@
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.304688" Rows="8.000000" Width="26"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000390" Rows="8.000000" Width="26"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="t1">
@@ -365,7 +365,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.101562" Rows="8.000000" Width="26"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="26"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="t1">

--- a/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
@@ -412,7 +412,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1,2" ActionCol="11" OidCol="12" CtidCol="3" SegmentIdCol="9" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.000000" Rows="0.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -442,7 +442,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.000000" Rows="0.000000" Width="34"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="34"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="x">
@@ -471,7 +471,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.000000" Rows="0.000000" Width="30"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="30"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="x">
@@ -502,7 +502,7 @@
             </dxl:HashExprList>
             <dxl:Assert ErrorCode="23514">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2.000000" Rows="0.000000" Width="30"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="30"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="x">
@@ -561,7 +561,7 @@
               </dxl:AssertConstraintList>
               <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.000000" Rows="0.000000" Width="38"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="38"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="x">
@@ -618,37 +618,37 @@
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="x">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="y">
                         <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="2" Alias="z">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="10" Alias="y">
                         <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="3" Alias="ctid">
-                        <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true" IsByValue="false"/>
+                        <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="4" Alias="xmin">
-                        <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="5" Alias="cmin">
-                        <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="6" Alias="xmax">
-                        <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="7" Alias="cmax">
-                        <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="8" Alias="tableoid">
-                        <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/UseDistributionSatisfactionForUniversalInnerChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UseDistributionSatisfactionForUniversalInnerChild.mdp
@@ -9,6 +9,14 @@
       <dxl:TraceFlags Value="103027,101001,102024,103001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -97,9 +105,9 @@
       </dxl:Difference>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="16">
-      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.089844" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000397" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -110,9 +118,9 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.066406" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="generate_series">
@@ -120,67 +128,83 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Not>
-              <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="generate_series" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="3" ColName="?column?" TypeMdid="0.23.1.0"/>
-              </dxl:IsDistinctFrom>
-            </dxl:Not>
-          </dxl:HashCondList>
-          <dxl:Result>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="generate_series">
-                <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                <dxl:Ident ColId="1" ColName="generate_series" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="generate_series" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="3" ColName="?column?" TypeMdid="0.23.1.0"/>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:HashCondList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="generate_series">
+                  <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:FuncExpr>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="?column?">
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:FuncExpr>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="3" Alias="?column?">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="2" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-            </dxl:Result>
-          </dxl:Result>
-        </dxl:HashJoin>
+          </dxl:HashJoin>
+        </dxl:Sort>
       </dxl:Aggregate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/WinFunc-Simple.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WinFunc-Simple.mdp
@@ -424,7 +424,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Window PartitionColumns="">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="26.140625" Rows="64.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.013235" Rows="64.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -440,7 +440,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="24.140625" Rows="64.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.012723" Rows="64.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -456,7 +456,7 @@
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="22.890625" Rows="64.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.010424" Rows="64.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -474,7 +474,7 @@
             <dxl:LimitOffset/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.890625" Rows="64.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.003166" Rows="64.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/WinFuncWithSubqArgs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WinFuncWithSubqArgs.mdp
@@ -293,57 +293,48 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Window PartitionColumns="">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="24.001953" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.021658" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="sum">
             <dxl:WindowFunc Mdid="0.2108.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0">
-              <dxl:Ident ColId="9" ColName="a1" TypeMdid="0.23.1.0"/>
-            </dxl:WindowFunc>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="23.001953" Rows="1000.000000" Width="4"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="9" Alias="a1">
-              <dxl:Ident ColId="9" ColName="a1" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="20.048828" Rows="1000.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="a1">
-                <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                  <dxl:TestExpr/>
-                  <dxl:ParamList>
-                    <dxl:Param ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
-                  </dxl:ParamList>
-                  <dxl:Result>
+              <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000181" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="a1">
+                      <dxl:Ident ColId="9" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="10" ColName="a2" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000116" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="a1">
                         <dxl:Ident ColId="9" ColName="a1" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:ProjElem ColId="10" Alias="a2">
                         <dxl:Ident ColId="10" ColName="a2" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Materialize Eager="false">
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="2.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="a1">
@@ -354,9 +345,10 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="2.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="a1">
@@ -367,67 +359,63 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="9" Alias="a1">
-                              <dxl:Ident ColId="9" ColName="a1" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="10" Alias="a2">
-                              <dxl:Ident ColId="10" ColName="a2" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.1018204.1.1" TableName="a">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="a1" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="10" Attno="2" ColName="a2" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:BroadcastMotion>
-                    </dxl:Materialize>
-                  </dxl:Result>
-                </dxl:SubPlan>
+                        <dxl:TableDescriptor Mdid="0.1018204.1.1" TableName="a">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="10" Attno="2" ColName="a2" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:GatherMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
+              </dxl:SubPlan>
+            </dxl:WindowFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="b2">
+              <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="b2">
+                <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="20.048828" Rows="1000.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="b2">
-                  <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1018227.1.1" TableName="b">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="b1" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b2" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Result>
+            <dxl:TableDescriptor Mdid="0.1018227.1.1" TableName="b">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="b1" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b2" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:GatherMotion>
         <dxl:WindowKeyList>
           <dxl:WindowKey>

--- a/src/backend/gporca/data/dxl/minidump/WindowFrame-SingleEdged.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WindowFrame-SingleEdged.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:CostModelConfig CostModelType="0" SegmentsForCosting="2"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647"/>
       <dxl:TraceFlags Value="103027,101013,103001,103016,103022,104002"/>
     </dxl:OptimizerConfig>
@@ -260,7 +260,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Window PartitionColumns="">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="4.685580" Rows="10.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.001178" Rows="10.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cn">
@@ -275,7 +275,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3.529330" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.001098" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cn">
@@ -288,7 +288,7 @@
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2.490268" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000739" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cn">
@@ -303,7 +303,7 @@
             <dxl:LimitOffset/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000137" Rows="10.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="cn">

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -4275,7 +4275,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
     <dxl:Plan Id="0" SpaceSize="114">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="974268139.795765" Rows="58129406.108810" Width="25"/>
+          <dxl:Cost StartupCost="0" TotalCost="1036737.502445" Rows="58129406.108810" Width="25"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="35" Alias="ship_month">
@@ -4295,7 +4295,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="973558551.318851" Rows="58129406.108810" Width="25"/>
+            <dxl:Cost StartupCost="0" TotalCost="1030212.476609" Rows="58129406.108810" Width="25"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="35" Alias="ship_month">
@@ -4317,7 +4317,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="93926778.130796" Rows="58129406.108810" Width="25"/>
+              <dxl:Cost StartupCost="0" TotalCost="928068.227812" Rows="58129406.108810" Width="25"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="35"/>
@@ -4339,7 +4339,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="79524079.906516" Rows="246206051.943378" Width="27"/>
+                <dxl:Cost StartupCost="0" TotalCost="897426.492173" Rows="246206051.943378" Width="27"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="35"/>
@@ -4360,7 +4360,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
               <dxl:Filter/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="60048795.500838" Rows="246206051.943378" Width="27"/>
+                  <dxl:Cost StartupCost="0" TotalCost="850127.970637" Rows="246206051.943378" Width="27"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="order_id">
@@ -4385,7 +4385,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="56802913.933226" Rows="246206051.943378" Width="27"/>
+                    <dxl:Cost StartupCost="0" TotalCost="839724.533912" Rows="246206051.943378" Width="27"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="35"/>
@@ -4406,7 +4406,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                   <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="37327629.527548" Rows="246206051.943378" Width="27"/>
+                      <dxl:Cost StartupCost="0" TotalCost="792426.012376" Rows="246206051.943378" Width="27"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="35" Alias="ship_month">
@@ -4426,7 +4426,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                     <dxl:OneTimeFilter/>
                     <dxl:Sequence>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="30835867.392322" Rows="246206051.943378" Width="27"/>
+                        <dxl:Cost StartupCost="0" TotalCost="789102.230675" Rows="246206051.943378" Width="27"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="order_id">
@@ -4507,7 +4507,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                       </dxl:PartitionSelector>
                       <dxl:DynamicTableScan PartIndexId="1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="30835867.392322" Rows="246206051.943378" Width="27"/>
+                          <dxl:Cost StartupCost="0" TotalCost="789102.230675" Rows="246206051.943378" Width="27"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="order_id">

--- a/src/backend/gporca/data/dxl/parse_tests/CostModelConfigLegacy.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/CostModelConfigLegacy.xml
@@ -1,1 +1,0 @@
-<dxl:CostModelConfig CostModelType="0" SegmentsForCosting="3" xmlns:dxl="http://greenplum.com/dxl/2010/12/"/>

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -1688,7 +1688,7 @@ CCostModelGPDB::CostBitmapTableScan(CMemoryPool *mp, CExpressionHandle &exprhdl,
 			pexprIndexCond->Pop()->Eopid() ||
 		1 < pcrsLocalUsed->Size() ||
 		(isInPredOnBtreeIndex && rows > 2.0 &&
-		 !GPOS_FTRACE(EopttraceCalibratedBitmapIndexCostModel)))
+		 GPOS_FTRACE(EopttraceLegacyCostModel)))
 	{
 		// Child is Bitmap AND/OR, or we use Multi column index or this is an IN predicate
 		// that's used with the "calibrated" cost model.
@@ -1763,9 +1763,9 @@ CCostModelGPDB::CostBitmapTableScan(CMemoryPool *mp, CExpressionHandle &exprhdl,
 			}
 		}
 
-		if (!GPOS_FTRACE(EopttraceCalibratedBitmapIndexCostModel))
+		if (GPOS_FTRACE(EopttraceLegacyCostModel))
 		{
-			// optimizer_cost_model = 'calibrated'
+			// optimizer_cost_model = 'legacy'
 			if (dNDVThreshold <= dNDV)
 			{
 				result = CostBitmapLargeNDV(pcmgpdb, pci, dNDV);
@@ -1777,7 +1777,7 @@ CCostModelGPDB::CostBitmapTableScan(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		}
 		else
 		{
-			// optimizer_cost_model = 'experimental'
+			// optimizer_cost_model = 'calibrated'|'experimental'
 			CDouble dBitmapIO =
 				pcmgpdb->GetCostModelParams()
 					->PcpLookup(CCostModelParamsGPDB::EcpBitmapIOCostSmallNDV)

--- a/src/backend/gporca/libgpdbcost/src/ICostModel.cpp
+++ b/src/backend/gporca/libgpdbcost/src/ICostModel.cpp
@@ -11,7 +11,7 @@
 
 #include "gpos/base.h"
 #include "gpos/string/CWStringConst.h"
-#include "gpdbcost/CCostModelGPDBLegacy.h"
+#include "gpdbcost/CCostModelGPDB.h"
 
 using namespace gpopt;
 using namespace gpdbcost;
@@ -30,7 +30,7 @@ using namespace gpdbcost;
 ICostModel *
 ICostModel::PcmDefault(CMemoryPool *mp)
 {
-	return GPOS_NEW(mp) CCostModelGPDBLegacy(mp, GPOPT_DEFAULT_SEGMENT_COUNT);
+	return GPOS_NEW(mp) CCostModelGPDB(mp, GPOPT_DEFAULT_SEGMENT_COUNT);
 }
 
 

--- a/src/backend/gporca/libgpdbcost/src/Makefile
+++ b/src/backend/gporca/libgpdbcost/src/Makefile
@@ -11,9 +11,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_builddir)/src/backend/gporca/gporca.mk
 
 OBJS        = CCostModelGPDB.o \
-              CCostModelGPDBLegacy.o \
               CCostModelParamsGPDB.o \
-              CCostModelParamsGPDBLegacy.o \
               ICostModel.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
@@ -54,7 +54,8 @@ public:
 	{
 		EcmtGPDBLegacy = 0,
 		EcmtGPDBCalibrated = 1,
-		EcmtSentinel = 2
+		EcmtGPDBExperimental = 2,
+		EcmtSentinel = 3
 	};
 
 	//---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -241,8 +241,11 @@ enum EOptTraceFlag
 	// Penalize HashJoins with a skewed hash distribute under them
 	EopttracePenalizeSkewedHashJoin = 104006,
 
-	// Use calibrated bitmap index cost model
-	EopttraceCalibratedBitmapIndexCostModel = 104007,
+	// Use legacy cost model
+	EopttraceLegacyCostModel = 104008,
+
+	// Use experimental cost model
+	EopttraceExperimentalCostModel = 104009,
 	///////////////////////////////////////////////////////
 	/////////// constant expression evaluator flags ///////
 	///////////////////////////////////////////////////////

--- a/src/backend/gporca/libnaucrates/src/CCostModelConfigSerializer.cpp
+++ b/src/backend/gporca/libnaucrates/src/CCostModelConfigSerializer.cpp
@@ -14,11 +14,6 @@ using gpos::CAutoRef;
 void
 CCostModelConfigSerializer::Serialize(CXMLSerializer &xml_serializer) const
 {
-	if (ICostModel::EcmtGPDBLegacy == m_cost_model->Ecmt())
-	{
-		return;
-	}
-
 	xml_serializer.OpenElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 		CDXLTokens::GetDXLTokenStr(EdxltokenCostModelConfig));

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerCostModel.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerCostModel.cpp
@@ -23,7 +23,6 @@
 #include "naucrates/dxl/xml/dxltokens.h"
 
 #include "gpdbcost/CCostModelGPDB.h"
-#include "gpdbcost/CCostModelGPDBLegacy.h"
 
 using namespace gpdxl;
 using namespace gpdbcost;
@@ -139,17 +138,16 @@ CParseHandlerCostModel::EndElement(const XMLCh *const,	// element_uri,
 
 	switch (m_cost_model_type)
 	{
+		// FIXME: Remove ICostModel::ECostModelType
+		// Right now, we use the same class for all cost models
 		case ICostModel::EcmtGPDBLegacy:
-			m_cost_model =
-				GPOS_NEW(m_mp) CCostModelGPDBLegacy(m_mp, m_num_of_segments);
-			break;
+		case ICostModel::EcmtGPDBExperimental:
 		case ICostModel::EcmtGPDBCalibrated:
 			CCostModelParamsGPDB *pcp;
 
 			if (NULL == m_parse_handler_cost_params)
 			{
 				pcp = NULL;
-				GPOS_ASSERT(false && "CostModelParam handler not set");
 			}
 			else
 			{

--- a/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
@@ -32,8 +32,6 @@
 #include "naucrates/md/CMDTypeInt8GPDB.h"
 #include "naucrates/md/CSystemId.h"
 
-#include "gpdbcost/CCostModelGPDBLegacy.h"
-
 #include "unittest/base.h"
 
 #include "naucrates/statistics/CPoint.h"
@@ -605,7 +603,7 @@ public:
 	static ICostModel *
 	GetCostModel(CMemoryPool *mp)
 	{
-		return GPOS_NEW(mp) CCostModelGPDBLegacy(mp, GPOPT_TEST_SEGMENTS);
+		return GPOS_NEW(mp) CCostModelGPDB(mp, GPOPT_TEST_SEGMENTS);
 	}
 
 	// create a datum with a given type, encoded value and int value

--- a/src/backend/gporca/server/include/unittest/gpopt/cost/CCostTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/cost/CCostTest.h
@@ -30,7 +30,7 @@ class CCostTest
 {
 private:
 	// test cost model parameters
-	static void TestParams(CMemoryPool *mp, BOOL fCalibrated);
+	static void TestParams(CMemoryPool *mp);
 
 public:
 	// unittests

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -28,8 +28,6 @@
 #include "gpopt/xforms/CXformFactory.h"
 #include "gpopt/optimizer/COptimizerConfig.h"
 
-#include "gpdbcost/CCostModelGPDBLegacy.h"
-
 // test headers
 
 #include "unittest/base.h"

--- a/src/backend/gporca/server/src/unittest/dxl/CParseHandlerCostModelTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/CParseHandlerCostModelTest.cpp
@@ -14,7 +14,6 @@
 
 #include "gpdbcost/CCostModelGPDB.h"
 #include "gpdbcost/CCostModelParamsGPDB.h"
-#include "gpdbcost/CCostModelParamsGPDBLegacy.h"
 
 
 #include "gpos/base.h"
@@ -164,41 +163,11 @@ Eres_SerializeCalibratedCostModel()
 	return gpos::GPOS_OK;
 }
 
-static gpos::GPOS_RESULT
-Eres_ParseLegacyCostModel()
-{
-	const CHAR dxl_filename[] =
-		"../data/dxl/parse_tests/CostModelConfigLegacy.xml";
-	Fixture fixture;
-
-	CMemoryPool *mp = fixture.Pmp();
-
-	gpos::CAutoRg<CHAR> a_szDXL(CDXLUtils::Read(mp, dxl_filename));
-
-	CParseHandlerCostModel *pphcm = fixture.PphCostModel();
-
-	fixture.Parse((const XMLByte *) a_szDXL.Rgt(), strlen(a_szDXL.Rgt()));
-
-	ICostModel *pcm = pphcm->GetCostModel();
-
-	GPOS_RTL_ASSERT(ICostModel::EcmtGPDBLegacy == pcm->Ecmt());
-	GPOS_RTL_ASSERT(3 == pcm->UlHosts());
-
-	CAutoRef<CCostModelParamsGPDBLegacy> pcpExpected(
-		GPOS_NEW(mp) CCostModelParamsGPDBLegacy(mp));
-	GPOS_RTL_ASSERT(pcpExpected->Equals(pcm->GetCostModelParams()));
-
-	return gpos::GPOS_OK;
-}
-
 gpos::GPOS_RESULT
 CParseHandlerCostModelTest::EresUnittest()
 {
-	CUnittest rgut[] = {
-		GPOS_UNITTEST_FUNC(Eres_ParseCalibratedCostModel),
-		GPOS_UNITTEST_FUNC(Eres_SerializeCalibratedCostModel),
-		GPOS_UNITTEST_FUNC(Eres_ParseLegacyCostModel),
-	};
+	CUnittest rgut[] = {GPOS_UNITTEST_FUNC(Eres_ParseCalibratedCostModel),
+						GPOS_UNITTEST_FUNC(Eres_SerializeCalibratedCostModel)};
 
 	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
 }

--- a/src/backend/gporca/server/src/unittest/gpopt/cost/CCostTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/cost/CCostTest.cpp
@@ -27,7 +27,6 @@
 #include "unittest/gpopt/CTestUtils.h"
 
 #include "gpdbcost/CCostModelGPDB.h"
-#include "gpdbcost/CCostModelGPDBLegacy.h"
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -135,67 +134,31 @@ CCostTest::EresUnittest_Bool()
 //
 //---------------------------------------------------------------------------
 void
-CCostTest::TestParams(CMemoryPool *mp, BOOL fCalibrated)
+CCostTest::TestParams(CMemoryPool *mp)
 {
 	CAutoTrace at(mp);
 	IOstream &os(at.Os());
 
-	ICostModelParams *pcp = NULL;
-	CDouble dSeqIOBandwidth(0.0);
-	CDouble dRandomIOBandwidth(0.0);
-	CDouble dTupProcBandwidth(0.0);
-	CDouble dNetBandwidth(0.0);
-	CDouble dSegments(0.0);
-	CDouble dNLJFactor(0.0);
-	CDouble dHashFactor(0.0);
-	CDouble dDefaultCost(0.0);
+	ICostModelParams *pcp =
+		((CCostModelGPDB *) COptCtxt::PoctxtFromTLS()->GetCostModel())
+			->GetCostModelParams();
 
-	if (fCalibrated)
-	{
-		pcp = ((CCostModelGPDB *) COptCtxt::PoctxtFromTLS()->GetCostModel())
-				  ->GetCostModelParams();
-
-		dSeqIOBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDB::EcpSeqIOBandwidth)->Get();
-		dRandomIOBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDB::EcpRandomIOBandwidth)->Get();
-		dTupProcBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDB::EcpTupProcBandwidth)->Get();
-		dNetBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDB::EcpNetBandwidth)->Get();
-		dSegments = pcp->PcpLookup(CCostModelParamsGPDB::EcpSegments)->Get();
-		dNLJFactor = pcp->PcpLookup(CCostModelParamsGPDB::EcpNLJFactor)->Get();
-		dHashFactor =
-			pcp->PcpLookup(CCostModelParamsGPDB::EcpHashFactor)->Get();
-		dDefaultCost =
-			pcp->PcpLookup(CCostModelParamsGPDB::EcpDefaultCost)->Get();
-	}
-	else
-	{
-		pcp =
-			((CCostModelGPDBLegacy *) COptCtxt::PoctxtFromTLS()->GetCostModel())
-				->GetCostModelParams();
-
-		dSeqIOBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpSeqIOBandwidth)
-				->Get();
-		dRandomIOBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpRandomIOBandwidth)
-				->Get();
-		dTupProcBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpTupProcBandwidth)
-				->Get();
-		dNetBandwidth =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpNetBandwidth)->Get();
-		dSegments =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpSegments)->Get();
-		dNLJFactor =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpNLJFactor)->Get();
-		dHashFactor =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpHashFactor)->Get();
-		dDefaultCost =
-			pcp->PcpLookup(CCostModelParamsGPDBLegacy::EcpDefaultCost)->Get();
-	}
+	CDouble dSeqIOBandwidth =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpSeqIOBandwidth)->Get();
+	CDouble dRandomIOBandwidth =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpRandomIOBandwidth)->Get();
+	CDouble dTupProcBandwidth =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpTupProcBandwidth)->Get();
+	CDouble dNetBandwidth =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpNetBandwidth)->Get();
+	CDouble dSegments =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpSegments)->Get();
+	CDouble dNLJFactor =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpNLJFactor)->Get();
+	CDouble dHashFactor =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpHashFactor)->Get();
+	CDouble dDefaultCost =
+		pcp->PcpLookup(CCostModelParamsGPDB::EcpDefaultCost)->Get();
 
 	os << std::endl << "Lookup cost model params by id: " << std::endl;
 	os << "Seq I/O bandwidth: " << dSeqIOBandwidth << std::endl;
@@ -256,21 +219,11 @@ CCostTest::EresUnittest_Params()
 	pmdp->AddRef();
 	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
 
-	{
-		// install opt context in TLS
-		CAutoOptCtxt aoc(mp, &mda, NULL, /* pceeval */
-						 CTestUtils::GetCostModel(mp));
+	// install opt context in TLS
+	CAutoOptCtxt aoc(mp, &mda, NULL, /* pceeval */
+					 GPOS_NEW(mp) CCostModelGPDB(mp, GPOPT_TEST_SEGMENTS));
 
-		TestParams(mp, false /*fCalibrated*/);
-	}
-
-	{
-		// install opt context in TLS
-		CAutoOptCtxt aoc(mp, &mda, NULL, /* pceeval */
-						 GPOS_NEW(mp) CCostModelGPDB(mp, GPOPT_TEST_SEGMENTS));
-
-		TestParams(mp, true /*fCalibrated*/);
-	}
+	TestParams(mp);
 
 	return GPOS_OK;
 }

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -97,8 +97,6 @@ const struct UnSupportedTestCase unSupportedTestCases[] = {
 	 gpdxl::ExmiExpr2DXLUnsupportedFeature},
 	{"../data/dxl/minidump/CTEWithOuterReferences.mdp", gpopt::ExmaGPOPT,
 	 gpopt::ExmiUnsupportedOp},
-	{"../data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp",
-	 gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound},
 	{"../data/dxl/minidump/CTEMisAlignedProducerConsumer.mdp", gpopt::ExmaGPOPT,
 	 gpopt::ExmiCTEProducerConsumerMisAligned}};
 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10885,14 +10885,15 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2');
 (7 rows)
 
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2', 47);
-                                  QUERY PLAN
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
-   ->  Seq Scan on bitmap_test  (cost=0.00..431.00 rows=2 width=4)
-         Filter: a = ANY ('{1,2,47}'::integer[])
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.647
-(5 rows)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..417.97 rows=4 width=4)
+   ->  Bitmap Heap Scan on bitmap_test  (cost=0.00..417.97 rows=2 width=4)
+         Recheck Cond: (a = ANY ('{1,2,47}'::integer[]))
+         ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a = ANY ('{1,2,47}'::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 -- Test Logging for unsupported features in ORCA
 -- start_ignore


### PR DESCRIPTION
One conflict in gporca regress answer file, otherwise clean backport of following commits:

```
commit 652a76f4151f09279d87ea41dab5eae3a503eae2
Author: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
Date:   Thu Dec 3 15:30:34 2020 -0800

    ORCA: Shuffle cost models
    ...
    
commit 727caa59586fafb28626588e8587fec054dc92cd
Author: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
Date:   Fri Dec 4 14:10:54 2020 -0800

    Re-enable test for unsupported BitmapIndexScan operator
    ...
    
commit 6ad30662ea8332ad62f1cb5fae501093d04fce72
Author: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
Date:   Sat Dec 5 01:15:53 2020 +0000

    Fix mdp file format leading to parsing error
    ...
```

Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6X-shuffle-orca-cost-models