### PR TITLE
docs - GP_SEGMENT_ID references content, not dbid

### DIFF
--- a/gpdb-doc/dita/admin_guide/load/topics/g-defining-a-command-based-writable-external-web-table.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-defining-a-command-based-writable-external-web-table.xml
@@ -92,7 +92,7 @@
                <row>
                   <entry colname="col1">$GP_SEGMENT_ID</entry>
                   <entry colname="col2">The ID number of the segment instance executing the external
-                     table command (same as <codeph>dbid</codeph> in
+                     table command (same as <codeph>content</codeph> in
                         <codeph>gp_segment_configuration</codeph>).</entry>
                </row>
                <row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2445,7 +2445,7 @@
   <topic id="gp_dbid">
     <title>gp_dbid</title>
     <body>
-      <p>The local content dbid if a segment.</p>
+      <p>The local content dbid of a segment.</p>
       <table id="gp_dbid_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_configuration_history.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_configuration_history.xml
@@ -44,7 +44,7 @@
               <codeph id="ev138567">dbid</codeph>
             </entry>
             <entry colname="col2">smallint</entry>
-            <entry colname="col3">gp_segment _configuration.dbid</entry>
+            <entry colname="col3">gp_segment_configuration.dbid</entry>
             <entry colname="col4">System-assigned ID. The unique identifier of a segment (or master)
               instance.</entry>
           </row>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_distributed_log.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_distributed_log.xml
@@ -29,8 +29,8 @@
               <codeph>segment_id</codeph>
             </entry>
             <entry colname="col2">smallint</entry>
-            <entry colname="col3">gp_segment_ configuration.content</entry>
-            <entry colname="col4">The content id if the segment. The master is always -1 (no
+            <entry colname="col3">gp_segment_configuration.content</entry>
+            <entry colname="col4">The content id of the segment. The master is always -1 (no
               content).</entry>
           </row>
           <row>
@@ -38,7 +38,7 @@
               <codeph>dbid</codeph>
             </entry>
             <entry colname="col2">small_int</entry>
-            <entry colname="col3">gp_segment_ configuration.dbid</entry>
+            <entry colname="col3">gp_segment_configuration.dbid</entry>
             <entry colname="col4">The unique id of the segment instance. </entry>
           </row>
           <row>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_pgdatabase.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_pgdatabase.xml
@@ -46,7 +46,7 @@
               <codeph>content</codeph>
             </entry>
             <entry colname="col2">smallint</entry>
-            <entry colname="col3">gp_segment_ configuration.content</entry>
+            <entry colname="col3">gp_segment_configuration.content</entry>
             <entry colname="col4">The ID for the portion of data on an instance. A primary segment
               instance and its mirror will have the same content ID.<p>For a segment the value is
                 from 0-<i>N-1</i>, where <i>N</i> is the number of segments in Greenplum Database.</p><p>For the master, the value is -1.</p></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_transaction_log.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_transaction_log.xml
@@ -28,8 +28,8 @@
               <codeph>segment_id</codeph>
             </entry>
             <entry colname="col2">smallint</entry>
-            <entry colname="col3">gp_segment_ configuration.content</entry>
-            <entry colname="col4">The content id if the segment. The master is always -1 (no
+            <entry colname="col3">gp_segment_configuration.content</entry>
+            <entry colname="col4">The content id of the segment. The master is always -1 (no
               content).</entry>
           </row>
           <row>
@@ -37,7 +37,7 @@
               <codeph>dbid</codeph>
             </entry>
             <entry colname="col2">smallint</entry>
-            <entry colname="col3">gp_segment_ configuration.dbid</entry>
+            <entry colname="col3">gp_segment_configuration.dbid</entry>
             <entry colname="col4">The unique id of the segment instance. </entry>
           </row>
           <row>


### PR DESCRIPTION
command-based writable web external table discussion states that $GP_SEGMENT_ID references the gp_segment_id dbid, when in fact it represents the content id.  update the docs accordingly.

this PR also includes a few edits for some related docs.
