### PR TITLE
Fix Orca stream operator<< precision

### DIFF
--- a/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Output.xml
+++ b/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Output.xml
@@ -10,24 +10,24 @@
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="20.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAQACAA==" DoubleValue="2.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAQACAA==" DoubleValue="2"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.875000" DistinctValues="14.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.125000" DistinctValues="1.142857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LREAAA==" DoubleValue="379900800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LREAAA==" DoubleValue="379900800000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="5" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="199.666667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" Value="ACcI7mpYAQA=" DoubleValue="378691260000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" Value="AAg5THNYAQA=" DoubleValue="378727200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" Value="ACcI7mpYAQA=" DoubleValue="378691260000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" Value="AAg5THNYAQA=" DoubleValue="378727200000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Output.xml
+++ b/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Output.xml
@@ -10,24 +10,24 @@
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="20.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAQACAA==" DoubleValue="2"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAQACAA==" DoubleValue="2.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.875000" DistinctValues="14.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.125000" DistinctValues="1.142857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LREAAA==" DoubleValue="379900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LREAAA==" DoubleValue="379900800000000.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="5" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="199.666667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" Value="ACcI7mpYAQA=" DoubleValue="378691260000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" Value="AAg5THNYAQA=" DoubleValue="378727200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" Value="ACcI7mpYAQA=" DoubleValue="378691260000000.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" Value="AAg5THNYAQA=" DoubleValue="378727200000000.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Merge-Output-Numeric.xml
+++ b/src/backend/gporca/data/dxl/statistics/Merge-Output-Numeric.xml
@@ -4,36 +4,36 @@
     <dxl:DerivedRelationStats Rows="2000.000000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="10.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.050000" DistinctValues="55713.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADAAAAgB0A1AU" DoubleValue="884.51999999999998"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.759999999998"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADAAAAgB0A1AU" DoubleValue="884.51999999999998181"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.75999999999839929"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032699" DistinctValues="7310.575199">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.759999999998"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.75999999999839929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.31999999999970896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.31999999999970896"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.31999999999970896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.217301" DistinctValues="48582.864200">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.31999999999970896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09000000000014552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09000000000014552"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09000000000014552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.100000" DistinctValues="10644.596075">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.550000000003"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09000000000014552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.55000000000291038"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.180000" DistinctValues="55713.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.550000000003"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.220000000001"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.55000000000291038"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.22000000000116415"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.120000" DistinctValues="20957.448924">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.220000000001"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEABIidA4=" DoubleValue="48722.370000000003"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.22000000000116415"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEABIidA4=" DoubleValue="48722.37000000000261934"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Merge-Output-Numeric.xml
+++ b/src/backend/gporca/data/dxl/statistics/Merge-Output-Numeric.xml
@@ -4,36 +4,36 @@
     <dxl:DerivedRelationStats Rows="2000.000000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="10.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.050000" DistinctValues="55713.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADAAAAgB0A1AU" DoubleValue="884.520000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.760000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADAAAAgB0A1AU" DoubleValue="884.51999999999998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.759999999998"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032699" DistinctValues="7310.575199">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.760000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.320000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgABADsjsB0=" DoubleValue="19019.759999999998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.320000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.320000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.217301" DistinctValues="48582.864200">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.320000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.090000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgACAAYCgAw=" DoubleValue="20518.32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.090000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.090000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.100000" DistinctValues="10644.596075">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.090000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.550000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAN0BhAM=" DoubleValue="30477.09"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.550000000003"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.180000" DistinctValues="55713.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.550000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.220000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgADAG8MfBU=" DoubleValue="33183.550000000003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.220000000001"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.120000" DistinctValues="20957.448924">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.220000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEABIidA4=" DoubleValue="48722.370000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEAOYSmAg=" DoubleValue="44838.220000000001"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADgEAAgAEABIidA4=" DoubleValue="48722.370000000003"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2416.638336" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2416.638336" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="1208.440000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="1208.440000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GT-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GT-MinBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60421.879156" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.039998" DistinctValues="1.999900">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GT-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GT-MinBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60421.879156" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.039998" DistinctValues="1.999900">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2416.638336" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2416.638336" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MinBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60422.000000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MinBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60422.000000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LT-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LT-MaxBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60421.758336" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039996" DistinctValues="1.999800">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LT-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LT-MaxBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60421.758336" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039996" DistinctValues="1.999800">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MaxBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60422.000000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MaxBoundary.xml
@@ -4,104 +4,104 @@
     <dxl:DerivedRelationStats Rows="60422.000000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="1208.440000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LTE-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="1208.440000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2351.201286" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2351.201286" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2636.091016" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-E-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2636.091016" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-GTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-GTE-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2351.201286" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-GTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-GTE-MaxBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2351.201286" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-LTE-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-LTE-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2636.091016" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-LTE-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-LTE-MinBoundary.xml
@@ -4,8 +4,8 @@
     <dxl:DerivedRelationStats Rows="2636.091016" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.00000000000000000"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
     </dxl:DerivedRelationStats>

--- a/src/backend/gporca/libgpos/include/gpos/io/IOstream.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/IOstream.h
@@ -31,7 +31,11 @@ class IOstream
 {
 protected:
 	// ctor
-	IOstream() = default;
+	IOstream() : m_fullPrecision(false)
+	{
+	}
+
+	BOOL m_fullPrecision;
 
 public:
 	enum EStreamManipulator
@@ -59,6 +63,12 @@ public:
 
 	// needs to be implemented by subclass
 	virtual IOstream &operator<<(const WCHAR *) = 0;
+
+	void
+	SetFullPrecision(BOOL fullPrecision)
+	{
+		m_fullPrecision = fullPrecision;
+	}
 };
 
 }  // namespace gpos

--- a/src/backend/gporca/libgpos/src/io/COstream.cpp
+++ b/src/backend/gporca/libgpos/src/io/COstream.cpp
@@ -213,7 +213,7 @@ COstream::operator<<(const DOUBLE input_double)
 {
 	if (m_fullPrecision)
 	{
-		return AppendFormat(GPOS_WSZ_LIT("%.17g"), input_double);
+		return AppendFormat(GPOS_WSZ_LIT("%.17f"), input_double);
 	}
 	return AppendFormat(GPOS_WSZ_LIT("%f"), input_double);
 }

--- a/src/backend/gporca/libgpos/src/io/COstream.cpp
+++ b/src/backend/gporca/libgpos/src/io/COstream.cpp
@@ -211,6 +211,10 @@ COstream::operator<<(LINT input_long_int)
 IOstream &
 COstream::operator<<(const DOUBLE input_double)
 {
+	if (m_fullPrecision)
+	{
+		return AppendFormat(GPOS_WSZ_LIT("%.17g"), input_double);
+	}
 	return AppendFormat(GPOS_WSZ_LIT("%f"), input_double);
 }
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/CXMLSerializer.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/CXMLSerializer.h
@@ -129,6 +129,12 @@ public:
 	// add a byte array attribute
 	void AddAttribute(const CWStringBase *pstrAttr, BOOL is_null,
 					  const BYTE *data, ULONG length);
+
+	void
+	SetFullPrecision(BOOL fullPrecision)
+	{
+		m_os.SetFullPrecision(fullPrecision);
+	}
 };
 
 }  // namespace gpdxl

--- a/src/backend/gporca/libnaucrates/src/md/CDXLBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLBucket.cpp
@@ -134,6 +134,7 @@ CDXLBucket::Serialize(CXMLSerializer *xml_serializer) const
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenStatsDistinct), m_distinct);
 
+	xml_serializer->SetFullPrecision(true);
 	SerializeBoundaryValue(
 		xml_serializer,
 		CDXLTokens::GetDXLTokenStr(EdxltokenStatsBucketLowerBound),
@@ -142,6 +143,7 @@ CDXLBucket::Serialize(CXMLSerializer *xml_serializer) const
 		xml_serializer,
 		CDXLTokens::GetDXLTokenStr(EdxltokenStatsBucketUpperBound),
 		m_upper_bound_dxl_datum, m_is_upper_closed);
+	xml_serializer->SetFullPrecision(false);
 
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -9750,6 +9750,7 @@ with x as (select * from foo_missing_stats) select count(*) from x x1, x x2 wher
 set allow_system_table_mods=true;
 delete from pg_statistic where starelid='foo_missing_stats'::regclass;
 delete from pg_statistic where starelid='bar_missing_stats'::regclass;
+set allow_system_table_mods=false;
 select count(*) from foo_missing_stats where a = 10;
  count 
 -------
@@ -9769,6 +9770,62 @@ with x as (select * from foo_missing_stats) select count(*) from x x1, x x2 wher
 (1 row)
 
 set optimizer_print_missing_stats = off;
+DROP TABLE IF EXISTS orca.table_with_small_statistic_precision_diff;
+NOTICE:  table "table_with_small_statistic_precision_diff" does not exist, skipping
+CREATE TABLE orca.table_with_small_statistic_precision_diff (
+    col1 double precision
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET allow_system_table_mods=true;
+DELETE FROM pg_statistic WHERE starelid='table_with_small_statistic_precision_diff'::regclass;
+INSERT INTO pg_statistic VALUES (
+'table_with_small_statistic_precision_diff'::regclass,
+1::smallint,
+True::boolean,
+0::real,
+8::integer,
+0::real,
+1::smallint,
+2::smallint,
+0::smallint,
+0::smallint,
+0::smallint,
+670::oid,
+672::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+E'{0.002}'::real[],
+NULL::real[],
+NULL::real[],
+NULL::real[],
+NULL::real[],
+E'{-0.25475}'::float8[],
+E'{-0.3,-0.2547399}'::float8[],
+NULL::float8[],
+NULL::float8[],
+NULL::float8[]);
+SET allow_system_table_mods=false;
+SELECT *
+FROM (
+    SELECT
+        *
+    FROM orca.table_with_small_statistic_precision_diff
+    UNION ALL
+    SELECT
+        *
+    FROM orca.table_with_small_statistic_precision_diff
+) x;
+ col1 
+------
+(0 rows)
+
 -- Push components of disjunctive predicates
 create table cust(cid integer, firstname text, lastname text) distributed by (cid);
 create table datedim(date_sk integer, year integer, moy integer) distributed by (date_sk);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -9988,6 +9988,7 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
 delete from pg_statistic where starelid='bar_missing_stats'::regclass;
 NOTICE:  One or more columns in the following table(s) do not have statistics: pg_statistic
 HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+set allow_system_table_mods=false;
 select count(*) from foo_missing_stats where a = 10;
 NOTICE:  One or more columns in the following table(s) do not have statistics: foo_missing_stats
 HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
@@ -10013,6 +10014,62 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
 (1 row)
 
 set optimizer_print_missing_stats = off;
+DROP TABLE IF EXISTS orca.table_with_small_statistic_precision_diff;
+NOTICE:  table "table_with_small_statistic_precision_diff" does not exist, skipping
+CREATE TABLE orca.table_with_small_statistic_precision_diff (
+    col1 double precision
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET allow_system_table_mods=true;
+DELETE FROM pg_statistic WHERE starelid='table_with_small_statistic_precision_diff'::regclass;
+INSERT INTO pg_statistic VALUES (
+'table_with_small_statistic_precision_diff'::regclass,
+1::smallint,
+True::boolean,
+0::real,
+8::integer,
+0::real,
+1::smallint,
+2::smallint,
+0::smallint,
+0::smallint,
+0::smallint,
+670::oid,
+672::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+E'{0.002}'::real[],
+NULL::real[],
+NULL::real[],
+NULL::real[],
+NULL::real[],
+E'{-0.25475}'::float8[],
+E'{-0.3,-0.2547399}'::float8[],
+NULL::float8[],
+NULL::float8[],
+NULL::float8[]);
+SET allow_system_table_mods=false;
+SELECT *
+FROM (
+    SELECT
+        *
+    FROM orca.table_with_small_statistic_precision_diff
+    UNION ALL
+    SELECT
+        *
+    FROM orca.table_with_small_statistic_precision_diff
+) x;
+ col1 
+------
+(0 rows)
+
 -- Push components of disjunctive predicates
 create table cust(cid integer, firstname text, lastname text) distributed by (cid);
 create table datedim(date_sk integer, year integer, moy integer) distributed by (date_sk);

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1437,12 +1437,66 @@ with x as (select * from foo_missing_stats) select count(*) from x x1, x x2 wher
 set allow_system_table_mods=true;
 delete from pg_statistic where starelid='foo_missing_stats'::regclass;
 delete from pg_statistic where starelid='bar_missing_stats'::regclass;
+set allow_system_table_mods=false;
 
 select count(*) from foo_missing_stats where a = 10;
 with x as (select * from foo_missing_stats) select count(*) from x x1, x x2 where x1.a = x2.a;
 with x as (select * from foo_missing_stats) select count(*) from x x1, x x2 where x1.a = x2.b;
 
 set optimizer_print_missing_stats = off;
+
+DROP TABLE IF EXISTS orca.table_with_small_statistic_precision_diff;
+CREATE TABLE orca.table_with_small_statistic_precision_diff (
+    col1 double precision
+);
+
+SET allow_system_table_mods=true;
+DELETE FROM pg_statistic WHERE starelid='table_with_small_statistic_precision_diff'::regclass;
+
+INSERT INTO pg_statistic VALUES (
+'table_with_small_statistic_precision_diff'::regclass,
+1::smallint,
+True::boolean,
+0::real,
+8::integer,
+0::real,
+1::smallint,
+2::smallint,
+0::smallint,
+0::smallint,
+0::smallint,
+670::oid,
+672::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+0::oid,
+E'{0.002}'::real[],
+NULL::real[],
+NULL::real[],
+NULL::real[],
+NULL::real[],
+E'{-0.25475}'::float8[],
+E'{-0.3,-0.2547399}'::float8[],
+NULL::float8[],
+NULL::float8[],
+NULL::float8[]);
+SET allow_system_table_mods=false;
+
+SELECT *
+FROM (
+    SELECT
+        *
+    FROM orca.table_with_small_statistic_precision_diff
+    UNION ALL
+    SELECT
+        *
+    FROM orca.table_with_small_statistic_precision_diff
+) x;
 
 -- Push components of disjunctive predicates
 create table cust(cid integer, firstname text, lastname text) distributed by (cid);


### PR DESCRIPTION
Issue is that string formatter in COstream used plain "%f" which may
lead to truncation of significant digits. By default it keeps 6 digits
after the decimal. This caused Orca to mistakenly identify two
inequivalent statistics with a small precision diff as being identical.
That mistake occasionally led to assertion errors when merging histogram
statistics.

Fix is to preserve the significant bits for double values. The scope of
the change is limited to bucket upper/lower bounds.