### PR TITLE
[Backport 6X] Pick number of distributed log buffers based on shared_buffers

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -624,6 +624,33 @@ DistributedLog_SharedShmemSize(void)
 }
 
 /*
+ * Number of shared Distributed Log buffers.
+ *
+ * On larger multi-processor systems, it is possible to have many distributed
+ * log page requests in flight at one time which could lead to disk access for
+ * distributed log page if the required page is not found in memory.  Testing
+ * revealed that we can get the best performance by having 128 distributed log
+ * buffers, more than that it doesn't improve performance.
+ *
+ * Unconditionally keeping the number of distributed log buffers to 128 did
+ * not seem like a good idea, because it would increase the minimum amount of
+ * shared memory required to start, which could be a problem for people
+ * running very small configurations.  The following formula seems to
+ * represent a reasonable compromise: people with very low values for
+ * shared_buffers will get fewer distributed log buffers as well, and everyone
+ * else will get 128.
+ *
+ * This logic is exactly same as used for CLOG buffers. Except the minimum
+ * used for CLOG buffers is 4 whereas we use 8 here, as that was the previous
+ * default and hence lets be conservative and not go below that number.
+ */
+Size
+DistributedLog_ShmemBuffers(void)
+{
+	return Min(128, Max(8, NBuffers / 512));
+}
+
+/*
  * Initialization of shared memory for the distributed log.
  */
 Size
@@ -637,7 +664,7 @@ DistributedLog_ShmemSize(void)
 	}
 	else
 	{
-		size = SimpleLruShmemSize(NUM_DISTRIBUTEDLOG_BUFFERS, 0);
+		size = SimpleLruShmemSize(DistributedLog_ShmemBuffers(), 0);
 		size += DistributedLog_SharedShmemSize();
 	}
 
@@ -654,7 +681,7 @@ DistributedLog_ShmemInit(void)
 
 	/* Set up SLRU for the distributed log. */
 	DistributedLogCtl->PagePrecedes = DistributedLog_PagePrecedes;
-	SimpleLruInit(DistributedLogCtl, "DistributedLogCtl", NUM_DISTRIBUTEDLOG_BUFFERS, 0,
+	SimpleLruInit(DistributedLogCtl, "DistributedLogCtl", DistributedLog_ShmemBuffers(), 0,
 				  DistributedLogControlLock, "pg_distributedlog");
 
 	/* Create or attach to the shared structure */

--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -262,8 +262,8 @@ NumLWLocks(void)
 	/* predicate.c needs one per old serializable xid buffer */
 	numLocks += NUM_OLDSERXID_BUFFERS;
 
-	/* cdbdistributedlog.c needs one per DistributedLog buffer */
-	numLocks += NUM_DISTRIBUTEDLOG_BUFFERS;
+	/* distributedlog.c needs one per DistributedLog buffer */
+	numLocks += DistributedLog_ShmemBuffers();
 
 	/* sharedsnapshot.c needs one per shared snapshot slot */
 	numLocks += NUM_SHARED_SNAPSHOT_SLOTS;

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -42,9 +42,6 @@ typedef struct DistributedLogEntry
 
 } DistributedLogEntry;
 
-/* Number of SLRU buffers to use for the distributed log */
-#define NUM_DISTRIBUTEDLOG_BUFFERS	8
-
 extern void DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
 								DistributedTransactionTimeStamp	distribTimeStamp,
 								DistributedTransactionId distribXid,
@@ -62,6 +59,7 @@ extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProg
 								 DistributedTransactionId oldestDistribXid);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
 
+extern Size DistributedLog_ShmemBuffers(void);
 extern Size DistributedLog_ShmemSize(void);
 extern void DistributedLog_ShmemInit(void);
 extern void DistributedLog_BootStrap(void);


### PR DESCRIPTION
Distributed log buffers were hard-coded to 8. Mostly in HTAP
work-load, it is possible to have many distributed log page requests
in flight at one time which could lead to disk access for distributed
log page if the required page is not found in memory. Testing revealed
that we can get the best performance by having 128 distributed log
buffers, more than that it doesn't improve performance.

Hence, seeking inspiration from CLOG buffers, number of distributed
log buffers are also selected based on shared_buffers.

Discussion:
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/l_iNnfwTF7s/m/Fk-6UVlbAwAJ
(cherry picked from commit 41a645bb0acc0f515d4d269b205fc78a764fcd5a)
