### PR TITLE
[6X Backport] Fix possible gprecoverseg stuck

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -341,8 +341,8 @@ class CommandResult():
         self.halt = halt
 
     def printResult(self):
-        res = "cmd had rc=%d completed=%s halted=%s\n  stdout='%s'\n  " \
-              "stderr='%s'" % (self.rc, str(self.completed), str(self.halt), self.stdout, self.stderr)
+        res = "cmd had rc=%s completed=%s halted=%s\n  stdout='%s'\n  " \
+              "stderr='%s'" % (str(self.rc), str(self.completed), str(self.halt), self.stdout, self.stderr)
         return res
 
     def wasSuccessful(self):


### PR DESCRIPTION
This is a clean backport of https://github.com/greenplum-db/gpdb/pull/11211

[Test pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_patch_gprecoverseg_stuck)

--- 

PR #9540 introduces `Incremental recovery/rebalance in parallel`, it
uses WorkerPool to start worker threads. But if error occured inside
run_pg_rewind()'s for loop, cleanup() would be called and all running
workers in the pool would be requested to halt. Unluckily, non-blocking
gpsubprocess.communicate2 would return but leave its returncode None:

> The None value indicates that the process hasn't terminated yet.

After this, inside Worker::run(), logger.debug(self.cmd) would throw
an exception:

> TypeError: %d format: a number is required, not NoneType

Then, logger.debug(self.cmd) again inside its catch, so `addFinishedWorkItem`
would be skipped. Consequently, pool.join() would wait forever in the main
thread.

It is just one use case, WorkerPool may also be used elsewhere.

Fix it by using %s instead of %d to print rc.

(cherry picked from commit 41f0100622a4e51e45dc1ae80e3f1f559aecb72d)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
