### PR TITLE
Mark rte variable assert only in bmcostestimate() to fix warning

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -7025,7 +7025,7 @@ bmcostestimate(struct PlannerInfo *root,
 {
 	IndexOptInfo *index = path->indexinfo;
 	RelOptInfo *baserel = index->rel;
-	RangeTblEntry *rte = planner_rt_fetch(baserel->relid, root);
+	RangeTblEntry *rte PG_USED_FOR_ASSERTS_ONLY = planner_rt_fetch(baserel->relid, root);
 	GenericCosts costs;
 
 	Assert(rte->rtekind == RTE_RELATION);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
