### PR TITLE
analyzedb - include FirstNormalObjectId

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -51,13 +51,13 @@ GET_ALL_DATA_TABLES_SQL = """
 select n.nspname as schemaname, c.relname as tablename
 from pg_class c, pg_namespace n
 where c.relnamespace = n.oid and c.relkind='r'::char
-and (c.relnamespace > 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
+and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
 and c.oid not in (select ftrelid from pg_foreign_table)
 """
 
 GET_VALID_DATA_TABLES_SQL = """
 select n.nspname as schemaname, c.relname as tablename from pg_class c, pg_namespace n where
-c.relnamespace = n.oid and c.oid in (%s) and c.relkind='r'::char and (c.relnamespace > 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog') and c.oid not in (select ftrelid from pg_foreign_table)
+c.relnamespace = n.oid and c.oid in (%s) and c.relkind='r'::char and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog') and c.oid not in (select ftrelid from pg_foreign_table)
 """
 
 GET_REQUESTED_AO_DATA_TABLE_INFO_SQL = """
@@ -85,7 +85,7 @@ GET_ALL_DATA_TABLES_IN_SCHEMA_SQL = """
 select n.nspname as schemaname, c.relname as tablename
 from pg_class c, pg_namespace n
 where c.relnamespace = n.oid and c.relkind='r'::char
- and (c.relnamespace > 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
+ and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
 and c.oid not in (select ftrelid from pg_foreign_table)
 and n.nspname = '%s'
 """
@@ -111,7 +111,7 @@ GET_REQUESTED_NON_AO_TABLES_SQL = """
 select n.nspname as schemaname, c.relname as tablename
 from pg_class c, pg_namespace n
 where c.relnamespace = n.oid and c.relkind='r'::char
-and (c.relnamespace > 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
+and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
 and c.oid not in (select ftrelid from pg_foreign_table)
 and c.oid not in (select relid from pg_appendonly)
 and c.oid in (%s)


### PR DESCRIPTION
pg_magic_oid.h:

> #define FirstNormalObjectId	16384

16384 is the first normal oid, analyzedb should not skip it.

When running pivotalguru/TPC-H on a fresh Greenplum cluster
inside containers, we met:

```
$ psql
postgres=# select oid,* from pg_namespace;
  oid  |      nspname    | nspowner |  nspacl
-------+-----------------+----------+-----------
 16384 | tpch            |       10 |

$ analyzedb -d postgres -s tpch --full -a -v
[WARNING]:-There are no tables or partitions to be analyzed. Exiting...
```

Fix: replace `relnamespace > 16384` with `relnamespace >= 16384`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
