### PR TITLE
6X: display gprecoverseg incremental status

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -414,7 +414,7 @@ class SegmentRewind(Command):
     """
 
     def __init__(self, name, target_host, target_datadir,
-                 source_host, source_port,
+                 source_host, source_port, progress_file,
                  verbose=False, ctxt=REMOTE):
 
         # Construct the source server libpq connection string
@@ -432,7 +432,12 @@ class SegmentRewind(Command):
         if verbose:
             rewind_cmd = rewind_cmd + ' --progress'
 
-        self.cmdStr = rewind_cmd + ' 2>&1'
+        # pg_rewind prints progress updates to stdout, but it also prints
+        # errors relating to relevant failures(like it will not rewind due to
+        # a corrupted pg_control file) to stderr.
+        rewind_cmd = rewind_cmd + " > {} 2>&1".format(pipes.quote(progress_file))
+
+        self.cmdStr = rewind_cmd
 
         Command.__init__(self, name, self.cmdStr, ctxt, target_host)
 

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -194,12 +194,16 @@ class GpMirrorListToBuild:
     class RewindSegmentInfo:
         """
         Which segments to run pg_rewind during incremental recovery.  The
-        targetSegment is of type gparray.Segment.
+        targetSegment is of type gparray.Segment.  All progressFiles should have
+        the same timeStamp.
         """
-        def __init__(self, targetSegment, sourceHostname, sourcePort):
+        def __init__(self, targetSegment, sourceHostname, sourcePort, timeStamp):
             self.targetSegment = targetSegment
             self.sourceHostname = sourceHostname
             self.sourcePort = sourcePort
+            self.progressFile = '%s/pg_rewind.%s.dbid%s.out' % (gplog.get_logger_dir(),
+                                                                timeStamp,
+                                                                targetSegment.getSegmentDbId())
 
     def buildMirrors(self, actionName, gpEnv, gpArray):
         """
@@ -285,6 +289,7 @@ class GpMirrorListToBuild:
         primariesToConvert = []
         convertPrimaryUsingFullResync = []
         fullResyncMirrorDbIds = {}
+        timeStamp = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
         for toRecover in self.__mirrorsToBuild:
             seg = toRecover.getFailoverSegment()
             if seg is None:
@@ -300,7 +305,8 @@ class GpMirrorListToBuild:
             if not toRecover.isFullSynchronization() \
                and seg.getSegmentRole() == gparray.ROLE_MIRROR:
                 rewindInfo[seg.getSegmentDbId()] = GpMirrorListToBuild.RewindSegmentInfo(
-                    seg, primarySeg.getSegmentHostName(), primarySeg.getSegmentPort())
+                    seg, primarySeg.getSegmentHostName(), primarySeg.getSegmentPort(),
+                    timeStamp)
 
             # The change in configuration to of the mirror to down requires that
             # the primary also be marked as unsynchronized.
@@ -352,8 +358,10 @@ class GpMirrorListToBuild:
         Run pg_rewind for incremental recovery.
         """
 
-        rewindFailedSegments = []
         # Run pg_rewind on all the targets
+        cmds = []
+        progressCmds = []
+        removeCmds= []
         for rewindSeg in rewindInfo.values():
             # Do CHECKPOINT on source to force TimeLineID to be updated in pg_control.
             # pg_rewind wants that to make incremental recovery successful finally.
@@ -384,15 +392,26 @@ class GpMirrorListToBuild:
                                    rewindSeg.targetSegment.getSegmentDataDirectory(),
                                    rewindSeg.sourceHostname,
                                    rewindSeg.sourcePort,
-                                   verbose=gplog.logging_is_verbose())
-            self.__pool.addCommand(cmd)
+                                   rewindSeg.progressFile,
+                                   verbose=True)
+            progressCmd, removeCmd = self.__getProgressAndRemoveCmds(rewindSeg.progressFile,
+                                                                     rewindSeg.targetSegment.getSegmentDbId(),
+                                                                     rewindSeg.targetSegment.getSegmentHostName())
+            cmds.append(cmd)
+            removeCmds.append(removeCmd)
+            if progressCmd:
+                progressCmds.append(progressCmd)
 
-        if self.__quiet:
-            self.__pool.join()
-        else:
-            base.join_and_indicate_progress(self.__pool)
 
-        for cmd in self.__pool.getCompletedItems():
+        completedCmds = self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "rewinding segments",
+                                                          suppressErrorCheck=True,
+                                                          progressCmds=progressCmds)
+
+        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(removeCmds, "removing rewind progress logfiles",
+                                                          suppressErrorCheck=False)
+
+        rewindFailedSegments = []
+        for cmd in completedCmds:
             self.__logger.debug('pg_rewind results: %s' % cmd.results)
             if not cmd.was_successful():
                 dbid = int(cmd.name.split(':')[1].strip())
@@ -400,8 +419,6 @@ class GpMirrorListToBuild:
                 self.__logger.warning(cmd.get_stdout())
                 self.__logger.warning("Incremental recovery failed for dbid %d. You must use gprecoverseg -F to recover the segment." % dbid)
                 rewindFailedSegments.append(rewindInfo[dbid].targetSegment)
-
-        self.__pool.empty_completed_items()
 
         return rewindFailedSegments
 
@@ -484,6 +501,27 @@ class GpMirrorListToBuild:
         # Make sure every line is updated with the final status.
         print_progress()
 
+    # There is race between when the recovery process creates the progressFile
+    # when this progressCmd is run. Thus, the progress command touches
+    # the file to ensure its presence before tailing.
+    def __getProgressAndRemoveCmds(self, progressFile, targetSegmentDbId, targetHostname):
+        progressCmd = None
+        if self.__progressMode != GpMirrorListToBuild.Progress.NONE:
+            progressCmd = GpMirrorListToBuild.ProgressCommand("tail the last line of the file",
+                                                              "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' | tail -1".format(
+                                                                  pipes.quote(progressFile)),
+                                                              targetSegmentDbId,
+                                                              progressFile,
+                                                              ctxt=base.REMOTE,
+                                                              remoteHost=targetHostname)
+
+        removeCmd = base.Command("remove file",
+                                 "rm -f %s" % pipes.quote(progressFile),
+                                 ctxt=base.REMOTE,
+                                 remoteHost=targetHostname)
+
+        return progressCmd, removeCmd
+
     def __runWaitAndCheckWorkerPoolForErrorsAndClear(self, cmds, actionVerb, suppressErrorCheck=False,
                                                      progressCmds=[]):
         for cmd in cmds:
@@ -499,7 +537,12 @@ class GpMirrorListToBuild:
 
         if not suppressErrorCheck:
             self.__pool.check_results()
+
+        completedRecoveryCmds = list(set(self.__pool.getCompletedItems()) & set(cmds))
+
         self.__pool.empty_completed_items()
+
+        return completedRecoveryCmds
 
     def __copyFiles(self, srcDir, destDir, fileNames):
         for name in fileNames:
@@ -591,30 +634,18 @@ class GpMirrorListToBuild:
         # tails this file to show recovery progress to the user, and removes the
         # file when one done. A new file is generated for each run of
         # gprecoverseg based on a timestamp.
-        #
-        # There is race between when the pg_basebackup log file is created and
-        # when the progress command is run. Thus, the progress command touches
-        # the file to ensure its present before tailing.
         self.__logger.info('Configuring new segments')
         cmds = []
         progressCmds = []
         removeCmds= []
         for hostName in destSegmentByHost.keys():
             for segment in destSegmentByHost[hostName]:
-                if self.__progressMode != GpMirrorListToBuild.Progress.NONE:
-                    progressCmds.append(
-                        GpMirrorListToBuild.ProgressCommand("tail the last line of the file",
-                                       "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' | tail -1".format(
-                                           pipes.quote(segment.progressFile)),
-                                       segment.getSegmentDbId(),
-                                       segment.progressFile,
-                                       ctxt=base.REMOTE,
-                                       remoteHost=hostName))
-                removeCmds.append(
-                    base.Command("remove file",
-                                 "rm -f %s" % pipes.quote(segment.progressFile),
-                                 ctxt=base.REMOTE,
-                                 remoteHost=hostName))
+                progressCmd, removeCmd = self.__getProgressAndRemoveCmds(segment.progressFile,
+                                                                         segment.getSegmentDbId(),
+                                                                         hostName)
+                removeCmds.append(removeCmd)
+                if progressCmd:
+                    progressCmds.append(progressCmd)
 
             cmds.append(
                 createConfigureNewSegmentCommand(hostName, 'configure blank segments', False))

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_buildmirrorsegments.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_buildmirrorsegments.py
@@ -1,7 +1,7 @@
 from mock import *
 from gp_unittest import *
 from gppylib.gparray import GpArray, Segment
-from gppylib.commands.base import WorkerPool
+from gppylib.commands.base import WorkerPool, CommandResult
 
 class GpMirrorListToBuildTestCase(GpTestCase):
 
@@ -24,9 +24,12 @@ class GpMirrorListToBuildTestCase(GpTestCase):
             # Mock the command to remove postmaster.pid as successful
             patch('gppylib.commands.base.Command.run', return_value=Mock()),
             patch('gppylib.commands.base.Command.get_return_code', return_value=0),
+            # Mock gplog which is used in RewindSegmentInfo below
+            patch('gppylib.gplog.get_logger_dir', return_value=Mock()),
             # Mock all pg_rewind commands to be not successful
             patch('gppylib.commands.base.Command.was_successful', return_value=False),
-            patch('gppylib.commands.base.Command.get_stdout', return_value='Mocking results')
+            patch('gppylib.commands.base.Command.get_stdout', return_value='Mocking results'),
+            patch('gppylib.commands.base.Command.results', return_value=CommandResult(1, 'stdout:Failed', 'stderr:Failed', True, False))
         ])
         from gppylib.operations.buildMirrorSegments import GpMirrorListToBuild
         # WorkerPool is the only valid parameter required in this test
@@ -39,13 +42,13 @@ class GpMirrorListToBuildTestCase(GpTestCase):
         m0 = Segment.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
         m1 = Segment.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
         rewindInfo[p0.dbid] = GpMirrorListToBuild.RewindSegmentInfo(
-            p0, p0.address, p0.port)
+            p0, p0.address, p0.port, "unused_timestamp")
         rewindInfo[p1.dbid] = GpMirrorListToBuild.RewindSegmentInfo(
-            p1, p1.address, p1.port)
+            p1, p1.address, p1.port, "unused_timestamp")
         rewindInfo[m0.dbid] = GpMirrorListToBuild.RewindSegmentInfo(
-            m0, m0.address, m0.port)
+            m0, m0.address, m0.port, "unused_timestamp")
         rewindInfo[m1.dbid] = GpMirrorListToBuild.RewindSegmentInfo(
-            m1, m1.address, m1.port)
+            m1, m1.address, m1.port, "unused_timestamp")
 
         # Test1: all 4 pg_rewind commands should fail due the "was_successful" patch
         failedSegments = g.run_pg_rewind(rewindInfo)

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -48,7 +48,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
 
-    Scenario: gprecoverseg displays pg_basebackup progress to the user
+    Scenario: gprecoverseg full recovery displays pg_basebackup progress to the user
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -60,6 +60,20 @@ Feature: gprecoverseg tests
         And gpAdminLogs directory has no "pg_basebackup*" files
         And all the segments are running
         And the segments are synchronized
+
+    Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user stops all primary processes
+        And user can start transactions
+        When the user runs "gprecoverseg -a -s"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "no rewind required" to stdout for each primary
+        And gpAdminLogs directory has no "pg_rewind*" files
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
 
     Scenario: gprecoverseg does not display pg_basebackup progress to the user when --no-progress option is specified
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -2,7 +2,7 @@ from time import sleep
 from gppylib.commands.base import Command, ExecutionError, REMOTE, WorkerPool
 from gppylib.db import dbconn
 from gppylib.commands import gp
-from gppylib.gparray import GpArray
+from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
 from test.behave_utils.utils import *
 import platform
 from behave import given, when, then
@@ -106,15 +106,18 @@ def runCommandOnRemoteSegment(context, cid, sql_cmd):
     psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
     Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)
 
-@then('gprecoverseg should print "{output}" to stdout for each mirror')
-def impl(context, output):
-    gparray = GpArray.initFromCatalog(dbconn.DbURL())
-    segments = gparray.getDbList()
+@then('gprecoverseg should print "{output}" to stdout for each {segment_type}')
+def impl(context, output, segment_type):
+    if segment_type not in ("primary", "mirror"):
+        raise Exception("Expected segment_type to be 'primary' or 'mirror', but found '%s'." % segment_type)
+    role = ROLE_PRIMARY if segment_type == 'primary' else ROLE_MIRROR
 
+    # use preferred_role as that is the dbid that runs the recovery process
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    segments = filter(lambda seg: seg.getSegmentPreferredRole() == role and seg.content >= 0, all_segments)
     for segment in segments:
-        if segment.isSegmentMirror():
-            expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
-            check_stdout_msg(context, expected)
+        expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
+        check_stdout_msg(context, expected)
 
 @then('pg_isready reports all primaries are accepting connections')
 def impl(context):
@@ -122,3 +125,12 @@ def impl(context):
     primary_segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary()]
     for seg in primary_segs:
         subprocess.check_call(['pg_isready', '-h', seg.getSegmentHostName(), '-p', str(seg.getSegmentPort())])
+
+@then('the cluster is rebalanced')
+def impl(context):
+    context.execute_steps(u'''
+        Then the user runs "gprecoverseg -a -s -r"
+        And gprecoverseg should return a return code of 0
+        And user can start transactions
+        And the segments are synchronized
+        ''')


### PR DESCRIPTION
Full recovery currently updates the display with progress updates provided by pg_basebackup; this commit does the same for incremental updates which uses pg_rewind.

The same design and implementation is done for both: the recovery command(pg_basebackup or pg_rewind) writes its progress to a log file, and gprecoverseg tails that file over the network to obtain updates.

This is not needed for 5X: 5X uses gpstate to show recovery progress. This is because the 5X database provides direct progress updates using filerep statistics.  6X uses walrep and does not provide the same mechanism.

There is a corresponding 7X PR: https://github.com/greenplum-db/gpdb/pull/11339.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
