### PR TITLE
gprecoverseg incremental status

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -419,7 +419,7 @@ class SegmentRewind(Command):
     """
 
     def __init__(self, name, target_host, target_datadir,
-                 source_host, source_port,
+                 source_host, source_port, progress_file,
                  verbose=False, ctxt=REMOTE):
 
         # Construct the source server libpq connection string
@@ -437,7 +437,12 @@ class SegmentRewind(Command):
         if verbose:
             rewind_cmd = rewind_cmd + ' --progress'
 
-        self.cmdStr = rewind_cmd + ' 2>&1'
+        # pg_rewind prints progress updates to stdout, but it also prints
+        # errors relating to relevant failures(like it will not rewind due to
+        # a corrupted pg_control file) to stderr.
+        rewind_cmd = rewind_cmd + " > {} 2>&1".format(pipes.quote(progress_file))
+
+        self.cmdStr = rewind_cmd
 
         Command.__init__(self, name, self.cmdStr, ctxt, target_host)
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -48,7 +48,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
 
-    Scenario: gprecoverseg displays pg_basebackup progress to the user
+    Scenario: gprecoverseg full recovery displays pg_basebackup progress to the user
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -60,6 +60,20 @@ Feature: gprecoverseg tests
         And gpAdminLogs directory has no "pg_basebackup*" files
         And all the segments are running
         And the segments are synchronized
+
+    Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user stops all primary processes
+        And user can start transactions
+        When the user runs "gprecoverseg -a -s"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each primary
+        And gpAdminLogs directory has no "pg_rewind*" files
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
 
     Scenario: gprecoverseg does not display pg_basebackup progress to the user when --no-progress option is specified
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -2,7 +2,7 @@ from time import sleep
 from gppylib.commands.base import Command, ExecutionError, REMOTE, WorkerPool
 from gppylib.db import dbconn
 from gppylib.commands import gp
-from gppylib.gparray import GpArray
+from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
 from test.behave_utils.utils import *
 import platform
 from behave import given, when, then
@@ -106,15 +106,18 @@ def runCommandOnRemoteSegment(context, cid, sql_cmd):
     psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
     Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)
 
-@then('gprecoverseg should print "{output}" to stdout for each mirror')
-def impl(context, output):
-    gparray = GpArray.initFromCatalog(dbconn.DbURL())
-    segments = gparray.getDbList()
+@then('gprecoverseg should print "{output}" to stdout for each {segment_type}')
+def impl(context, output, segment_type):
+    if segment_type not in ("primary", "mirror"):
+        raise Exception("Expected segment_type to be 'primary' or 'mirror', but found '%s'." % segment_type)
+    role = ROLE_PRIMARY if segment_type == 'primary' else ROLE_MIRROR
 
+    # use preferred_role as that is the dbid that runs the recovery process
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    segments = filter(lambda seg: seg.getSegmentPreferredRole() == role and seg.content >= 0, all_segments)
     for segment in segments:
-        if segment.isSegmentMirror():
-            expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
-            check_stdout_msg(context, expected)
+        expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
+        check_stdout_msg(context, expected)
 
 @then('pg_isready reports all primaries are accepting connections')
 def impl(context):
@@ -122,3 +125,12 @@ def impl(context):
     primary_segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary()]
     for seg in primary_segs:
         subprocess.check_call(['pg_isready', '-h', seg.getSegmentHostName(), '-p', str(seg.getSegmentPort())])
+
+@then('the cluster is rebalanced')
+def impl(context):
+    context.execute_steps(u'''
+        Then the user runs "gprecoverseg -a -s -r"
+        And gprecoverseg should return a return code of 0
+        And user can start transactions
+        And the segments are synchronized
+        ''')


### PR DESCRIPTION
Full recovery currently updates the display with progress updates provided by pg_basebackup; this commit does the same for incremental updates which uses pg_rewind.

The same design and implementation is done for both: the recovery command(pg_basebackup or pg_rewind) writes its progress to a log file, and gprecoverseg tails that file over the network to obtain updates.

There is a corresponding 6X PR: https://github.com/greenplum-db/gpdb/pull/11338

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
