### PR TITLE
Check the return value of 'ZSTD_initDStream'

### DIFF
--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -1342,7 +1342,9 @@ BufFileEndCompression(BufFile *file)
 	file->zstd_context->dctx = ZSTD_createDStream();
 	if (!file->zstd_context->dctx)
 		elog(ERROR, "out of memory");
-	ZSTD_initDStream(file->zstd_context->dctx);
+	ret = ZSTD_initDStream(file->zstd_context->dctx);
+	if (ZSTD_isError(ret))
+		elog(ERROR, "failed to initialize zstd dstream: %s", ZSTD_getErrorName(ret));
 
 	file->compressed_buffer.src = palloc(BLCKSZ);
 	file->compressed_buffer.size = 0;


### PR DESCRIPTION
'49116f6d' fix the problem for 'ZSTD_initCStream', should check the value of
'ZSTD_initDStream' as well.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
