### PR TITLE
Truncate distributed log when vacuuming database

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -90,7 +90,6 @@ typedef struct DistributedLogShmem
 	 * we compute a new snapshot).
 	 */
 	volatile TransactionId	oldestXmin;
-
 } DistributedLogShmem;
 
 static DistributedLogShmem *DistributedLogShared = NULL;
@@ -99,7 +98,6 @@ static int	DistributedLog_ZeroPage(int page, bool writeXlog);
 static bool DistributedLog_PagePrecedes(int page1, int page2);
 static void DistributedLog_WriteZeroPageXlogRec(int page);
 static void DistributedLog_WriteTruncateXlogRec(int page);
-static void DistributedLog_Truncate(TransactionId oldestXmin);
 
 /*
  * Initialize the value for oldest local XID that might still be visible
@@ -112,18 +110,15 @@ static void DistributedLog_Truncate(TransactionId oldestXmin);
  * The caller is expected to hold DistributedLogControlLock on entry.
  */
 void
-DistributedLog_InitOldestXmin(void)
+DistributedLog_InitOldestXmin(TransactionId oldestActiveXid, TransactionId nextXid)
 {
-	TransactionId oldestXmin = ShmemVariableCache->oldestXid;
-	TransactionId latestXid = ShmemVariableCache->latestCompletedXid;
-
 	/*
-	 * Start scanning from oldest datfrozenxid, until we find a
+	 * Start scanning from oldest active xid, until we find a
 	 * valid page.
 	 */
 	for (;;)
 	{
-		int			page = TransactionIdToPage(oldestXmin);
+		int			page = TransactionIdToPage(oldestActiveXid);
 		TransactionId xid;
 
 		if (SimpleLruDoesPhysicalPageExist(DistributedLogCtl, page))
@@ -133,19 +128,19 @@ DistributedLog_InitOldestXmin(void)
 		}
 
 		/* Advance to the first XID on the next page */
-		xid = AdvanceTransactionIdToNextPage(oldestXmin);
+		xid = AdvanceTransactionIdToNextPage(oldestActiveXid);
 
 		/* but don't go past oldestLocalXmin */
-		if (TransactionIdFollows(xid, latestXid))
+		if (TransactionIdFollows(xid, nextXid))
 		{
-			oldestXmin = latestXid;
+			oldestActiveXid = nextXid;
 			break;
 		}
 
-		oldestXmin = xid;
+		oldestActiveXid = xid;
 	}
 
-	pg_atomic_write_u32((pg_atomic_uint32 *)&DistributedLogShared->oldestXmin, oldestXmin);
+	pg_atomic_write_u32((pg_atomic_uint32 *)&DistributedLogShared->oldestXmin, oldestActiveXid);
 }
 /*
  * Advance the "oldest xmin" among distributed snapshots.
@@ -192,7 +187,6 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 								   dbname?dbname: "", "");
 #endif
 
-	LWLockAcquire(DistributedLogTruncateLock, LW_SHARED);
 	oldestXmin = (TransactionId)pg_atomic_read_u32((pg_atomic_uint32 *)&DistributedLogShared->oldestXmin);
 	oldOldestXmin = oldestXmin;
 	Assert(oldestXmin != InvalidTransactionId);
@@ -268,7 +262,7 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 
 		while (1)
 		{
-			if (pg_atomic_compare_exchange_u32((pg_atomic_uint32 *)&DistributedLogShared->oldestXmin, 
+			if (pg_atomic_compare_exchange_u32((pg_atomic_uint32 *)&DistributedLogShared->oldestXmin,
 											&expected, (uint32)oldestXmin))
 				break;
 
@@ -276,11 +270,6 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 				break;
 		}
 	}
-
-	LWLockRelease(DistributedLogTruncateLock);
-
-	if (TransactionIdToSegment(oldOldestXmin) < TransactionIdToSegment(oldestXmin))
-		DistributedLog_Truncate(oldestXmin);
 
 	return oldestXmin;
 }
@@ -473,7 +462,6 @@ DistributedLog_CommittedCheck(
 	DistributedLogEntry *ptr;
 	TransactionId oldestXmin;
 
-
 	oldestXmin = (TransactionId)pg_atomic_read_u32((pg_atomic_uint32 *)&DistributedLogShared->oldestXmin);
 	if (oldestXmin == InvalidTransactionId)
 		elog(PANIC, "DistributedLog's OldestXmin not initialized yet");
@@ -484,14 +472,12 @@ DistributedLog_CommittedCheck(
 		return false;
 	}
 
-	LWLockAcquire(DistributedLogTruncateLock, LW_SHARED);
 	slotno = SimpleLruReadPage_ReadOnly(DistributedLogCtl, page, localXid);
 	ptr = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
 	ptr += entryno;
 	*distribXid = ptr->distribXid;
 	ptr = NULL;
 	LWLockRelease(DistributedLogControlLock);
-	LWLockRelease(DistributedLogTruncateLock);
 
 	if (*distribXid != 0)
 	{
@@ -823,7 +809,7 @@ DistributedLog_Startup(TransactionId oldestActiveXid,
 		DistributedLogCtl->shared->page_dirty[slotno] = true;
 	}
 
-	DistributedLog_InitOldestXmin();
+	DistributedLog_InitOldestXmin(oldestActiveXid, nextXid);
 
 	LWLockRelease(DistributedLogControlLock);
 }
@@ -927,14 +913,14 @@ DistributedLog_Extend(TransactionId newestXact)
  * a removable segment.
  *
  */
-static void
+void
 DistributedLog_Truncate(TransactionId oldestXmin)
 {
 	int			cutoffPage;
 
-	Assert(!IS_QUERY_DISPATCHER());
+	if (IS_QUERY_DISPATCHER())
+		return;
 
-	LWLockAcquire(DistributedLogTruncateLock, LW_EXCLUSIVE);
 	/*
 	 * The cutoff point is the start of the segment containing oldestXact. We
 	 * pass the *page* containing oldestXact to SimpleLruTruncate.
@@ -947,17 +933,13 @@ DistributedLog_Truncate(TransactionId oldestXmin)
 
 	/* Check to see if there's any files that could be removed */
 	if (!SlruScanDirectory(DistributedLogCtl, SlruScanDirCbReportPresence, &cutoffPage))
-	{
-		LWLockRelease(DistributedLogTruncateLock);
-		return;					/* nothing to remove */
-	}
+		return;
 
 	/* Write XLOG record and flush XLOG to disk */
 	DistributedLog_WriteTruncateXlogRec(cutoffPage);
 
 	/* Now we can remove the old DistributedLog segment(s) */
 	SimpleLruTruncate(DistributedLogCtl, cutoffPage);
-	LWLockRelease(DistributedLogTruncateLock);
 }
 
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8070,6 +8070,9 @@ StartupXLOG(void)
 	UpdateControlFile();
 	LWLockRelease(ControlFileLock);
 
+	/* truncate distributed log to oldest active xid */
+	DistributedLog_Truncate(oldestActiveXID);
+
 	/*
 	 * If there were cascading standby servers connected to us, nudge any wal
 	 * sender processes to notice that we've been promoted.

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -28,6 +28,7 @@
 
 #include "access/clog.h"
 #include "access/commit_ts.h"
+#include "access/distributedlog.h"
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
@@ -1925,6 +1926,7 @@ vac_truncate_clog(TransactionId frozenXID,
 	TruncateCLOG(frozenXID, oldestxid_datoid);
 	TruncateCommitTs(frozenXID);
 	TruncateMultiXact(minMulti, minmulti_datoid);
+	DistributedLog_Truncate(frozenXID);
 
 	/*
 	 * Update the wrap limit for GetNewTransactionId and creation of new

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -60,8 +60,7 @@ ErrorLogLock						50
 SessionStateLock					51
 RelfilenodeGenLock					52
 WorkFileManagerLock					53
-DistributedLogTruncateLock			54
-TwophaseCommitLock				55
-ShareInputScanLock				56
-FTSReplicationStatusLock			57
-GxidBumpLock						58
+TwophaseCommitLock				54
+ShareInputScanLock				55
+FTSReplicationStatusLock			56
+GxidBumpLock						57

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -38,7 +38,6 @@
 typedef struct DistributedLogEntry
 {
 	DistributedTransactionId distribXid;
-
 } DistributedLogEntry;
 
 extern void DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
@@ -66,7 +65,8 @@ extern void DistributedLog_CheckPoint(void);
 extern void DistributedLog_Extend(TransactionId newestXid);
 extern bool DistributedLog_GetLowWaterXid(
 							  TransactionId *lowWaterXid);
-extern void DistributedLog_InitOldestXmin(void);
+extern void DistributedLog_InitOldestXmin(TransactionId oldestActiveXid, TransactionId nextXid);
+extern void DistributedLog_Truncate(TransactionId oldestXmin);
 
 /* XLOG stuff */
 #define DISTRIBUTEDLOG_ZEROPAGE		0x00

--- a/src/test/isolation2/input/distributedlog_truncate.source
+++ b/src/test/isolation2/input/distributedlog_truncate.source
@@ -1,0 +1,90 @@
+-- start_ignore
+create extension if not exists gp_inject_fault;
+
+create or replace function test_consume_xids(int4) returns void
+as '@abs_builddir@/../regress/regress.so', 'test_consume_xids'
+language C;
+
+create or replace language plpython3u;
+
+create or replace function num_distributed_log_files(content int, is_primary bool)
+returns int as
+$$
+    import os, os.path
+    result = plpy.execute("select datadir from gp_segment_configuration where content=%d and role = '%c'" % (content, 'p' if is_primary else 'm'))
+    datadir = result[0]['datadir']
+    path = os.path.join(datadir, 'pg_distributedlog')
+    return len([name for name in os.listdir(path) if os.path.isfile(os.path.join(path, name))])
+$$
+language plpython3u;
+
+!\retcode gpconfig -c debug_burn_xids -v on --skipvalidation;
+!\retcode gpstop -au;
+-- end_ignore
+
+-- test 1: vacuum database will truncate distributed log files to the frozen xid
+ 
+-- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
+-- of that, the age of template0 should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+show autovacuum_freeze_max_age;
+0U: select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
+
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+
+checkpoint;
+
+-- more than (200 * 1000000 / 1024 / 1024 * 8) files, each xid takes 8 byes, max size of the file is 1MB.
+select num_distributed_log_files(0, true) > 200 * 1000000 / 1024 / 1024 * 8;
+select num_distributed_log_files(0, false) > 200 * 1000000 / 1024 / 1024 * 8;
+
+select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- vacuum database will froze the xid and cut off the distributed log to the frozen xid.
+!\retcode vacuumdb -a;
+select num_distributed_log_files(0, true) < 200 * 1000000 / 1024 / 1024 * 8;
+select * from wait_for_replication_replay(0, 5000);
+select num_distributed_log_files(0, false) < 200 * 1000000 / 1024 / 1024 * 8;
+
+-- test 2: database startup will truncate distributed log files to the oldest active xid.
+create table t_distributedlog_truncate(a int);
+insert into t_distributedlog_truncate select generate_series(1,10);
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+
+select num_distributed_log_files(0, true) > 200 * 1000000 / 1024 / 1024 * 8;
+select num_distributed_log_files(0, false) > 200 * 1000000 / 1024 / 1024 * 8;
+
+-- start_ignore
+!\retcode gpstop -ari;
+-- end_ignore
+
+1: select num_distributed_log_files(0, true) < 200 * 1000000 / 1024 / 1024 * 8;
+1: select * from wait_for_replication_replay(0, 5000);
+1: select num_distributed_log_files(0, false) < 200 * 1000000 / 1024 / 1024 * 8;
+1: select count(*) from t_distributedlog_truncate;
+1: drop table t_distributedlog_truncate;
+
+-- start_ignore
+!\retcode vacuumdb -a;
+!\retcode gpconfig -c debug_burn_xids -v off --skipvalidation;
+!\retcode gpstop -au;
+-- end_ignore
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -262,3 +262,6 @@ test: orphan_temp_table
 
 # test if gxid is valid or not on the cluster after running the tests
 test: check_gxid
+
+# test distributed log is truncate during vaccum or startup
+test: distributedlog_truncate

--- a/src/test/isolation2/output/distributedlog_truncate.source
+++ b/src/test/isolation2/output/distributedlog_truncate.source
@@ -1,0 +1,268 @@
+-- start_ignore
+create extension if not exists gp_inject_fault;
+CREATE
+
+create or replace function test_consume_xids(int4) returns void as '/home/gpadmin/workspace/gpdb/src/test/isolation2/../regress/regress.so', 'test_consume_xids' language C;
+CREATE
+
+create or replace language plpython3u;
+CREATE
+
+create or replace function num_distributed_log_files(content int, is_primary bool) returns int as $$ import os, os.path result = plpy.execute("select datadir from gp_segment_configuration where content=%d and role = '%c'" % (content, 'p' if is_primary else 'm')) datadir = result[0]['datadir'] path = os.path.join(datadir, 'pg_distributedlog') return len([name for name in os.listdir(path) if os.path.isfile(os.path.join(path, name))]) $$ language plpython3u;
+CREATE
+
+!\retcode gpconfig -c debug_burn_xids -v on --skipvalidation;
+-- start_ignore
+20210112:12:39:31:453180 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c debug_burn_xids -v on --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -au;
+-- start_ignore
+20210112:12:39:32:453305 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -au
+20210112:12:39:32:453305 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210112:12:39:32:453305 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20210112:12:39:32:453305 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20210112:12:39:32:453305 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14173.ge595fc33a25 build dev'
+20210112:12:39:32:453305 gpstop:09c5497cf854:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+-- test 1: vacuum database will truncate distributed log files to the frozen xid
+ -- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
+-- of that, the age of template0 should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+show autovacuum_freeze_max_age;
+ autovacuum_freeze_max_age 
+---------------------------
+ 200000000                 
+(1 row)
+0U: select age(datfrozenxid) < 200 * 1000000 from pg_database where datname='template0';
+ ?column? 
+----------
+ t        
+(1 row)
+
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+
+checkpoint;
+CHECKPOINT
+
+-- more than (200 * 1000000 / 1024 / 1024 * 8) files, each xid takes 8 byes, max size of the file is 1MB.
+select num_distributed_log_files(0, true) > 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+select num_distributed_log_files(0, false) > 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+
+select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+ gp_segment_id | ?column? 
+---------------+----------
+ 2             | t        
+ 1             | t        
+ 0             | f        
+(3 rows)
+
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- vacuum database will froze the xid and cut off the distributed log to the frozen xid.
+!\retcode vacuumdb -a;
+-- start_ignore
+vacuumdb: vacuuming database "gpadmin"
+vacuumdb: vacuuming database "isolation2test"
+vacuumdb: vacuuming database "postgres"
+vacuumdb: vacuuming database "template1"
+
+-- end_ignore
+(exited with code 0)
+select num_distributed_log_files(0, true) < 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+select * from wait_for_replication_replay(0, 5000);
+ wait_for_replication_replay 
+-----------------------------
+ t                           
+(1 row)
+select num_distributed_log_files(0, false) < 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+
+-- test 2: database startup will truncate distributed log files to the oldest active xid.
+create table t_distributedlog_truncate(a int);
+CREATE
+insert into t_distributedlog_truncate select generate_series(1,10);
+INSERT 10
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+
+select num_distributed_log_files(0, true) > 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+select num_distributed_log_files(0, false) > 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+
+-- start_ignore
+!\retcode gpstop -ari;
+-- start_ignore
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -ari
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14173.ge595fc33a25 build dev'
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Stopping master standby host 09c5497cf854 mode=immediate
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown standby process on 09c5497cf854
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210112:12:40:40:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20210112:12:40:41:453444 gpstop:09c5497cf854:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+1: select num_distributed_log_files(0, true) < 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+1: select * from wait_for_replication_replay(0, 5000);
+ wait_for_replication_replay 
+-----------------------------
+ t                           
+(1 row)
+1: select num_distributed_log_files(0, false) < 200 * 1000000 / 1024 / 1024 * 8;
+ ?column? 
+----------
+ t        
+(1 row)
+1: select count(*) from t_distributedlog_truncate;
+ count 
+-------
+ 10    
+(1 row)
+1: drop table t_distributedlog_truncate;
+DROP
+
+-- start_ignore
+!\retcode vacuumdb -a;
+-- start_ignore
+vacuumdb: vacuuming database "gpadmin"
+vacuumdb: vacuuming database "isolation2test"
+vacuumdb: vacuuming database "postgres"
+vacuumdb: vacuuming database "regression"
+vacuumdb: vacuuming database "template1"
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c debug_burn_xids -v off --skipvalidation;
+-- start_ignore
+20210112:12:40:45:453865 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c debug_burn_xids -v off --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -au;
+-- start_ignore
+20210112:12:40:45:453990 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -au
+20210112:12:40:45:453990 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210112:12:40:45:453990 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20210112:12:40:45:453990 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20210112:12:40:45:453990 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14173.ge595fc33a25 build dev'
+20210112:12:40:45:453990 gpstop:09c5497cf854:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+


### PR DESCRIPTION
Truncate distributed log at the time of advancing oldest xmin can lead to heavey
lock contention on 'DistributedLogControlLock' and 'DistributedLogTruncateLock'.
It's safe to truncate the distributed log to the frozen xid when vacuuming the
database and hence can get rid of 'DistributedLogTruncateLock'. This commit also
truncate the distributed log and bump 'DistributedLogShared->oldestXmin' to the
oldest active xid when startup.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
