### PR TITLE
README.macOS.bash: add zstd and pkg-config

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -19,6 +19,8 @@ brew install libyaml   # enables `--enable-mapreduce`
 brew install libevent # gpfdist
 brew install apr # gpfdist
 brew install apr-util # gpfdist
+brew install zstd
+brew install pkg-config
 brew link --force apr
 brew link --force apr-util
 


### PR DESCRIPTION
For 7X, add zstd and pkg-config to README.macOS.bash.