### PR TITLE
Add --hba-hostnames to the help text of gpinitstandby

### DIFF
--- a/gpMgmt/doc/gpinitstandby_help
+++ b/gpMgmt/doc/gpinitstandby_help
@@ -127,6 +127,9 @@ OPTIONS
 
  The host name of the standby master host. 
 
+--hba-hostnames
+
+ Optional. use hostnames instead of CIDR in pg_hba.conf
 
 -v
 


### PR DESCRIPTION
Add --hba-hostnames to the help text of gpinitstandby
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
