### PR TITLE
6X: Coerce unknown-type literals to type text instead of cstring

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -34,6 +34,7 @@ static void check_invalid_indexes(void);
 static void check_foreign_key_constraints_on_root_partition(void);
 static void check_views_with_unsupported_lag_lead_function(void);
 static void check_views_with_fabricated_anyarray_casts(void);
+static void check_views_with_fabricated_unknown_casts(void);
 
 
 /*
@@ -63,6 +64,7 @@ check_greenplum(void)
 	check_invalid_indexes();
 	check_views_with_unsupported_lag_lead_function();
 	check_views_with_fabricated_anyarray_casts();
+	check_views_with_fabricated_unknown_casts();
 }
 
 /*
@@ -1331,6 +1333,82 @@ check_views_with_fabricated_anyarray_casts()
 		pg_fatal("Your installation contains views having anyarray\n"
 				 "casts. Drop the view or recreate the view without explicit \n"
 				 "array-type type casts before running the upgrade. Alternatively, drop the view \n"
+				 "before the upgrade and recreate the view after the upgrade. \n"
+				 "A list of views is in the file:\n"
+				 "\t%s\n\n", output_path);
+	}
+	else
+		check_ok();
+}
+
+static void
+check_views_with_fabricated_unknown_casts()
+{
+	char		output_path[MAXPGPATH];
+	FILE		*script = NULL;
+	bool		found = false;
+	int			dbnum;
+	int			i_viewname;
+
+	prep_status("Checking for non-dumpable views with unknown casts");
+
+	snprintf(output_path, sizeof(output_path), "view_unknown_casts.txt");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		int			rowno;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn;
+		bool		db_used = false;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+		PQclear(executeQueryOrDie(conn, "SET search_path TO 'public';"));
+
+		/* Install check support function */
+		PQclear(executeQueryOrDie(conn,
+									 "CREATE OR REPLACE FUNCTION "
+									 "view_has_unknown_casts(OID) "
+									 "RETURNS BOOL "
+									 "AS '$libdir/pg_upgrade_support' "
+									 "LANGUAGE C STRICT;"));
+		res = executeQueryOrDie(conn,
+								"SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname "
+								"FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
+								"WHERE c.relkind = 'v' AND "
+								"view_has_unknown_casts(c.oid) = TRUE;");
+
+		PQclear(executeQueryOrDie(conn, "DROP FUNCTION view_has_unknown_casts(OID);"));
+		PQclear(executeQueryOrDie(conn, "SET search_path to 'pg_catalog';"));
+
+		ntups = PQntuples(res);
+		i_viewname = PQfnumber(res, "badviewname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_fatal("Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database: %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s \n",
+					PQgetvalue(res, rowno, i_viewname));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		fclose(script);
+		pg_log(PG_REPORT, "fatal\n");
+		pg_fatal("Your installation contains views having unknown\n"
+				 "casts. Drop the view or recreate the view with explicit \n"
+				 "unknown::text type casts before running the upgrade. Alternatively, drop the view \n"
 				 "before the upgrade and recreate the view after the upgrade. \n"
 				 "A list of views is in the file:\n"
 				 "\t%s\n\n", output_path);

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -435,7 +435,7 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(infunc));
 
 			/* do unknownout(Var) */
-			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node),
+			fe = makeFuncExpr(outfunc, TEXTOID, list_make1(node),
 							  InvalidOid, InvalidOid, cformat);
 			fe->location = location;
 

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -136,3 +136,25 @@ SELECT pg_get_viewdef('view_with_array_op_expr');
   SELECT ('{1}'::integer[] = '{2}'::integer[]);
 (1 row)
 
+-- Coerce unknown-type literals to type text
+CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
+WARNING:  column "field_unknown" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
+\d+ unknown_v2
+                 View "public.unknown_v2"
+    Column     | Type | Modifiers | Storage | Description 
+---------------+------+-----------+---------+-------------
+ field_unknown | date |           | plain   | 
+View definition:
+ SELECT unknown_v1.field_unknown::text::date AS field_unknown
+   FROM unknown_v1;
+
+SELECT * FROM unknown_v2;
+ field_unknown 
+---------------
+ 12-13-2020
+(1 row)
+
+DROP VIEW unknown_v2;
+DROP VIEW unknown_v1;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -79,3 +79,11 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 -- correct internal representation
 CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
 SELECT pg_get_viewdef('view_with_array_op_expr');
+
+-- Coerce unknown-type literals to type text
+CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
+CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
+\d+ unknown_v2
+SELECT * FROM unknown_v2;
+DROP VIEW unknown_v2;
+DROP VIEW unknown_v1;


### PR DESCRIPTION
```
CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS
field_unknown;
CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
```

The definition was this before this commit:
```
SELECT unknown_v1.field_unknown::cstring::date AS field_unknown
  FROM unknown_v1;
```
Which would error out with `ERROR: cannot cast type cstring to date`.

This commit coerces unknown-type literals to type text instead of
cstring while converting stored expressions/querytrees back to source
text.

Upstream also chose text, Greenplum 7 too (PR #9655, #9686), but they
broke behaviors, we could not do that refactor on 6X_STABLE branch.

    commit 1e7c4bb0049732ece651d993d03bb6772e5d281a
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Wed Jan 25 09:17:18 2017 -0500

        Change unknown-type literals to type text in SELECT and RETURNING lists.

        Previously, we left such literals alone if the query or subquery had
        no properties forcing a type decision to be made (such as an ORDER BY or
        DISTINCT clause using that output column).  This meant that "unknown" could
        be an exposed output column type, which has never been a great idea because
        it could result in strange failures later on.  For example, an outer query
        that tried to do any operations on an unknown-type subquery output would
        generally fail with some weird error like "failed to find conversion
        function from unknown to text" or "could not determine which collation to
        use for string comparison".  Also, if the case occurred in a CREATE VIEW's
        query then the view would have an unknown-type column, causing similar
        failures in queries trying to use the view.

        To fix, at the tail end of parse analysis of a query, forcibly convert any
        remaining "unknown" literals in its SELECT or RETURNING list to type text.
        However, provide a switch to suppress that, and use it in the cases of
        SELECT inside a set operation or INSERT command.  In those cases we already
        had type resolution rules that make use of context information from outside
        the subquery proper, and we don't want to change that behavior.

        Also, change creation of an unknown-type column in a relation from a
        warning to a hard error.  The error should be unreachable now in CREATE
        VIEW or CREATE MATVIEW, but it's still possible to explicitly say "unknown"
        in CREATE TABLE or CREATE (composite) TYPE.  We want to forbid that because
        it's nothing but a foot-gun.

        This change creates a pg_upgrade failure case: a matview that contains an
        unknown-type column can't be pg_upgraded, because reparsing the matview's
        defining query will now decide that the column is of type text, which
        doesn't match the cstring-like storage that the old materialized column
        would actually have.  Add a checking pass to detect that.  While at it,
        we can detect tables or composite types that would fail, essentially
        for free.  Those would fail safely anyway later on, but we might as
        well fail earlier.

        This patch is by me, but it owes something to previous investigations
        by Rahila Syed.  Also thanks to Ashutosh Bapat and Michael Paquier for
        review.

        Discussion: https://postgr.es/m/CAH2L28uwwbL9HUM-WR=hromW1Cvamkn7O-g8fPY2m=_7muJ0oA@mail.gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
