### PR TITLE
Set delimeter on ListObjects S3 request

### DIFF
--- a/gpcontrib/gpcloud/include/s3url.h
+++ b/gpcontrib/gpcloud/include/s3url.h
@@ -9,7 +9,7 @@
 class S3Url {
    public:
     S3Url(const string &sourceUrl, bool useHttps = true, const string &version = "",
-          const string &region = "");
+          const string &region = "", const string &delimiter = "");
 
     string getFullUrlForCurl() const;
     string getHostForCurl() const;
@@ -43,9 +43,17 @@ class S3Url {
         return version;
     }
 
+    const string &getDelimeter() const {
+        return delimeter;
+    }
+
     void setPrefix(const string &prefix) {
         this->prefix = prefix;
     };
+
+    void setDelimiter(const string &delimuter) {
+        this->delimiter = delimuter;
+    }
 
     bool isValidUrl() const;
 

--- a/gpcontrib/gpcloud/src/s3interface.cpp
+++ b/gpcontrib/gpcloud/src/s3interface.cpp
@@ -300,6 +300,10 @@ ListBucketResult S3InterfaceService::listBucket(S3Url &s3Url) {
             querySs << (marker.empty() ? "prefix=" : "&prefix=") << encodedPrefix;
         }
         s3Url.setPrefix("");
+        
+        // rfc1738 - encoded '/' symbol
+        s3Url.setDelimeter("%2F");
+        
         string queryStr = querySs.str();
 
         Response resp = getBucketResponse(s3Url, queryStr);

--- a/gpcontrib/gpcloud/src/s3url.cpp
+++ b/gpcontrib/gpcloud/src/s3url.cpp
@@ -41,6 +41,11 @@ string S3Url::getFullUrlForCurl() const {
 
     fullUrl << this->getSchema() << "://" << this->getHostForCurl() << "/" << this->getBucket()
             << "/" << this->getPrefix();
+    
+    if (this->getDelimiter().length()) {
+        /* set delimiter, if any specifed */
+        fullUrl << this->getDelimiter();
+    }
 
     return fullUrl.str();
 }


### PR DESCRIPTION
The [documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects) currently states that a NextMarker will be returned for s3.list_objects only if you have delimiter request parameter specified. Apparently popular solutions (aws, minio) work without it, but others still require this parameter


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
