### PR TITLE
Fix aocsseg inconsistency when rollback add column

### DIFF
--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -628,10 +628,7 @@ ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the c
  1     | 0          | 1              | 10       | 2        | 1     
  1     | 1          | 129            | 10       | 2        | 1     
  1     | 2          | 257            | 10       | 2        | 1     
- 2     | 0          | 2              | 0        | 0        | 1     
- 2     | 1          | 130            | 0        | 0        | 1     
- 2     | 2          | 258            | 0        | 0        | 1     
-(6 rows)
+(3 rows)
 -- generates truncate xlog record for all the files having entry in
 -- pg_aocsseg table.
 6:VACUUM crash_vacuum_in_appendonly_insert_1;

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -828,3 +828,22 @@ Options: appendonly=true, orientation=column
 
 DROP TABLE aocs_alter_add_col_no_compress;
 RESET gp_add_column_inherits_table_setting;
+--
+-- Test case: validate pg_aocsseg consistency after alter table
+-- add column with rollback.
+--
+-- pg_aocsseg stores vpinfo structure with serialized EOF information
+-- for every column in AOCS table. If transaction adds new columns,
+-- spawns new pg_aocsseg entries and rollbacks, check there is no
+-- inconsistency in pg_aocsseg after it (with vacuum).
+--
+SET gp_default_storage_options='appendonly=true, orientation=column';
+CREATE TABLE aocs_alter_add_col_no_compress AS
+   SELECT g AS a, g AS b FROM generate_series(1, 10) AS g DISTRIBUTED BY (a);
+BEGIN;
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN c int;
+UPDATE aocs_alter_add_col_no_compress SET c = 1;
+ROLLBACK;
+VACUUM aocs_alter_add_col_no_compress;
+DROP TABLE aocs_alter_add_col_no_compress;
+RESET gp_default_storage_options;


### PR DESCRIPTION
Before current commit we initailized `pg_aocsseg` entries with frozen tuples to make these entries implicitly visible even after rollback. It is a working approach for AO tables, but AOC tables store additional `vpinfo` structure with serialized information about every column EOF. This can cause inconsistency between `vpinfo` structure in `pg_aocsseg` entries and the actual number of columns in a table when we modify the amount of columns under explicit transaction and rollback it later. As a result we fail on asserts in `GetAllAOCSFileSegInfo_pg_aocsseg_rel()` or (in a case of a build without asserts) in some unpredictable places in the code when retrieve metadata from `pg_aocsseg`.

As a fix this commit inserts simple tuples to `pg_aocsseg` but still insert frozen tuples to `gp_fastsequence` (as it generates row numbers for segment files and should never be rollbacked to avoid inconsistency in index pointers of the AO/AOC tables).

This PR should be backported to 5X_STABLE as well (master is not affected).

