### PR TITLE
Fix that pgstat_send_qd_tabstats will report statistics redundantly for Replicated Table.

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4584,13 +4584,28 @@ pgstat_send_qd_tabstats(void)
 	{
 		PgStatTabRecordFromQE		record;
 		PgStat_TableStatus		   *tabstat = trans->parent;
+		GpPolicy *gppolicy = GpPolicyFetch(tabstat->t_id);
 
-		/*
-		 * No need to send catalog table's pgstat to QD since if the catalog
-		 * table get updated on QE, QD should have the same update.
-		 */
-		if (tabstat->t_id < FirstNormalObjectId)
-			continue;
+		switch (gppolicy->ptype)
+		{
+			case POLICYTYPE_ENTRY:
+				/*
+				 * No need to send catalog table's pgstat to QD since if the catalog
+				 * table get updated on QE, QD should have the same update.
+				 */
+				continue;
+			case POLICYTYPE_REPLICATED:
+				/*
+				 * gppolicy->numsegments has the same value on all segments even when we are doing expand.
+				 */
+				if (GpIdentity.segindex != tabstat->t_id % gppolicy->numsegments)
+					continue;
+				break;
+			case POLICYTYPE_PARTITIONED:
+				break;
+			default:
+				elog(ERROR, "unrecognized policy type %d", gppolicy->ptype);
+		}
 
 		record.table_stat.tuples_inserted = trans->tuples_inserted;
 		record.table_stat.tuples_updated = trans->tuples_updated;

--- a/src/test/regress/input/pgstat_qd_tabstat.source
+++ b/src/test/regress/input/pgstat_qd_tabstat.source
@@ -1,3 +1,4 @@
+create extension if not exists gp_debug_numsegments;
 -- Turn off auto_stat to avoid ANALYZE
 set gp_autostats_mode = none;
 
@@ -72,10 +73,8 @@ select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n
 
 -- Test pgstat table stat in ALTER TABLE EXPAND TABLE on QD;
 -- Thanks @uglthinx for telling me this way to execute ALTER TABLE EXPAND manually
+select gp_debug_set_create_table_default_numsegments(1);
 create table table_for_expand(i int, j varchar) distributed by (i);
-set allow_system_table_mods=true;
-update gp_distribution_policy set numsegments = 1 where localoid = 'table_for_expand'::regclass;
-set allow_system_table_mods to default;
 insert into table_for_expand select i, 'hello' || i from generate_series(1, 333) f(i);
 select count(distinct gp_segment_id) from table_for_expand;
 select pg_sleep(0.77); -- Force pgstat_report_stat() to send tabstat.
@@ -84,6 +83,7 @@ alter table table_for_expand expand table;
 select count(distinct gp_segment_id) from table_for_expand;
 select pg_sleep(0.77); -- Force pgstat_report_stat() to send tabstat.
 select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'table_for_expand'::regclass;
+select gp_debug_reset_create_table_default_numsegments();
 
 
 -- Test pgstat table stat in INSERT/UPDATE/DELETE on QD

--- a/src/test/regress/output/pgstat_qd_tabstat.source
+++ b/src/test/regress/output/pgstat_qd_tabstat.source
@@ -1,3 +1,4 @@
+create extension if not exists gp_debug_numsegments;
 -- Turn off auto_stat to avoid ANALYZE
 set gp_autostats_mode = none;
 -- Test pgstat table stat for copy on QD
@@ -164,10 +165,13 @@ select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n
 
 -- Test pgstat table stat in ALTER TABLE EXPAND TABLE on QD;
 -- Thanks @uglthinx for telling me this way to execute ALTER TABLE EXPAND manually
+select gp_debug_set_create_table_default_numsegments(1);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 1
+(1 row)
+
 create table table_for_expand(i int, j varchar) distributed by (i);
-set allow_system_table_mods=true;
-update gp_distribution_policy set numsegments = 1 where localoid = 'table_for_expand'::regclass;
-set allow_system_table_mods to default;
 insert into table_for_expand select i, 'hello' || i from generate_series(1, 333) f(i);
 select count(distinct gp_segment_id) from table_for_expand;
  count 
@@ -204,6 +208,12 @@ select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n
  n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
 -----------+-----------+-----------+---------------+------------+------------+---------------------
        333 |         0 |         0 |             0 |        333 |          0 |                 333
+(1 row)
+
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
 (1 row)
 
 -- Test pgstat table stat in INSERT/UPDATE/DELETE on QD


### PR DESCRIPTION
I think we can introduce a template engine to generate regress tests based on the regress test template. The content of regress test template as follow(based on Liquid):

```liquid
select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables where relid = 'table_for_truncate_abort'::regclass;
{% if 'replicated' in amit_conf_distby %}
{% comment %}
ORCA can't be used in the replicated table, the update of table_for_iud will not be implemented by delete + insert
{% endcomment %}
1600|301|777|0|777|1124|777
{% else %}
1901|0|1078|0|777|1124|777
{% endif %}
{% if 'replicated' not in amit_conf_distby %}
{% comment %}
ERROR:  PARTITION BY clause cannot be used with DISTRIBUTED REPLICATED clause
So don't do the following test in DISTRIBUTED REPLICATED
{% endcomment %}
-- Test pgstat table stat for partition table on QD
CREATE TABLE rankpart (id int, rank int, product int)
with ({{amit_conf_opts}})
{{amit_conf_distby}} PARTITION BY RANGE (rank)
( START (1) END (10) EVERY (5),
  DEFAULT PARTITION extra );
...
{% endif %}
```

`amit_conf_distby` will be replaced by `appendonly=false`, `appendonly=true,orientation=row`, `appendonly=true,orientation=column`, and `amit_conf_distby` will be replaced by `distributed randomly`, `distributed replicated`, `''`(an empty string which means `distributed by`). So that we can test pgstat_qd_tabstat on heap/ao_row/ao_column and/or `distributed by`/`distributed replicated`/`distributed randomly`.

```
test pgstat_qd_tabstat-heap_hash_dist ... ok (83.60 sec)  (diff:0.13 sec)
test pgstat_qd_tabstat-heap_rand_dist ... ok (83.65 sec)  (diff:0.14 sec)
test pgstat_qd_tabstat-heap_replicated ... ok (63.62 sec)  (diff:0.13 sec)
test pgstat_qd_tabstat-aoro_hash_dist ... ok (84.45 sec)  (diff:0.13 sec)
test pgstat_qd_tabstat-aoro_rand_dist ... ok (84.58 sec)  (diff:0.14 sec)
test pgstat_qd_tabstat-aoro_replicated ... ok (64.32 sec)  (diff:0.13 sec)
test pgstat_qd_tabstat-aoco_hash_dist ... ok (86.36 sec)  (diff:0.13 sec)
test pgstat_qd_tabstat-aoco_rand_dist ... ok (86.47 sec)  (diff:0.14 sec)
test pgstat_qd_tabstat-aoco_replicated ... or (65.70 sec)  (diff:0.25 sec)
```

