### PR TITLE
Fix Bitmap Heap Scan on AO's sparse bitmap index.

### DIFF
--- a/src/test/isolation2/expected/bitmap_index_ao_sparse.out
+++ b/src/test/isolation2/expected/bitmap_index_ao_sparse.out
@@ -1,0 +1,128 @@
+--
+-- Test, run Bitmap Heap Scan on AO/AOCS table's sparse bitmap index.
+-- Here start two transactions in the same time to insert tuples
+-- into different seg file. Then create bitmap index on it.
+-- This will lead to very sparse bitmap index.
+-- Since the tid in bitmap index for AO is composed of segfile no,
+-- and row no.
+--
+
+-- Test AO table.
+CREATE TABLE ao_sparse (id int) with(appendonly = true) DISTRIBUTED BY (id);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+1: INSERT INTO ao_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+2: INSERT INTO ao_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+
+-- Let's check the total tuple count with id=97,99 without bitmap index.
+SELECT count(*) FROM ao_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ count 
+-------
+ 400   
+(1 row)
+
+CREATE INDEX idx_ao_sparse_id ON ao_sparse USING bitmap (id);
+CREATE
+
+
+-- Should generate Bitmap Heap Scan on the bitmap index.
+1: set optimizer = off;
+SET
+1: EXPLAIN (COSTS OFF) SELECT * FROM ao_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ QUERY PLAN                                            
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)              
+   ->  Bitmap Heap Scan on ao_sparse                   
+         Recheck Cond: ((id >= 97) AND (id <= 99))     
+         Filter: (gp_segment_id = 0)                   
+         ->  Bitmap Index Scan on idx_ao_sparse_id     
+               Index Cond: ((id >= 97) AND (id <= 99)) 
+ Optimizer: Postgres query optimizer                   
+(7 rows)
+
+-- We used to hit assertion failure since it generates a empty bitmap for a block's PagetableEntry.
+-- In BitmapHeapNext, if table_scan_bitmap_next_block returns false(which means the block should be
+-- skipped), but we still try to fetch tuple through table_scan_bitmap_next_tuple, and it didn't find
+-- the PagetableEntry is empty.
+-- This error happens only when we fetch multiple LOVs when doing bitmap heap scan on bitmap index for
+-- AO tables. AOCS table and "SELECT count(*) FROM ao_sparse WHERE id = 97" works fine.
+1: SELECT count(*) FROM ao_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ count 
+-------
+ 400   
+(1 row)
+
+-- This query doesn't have any issue.
+1: SELECT count(*) FROM ao_sparse WHERE id = 97;
+ count 
+-------
+ 200   
+(1 row)
+
+
+-- Test AOCS table.
+CREATE TABLE aocs_sparse (id int) with(appendonly = true, orientation = COLUMN) DISTRIBUTED BY (id);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+1: INSERT INTO aocs_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+2: INSERT INTO aocs_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+
+-- Let's check the total tuple count with id=97 without bitmap index.
+SELECT count(*) FROM aocs_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ count 
+-------
+ 400   
+(1 row)
+
+CREATE INDEX idx_ao_sparse_id ON aocs_sparse USING bitmap (id);
+ERROR:  relation "idx_ao_sparse_id" already exists
+
+
+-- Should generate Bitmap Heap Scan on the bitmap index.
+1: EXPLAIN (COSTS OFF) SELECT * FROM aocs_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ QUERY PLAN                                                          
+---------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)                            
+   ->  Seq Scan on aocs_sparse                                       
+         Filter: ((id >= 97) AND (id <= 99) AND (gp_segment_id = 0)) 
+ Optimizer: Postgres query optimizer                                 
+(4 rows)
+
+-- This doesn't have any issue, but let's make sure it will not make any error in future.
+1: SELECT count(*) FROM aocs_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ count 
+-------
+ 400   
+(1 row)
+
+-- This query doesn't have any issue.
+1: SELECT count(*) FROM ao_sparse WHERE id = 97;
+ count 
+-------
+ 200   
+(1 row)
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -54,7 +54,7 @@ test: deadlock_under_entry_db_singleton
 #  conflict when running in parallel with other cases.
 test: misc
 
-test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
+test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue bitmap_index_ao_sparse
 
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend

--- a/src/test/isolation2/sql/bitmap_index_ao_sparse.sql
+++ b/src/test/isolation2/sql/bitmap_index_ao_sparse.sql
@@ -1,0 +1,70 @@
+--
+-- Test, run Bitmap Heap Scan on AO/AOCS table's sparse bitmap index.
+-- Here start two transactions in the same time to insert tuples
+-- into different seg file. Then create bitmap index on it.
+-- This will lead to very sparse bitmap index.
+-- Since the tid in bitmap index for AO is composed of segfile no,
+-- and row no.
+--
+
+-- Test AO table.
+CREATE TABLE ao_sparse (id int) with(appendonly = true) DISTRIBUTED BY (id);
+
+1: begin;
+2: begin;
+
+1: INSERT INTO ao_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+2: INSERT INTO ao_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+
+1: commit;
+2: commit;
+
+-- Let's check the total tuple count with id=97,99 without bitmap index.
+SELECT count(*) FROM ao_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+CREATE INDEX idx_ao_sparse_id ON ao_sparse USING bitmap (id);
+
+
+-- Should generate Bitmap Heap Scan on the bitmap index.
+1: set optimizer = off;
+1: EXPLAIN (COSTS OFF) SELECT * FROM ao_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+-- We used to hit assertion failure since it generates a empty bitmap for a block's PagetableEntry.
+-- In BitmapHeapNext, if table_scan_bitmap_next_block returns false(which means the block should be
+-- skipped), but we still try to fetch tuple through table_scan_bitmap_next_tuple, and it didn't find
+-- the PagetableEntry is empty.
+-- This error happens only when we fetch multiple LOVs when doing bitmap heap scan on bitmap index for
+-- AO tables. AOCS table and "SELECT count(*) FROM ao_sparse WHERE id = 97" works fine.
+1: SELECT count(*) FROM ao_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+-- This query doesn't have any issue.
+1: SELECT count(*) FROM ao_sparse WHERE id = 97;
+
+
+-- Test AOCS table.
+CREATE TABLE aocs_sparse (id int) with(appendonly = true, orientation = COLUMN) DISTRIBUTED BY (id);
+
+1: begin;
+2: begin;
+
+1: INSERT INTO aocs_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+2: INSERT INTO aocs_sparse SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+
+1: commit;
+2: commit;
+
+-- Let's check the total tuple count with id=97 without bitmap index.
+SELECT count(*) FROM aocs_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+CREATE INDEX idx_ao_sparse_id ON aocs_sparse USING bitmap (id);
+
+
+-- Should generate Bitmap Heap Scan on the bitmap index.
+1: EXPLAIN (COSTS OFF) SELECT * FROM aocs_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+-- This doesn't have any issue, but let's make sure it will not make any error in future.
+1: SELECT count(*) FROM aocs_sparse WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+-- This query doesn't have any issue.
+1: SELECT count(*) FROM ao_sparse WHERE id = 97;
+


### PR DESCRIPTION
If there are multiple LOV items matched for the scan, and the index is on an
AO table, the `tbm_iterate_page` will generate empty bitmap for a block's
PagetableEntry.
Then in BitmapHeapNext, table_scan_bitmap_next_block returns false(which means
the block should be skipped) for the empty PagetableEntry, but we still try
to fetch tuple through table_scan_bitmap_next_tuple, and the code didn't find
out the PagetableEntry is empty cause `aoscan->rs_cindex != tbmres->ntuples`.

Actually I think we should set `tbmres = NULL` if `table_scan_bitmap_next_block`
return false. But seems we are using upsream's logic, so just fix
with current logic.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
