### PR TITLE
Fix that kill_9_segment_processes can not get a list of processes to kill.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -112,9 +112,9 @@ kill -9 all the processes associated with that segment.
 If pid is -1, then the postmaster is already stopped, 
 so we check for any leftover processes for that segment 
 and kill -9 those processes
-E.g postgres: port 45002, logger process
-    postgres: port 45002, sweeper process
-    postgres: port 45002, checkpoint process
+E.g postgres:  45002, logger process
+    postgres:  45002, sweeper process
+    postgres:  45002, checkpoint process
 """
 
 
@@ -129,7 +129,7 @@ def kill_9_segment_processes(datadir, port, pid):
         pid_list = [pid]
 
     cmd = Command('get a list of processes to kill -9',
-                  cmdStr='ps ux | grep "[p]ostgres:\s*port\s*%s" | awk \'{print $2}\'' % (port))
+                  cmdStr='ps ux | grep "[p]ostgres:\s*%s" | awk \'{print $2}\'' % (port))
 
     try:
         cmd.run(validateAfter=True)


### PR DESCRIPTION
It can not get a list of postgres processes in the kill_9_segment_processes function when the gpdb system is running. Thanks for your review.
Please see the log below : 
[gpadmin@mdw ~]$ ps ux | grep "[p]ostgres:\s*port\s*5434" | awk '{print $2}'
[gpadmin@mdw ~]$ ps ux | grep "[p]ostgres:\s*5434" | awk '{print $2}'
8873
8876
8877
8878
8879
8881
8894
8896
8897
8941
[gpadmin@mdw ~]$ ps ux | grep "[p]ostgres:\s*5434" 
gpadmin  8873  0.0  0.0 239984  5264 ?        Ss   Jan16   0:02 postgres:  5434, master logger process   
gpadmin  8876  0.0  0.0 477124  8500 ?        Ss   Jan16   0:00 postgres:  5434, checkpointer process   
gpadmin  8877  0.0  0.0 477012  4960 ?        Ss   Jan16   0:00 postgres:  5434, writer process   
gpadmin  8878  0.0  0.0 477012  8648 ?        Ss   Jan16   0:00 postgres:  5434, wal writer process   
gpadmin  8879  0.0  0.0 242372  4864 ?        Ss   Jan16   0:01 postgres:  5434, stats collector process   
gpadmin  8881  0.0  0.0 545160 12304 ?        Ssl  Jan16   0:11 postgres:  5434, bgworker: ftsprobe process   
gpadmin  8894  0.0  0.0 242100  6992 ?        Ss   Jan16   0:03 postgres:  5434, bgworker: ic proxy process   
gpadmin  8896  0.0  0.0 477012  4360 ?        Ss   Jan16   0:04 postgres:  5434, bgworker: sweeper process   
gpadmin  8897  0.0  0.0 477012  4864 ?        Ss   Jan16   0:36 postgres:  5434, bgworker: stats sender process   
gpadmin  8941  0.0  0.0 477148  4856 ?        Ss   Jan16   1:20 postgres:  5434, bgworker: metrics collector 




## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
