### PR TITLE
Fix orphan temp table on the coordinator

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -131,7 +131,7 @@ static void performDtxProtocolCommitPrepared(const char *gid, bool raiseErrorIfN
 static void performDtxProtocolAbortPrepared(const char *gid, bool raiseErrorIfNotFound);
 static void sendWaitGxidsToQD(List *waitGxids);
 
-extern void CheckForResetSession(void);
+extern void GpDropTempTables(void);
 
 /**
  * All assignments of the global DistributedTransactionContext should go through this function

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -720,7 +720,6 @@ CheckForResetSession(void)
 		return;
 
 	/* Do the session id change early. */
-
 	if (NeedResetSession)
 	{
 		/* If we have gangs, we can't change our session ID. */
@@ -745,6 +744,10 @@ CheckForResetSession(void)
 			 "The new session id = %d", oldSessionId, newSessionId);
 	}
 
+	/*
+	 * When it's in transaction block, need to bump the session id, e.g. retry COMMIT PREPARED,
+	 * but defer drop temp table to the main loop in PostgresMain().
+	 */
 	if (IsTransactionOrTransactionBlock())
 	{
 		NeedResetSession = false;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -706,16 +706,15 @@ void DisconnectAndDestroyUnusedQEs(void)
 /*
  * Drop any temporary tables associated with the current session and
  * use a new session id since we have effectively reset the session.
- *
- * Call this procedure outside of a transaction.
  */
 void
-CheckForResetSession(void)
+GpDropTempTables(void)
 {
 	int			oldSessionId = 0;
 	int			newSessionId = 0;
 	Oid			dropTempNamespaceOid;
 
+	/* No need to reset session or drop temp tables */
 	if (!NeedResetSession && OldTempNamespace == InvalidOid)
 		return;
 
@@ -877,5 +876,5 @@ void
 ResetAllGangs(void)
 {
 	DisconnectAndDestroyAllGangs(true);
-	CheckForResetSession();
+	GpDropTempTables();
 }

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -716,31 +716,34 @@ CheckForResetSession(void)
 	int			newSessionId = 0;
 	Oid			dropTempNamespaceOid;
 
-	if (!NeedResetSession)
+	if (!NeedResetSession && OldTempNamespace == InvalidOid)
 		return;
 
 	/* Do the session id change early. */
 
-	/* If we have gangs, we can't change our session ID. */
-	Assert(!cdbcomponent_qesExist());
-
-	oldSessionId = gp_session_id;
-	ProcNewMppSessionId(&newSessionId);
-
-	gp_session_id = newSessionId;
-	gp_command_count = 0;
-	pgstat_report_sessionid(newSessionId);
-
-	/* Update the slotid for our singleton reader. */
-	if (SharedLocalSnapshotSlot != NULL)
+	if (NeedResetSession)
 	{
-		LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
-		SharedLocalSnapshotSlot->slotid = gp_session_id;
-		LWLockRelease(SharedLocalSnapshotSlot->slotLock);
-	}
+		/* If we have gangs, we can't change our session ID. */
+		Assert(!cdbcomponent_qesExist());
 
-	elog(LOG, "The previous session was reset because its gang was disconnected (session id = %d). "
-		 "The new session id = %d", oldSessionId, newSessionId);
+		oldSessionId = gp_session_id;
+		ProcNewMppSessionId(&newSessionId);
+
+		gp_session_id = newSessionId;
+		gp_command_count = 0;
+		pgstat_report_sessionid(newSessionId);
+
+		/* Update the slotid for our singleton reader. */
+		if (SharedLocalSnapshotSlot != NULL)
+		{
+			LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
+			SharedLocalSnapshotSlot->slotid = gp_session_id;
+			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+		}
+
+		elog(LOG, "The previous session was reset because its gang was disconnected (session id = %d). "
+			 "The new session id = %d", oldSessionId, newSessionId);
+	}
 
 	if (IsTransactionOrTransactionBlock())
 	{

--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -20,6 +20,7 @@
 
 #include "executor/executor.h"
 #include "miscadmin.h"
+#include "utils/faultinjector.h"
 #include "utils/memutils.h"
 
 
@@ -127,6 +128,8 @@ ExecScan(ScanState *node,
 	ExprContext *econtext;
 	ExprState  *qual;
 	ProjectionInfo *projInfo;
+
+	SIMPLE_FAULT_INJECTOR("before_exec_scan");
 
 	/*
 	 * Fetch data from node

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5164,7 +5164,7 @@ PostgresMain(int argc, char *argv[],
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			CheckForResetSession();
+			GpDropTempTables();
 			StartIdleResourceCleanupTimers();
 		}
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -74,7 +74,7 @@ extern void RecycleGang(Gang *gp, bool forceDestroy);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);
 extern void DisconnectAndDestroyUnusedQEs(void);
 
-extern void CheckForResetSession(void);
+extern void GpDropTempTables(void);
 extern void ResetAllGangs(void);
 
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -1,0 +1,46 @@
+-- Test orphan temp table on coordinator.
+-- Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
+
+-- create a temp table
+1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+CREATE
+
+-- panic on segment 0
+2: SELECT gp_inject_fault('before_read_command', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- wait 1 seconds, the fault inject handler process will call ReadCommand in
+-- PostgresMain loop, but the 'gp_inject_fault' query will return before that it
+-- gets there.
+1: select pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- the backend process has exit due to segment reset.
+1: SELECT * FROM test_temp_table_cleanup;
+ERROR:  Error on receive from seg0 slice1 172.17.0.4:7002 pid=381114: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- we should not see the temp table on the coordinator
+1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+ oid | relname | relnamespace 
+-----+---------+--------------
+(0 rows)
+
+-- the temp table is left on segment 0, it should be dropped by autovacuum later
+0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
+ relname                 
+-------------------------
+ test_temp_table_cleanup 
+(1 row)
+
+-- no temp table left on other segments
+1U: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+ oid | relname | relnamespace 
+-----+---------+--------------
+(0 rows)

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -6,31 +6,22 @@
 CREATE
 
 -- panic on segment 0
-2: SELECT gp_inject_fault('before_read_command', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+1: SELECT gp_inject_fault('before_exec_scan', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
--- wait 1 seconds, the fault inject handler process will call ReadCommand in
--- PostgresMain loop, but the 'gp_inject_fault' query will return before that it
--- gets there.
-1: select pg_sleep(1);
- pg_sleep 
-----------
-          
-(1 row)
 
--- the backend process has exit due to segment reset.
+-- trigger 'before_exec_scan' panic in ExecScan
 1: SELECT * FROM test_temp_table_cleanup;
-ERROR:  Error on receive from seg0 slice1 172.17.0.4:7002 pid=381114: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
+ERROR:  fault triggered, fault name:'before_exec_scan' fault type:'panic'  (seg0 slice1 172.17.0.4:7002 pid=437900)
 
 -- we should not see the temp table on the coordinator
 1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
  oid | relname | relnamespace 
 -----+---------+--------------
 (0 rows)
+
 
 -- the temp table is left on segment 0, it should be dropped by autovacuum later
 0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
@@ -44,3 +35,9 @@ ERROR:  Error on receive from seg0 slice1 172.17.0.4:7002 pid=381114: server clo
  oid | relname | relnamespace 
 -----+---------+--------------
 (0 rows)
+
+1: SELECT gp_inject_fault('before_exec_scan', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -257,8 +257,8 @@ test: concurrent_drop_truncate_tablespace
 # Test for distributed commit array overflow during replay on standby 
 test: standby_replay_dtx_info 
 
+# test the orphan temp table is dropped on the coordinator when panic happens on segment
+test: orphan_temp_table 
+
 # test if gxid is valid or not on the cluster after running the tests
 test: check_gxid
-
-# test if there is orphan temp table on the coordinator
-test: orphan_temp_table 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -259,3 +259,6 @@ test: standby_replay_dtx_info
 
 # test if gxid is valid or not on the cluster after running the tests
 test: check_gxid
+
+# test if there is orphan temp table on the coordinator
+test: orphan_temp_table 

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -5,20 +5,19 @@
 1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
 
 -- panic on segment 0
-2: SELECT gp_inject_fault('before_read_command', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
--- wait 1 seconds, the fault inject handler process will call ReadCommand in
--- PostgresMain loop, but the 'gp_inject_fault' query will return before that it
--- gets there.
-1: select pg_sleep(1);
+1: SELECT gp_inject_fault('before_exec_scan', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
 
--- the backend process has exit due to segment reset.
+-- trigger 'before_exec_scan' panic in ExecScan
 1: SELECT * FROM test_temp_table_cleanup;
 
 -- we should not see the temp table on the coordinator
 1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+
 
 -- the temp table is left on segment 0, it should be dropped by autovacuum later
 0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
 
 -- no temp table left on other segments
 1U: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+
+1: SELECT gp_inject_fault('before_exec_scan', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -1,0 +1,24 @@
+-- Test orphan temp table on coordinator. 
+-- Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
+
+-- create a temp table
+1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+
+-- panic on segment 0
+2: SELECT gp_inject_fault('before_read_command', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+-- wait 1 seconds, the fault inject handler process will call ReadCommand in
+-- PostgresMain loop, but the 'gp_inject_fault' query will return before that it
+-- gets there.
+1: select pg_sleep(1);
+
+-- the backend process has exit due to segment reset.
+1: SELECT * FROM test_temp_table_cleanup;
+
+-- we should not see the temp table on the coordinator
+1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+
+-- the temp table is left on segment 0, it should be dropped by autovacuum later
+0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
+
+-- no temp table left on other segments
+1U: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';


### PR DESCRIPTION
When the backend process panics on the segment, temp tables should be dropped
on the coordinator. Before this, QD only resets the gang upon detecting the QE crash
but not dropping temp tables because it's still in a transaction block at that point.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change