### PR TITLE
Small recovery related fixes.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -712,10 +712,10 @@ class GpRecoverSegmentProgram:
         loggingGroup = addStandardLoggingAndHelpOptions(parser, True)
         loggingGroup.add_option("-s", None, default=None, action='store_false',
                                 dest='showProgressInplace',
-                                help='Show pg_basebackup progress sequentially instead of inplace')
+                                help='Show pg_basebackup/pg_rewind progress sequentially instead of inplace')
         loggingGroup.add_option("--no-progress",
                                 dest="showProgress", default=True, action="store_false",
-                                help="Suppress pg_basebackup progress output")
+                                help="Suppress pg_basebackup/pg_rewind progress output")
 
         addTo = OptionGroup(parser, "Connection Options")
         parser.add_option_group(addTo)

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -221,14 +221,14 @@ be cancelled and rolled back.
 
 -s
 
-Show pg_basebackup progress sequentially instead of inplace. Useful when
-writing to a file, or if a tty does not support escape sequences. Defaults to
-showing the progress inplace.
+Show pg_rewind/pg_basebackup progress sequentially instead of inplace. Useful
+when writing to a file, or if a tty does not support escape sequences. Defaults
+to showing the progress inplace.
 
 
 --no-progress
 
-Do not show pg_basebackup progress. Useful when writing to a
+Do not show pg_rewind/pg_basebackup progress. Useful when writing to a
 file. Defaults to showing the progress.
 
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6496,7 +6496,12 @@ StartupXLOG(void)
 		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY)
 	{
 		RemoveTempXlogFiles();
+		ereport(LOG,
+				(errmsg("force synchronization of the data directory since the"
+						" database system was uncleanly shut down.")));
 		SyncDataDirectory();
+		ereport(LOG,
+				(errmsg("synchronization of the data directory is finished.")));
 		if (Gp_role == GP_ROLE_DISPATCH)
 			*shmCleanupBackends = true;
 	}


### PR DESCRIPTION
1. For unclean shutdown, need to fsync the whole pg data directory which is time-consuming. Log it in case users want to check the recovery time when recovery is slow.

2. gprecoverseg help page is out of date. Now that it supports progress report for incremental recovery.