### PR TITLE
[WIP] Just fsync those affected files during pg_rewind.

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -100,23 +100,6 @@
 // 64 bits on some platforms
 #define pg_lseek64(a,b,c) (int64)lseek(a,b,c)
 
-
-/* Define PG_FLUSH_DATA_WORKS if we have an implementation for pg_flush_data */
-#if defined(HAVE_SYNC_FILE_RANGE)
-#define PG_FLUSH_DATA_WORKS 1
-#elif defined(USE_POSIX_FADVISE) && defined(POSIX_FADV_DONTNEED)
-#define PG_FLUSH_DATA_WORKS 1
-#endif
-
-/* Define PG_FLUSH_DATA_WORKS if we have an implementation for pg_flush_data */
-#if defined(HAVE_SYNC_FILE_RANGE)
-#define PG_FLUSH_DATA_WORKS 1
-#elif !defined(WIN32) && defined(MS_ASYNC)
-#define PG_FLUSH_DATA_WORKS 1
-#elif defined(USE_POSIX_FADVISE) && defined(POSIX_FADV_DONTNEED)
-#define PG_FLUSH_DATA_WORKS 1
-#endif
-
 /*
  * We must leave some file descriptors free for system(), the dynamic loader,
  * and other code that tries to open files without consulting fd.c.  This

--- a/src/common/file_utils.c
+++ b/src/common/file_utils.c
@@ -22,22 +22,11 @@
 #include "common/file_utils.h"
 #include "common/logging.h"
 
-
-/* Define PG_FLUSH_DATA_WORKS if we have an implementation for pg_flush_data */
-#if defined(HAVE_SYNC_FILE_RANGE)
-#define PG_FLUSH_DATA_WORKS 1
-#elif defined(USE_POSIX_FADVISE) && defined(POSIX_FADV_DONTNEED)
-#define PG_FLUSH_DATA_WORKS 1
-#endif
-
 /*
  * pg_xlog has been renamed to pg_wal in version 10.
  */
 #define MINIMUM_VERSION_FOR_PG_WAL	100000
 
-#ifdef PG_FLUSH_DATA_WORKS
-static int	pre_sync_fname(const char *fname, bool isdir);
-#endif
 static void walkdir(const char *path,
 					int (*action) (const char *fname, bool isdir),
 					bool process_symlinks);
@@ -212,7 +201,7 @@ walkdir(const char *path,
  */
 #ifdef PG_FLUSH_DATA_WORKS
 
-static int
+int
 pre_sync_fname(const char *fname, bool isdir)
 {
 	int			fd;

--- a/src/include/common/file_utils.h
+++ b/src/include/common/file_utils.h
@@ -15,6 +15,9 @@
 #ifndef FILE_UTILS_H
 #define FILE_UTILS_H
 
+#ifdef PG_FLUSH_DATA_WORKS
+extern int  pre_sync_fname(const char *fname, bool isdir);
+#endif
 extern int	fsync_fname(const char *fname, bool isdir);
 extern void fsync_pgdata(const char *pg_data, int serverVersion);
 extern void fsync_dir_recurse(const char *dir);

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -342,3 +342,12 @@
  */
 /* #define HEAPDEBUGALL */
 /* #define ACLDEBUG */
+
+/* Define PG_FLUSH_DATA_WORKS if we have an implementation for pg_flush_data */
+#if defined(HAVE_SYNC_FILE_RANGE)
+#define PG_FLUSH_DATA_WORKS 1
+#elif !defined(WIN32) && defined(MS_ASYNC)
+#define PG_FLUSH_DATA_WORKS 1
+#elif defined(USE_POSIX_FADVISE) && defined(POSIX_FADV_DONTNEED)
+#define PG_FLUSH_DATA_WORKS 1
+#endif


### PR DESCRIPTION
There is no need of doing fsync on the whole pg data directory given
the directory might include millions of files. The target directory should
be consistent and be fsync-ed already before pg_rewind due to the
prerequisite of clean shutdown.

Also PG_FLUSH_DATA_WORKS and pg_flush_data are a bit misnamed.
Need to rename them?

Marking [WIP] since need of double-checking the code logic and possible
discussion. We may want to contribute this to upstream at first?