### PR TITLE
Remove fixme and code for the "ctas with no data"

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -404,23 +404,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			/* QD-only query, no dispatching required */
 			shouldDispatch = false;
 		}
-
-		/*
-		 * If this is CREATE TABLE AS ... WITH NO DATA, there's no need
-		 * need to actually execute the plan.
-		 *
-		 * GPDB_12_MERGE_FIXME: it would be nice to apply this optimization to
-		 * materialized views as well but then QEs cannot tell the difference
-		 * between CTAS and materialized view when CreateStmt is dispatched to
-		 * QEs (see createas.c).  QEs must populate rules for materialized
-		 * views, which doesn't happen if this optimization is applied as is.
-		 */
-		if (queryDesc->plannedstmt->intoClause &&
-			queryDesc->plannedstmt->intoClause->skipData &&
-			queryDesc->plannedstmt->intoClause->viewQuery == NULL)
-		{
-			shouldDispatch = false;
-		}
 	}
 	else if (Gp_role == GP_ROLE_EXECUTE)
 	{


### PR DESCRIPTION
Remove the codes for that the shouldDispatch never be true. The
"Create table ... as ..." statement will call "DefineRelation" rather
than "ExecStart" when "plannedstmt->intoClause->skipData" is true

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
