### PR TITLE
Only update locals on photon3

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -388,26 +388,24 @@ if [ "${BLDWRAP_POSTGRES_CONF_ADDONS}" != "__none__" ]  && \
 fi
 
 # photon requires explicitly setting locale during gpinitsystem
-if grep -q photon /etc/os-release; then
+if [ -f /etc/os-release ] && [ grep -q photon /etc/os-release ]; then
     LOCALE_OPTS="-n en_US.UTF-8"
-else
-    LOCALE_OPTS="-n en_US.utf8"
 fi
 
 if [ -f "${CLUSTER_CONFIG_POSTGRES_ADDONS}" ]; then
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} ${LOCALE_OPTS} \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} ${LOCALE_OPTS} "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} "$@"
 else
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} ${LOCALE_OPTS} \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} ${LOCALE_OPTS} "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} "$@"
 fi
 RETURN=$?
 


### PR DESCRIPTION
Don't set locals when it's not phton

The issue comes when make a demo cluster on mac os platform which reported by gp-management team. The code before this PR is that it hardcode locale to en_US.utf8 in all platform except photon 3 platform, which cause issues in mac os platform when gpinitsystem, the error is `Unable to locate locale value en_US.utf8 on this host`

have tested on mac os to make a demo cluster, the issue has gone.

Co-authored-by: Brent Doil <bdoil@vmware.com>
Co-authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
