### PR TITLE
Fix broken pre7->7 pg_upgrade related to the 64bit gxid work.

### DIFF
--- a/src/bin/pg_upgrade/controldata.c
+++ b/src/bin/pg_upgrade/controldata.c
@@ -605,6 +605,16 @@ get_control_data(ClusterInfo *cluster, bool live_check)
 		}
 	}
 
+	/*
+	 * GPDB specific: No such entry in pg_control data on gpdb 6 and below.
+	 * We set it as FirstDistributedTransactionId instead.
+	 *
+	 */
+	if  (GET_MAJOR_VERSION(cluster->major_version) < 1200) {
+		cluster->controldata.chkpnt_nxtgxid = FirstDistributedTransactionId;
+		got_gxid = true;
+	}
+
 	/* verify that we got all the mandatory pg_control data */
 	if (!got_xid || !got_gxid || !got_oid ||
 		!got_multi ||


### PR DESCRIPTION
There is no next gxid value in pg_control data in pre-7 version.  We need to
initialize it in those versions. Ideally during upgrade, those distributed logs
should be all zero-paged so there is no worry about distributed log format
change also due to the 64bit gxid work. (I saw a TODO in
DistributedLog_Startup() but that should be thought separately).