### PR TITLE
Fix memory leak in ORCA translator CreateGroupingSetsForRollup()

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1182,6 +1182,7 @@ CTranslatorUtils::CreateGroupingSetsForRollup(CMemoryPool *mp,
 			mp, gs_current->content, num_cols, group_col_pos, group_cols,
 			false /* use_group_clause */);
 		current_result->Union(bset);
+		bset->Release();
 		col_attnos_arr->Append(GPOS_NEW(mp) CBitSet(mp, *current_result));
 	}
 	// add an empty set


### PR DESCRIPTION
Jesse found this memory leak that was introduced in my previous commit
df3ce784285f7d9ceccfa761fd790ece65b65cde.

Adding some notes for how to detect ORCA memory leaks:

Just run ORCA MDP tests should detect memory leaks inside of gporca.
However, the translator code under gpopt is not tested by the MDP tests,
and we by default use GPDB memory contexts in the translator.

One way to detect memory leaks in the ORCA translator code is to set
"optimizer_use_gpdb_allocators=0" in the gpconfig files and run the
relevant queries. By doing that we instead use ORCA memory contexts and
ORCA will be able to detect the memory leaks.

Reported-by: Jesse Zhang <sbjesse@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
