### PR TITLE
gprecoverseg: don't recover unreachable segments

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -108,6 +108,10 @@ class Segment:
         self.port=port
         self.datadir=datadir
 
+        # Segments are "unreachable" if their host is not reachable.
+        # See detect_unreachable_hosts.py
+        self.unreachable = False
+
         # Todo: Remove old dead code
         self.valid = (status == 'u')
 

--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -5,8 +5,8 @@ include $(top_builddir)/src/Makefile.global
 
 PROGRAMS= initstandby.py test_utils_helper.py
 
-DATA= __init__.py buildMirrorSegments.py deletesystem.py package.py \
-	rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
+DATA= __init__.py buildMirrorSegments.py deletesystem.py detect_unreachable_hosts.py \
+	package.py rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
 	unix.py update_pg_hba_conf.py utils.py
 
 installdirs:

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -1,0 +1,46 @@
+from gppylib import gplog
+from gppylib.commands.base import Command
+from gppylib.commands import base
+from gppylib.gparray import STATUS_DOWN
+
+logger = gplog.get_default_logger()
+
+
+def get_unreachable_segment_hosts(hosts_excluding_master, num_workers):
+    pool = base.WorkerPool(numWorkers=num_workers)
+    try:
+        for host in hosts_excluding_master:
+            cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
+            pool.addCommand(cmd)
+        pool.join()
+    finally:
+        pool.haltWork()
+        pool.joinWorkers()
+
+    # There's no good way to map a CommandResult back to its originating Command so instead
+    # of looping through and finding the hosts that errored out, we remove any hosts that
+    # succeeded from the hosts_excluding_master and any remaining hosts will be ones that were unreachable.
+    for item in pool.getCompletedItems():
+        result = item.get_results()
+        if result.rc == 0:
+            host = result.stdout.strip()
+            hosts_excluding_master.remove(host)
+
+    if len(hosts_excluding_master) > 0:
+        logger.warning("One or more hosts are not reachable via SSH.  Any segments on those hosts will be marked down")
+        for host in sorted(hosts_excluding_master):
+            logger.warning("Host %s is unreachable" % host)
+        return hosts_excluding_master
+    return None
+
+
+def mark_segments_down_for_unreachable_hosts(segmentPairs, unreachable_hosts):
+    # We only mark the segment down in gparray for use by later checks, as
+    # setting the actual segment down in gp_segment_configuration leads to
+    # an inconsistent state and may prevent the database from starting.
+    for segmentPair in segmentPairs:
+        for seg in [segmentPair.primaryDB, segmentPair.mirrorDB]:
+            host = seg.getSegmentHostName()
+            if host in unreachable_hosts:
+                logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
+                seg.setSegmentStatus(STATUS_DOWN)

--- a/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
@@ -13,6 +13,10 @@ def config_primaries_for_replication(gpArray, hba_hostnames):
 
     try:
         for segmentPair in gpArray.getSegmentList():
+            # We cannot update the pg_hba.conf which uses ssh for hosts that are unreachable.
+            if segmentPair.primaryDB.unreachable or segmentPair.mirrorDB.unreachable:
+                continue
+
             # Start with an empty string so that the later .join prepends a newline to the first entry
             entries = ['']
             # Add the samehost replication entry to support single-host development
@@ -55,4 +59,3 @@ def config_primaries_for_replication(gpArray, hba_hostnames):
 
     else:
         logger.info("Successfully modified pg_hba.conf on primary segments to allow replication connections")
-

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -64,6 +64,7 @@ class GpRecoversegTestCase(GpTestCase):
 
         self.gpArrayMock = MagicMock(spec=GpArray)
         self.gpArrayMock.getDbList.side_effect = [[self.primary0], [self.primary0], [self.primary0]]
+        self.gpArrayMock.segmentPairs = []
         self.gpArrayMock.hasMirrors = True
         self.gpArrayMock.isStandardArray.return_value = (True, None)
         self.gpArrayMock.coordinator = self.gparray.coordinator

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -30,6 +30,7 @@ try:
     from gppylib.heapchecksum import HeapChecksum
     from gppylib.commands.pg import PgControlData
     from gppylib.operations.startSegments import *
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts, mark_segments_down_for_unreachable_hosts
     from gppylib.utils import TableLogger
     from gppylib.gp_era import GpEraFile
 except ImportError as e:
@@ -112,12 +113,13 @@ class GpStart:
                 return 0
 
             num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
+            hosts = set(self.gparray.get_hostlist(includeMaster=False))
             # We check for unreachable segment hosts first thing, because if a host is down but its segments
             # are marked up, later checks can return invalid or misleading results and the cluster may not
             # start in a good state.
-            unreachable_hosts = self.get_unreachable_segment_hosts(num_workers)
+            unreachable_hosts = get_unreachable_segment_hosts(hosts, num_workers)
             if unreachable_hosts:
-                self.mark_segments_down_for_unreachable_hosts(unreachable_hosts)
+                mark_segments_down_for_unreachable_hosts(self.gparray.segmentPairs, unreachable_hosts)
 
             if self.skip_heap_checksum_validation:
                 self.coordinator_checksum_value = None
@@ -293,46 +295,6 @@ class GpStart:
         cmd.run(validateAfter=True)
         logger.info("Coordinator Stopped...")
         raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as coordinator.")
-
-    def get_unreachable_segment_hosts(self, num_workers):
-        hostlist = set(self.gparray.get_hostlist(includeMaster=False))
-
-        pool = base.WorkerPool(numWorkers=num_workers)
-        try:
-            for host in hostlist:
-                cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
-                pool.addCommand(cmd)
-            pool.join()
-        finally:
-            pool.haltWork()
-            pool.joinWorkers()
-
-        # There's no good way to map a CommandResult back to its originating Command so instead
-        # of looping through and finding the hosts that errored out, we remove any hosts that
-        # succeeded from the hostlist and any remaining hosts will be ones that were unreachable.
-        for item in pool.getCompletedItems():
-            result = item.get_results()
-            if result.rc == 0:
-                host = result.stdout.strip()
-                hostlist.remove(host)
-
-        if len(hostlist) > 0:
-            logger.warning("One or more hosts are not reachable via SSH.  Any segments on those hosts will be marked down")
-            for host in sorted(hostlist):
-                logger.warning("Host %s is unreachable" % host)
-            return hostlist
-        return None
-
-    def mark_segments_down_for_unreachable_hosts(self, unreachable_hosts):
-        # We only mark the segment down in gparray for use by later checks, as
-        # setting the actual segment down in gp_segment_configuration leads to
-        # an inconsistent state and may prevent the database from starting.
-        for segmentPair in self.gparray.segmentPairs:
-            for seg in [segmentPair.primaryDB, segmentPair.mirrorDB]:
-                host = seg.getSegmentHostName()
-                if host in unreachable_hosts:
-                    logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
-                    seg.setSegmentStatus(STATUS_DOWN)
 
     ######
     def _recovery_startup(self):

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -144,6 +144,7 @@ def set_guc_value(context, guc, value):
 # this can be done to have the test run faster...
 # gpconfig -c gp_fts_mark_mirror_down_grace_period -v 5
 # postgres=# show gp_fts_mark_mirror_down_grace_period;
+@given('the status of the {seg_type} on content {content} should be "{expected_status}"')
 @then('the status of the {seg_type} on content {content} should be "{expected_status}"')
 def impl(context, seg_type, content, expected_status):
     if seg_type == "primary":

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -188,6 +188,8 @@ def impl(conetxt, tabname):
         sql = ("alter table t exchange partition for (2018) with table {tabname} without validation").format(tabname=tabname)
         dbconn.execSQL(conn, sql)
         conn.commit()
+    conn.close()
+
 
 @given('the user executes "{sql}" with named connection "{cname}"')
 def impl(context, cname, sql):

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -29,6 +29,8 @@ if coordinator_data_dir is None:
     raise Exception('MASTER_DATA_DIRECTORY is not set')
 
 
+# query_sql returns a cursor object, so the caller is responsible for closing
+# the dbconn connection.
 def query_sql(dbname, sql):
     result = None
 


### PR DESCRIPTION
Add a check to gprecoverseg to skip attempting recovery of segments that are down and whose hosts are unreachable.

Also extract previous unreachable host logic from gpstart to avoid redundancy.

Pipeline is [here](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/7X_gprecoverseg_down_host).