### PR TITLE
Run clang-tidy job in travis CI in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,26 +120,7 @@ matrix:
                   sources: *common_sources
                   packages: *common_packages
 
-        - name: check-format
-          stage: lint
-          os: linux
-          dist: focal
-          addons:
-            apt:
-              packages:
-                - clang-format-10
-                - parallel
-          before_install: ~
-          install: ~
-          before_script: ~
-          after_script: ~
-          script:
-            - env CLANG_FORMAT=clang-format-10 src/tools/fmt gen
-            - git diff --exit-code
-            - env CLANG_FORMAT=clang-format-10 src/tools/fmt chk
-
         - name: clang-tidy
-          stage: lint
           os: linux
           dist: focal
           addons:
@@ -162,6 +143,24 @@ matrix:
             - CLANG_TIDY=clang-tidy-11 src/tools/tidy chk build.debug
             - CXX=clang++-11 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -Hsrc/backend/gporca -Bbuild.relwithdebinfo
             - CLANG_TIDY=clang-tidy-11 src/tools/tidy chk build.relwithdebinfo
+
+        - name: check-format
+          stage: lint
+          os: linux
+          dist: focal
+          addons:
+            apt:
+              packages:
+                - clang-format-10
+                - parallel
+          before_install: ~
+          install: ~
+          before_script: ~
+          after_script: ~
+          script:
+            - env CLANG_FORMAT=clang-format-10 src/tools/fmt gen
+            - git diff --exit-code
+            - env CLANG_FORMAT=clang-format-10 src/tools/fmt chk
 
 stages:
   - lint


### PR DESCRIPTION
clang-tidy job takes ~11 mins to run. Hence, instead of running it
serially better to run in parallel with other tests to cut down
feedback time.

This should help to cut down full travis CI feedback time for PRs from
~41 mins to ~30 mins.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
