### PR TITLE
gpinitsystem: DEFAULT_LOCALE_SETTING determined by output of locale -a

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1151,7 +1151,7 @@ case $OS_TYPE in
 		PG_METHOD="ident"
 		HOST_ARCH_TYPE="uname -i"
 		NOLINE_ECHO="$ECHO -e"
-		DEFAULT_LOCALE_SETTING=en_US.utf8
+		DEFAULT_LOCALE_SETTING=`locale -a | grep -i en_US.utf*8 | head -1`
 		PING6=`findCmdInPath ping6`
 		PING_TIME="-c 1"
 		;;


### PR DESCRIPTION
Rather than hard coding DEFAULT_LOCALE_SETTING to en_US.utf8 on linux, which is not available on all platforms, use locale -a output.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/7X_gpinitsystem_default_locale)