### PR TITLE
Fail gporca_test if the unit test name is invalid

### DIFF
--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -392,14 +392,25 @@ add_orca_test(CMinidumpWithConstExprEvaluatorTest)
 add_orca_test(CParseHandlerManagerTest)
 add_orca_test(CParseHandlerTest)
 add_orca_test(CParseHandlerCostModelTest)
-add_orca_test(CParseHandlerOptimizerConfigTest)
+# FIXME: this following test was first introduced (but as a typo) in
+# greenplum-db/gporca#355. I've corrected the typo but it's not clear whether
+# it ever passed, but we should give it a best-effort resurrection.
+if (FALSE)
+add_orca_test(CParseHandlerOptimizerConfigSerializeTest)
+endif()
 add_orca_test(CStatisticsTest)
 add_orca_test(CPointTest)
 add_orca_test(CBucketTest)
 add_orca_test(CHistogramTest)
 add_orca_test(CMCVTest)
 add_orca_test(CJoinCardinalityTest)
+# FIXME: the following test was first introduced in greenplum-db/gporca#360,
+# reverted in greenplum-db/gporca#442, and re-added in
+# greenplum-db/gporca#506 (NOT! because only the CMakeLists.txt part was
+# added back). Resurrect this.
+if (FALSE)
 add_orca_test(CJoinCardinalityNDVBasedEqPredTest)
+endif()
 add_orca_test(CFilterCardinalityTest)
 add_orca_test(CTranslatorDXLToExprTest)
 add_orca_test(CTranslatorExprToDXLTest)

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -350,7 +350,14 @@ PvExec(void *pv)
 	else
 	{
 		GPOS_ASSERT(fUnittest);
-		tests_failed = CUnittest::Driver(&bv);
+		if (!bv.IsEmpty())
+		{
+			tests_failed = CUnittest::Driver(&bv);
+		}
+		else
+		{
+			tests_failed = 1;
+		}
 	}
 
 	return NULL;


### PR DESCRIPTION
Currently we happily return a 0 (success) status even if we print a
warning that the argument to "-u" or "-x" isn't valid. This has led to
an incomplete removal when we try to delete and disable tests recently
(greenplum-db/gpdb#11336).

~~## Why is this marked as WIP, is this ready for review?~~
~~Yes it's actually reviewable. The reason it's marked as a "draft" is because we cannot merge this without failing 172 tests in CI right now (because of #11336). So this needs to wait and rebase on the follow-up of #11336 before merging.~~

## Update
Now that #11427 is merged, I can change this to "ready for review". The two commits are intended to be squashed, but I've separated them for ease of review.

### The bad news
I had to disable two dead-on-arrival tests to get the suite passing, and left two FIXME's, so that's sad

### The good news
We're lucky to have such exhibits to prove the usefulness of this patch :)


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
