### PR TITLE
Remove fixme in function 'index_create'

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -903,7 +903,6 @@ index_create(Relation heapRelation,
 	 */
 	if (!OidIsValid(indexRelationId))
 	{
-		/* GPDB_12_MERGE_FIXME: Do we still need special treatment for IsBinaryUpgrade? */
 		indexRelationId = GetNewOidForRelation(pg_class, ClassOidIndexId,
 											   Anum_pg_class_oid,
 											   (char *) indexRelationName,


### PR DESCRIPTION
We have already considered IsBinaryUpgrade in GetNewOrPreassignedOid,
so there is no need to deal with this variable in index_create.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
