### PR TITLE
Correct pgstat for materialized view after REFRESH MATERIALIZED

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -618,17 +618,17 @@ FROM
          relid,
          schemaname,
          relname,
-         sum(seq_scan) as seq_scan,
-         sum(seq_tup_read) as seq_tup_read,
-         sum(idx_scan) as idx_scan,
-         sum(idx_tup_fetch) as idx_tup_fetch,
-         sum(n_tup_ins) as n_tup_ins,
-         sum(n_tup_upd) as n_tup_upd,
-         sum(n_tup_del) as n_tup_del,
-         sum(n_tup_hot_upd) as n_tup_hot_upd,
-         sum(n_live_tup) as n_live_tup,
-         sum(n_dead_tup) as n_dead_tup,
-         sum(n_mod_since_analyze) as n_mod_since_analyze,
+         case when d.policytype = 'r' then (sum(seq_scan)/d.numsegments)::bigint else sum(seq_scan) end seq_scan,
+         case when d.policytype = 'r' then (sum(seq_tup_read)/d.numsegments)::bigint else sum(seq_tup_read) end seq_tup_read,
+         case when d.policytype = 'r' then (sum(idx_scan)/d.numsegments)::bigint else sum(idx_scan) end idx_scan,
+         case when d.policytype = 'r' then (sum(idx_tup_fetch)/d.numsegments)::bigint else sum(idx_tup_fetch) end idx_tup_fetch,
+         case when d.policytype = 'r' then (sum(n_tup_ins)/d.numsegments)::bigint else sum(n_tup_ins) end n_tup_ins,
+         case when d.policytype = 'r' then (sum(n_tup_upd)/d.numsegments)::bigint else sum(n_tup_upd) end n_tup_upd,
+         case when d.policytype = 'r' then (sum(n_tup_del)/d.numsegments)::bigint else sum(n_tup_del) end n_tup_del,
+         case when d.policytype = 'r' then (sum(n_tup_hot_upd)/d.numsegments)::bigint else sum(n_tup_hot_upd) end n_tup_hot_upd,
+         case when d.policytype = 'r' then (sum(n_live_tup)/d.numsegments)::bigint else sum(n_live_tup) end n_live_tup,
+         case when d.policytype = 'r' then (sum(n_dead_tup)/d.numsegments)::bigint else sum(n_dead_tup) end n_dead_tup,
+         case when d.policytype = 'r' then (sum(n_mod_since_analyze)/d.numsegments)::bigint else sum(n_mod_since_analyze) end n_mod_since_analyze,
          max(last_vacuum) as last_vacuum,
          max(last_autovacuum) as last_autovacuum,
          max(last_analyze) as last_analyze,
@@ -638,10 +638,10 @@ FROM
          max(analyze_count) as analyze_count,
          max(autoanalyze_count) as autoanalyze_count
      FROM
-         gp_dist_random('pg_stat_all_tables_internal')
+         gp_dist_random('pg_stat_all_tables_internal'), gp_distribution_policy as d
      WHERE
-             relid >= 16384
-     GROUP BY relid, schemaname, relname
+             relid >= 16384 and relid = d.localoid
+     GROUP BY relid, schemaname, relname, d.policytype, d.numsegments
 
      UNION ALL
 

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4624,7 +4624,7 @@ pgstat_send_qd_tabstats(void)
 		appendBinaryStringInfo(
 			&stat_data, (char *)&record, sizeof(PgStatTabRecordFromQE));
 		ereport(DEBUG3,
-				(errmsg("Send pgstat for current xact nest_level: %d, table oid: %d. "
+				(errmsg("Send pgstat for current xact nest_level: %d, rel oid: %d. "
 						"Inserted: %ld, updated: %ld, deleted: %ld.",
 						nest_level, tabstat->t_id,
 						trans->tuples_inserted, trans->tuples_updated,

--- a/src/test/regress/input/pgstat_qd_tabstat.source
+++ b/src/test/regress/input/pgstat_qd_tabstat.source
@@ -223,4 +223,34 @@ select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n
 select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'rankpart_1_prt_3'::regclass;
 select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'rankpart_1_prt_extra'::regclass;
 
+
+-- Test pgstat matview stat with distributed policy.
+create table base_table(i int, j int, z int ) distributed by (i);
+insert into base_table select i,i,i from generate_series(1, 100) i;
+create materialized view mt as select * from base_table where z>=50;
+select pg_sleep(0.77); -- Force pgstat_report_stat() to send tabstat.
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+insert into base_table select i,i,i from generate_series(1, 100) i;
+refresh materialized view mt;
+select pg_sleep(0.77) from gp_dist_random('gp_id'); -- Force pgstat_report_stat() to send tabstat.
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+-- pg_stat_all_tables collects gpstats across segments
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables where relid = 'mt'::regclass;
+
+drop materialized view mt;
+drop table base_table;
+
+-- Test pgstat matview stat with replicated policy.
+create table base_table(i int, j int, z int ) distributed replicated;
+insert into base_table select i,i,i from generate_series(1, 100) i;
+create materialized view mt as select * from base_table where z>=50 distributed replicated;
+select pg_sleep(0.77); -- Force pgstat_report_stat() to send tabstat.
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+insert into base_table select i,i,i from generate_series(1, 100) i;
+refresh materialized view mt;
+select pg_sleep(0.77) from gp_dist_random('gp_id'); -- Force pgstat_report_stat() to send tabstat.
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+-- pg_stat_all_tables collects gpstats across segments
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables where relid = 'mt'::regclass;
+
 reset gp_autostats_mode;

--- a/src/test/regress/output/pgstat_qd_tabstat.source
+++ b/src/test/regress/output/pgstat_qd_tabstat.source
@@ -486,4 +486,86 @@ select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n
        300 |         0 |        10 |             0 |        300 |          0 |                 300
 (1 row)
 
+-- Test pgstat matview stat with distributed policy.
+create table base_table(i int, j int, z int ) distributed by (i);
+insert into base_table select i,i,i from generate_series(1, 100) i;
+create materialized view mt as select * from base_table where z>=50;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select pg_sleep(0.77); -- Force pgstat_report_stat() to send tabstat.
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+ n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+-----------+-----------+-----------+---------------+------------+------------+---------------------
+        51 |         0 |         0 |             0 |         51 |          0 |                  51
+(1 row)
+
+insert into base_table select i,i,i from generate_series(1, 100) i;
+refresh materialized view mt;
+select pg_sleep(0.77) from gp_dist_random('gp_id'); -- Force pgstat_report_stat() to send tabstat.
+ pg_sleep 
+----------
+ 
+ 
+ 
+(3 rows)
+
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+ n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+-----------+-----------+-----------+---------------+------------+------------+---------------------
+       153 |         0 |         0 |             0 |        102 |          0 |                 153
+(1 row)
+
+-- pg_stat_all_tables collects gpstats across segments
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables where relid = 'mt'::regclass;
+ n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+-----------+-----------+-----------+---------------+------------+------------+---------------------
+       153 |         0 |         0 |             0 |        102 |          0 |                 153
+(1 row)
+
+drop materialized view mt;
+drop table base_table;
+-- Test pgstat matview stat with replicated policy.
+create table base_table(i int, j int, z int ) distributed replicated;
+insert into base_table select i,i,i from generate_series(1, 100) i;
+create materialized view mt as select * from base_table where z>=50 distributed replicated;
+select pg_sleep(0.77); -- Force pgstat_report_stat() to send tabstat.
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+ n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+-----------+-----------+-----------+---------------+------------+------------+---------------------
+        51 |         0 |         0 |             0 |         51 |          0 |                  51
+(1 row)
+
+insert into base_table select i,i,i from generate_series(1, 100) i;
+refresh materialized view mt;
+select pg_sleep(0.77) from gp_dist_random('gp_id'); -- Force pgstat_report_stat() to send tabstat.
+ pg_sleep 
+----------
+ 
+ 
+ 
+(3 rows)
+
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables_internal where relid = 'mt'::regclass;
+ n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+-----------+-----------+-----------+---------------+------------+------------+---------------------
+       153 |         0 |         0 |             0 |        102 |          0 |                 153
+(1 row)
+
+-- pg_stat_all_tables collects gpstats across segments
+select n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze from pg_stat_all_tables where relid = 'mt'::regclass;
+ n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+-----------+-----------+-----------+---------------+------------+------------+---------------------
+       153 |         0 |         0 |             0 |        102 |          0 |                 153
+(1 row)
+
 reset gp_autostats_mode;


### PR DESCRIPTION
The REFRESH MATERIALIZED used to count pgstat on QD. But it always
result to 0 since the es_processed are not colleted from segments.
In GPDB, we should count the pgstat on segments and union them on
QD, so both the segments and coordinator will have pgstat for this
relation.
This fix issue: https://github.com/greenplum-db/gpdb/issues/11375

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
