### PR TITLE
[6X] Backdown and retry for "No route to host" in gpfdist ext table

### DIFF
--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -19,7 +19,7 @@
 
 /* GUC */
 int readable_external_table_timeout = 0;
-int write_to_gpfdist_timeout = 300;
+int gpfdist_retry_timeout = 300;
 
 /*
  * url_fopen

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -19,6 +19,7 @@
 
 /* GUC */
 int readable_external_table_timeout = 0;
+int write_to_gpfdist_timeout = 300;
 
 /*
  * url_fopen

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -21,6 +21,7 @@
 #include <arpa/inet.h>
 
 #include <curl/curl.h>
+#include <time.h>
 
 #include "cdb/cdbsreh.h"
 #include "cdb/cdbutil.h"
@@ -553,8 +554,10 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 	/* retry in case server return timeout error */
 	unsigned int wait_time = 1;
 	unsigned int retry_count = 0;
-	/* retry at most twice(300 seconds * 2) when CURLE_OPERATION_TIMEDOUT happens */
-	unsigned int timeout_count = 0;
+	/* retry at most 300s by default when any error happens */
+	time_t start_time = time(NULL);
+	time_t now;
+	time_t end_time = start_time + write_to_gpfdist_timeout;
 
 	while (true)
 	{
@@ -563,30 +566,12 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		 * when work load is high:
 		 *	- 'could not connect to server'
 		 *	- gpfdist return timeout (HTTP 408)
-		 * By default it will wait at most 127 seconds before abort.
-		 * 1 + 2 + 4 + 8 + 16 + 32 + 64 = 127
+		 * By default it will wait at least write_to_gpfdist_timeout seconds before abort.
 		 */
 		CURLcode e = curl_easy_perform(file->curl->handle);
 		if (CURLE_OK != e)
 		{
-			/* For curl timeout, retry 2 times before reporting error */
-			if (CURLE_OPERATION_TIMEDOUT == e)
-			{
-				timeout_count++;
-				elog(LOG, "curl operation timeout, timeout_count = %d", timeout_count);
-				if (timeout_count >= 2)
-				{
-					ereport(ERROR,
-					(errcode(ERRCODE_CONNECTION_FAILURE),
-					errmsg("error when writing data to gpfdist %s, quit after %d timeout_count",
-							file->curl_url, timeout_count)));
-				}
-				continue;
-			}
-			else
-			{
-				elog(LOG, "%s error (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
-			}
+			elog(LOG, "%s response (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
 		}
 		else
 		{
@@ -614,20 +599,25 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		}
 
 		/*
-		 * For FDIST_TIMEOUT and curl errors except CURLE_OPERATION_TIMEDOUT
-		 * Retry until MAX_TRY_WAIT_TIME
+		 * Retry until end_time is reached
 		 */
-		if (wait_time > MAX_TRY_WAIT_TIME)
+		now = time(NULL);
+		if (now >= end_time)
 		{
+			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, write_to_gpfdist_timeout = %d",
+				wait_time, now - start_time, write_to_gpfdist_timeout);
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
 					 errmsg("error when writing data to gpfdist %s, quit after %d tries",
-							file->curl_url, retry_count+1)));
+							file->curl_url, retry_count + 1)));
 		}
 		else
 		{
-			elog(LOG, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
 			unsigned int for_wait = 0;
+			wait_time = wait_time > MAX_TRY_WAIT_TIME ? MAX_TRY_WAIT_TIME : wait_time;
+			/* For last retry before end_time */
+			wait_time = wait_time > end_time - now ? end_time - now : wait_time;
+			elog(LOG, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
 			while (for_wait++ < wait_time)
 			{
 				pg_usleep(1000000);
@@ -1194,7 +1184,8 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	{
 		// TIMEOUT for POST only, GET is single HTTP request,
 		// probablity take long time.
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, 300L);
+		elog(LOG, "write_to_gpfdist_timeout = %d", write_to_gpfdist_timeout);
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)write_to_gpfdist_timeout);
 
 		/*init sequence number*/
 		file->seq_number = 1;

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -97,7 +97,6 @@ typedef struct
 
 } URL_CURL_FILE;
 
-
 #if BYTE_ORDER == BIG_ENDIAN
 #define local_htonll(n)  (n)
 #define local_ntohll(n)  (n)
@@ -152,6 +151,9 @@ static void extract_http_domain(char* i_path, char* o_domain, int dlen);
 
 /* we use a global one for convenience */
 static CURLM *multi_handle = 0;
+
+static int
+fill_buffer(URL_CURL_FILE *curl, int want);
 
 /*
  * A helper macro, to call curl_easy_setopt(), and ereport() if it fails.
@@ -442,6 +444,10 @@ check_response(URL_CURL_FILE *file, int *rc, char **response_string)
 			/* get the os level errno, and string representation of it */
 			if (curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno) == CURLE_OK)
 			{
+				if (oserrno == EHOSTUNREACH)
+				{
+					return oserrno;
+				}
 				if (oserrno != 0)
 					snprintf(connmsg, sizeof connmsg, "error code = %d (%s)",
 							 (int) oserrno, strerror((int)oserrno));
@@ -540,17 +546,12 @@ get_gpfdist_status(URL_CURL_FILE *file)
 	curl_easy_cleanup(status_handle);
 }
 
-/**
- * Send curl request and check response.
- * If failed, will retry multiple times.
- * Return true if succeed, false otherwise.
- */
-static void
-gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
-{
-	int 		response_code;
-	char	   *response_string = NULL;
+/* Return true to retry */
+typedef bool (*perform_func)(URL_CURL_FILE *file);
 
+static void
+gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
+{
 	/* retry in case server return timeout error */
 	unsigned int wait_time = 1;
 	unsigned int retry_count = 0;
@@ -561,43 +562,10 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 
 	while (true)
 	{
-		/*
-		 * Use backoff policy to call curl_easy_perform to fix following error
-		 * when work load is high:
-		 *	- 'could not connect to server'
-		 *	- gpfdist return timeout (HTTP 408)
-		 * By default it will wait at least write_to_gpfdist_timeout seconds before abort.
-		 */
-		CURLcode e = curl_easy_perform(file->curl->handle);
-		if (CURLE_OK != e)
+		if (!func(file))
 		{
-			elog(LOG, "%s response (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
+			return;
 		}
-		else
-		{
-			/* check the response from server */                                              	
-			response_code = check_response(file, &response_code, &response_string);
-			switch (response_code)
-			{
-				case 0:
-					/* Success! */
-					return;
-
-				case FDIST_TIMEOUT:
-					elog(LOG, "%s timeout from gpfdist", file->curl_url);
-					break;
-
-				default:
-					ereport(ERROR,
-							(errcode(ERRCODE_CONNECTION_FAILURE),
-							 errmsg("error while getting response from gpfdist on %s (code %d, msg %s)",
-									file->curl_url, response_code, response_string)));
-			}
-			if (response_string)
-				pfree(response_string);
-			response_string = NULL;
-		}
-
 		/*
 		 * Retry until end_time is reached
 		 */
@@ -608,8 +576,8 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 				wait_time, now - start_time, write_to_gpfdist_timeout);
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
-					 errmsg("error when writing data to gpfdist %s, quit after %d tries",
-							file->curl_url, retry_count + 1)));
+					 errmsg("error when connecting to gpfdist %s, quit after %d tries",
+							file->curl_url, retry_count+1)));
 		}
 		else
 		{
@@ -629,6 +597,92 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 	}
 }
 
+static bool multi_perform_work(URL_CURL_FILE *file)
+{
+	int 		response_code;
+	char	   *response_string = NULL;
+	int e;
+	char *effective_url;
+
+	if (CURLE_OK != (e = curl_multi_add_handle(multi_handle, file->curl->handle)))
+	{
+		if (CURLM_CALL_MULTI_PERFORM != e)
+			elog(ERROR, "internal error: curl_multi_add_handle failed (%d - %s)",
+				 e, curl_easy_strerror(e));
+	}
+	file->curl->in_multi_handle = true;
+
+	while (CURLM_CALL_MULTI_PERFORM ==
+		   (e = curl_multi_perform(multi_handle, &file->still_running)));
+	if (e != CURLE_OK)
+		elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
+			 e, curl_easy_strerror(e));
+	/* read some bytes to make sure the connection is established */
+	fill_buffer(file, 1);
+
+	/* check the connection for GET request */
+	int code = check_response(file, &response_code, &response_string);
+	switch (code)
+	{
+		case 0:
+			return false;
+		case EHOSTUNREACH:
+			curl_easy_getinfo(file->curl->handle, CURLINFO_EFFECTIVE_URL, &effective_url);
+			elog(LOG, "gpfdist request failed on seg%d, error: %s, effective url %s",
+				GpIdentity.segindex, strerror(EHOSTUNREACH), effective_url);
+			curl_multi_remove_handle(multi_handle, file->curl->handle);
+			curl_multi_cleanup(multi_handle);
+			multi_handle = curl_multi_init();
+			return true;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("could not open \"%s\" for reading", file->common.url),
+					 errdetail("Unexpected response from gpfdist server: %d - %s",
+							   response_code, response_string)));
+	}
+}
+
+static bool easy_perform_work(URL_CURL_FILE *file)
+{
+	int 		response_code;
+	char	   *response_string = NULL;
+	/*
+	 * Use backoff policy to call curl_easy_perform to fix following error
+	 * when work load is high:
+	 *	- 'could not connect to server'
+	 *	- gpfdist return timeout (HTTP 408)
+	 * By default it will wait at least write_to_gpfdist_timeout seconds before abort.
+	 */
+	CURLcode e = curl_easy_perform(file->curl->handle);
+	if (CURLE_OK != e)
+	{
+		elog(LOG, "%s response (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
+	}
+	else
+	{
+		/* check the response from server */
+		response_code = check_response(file, &response_code, &response_string);
+		switch (response_code)
+		{
+			case 0:
+				/* Success! */
+				return false;
+			case FDIST_TIMEOUT:
+				elog(LOG, "%s timeout from gpfdist", file->curl_url);
+				break;
+			default:
+				ereport(ERROR,
+						(errcode(ERRCODE_CONNECTION_FAILURE),
+						 errmsg("error while getting response from gpfdist on %s (code %d, msg %s)",
+								file->curl_url, response_code, response_string)));
+		}
+		if (response_string)
+			pfree(response_string);
+		response_string = NULL;
+	}
+	return true;
+}
 
 /*
  * fill_buffer
@@ -1339,34 +1393,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	 */
 	if (!forwrite)
 	{
-		int			response_code;
-		char	   *response_string;
-
-		if (CURLE_OK != (e = curl_multi_add_handle(multi_handle, file->curl->handle)))
-		{
-			if (CURLM_CALL_MULTI_PERFORM != e)
-				elog(ERROR, "internal error: curl_multi_add_handle failed (%d - %s)",
-					 e, curl_easy_strerror(e));
-		}
-		file->curl->in_multi_handle = true;
-
-		while (CURLM_CALL_MULTI_PERFORM ==
-			   (e = curl_multi_perform(multi_handle, &file->still_running)));
-
-		if (e != CURLE_OK)
-			elog(ERROR, "internal error: curl_multi_perform failed (%d - %s)",
-				 e, curl_easy_strerror(e));
-
-		/* read some bytes to make sure the connection is established */
-		fill_buffer(file, 1);
-
-		/* check the connection for GET request */
-		if (check_response(file, &response_code, &response_string))
-			ereport(ERROR,
-					(errcode(ERRCODE_CONNECTION_FAILURE),
-					 errmsg("could not open \"%s\" for reading", file->common.url),
-					 errdetail("Unexpected response from gpfdist server: %d - %s",
-							   response_code, response_string)));
+		gp_perform_backoff_and_check_response(file, multi_perform_work);
 	}
 	else
 	{
@@ -1375,7 +1402,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDSIZE, 0);
 
 		/* post away and check response, retry if failed (timeout or * connect error) */
-		gp_curl_easy_perform_backoff_and_check_response(file);
+		gp_perform_backoff_and_check_response(file, easy_perform_work);
 		file->seq_number++;
 	}
 
@@ -1705,7 +1732,7 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 
 	replace_httpheader(file, "X-GP-SEQ", seq);
 
-	gp_curl_easy_perform_backoff_and_check_response(file);
+	gp_perform_backoff_and_check_response(file, easy_perform_work);
 	file->seq_number++;
 }
 
@@ -1723,7 +1750,7 @@ gp_proto0_write_done(URL_CURL_FILE *file)
 	CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDSIZE, 0);
 
 	/* post away! */
-	gp_curl_easy_perform_backoff_and_check_response(file);
+	gp_perform_backoff_and_check_response(file, easy_perform_work);
 }
 
 static size_t

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -550,7 +550,7 @@ get_gpfdist_status(URL_CURL_FILE *file)
 typedef bool (*perform_func)(URL_CURL_FILE *file);
 
 static void
-gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
+gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func perform)
 {
 	/* retry in case server return timeout error */
 	unsigned int wait_time = 1;
@@ -558,11 +558,11 @@ gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
 	/* retry at most 300s by default when any error happens */
 	time_t start_time = time(NULL);
 	time_t now;
-	time_t end_time = start_time + write_to_gpfdist_timeout;
+	time_t end_time = start_time + gpfdist_retry_timeout;
 
 	while (true)
 	{
-		if (!func(file))
+		if (!perform(file))
 		{
 			return;
 		}
@@ -572,8 +572,8 @@ gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
 		now = time(NULL);
 		if (now >= end_time)
 		{
-			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, write_to_gpfdist_timeout = %d",
-				wait_time, now - start_time, write_to_gpfdist_timeout);
+			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, gpfdist_retry_timeout = %d",
+				wait_time, now - start_time, gpfdist_retry_timeout);
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
 					 errmsg("error when connecting to gpfdist %s, quit after %d tries",
@@ -652,7 +652,7 @@ static bool easy_perform_work(URL_CURL_FILE *file)
 	 * when work load is high:
 	 *	- 'could not connect to server'
 	 *	- gpfdist return timeout (HTTP 408)
-	 * By default it will wait at least write_to_gpfdist_timeout seconds before abort.
+	 * By default it will wait at least gpfdist_retry_timeout seconds before abort.
 	 */
 	CURLcode e = curl_easy_perform(file->curl->handle);
 	if (CURLE_OK != e)
@@ -1238,8 +1238,8 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	{
 		// TIMEOUT for POST only, GET is single HTTP request,
 		// probablity take long time.
-		elog(LOG, "write_to_gpfdist_timeout = %d", write_to_gpfdist_timeout);
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)write_to_gpfdist_timeout);
+		elog(LOG, "gpfdist_retry_timeout = %d", gpfdist_retry_timeout);
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)gpfdist_retry_timeout);
 
 		/*init sequence number*/
 		file->seq_number = 1;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3099,12 +3099,12 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"write_to_gpfdist_timeout", PGC_USERSET, EXTERNAL_TABLES,
+		{"gpfdist_retry_timeout", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Timeout (in seconds) for writing data to gpfdist server."),
 			gettext_noop("Default value is 300."),
 			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
 		},
-		&write_to_gpfdist_timeout,
+		&gpfdist_retry_timeout,
 		300, 1, 7200,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3099,6 +3099,17 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"write_to_gpfdist_timeout", PGC_USERSET, EXTERNAL_TABLES,
+			gettext_noop("Timeout (in seconds) for writing data to gpfdist server."),
+			gettext_noop("Default value is 300."),
+			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
+		},
+		&write_to_gpfdist_timeout,
+		300, 1, 7200,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"writable_external_table_bufsize", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Buffer size in kilobytes for writable external table before writing data to gpfdist."),
 			gettext_noop("Valid value is between 32K and 128M: [32, 131072]."),

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -514,6 +514,20 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
+-- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
+
+CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
+
+CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
+
+-- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
+set write_to_gpfdist_timeout = 20;
+INSERT INTO wext_test_guc SELECT * FROM test_guc;
+
+DROP TABLE IF EXISTS test_guc;
+DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
+
 --
 -- get an error for missing gpfdist
 --

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -514,7 +514,7 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
--- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
+-- Test GUC gpfdist_retry_timeout. gpfdist is stopped, insert will retry until timeout
 
 CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
 INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
@@ -522,7 +522,7 @@ INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
 CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
 
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
-set write_to_gpfdist_timeout = 20;
+set gpfdist_retry_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 
 DROP TABLE IF EXISTS test_guc;

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -692,12 +692,12 @@ DROP TABLE IF EXISTS table_multi_locations;
 DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- start_ignore
 -- end_ignore
--- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
+-- Test GUC gpfdist_retry_timeout. gpfdist is stopped, insert will retry until timeout
 CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
 INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
 CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
-set write_to_gpfdist_timeout = 20;
+set gpfdist_retry_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 ERROR:  error when connecting to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
 DROP TABLE IF EXISTS test_guc;

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -692,6 +692,16 @@ DROP TABLE IF EXISTS table_multi_locations;
 DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- start_ignore
 -- end_ignore
+-- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
+CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
+CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
+-- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
+set write_to_gpfdist_timeout = 20;
+INSERT INTO wext_test_guc SELECT * FROM test_guc;
+ERROR:  error when writing data to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
+DROP TABLE IF EXISTS test_guc;
+DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
 --
 -- get an error for missing gpfdist
 --

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -699,7 +699,7 @@ CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist:
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
 set write_to_gpfdist_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
-ERROR:  error when writing data to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
+ERROR:  error when connecting to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
 DROP TABLE IF EXISTS test_guc;
 DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
 --

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -113,5 +113,6 @@ extern size_t url_custom_fwrite(void *ptr, size_t size, URL_FILE *file, CopyStat
 
 /* GUC */
 extern int readable_external_table_timeout;
+extern int write_to_gpfdist_timeout;
 
 #endif

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -113,6 +113,6 @@ extern size_t url_custom_fwrite(void *ptr, size_t size, URL_FILE *file, CopyStat
 
 /* GUC */
 extern int readable_external_table_timeout;
-extern int write_to_gpfdist_timeout;
+extern int gpfdist_retry_timeout;
 
 #endif

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -439,7 +439,7 @@
 		"quote_all_identifiers",
 		"random_page_cost",
 		"readable_external_table_timeout",
-		"write_to_gpfdist_timeout",
+		"gpfdist_retry_timeout",
 		"repl_catchup_within_range",
 		"resource_cleanup_gangs_on_wait",
 		"resource_scheduler",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -439,6 +439,7 @@
 		"quote_all_identifiers",
 		"random_page_cost",
 		"readable_external_table_timeout",
+		"write_to_gpfdist_timeout",
 		"repl_catchup_within_range",
 		"resource_cleanup_gangs_on_wait",
 		"resource_scheduler",


### PR DESCRIPTION
Reading from gpfdist external table can generate lots of HTTP traffic
in very short time window. This may cause intermittent network issues
resulting in "No route to host" error. Backdown and retry in such scenario.

Reuse the backdown and retry logic for writable external table as
gp_perform_backoff_and_check_response. Pass read/write specific
part as function pointer(multi_perform_work/easy_perform_work).   

   (cherry picked from commit 7f1589a786e7fd9cac950ee104a729e370ec3606)

This patch depends on gpfdist_retry_timeout GUC. So backport the commit of adding gpfdist_retry_timeout GUC too.
(cherry picked from commit ab73713211e93a95e696429f4821e893ee3397de)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
