### PR TITLE
Resolve FIXME in nodeBitmapOr

### DIFF
--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -162,6 +162,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 			else
 			{
 				tbm_intersect(hbm, (TIDBitmap *)subresult);
+				tbm_generic_free(subresult);
 			}
 
 			/*
@@ -173,13 +174,6 @@ MultiExecBitmapAnd(BitmapAndState *node)
 			 */
 			if (tbm_is_empty(hbm))
 			{
-				/*
-				 * GPDB_84_MERGE_FIXME: If we saw any StreamBitmap inputs, we
-				 * will create an OpStream to AND the empty result with the
-				 * StreamBitmaps we saw already. We could just close them now,
-				 * and return an empty hash bitmap here, but I'm not sure how
-				 * to close the already-opened stream bitmaps correctly.
-				 */
 				empty = true;
 				break;
 			}
@@ -196,6 +190,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
    				{
 	   				StreamBitmap *s = (StreamBitmap *)subresult;
 	   				stream_move_node((StreamBitmap *)node->bitmap, s, BMS_AND);
+					tbm_generic_free(subresult);
 			   	}
 			}
    			else

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -120,9 +120,6 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 		if (node->ss.ps.instrument && (node->ss.ps.instrument)->need_cdb)
 			tbm_generic_set_instrument(bitmap, node->ss.ps.instrument);
 
-		if (node->biss_result == NULL)
-			node->biss_result = (Node *) bitmap;
-
 		doscan = ExecIndexAdvanceArrayKeys(node->biss_ArrayKeys,
 										   node->biss_NumArrayKeys);
 		if (doscan)				/* reset index scan */
@@ -183,21 +180,6 @@ ExecReScanBitmapIndexScan(BitmapIndexScanState *node)
 		index_rescan(node->biss_ScanDesc,
 					 node->biss_ScanKeys, node->biss_NumScanKeys,
 					 NULL, 0);
-
-	/* Sanity check */
-	if (node->biss_result &&
-		(!IsA(node->biss_result, TIDBitmap) && !IsA(node->biss_result, StreamBitmap)))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("the returning bitmap in nodeBitmapIndexScan is invalid")));
-	}
-
-	if (NULL != node->biss_result)
-	{
-		tbm_generic_free(node->biss_result);
-		node->biss_result = NULL;
-	}
 }
 
 /* ----------------------------------------------------------------
@@ -231,9 +213,6 @@ ExecEndBitmapIndexScan(BitmapIndexScanState *node)
 		index_endscan(indexScanDesc);
 	if (indexRelationDesc)
 		index_close(indexRelationDesc, NoLock);
-
-	tbm_generic_free(node->biss_result);
-	node->biss_result = NULL;
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -169,16 +169,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 			else
 			{
 				tbm_union(result, (TIDBitmap *)subresult);
-				/* GPDB_12_MERGE_FIXME: don't free the bitmap here, causes
-				 * assertion failure with:
-				 *
-				 * set enable_seqscan=off;
-				 * SELECT * FROM tenk1 WHERE thousand = 42 AND (tenthous = 1 OR tenthous = 3 OR tenthous = 42);
-				 *
-				 * I'm not sure why that's not cool in GPDB, even though in upstream, there's
-				 * a tbm_free() call here
-				 */
-				//tbm_generic_free(subresult);
+				tbm_generic_free(subresult);
 			}
 		}
 		else
@@ -190,6 +181,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 				{
 					StreamBitmap *s = (StreamBitmap *)subresult;
 					stream_move_node((StreamBitmap *)node->bitmap, s, BMS_OR);
+					tbm_generic_free(subresult);
 				}
 			}
 			else

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -1989,11 +1989,9 @@ tbm_stream_block(StreamBMIterator *iterator, PagetableEntry *e)
 static void
 tbm_stream_free(StreamNode *self)
 {
-	/*
-	 * self->opaque is actually a reference to node->bitmap from BitmapIndexScanState
-	 * BitmapIndexScanState would have freed the self->opaque already so we shouldn't
-	 * access now.
-	 */
+	TIDBitmap *tbm = self->opaque;
+	Assert(self->type == BMS_INDEX);
+	tbm_free(tbm);
 	pfree(self);
 }
 


### PR DESCRIPTION
For upstream, `BitmapIndexScanState.biss_result` only used to store
`tbm_create` result in `MultiExecBitmapOr` and BitmapIndexScanState does
not have the responsibility to free it, and normally BitmapIndexScanState
always has a new biss_result each time.
But for GPDB, AM `amgetbitmap` may return different types of node like
`TIDBitmap` and `StreamBitmap`. And we used to store the node as
`BitmapIndexScanState.biss_result` and make BitmapIndexScanState take
care of it. This leads GPDB to have different code logic compare with
upstream. Actually, this is not needed, we can just do as upstream does.
Free the bitmap as soon as possible.
So refactor it to make code consistent with upstream.

Also remove a GPDB_84_MERGE_FIXME in nodeBitmapAnd.c which should
not have any issues now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
