### PR TITLE
gpdemo: Only pass locale to gpinitsystem on Photon

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -388,8 +388,11 @@ if [ "${BLDWRAP_POSTGRES_CONF_ADDONS}" != "__none__" ]  && \
 fi
 
 # photon requires explicitly setting locale during gpinitsystem
-if [ -f /etc/os-release ] && [ grep -q photon /etc/os-release ]; then
-    LOCALE_OPTS="-n en_US.UTF-8"
+# TODO: This hack will go away when gpinitsystem automatically using default system locale.
+if [ -f /etc/os-release ]; then
+    if grep -q photon /etc/os-release; then
+        LOCALE_OPTS="-n en_US.UTF-8"
+    fi
 fi
 
 if [ -f "${CLUSTER_CONFIG_POSTGRES_ADDONS}" ]; then


### PR DESCRIPTION
Don't set locale when it's not Photon

- Fix bug in demo_cluster.sh ` [: too many arguments` on Centos

Co-authored-by: Brent Doil <bdoil@vmware.com>
Co-authored-by: Shaoqi Bai <bshaoqi@vmware.com>