### PR TITLE
Disable ORCA's statistics missing NOTICE

### DIFF
--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -127,4 +127,9 @@ s/ERROR:  could not devise a query plan for the given query \(.*\)/ERROR:  could
 m/^DETAIL:.*gid=.*/
 s/gid=\d+/gid DUMMY/
 
+m/NOTICE:  One or more columns in the following table\(s\) do not have statistics: /
+s/.//gs
+m/HINT:  For non-partitioned tables, run analyze .+\. For partitioned tables, run analyze rootpartition .+\. See log for columns missing statistics\./
+s/.//gs
+
 -- end_matchsubs


### PR DESCRIPTION
The following NOTICE is generated by ORCA when it plans a partitioned table
that does not have stats. Although it is a useful messages for the end user, it
causes noise & flaky failures in ICW. This commit ignores these NOTICEs.

HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
NOTICE:  One or more columns in the following table(s) do not have statistics: dml_union_s

