### PR TITLE
Resolve FIXME in indexam.c

### DIFF
--- a/contrib/bloom/bloom.h
+++ b/contrib/bloom/bloom.h
@@ -193,7 +193,7 @@ extern bool blinsert(Relation index, Datum *values, bool *isnull,
 					 IndexUniqueCheck checkUnique,
 					 struct IndexInfo *indexInfo);
 extern IndexScanDesc blbeginscan(Relation r, int nkeys, int norderbys);
-extern int64 blgetbitmap(IndexScanDesc scan, TIDBitmap *tbm);
+extern int64 blgetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern void blrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 					 ScanKey orderbys, int norderbys);
 extern void blendscan(IndexScanDesc scan);

--- a/contrib/bloom/blscan.c
+++ b/contrib/bloom/blscan.c
@@ -79,14 +79,32 @@ blendscan(IndexScanDesc scan)
  * Insert all matching tuples into a bitmap.
  */
 int64
-blgetbitmap(IndexScanDesc scan, TIDBitmap *tbm)
+blgetbitmap(IndexScanDesc scan, Node **bmNodeP)
 {
 	int64		ntids = 0;
 	BlockNumber blkno = BLOOM_HEAD_BLKNO,
 				npages;
 	int			i;
+	TIDBitmap  *tbm;
 	BufferAccessStrategy bas;
 	BloomScanOpaque so = (BloomScanOpaque) scan->opaque;
+
+	/*
+	 * GPDB specific code. Since GPDB also support StreamBitmap
+	 * in bitmap index. So normally we need to create specific bitmap
+	 * node in the amgetbitmap AM.
+	 */
+	Assert(bmNodeP);
+	if (*bmNodeP == NULL)
+	{
+		/* XXX should we use less than work_mem for this? */
+		tbm = tbm_create(work_mem * 1024L, NULL);
+		*bmNodeP = (Node *) tbm;
+	}
+	else if (!IsA(*bmNodeP, TIDBitmap))
+		elog(ERROR, "non bloom bitmap");
+	else
+		tbm = (TIDBitmap *)*bmNodeP;
 
 	if (so->sign == NULL)
 	{

--- a/gpcontrib/gp_internal_tools/gp_instrument_shmem.c
+++ b/gpcontrib/gp_internal_tools/gp_instrument_shmem.c
@@ -170,8 +170,8 @@ gp_instrument_shmem_detail(PG_FUNCTION_ARGS)
 		values[4] = Int32GetDatum(slot->pid);
 		values[5] = Int16GetDatum(slot->nid);
 		values[6] = Int64GetDatum((int64) ((slot->data).tuplecount));
-		values[7] = Int64GetDatum((int64) ((slot->data).ntuples));
-		values[8] = Int64GetDatum((int64) ((slot->data).nloops));
+		values[7] = Int64GetDatum((int64) ((slot->data).nloops));
+		values[8] = Int64GetDatum((int64) ((slot->data).ntuples));
 
 		HeapTuple	tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		Datum		result = HeapTupleGetDatum(tuple);

--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -243,10 +243,9 @@ stream_begin_iterate(StreamNode *self, StreamBMIterator *iterator)
 /*
  * bmgetbitmap() -- return a stream bitmap.
  */
-Node *
-bmgetbitmap(IndexScanDesc scan, Node *bm)
+int64
+bmgetbitmap(IndexScanDesc scan, Node **bmNodeP)
 {
-	/* We ignore the second argument as we're returning a hash bitmap */
 	IndexStream	 *is;
 	BMScanPosition	scanPos;
 	bool res;
@@ -283,22 +282,28 @@ bmgetbitmap(IndexScanDesc scan, Node *bm)
 		}
 	}
 
-	if (!bm)
+	/*
+	 * GPDB specific code. Since GPDB also support StreamBitmap
+	 * in bitmap index. So normally we need to create specific bitmap
+	 * node in the amgetbitmap AM.
+	 */
+	Assert(bmNodeP);
+	if (*bmNodeP == NULL)
 	{
 		StreamBitmap *sb = makeNode(StreamBitmap);
 		sb->streamNode = is;
-		bm = (Node *)sb;
+		*bmNodeP = (Node *) sb;
 	}
-	else if (IsA(bm, StreamBitmap))
-	{
-		stream_add_node((StreamBitmap *)bm, is, BMS_OR);
-	}
+	else if (IsA(*bmNodeP, StreamBitmap))
+		stream_add_node((StreamBitmap *)*bmNodeP, is, BMS_OR);
 	else
-	{
 		elog(ERROR, "non stream bitmap");
-	}
 
-	return bm;
+	/*
+	 * XXX We don't have a precise idea of the number of heap tuples
+	 * involved.
+	 */
+	return 1;
 }
 
 /*

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -70,6 +70,7 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 {
 	Node	   *bitmap = NULL;
 	IndexScanDesc scandesc;
+	double		nTuples = 0;
 	bool		doscan;
 
 	/* Make sure we are not leaking a previous bitmap */
@@ -102,7 +103,7 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	/* Get bitmap from index */
 	while (doscan)
 	{
-		bitmap = index_getbitmap(scandesc, node->biss_result);
+		nTuples += (double) index_getbitmap(scandesc, &bitmap);
 
 		if ((NULL != bitmap) &&
 			!(IsA(bitmap, TIDBitmap) || IsA(bitmap, StreamBitmap)))
@@ -131,9 +132,8 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	}
 
 	/* must provide our own instrumentation support */
-	/* GPDB: Report "1 tuple", actually meaning "1 bitmap" */
 	if (node->ss.ps.instrument)
-		InstrStopNode(node->ss.ps.instrument, 1 /* nTuples */);
+		InstrStopNode(node->ss.ps.instrument, nTuples);
 
 	return (Node *) bitmap;
 }

--- a/src/include/access/amapi.h
+++ b/src/include/access/amapi.h
@@ -131,8 +131,8 @@ typedef bool (*amgettuple_function) (IndexScanDesc scan,
 									 ScanDirection direction);
 
 /* fetch all valid tuples */
-typedef Node *(*amgetbitmap_function) (IndexScanDesc scan,
-									   Node *tbm);
+typedef int64 (*amgetbitmap_function) (IndexScanDesc scan,
+									   Node **bmNodeP);
 
 /* end index scan */
 typedef void (*amendscan_function) (IndexScanDesc scan);

--- a/src/include/access/bitmap_private.h
+++ b/src/include/access/bitmap_private.h
@@ -247,7 +247,7 @@ extern bool bminsert(Relation rel, Datum *values, bool *isnull,
 					 struct IndexInfo *indexInfo);
 extern IndexScanDesc bmbeginscan(Relation rel, int nkeys, int norderbys);
 extern bool bmgettuple(IndexScanDesc scan, ScanDirection dir);
-extern Node *bmgetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 bmgetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern void bmrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 		 ScanKey orderbys, int norderbys);
 extern void bmendscan(IndexScanDesc scan);

--- a/src/include/access/brin_internal.h
+++ b/src/include/access/brin_internal.h
@@ -92,7 +92,7 @@ extern bool brininsert(Relation idxRel, Datum *values, bool *nulls,
 					   IndexUniqueCheck checkUnique,
 					   struct IndexInfo *indexInfo);
 extern IndexScanDesc brinbeginscan(Relation r, int nkeys, int norderbys);
-extern Node *bringetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 bringetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern void brinrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 					   ScanKey orderbys, int norderbys);
 extern void brinendscan(IndexScanDesc scan);

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -164,7 +164,7 @@ struct TupleTableSlot;
 extern bool index_fetch_heap(IndexScanDesc scan, struct TupleTableSlot *slot);
 extern bool index_getnext_slot(IndexScanDesc scan, ScanDirection direction,
 							   struct TupleTableSlot *slot);
-extern Node *index_getbitmap(IndexScanDesc scan, Node *bitmap);
+extern int64 index_getbitmap(IndexScanDesc scan, Node **bitmapP);
 
 extern IndexBulkDeleteResult *index_bulk_delete(IndexVacuumInfo *info,
 												IndexBulkDeleteResult *stats,

--- a/src/include/access/gin_private.h
+++ b/src/include/access/gin_private.h
@@ -371,7 +371,7 @@ extern void ginNewScanKey(IndexScanDesc scan);
 extern void ginFreeScanKeys(GinScanOpaque so);
 
 /* ginget.c */
-extern Node *gingetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 gingetbitmap(IndexScanDesc scan, Node **bmNodeP);
 
 /* ginlogic.c */
 extern void ginInitConsistentFunction(GinState *ginstate, GinScanKey key);

--- a/src/include/access/gist_private.h
+++ b/src/include/access/gist_private.h
@@ -465,7 +465,7 @@ extern XLogRecPtr gistXLogSplit(bool page_is_leaf,
 
 /* gistget.c */
 extern bool gistgettuple(IndexScanDesc scan, ScanDirection dir);
-extern Node *gistgetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 gistgetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern bool gistcanreturn(Relation index, int attno);
 
 /* gistvalidate.c */

--- a/src/include/access/hash.h
+++ b/src/include/access/hash.h
@@ -350,7 +350,7 @@ extern bool hashinsert(Relation rel, Datum *values, bool *isnull,
 					   IndexUniqueCheck checkUnique,
 					   struct IndexInfo *indexInfo);
 extern bool hashgettuple(IndexScanDesc scan, ScanDirection dir);
-extern Node *hashgetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 hashgetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern IndexScanDesc hashbeginscan(Relation rel, int nkeys, int norderbys);
 extern void hashrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 					   ScanKey orderbys, int norderbys);

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -703,7 +703,7 @@ extern IndexScanDesc btbeginscan(Relation rel, int nkeys, int norderbys);
 extern Size btestimateparallelscan(void);
 extern void btinitparallelscan(void *target);
 extern bool btgettuple(IndexScanDesc scan, ScanDirection dir);
-extern Node *btgetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 btgetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern void btrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 					 ScanKey orderbys, int norderbys);
 extern void btparallelrescan(IndexScanDesc scan);

--- a/src/include/access/spgist.h
+++ b/src/include/access/spgist.h
@@ -210,7 +210,7 @@ extern IndexScanDesc spgbeginscan(Relation rel, int keysz, int orderbysz);
 extern void spgendscan(IndexScanDesc scan);
 extern void spgrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 					  ScanKey orderbys, int norderbys);
-extern Node *spggetbitmap(IndexScanDesc scan, Node *tbm);
+extern int64 spggetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern bool spggettuple(IndexScanDesc scan, ScanDirection dir);
 extern bool spgcanreturn(Relation index, int attno);
 

--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -2365,8 +2365,8 @@ create index ab_a3_b3_a_idx on ab_a3_b3 (a);
 set enable_hashjoin = 0;
 set enable_mergejoin = 0;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(0, 0, 1)');
-                                        explain_parallel_append                                        
--------------------------------------------------------------------------------------------------------
+                                    explain_parallel_append                                     
+------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
@@ -2379,15 +2379,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
@@ -2435,8 +2435,8 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 
 insert into lprt_a values(3),(3);
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 3)');
-                                        explain_parallel_append                                        
--------------------------------------------------------------------------------------------------------
+                                    explain_parallel_append                                     
+------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=2 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
@@ -2449,27 +2449,27 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
@@ -2481,8 +2481,8 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 (41 rows)
 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
-                                        explain_parallel_append                                        
--------------------------------------------------------------------------------------------------------
+                                    explain_parallel_append                                     
+------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
@@ -2495,15 +2495,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
@@ -2610,7 +2610,7 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
          ->  Bitmap Heap Scan on ab_a3_b2 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
-               ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=1 loops=1)
+               ->  Bitmap Index Scan on ab_a3_b2_a_idx (never executed)
                      Index Cond: (a = $0)
          ->  Bitmap Heap Scan on ab_a3_b3 (never executed)
                Recheck Cond: (a = $0)
@@ -2633,7 +2633,7 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
                ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2679,7 +2679,7 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
                ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2785,7 +2785,7 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
    ->  Nested Loop (never executed)
          ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                Recheck Cond: (a = 1)
-               ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+               ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
@@ -2810,7 +2810,7 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                ->  Append (actual rows=1 loops=1)
                      ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                            Recheck Cond: (a = 1)
-                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                  Index Cond: (a = 1)
                      ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (actual rows=1 loops=1)
                            Recheck Cond: (a = 1)
@@ -2944,7 +2944,7 @@ select * from tbl1 join tprt on tbl1.col1 > tprt.col1;
                            Index Cond: (col1 < tbl1.col1)
                ->  Bitmap Heap Scan on tprt_2 (actual rows=2 loops=1)
                      Recheck Cond: (tbl1.col1 > col1)
-                     ->  Bitmap Index Scan on tprt2_idx (actual rows=1 loops=1)
+                     ->  Bitmap Index Scan on tprt2_idx (actual rows=2 loops=1)
                            Index Cond: (col1 < tbl1.col1)
                ->  Bitmap Heap Scan on tprt_3 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
@@ -3039,7 +3039,7 @@ select * from tbl1 inner join tprt on tbl1.col1 > tprt.col1;
                            Index Cond: (col1 < tbl1.col1)
                ->  Bitmap Heap Scan on tprt_2 (actual rows=2 loops=4)
                      Recheck Cond: (tbl1.col1 > col1)
-                     ->  Bitmap Index Scan on tprt2_idx (actual rows=1 loops=4)
+                     ->  Bitmap Index Scan on tprt2_idx (actual rows=2 loops=4)
                            Index Cond: (col1 < tbl1.col1)
                ->  Bitmap Heap Scan on tprt_3 (actual rows=1 loops=2)
                      Recheck Cond: (tbl1.col1 > col1)
@@ -3078,7 +3078,7 @@ select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
                            Index Cond: (col1 = tbl1.col1)
                ->  Bitmap Heap Scan on tprt_3 (actual rows=0 loops=2)
                      Recheck Cond: (col1 = tbl1.col1)
-                     ->  Bitmap Index Scan on tprt3_idx (actual rows=1 loops=2)
+                     ->  Bitmap Index Scan on tprt3_idx (actual rows=0 loops=2)
                            Index Cond: (col1 = tbl1.col1)
                ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -2396,8 +2396,8 @@ create index ab_a3_b3_a_idx on ab_a3_b3 (a);
 set enable_hashjoin = 0;
 set enable_mergejoin = 0;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(0, 0, 1)');
-                                        explain_parallel_append                                        
--------------------------------------------------------------------------------------------------------
+                                    explain_parallel_append                                     
+------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
@@ -2410,15 +2410,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
@@ -2466,8 +2466,8 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 
 insert into lprt_a values(3),(3);
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 3)');
-                                        explain_parallel_append                                        
--------------------------------------------------------------------------------------------------------
+                                    explain_parallel_append                                     
+------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=2 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
@@ -2480,27 +2480,27 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
@@ -2512,8 +2512,8 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 (41 rows)
 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
-                                        explain_parallel_append                                        
--------------------------------------------------------------------------------------------------------
+                                    explain_parallel_append                                     
+------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
@@ -2526,15 +2526,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
@@ -2641,7 +2641,7 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
          ->  Bitmap Heap Scan on ab_a3_b2 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
-               ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=1 loops=1)
+               ->  Bitmap Index Scan on ab_a3_b2_a_idx (never executed)
                      Index Cond: (a = $0)
          ->  Bitmap Heap Scan on ab_a3_b3 (never executed)
                Recheck Cond: (a = $0)
@@ -2664,7 +2664,7 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
                ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2710,7 +2710,7 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
                ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2816,7 +2816,7 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
    ->  Nested Loop (never executed)
          ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                Recheck Cond: (a = 1)
-               ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+               ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
@@ -2841,7 +2841,7 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                ->  Append (actual rows=1 loops=1)
                      ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                            Recheck Cond: (a = 1)
-                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=1 loops=1)
+                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                  Index Cond: (a = 1)
                      ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (actual rows=1 loops=1)
                            Recheck Cond: (a = 1)


### PR DESCRIPTION
GPDB has a different definition of amgetbitmap with upstream.
Since GPDB also supports StreamBitmap in bitmap index. So normally
we need to create a specific bitmap node in the amgetbitmap AM.
We used to return the created node, this leads to losing the tuples
matched in the bitmap.
So I refactor the amgetbitmap function definition to set bitmap
through pointer and then return the tuples matched in the bitmap.

For GPDB specific bitmap index, it's hard to get matched tuples
in amgetbitmap AM, so ignore it for now.

Also correct the `gp_instrument_shmem_detail` UDF which used to
return wrong results.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
