### PR TITLE
[6X backport] gprecoverseg: don't recover unreachable segments

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -106,6 +106,10 @@ class Segment:
         self.port=port
         self.datadir=datadir
 
+        # Segments are "unreachable" if their host is not reachable.
+        # See detect_unreachable_hosts.py
+        self.unreachable = False
+
         # Todo: Remove old dead code
         self.valid = (status == 'u')
 

--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -5,8 +5,8 @@ include $(top_builddir)/src/Makefile.global
 
 PROGRAMS= initstandby.py test_utils_helper.py
 
-DATA= __init__.py buildMirrorSegments.py deletesystem.py package.py \
-	rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
+DATA= __init__.py buildMirrorSegments.py deletesystem.py detect_unreachable_hosts.py \
+	package.py rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
 	unix.py update_pg_hba_conf.py utils.py
 
 installdirs:

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -1,0 +1,46 @@
+from gppylib import gplog
+from gppylib.commands.base import Command
+from gppylib.commands import base
+from gppylib.gparray import STATUS_DOWN
+
+logger = gplog.get_default_logger()
+
+
+def get_unreachable_segment_hosts(hosts_excluding_master, num_workers):
+    pool = base.WorkerPool(numWorkers=num_workers)
+    try:
+        for host in hosts_excluding_master:
+            cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
+            pool.addCommand(cmd)
+        pool.join()
+    finally:
+        pool.haltWork()
+        pool.joinWorkers()
+
+    # There's no good way to map a CommandResult back to its originating Command so instead
+    # of looping through and finding the hosts that errored out, we remove any hosts that
+    # succeeded from the hosts_excluding_master and any remaining hosts will be ones that were unreachable.
+    for item in pool.getCompletedItems():
+        result = item.get_results()
+        if result.rc == 0:
+            host = result.stdout.strip()
+            hosts_excluding_master.remove(host)
+
+    if len(hosts_excluding_master) > 0:
+        logger.warning("One or more hosts are not reachable via SSH.  Any segments on those hosts will be marked down")
+        for host in sorted(hosts_excluding_master):
+            logger.warning("Host %s is unreachable" % host)
+        return hosts_excluding_master
+    return None
+
+
+def mark_segments_down_for_unreachable_hosts(segmentPairs, unreachable_hosts):
+    # We only mark the segment down in gparray for use by later checks, as
+    # setting the actual segment down in gp_segment_configuration leads to
+    # an inconsistent state and may prevent the database from starting.
+    for segmentPair in segmentPairs:
+        for seg in [segmentPair.primaryDB, segmentPair.mirrorDB]:
+            host = seg.getSegmentHostName()
+            if host in unreachable_hosts:
+                logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
+                seg.setSegmentStatus(STATUS_DOWN)

--- a/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
@@ -13,6 +13,10 @@ def config_primaries_for_replication(gpArray, hba_hostnames):
 
     try:
         for segmentPair in gpArray.getSegmentList():
+            # We cannot update the pg_hba.conf which uses ssh for hosts that are unreachable.
+            if segmentPair.primaryDB.unreachable or segmentPair.mirrorDB.unreachable:
+                continue
+
             # Start with an empty string so that the later .join prepends a newline to the first entry
             entries = ['']
             # Add the samehost replication entry to support single-host development
@@ -55,4 +59,3 @@ def config_primaries_for_replication(gpArray, hba_hostnames):
 
     else:
         logger.info("Successfully modified pg_hba.conf on primary segments to allow replication connections")
-        

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -26,6 +26,7 @@ from gppylib.commands import gp, pg, unix
 from gppylib.commands.base import Command, WorkerPool
 from gppylib.db import dbconn
 from gppylib.gpparseopts import OptParser, OptChecker
+from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
 from gppylib.operations.startSegments import *
 from gppylib.operations.buildMirrorSegments import *
 from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
@@ -287,6 +288,10 @@ class GpRecoverSegmentProgram:
             peerForFailedSegment = peersForFailedSegments[index]
 
             peerForFailedSegmentDbId = peerForFailedSegment.getSegmentDbId()
+
+            if failedSegment.unreachable:
+                continue
+
             segs.append(GpMirrorToBuild(failedSegment, peerForFailedSegment, failoverSegments[index],
                                         self.__options.forceFullResynchronization))
 
@@ -422,6 +427,9 @@ class GpRecoverSegmentProgram:
                 failoverSegment.setSegmentAddress(newRecoverAddress)
                 port = portAssigner.findAndReservePort(newRecoverHost, newRecoverAddress)
                 failoverSegment.setSegmentPort(port)
+
+            if failedSegment.unreachable:
+                continue
 
             segs.append(GpMirrorToBuild(failedSegment, liveSegment, failoverSegment, forceFull))
 
@@ -577,6 +585,18 @@ class GpRecoverSegmentProgram:
         confProvider = configInterface.getConfigurationProvider().initializeProvider(gpEnv.getMasterPort())
 
         gpArray = confProvider.loadSystemConfig(useUtilityMode=False)
+
+        num_workers = min(len(gpArray.get_hostlist()), self.__options.parallelDegree)
+        hosts = set(gpArray.get_hostlist(includeMaster=False))
+        unreachable_hosts = get_unreachable_segment_hosts(hosts, num_workers)
+        for i, segmentPair in enumerate(gpArray.segmentPairs):
+            if segmentPair.primaryDB.getSegmentHostName() in unreachable_hosts:
+                logger.warning("Not recovering segment %d because %s is unreachable" % (segmentPair.primaryDB.dbid, segmentPair.primaryDB.getSegmentHostName()))
+                gpArray.segmentPairs[i].primaryDB.unreachable = True
+
+            if segmentPair.mirrorDB.getSegmentHostName() in unreachable_hosts:
+                logger.warning("Not recovering segment %d because %s is unreachable" % (segmentPair.mirrorDB.dbid, segmentPair.mirrorDB.getSegmentHostName()))
+                gpArray.segmentPairs[i].mirrorDB.unreachable = True
 
         if not gpArray.hasMirrors:
             raise ExceptionNoStackTraceNeeded(

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -64,6 +64,7 @@ class GpRecoversegTestCase(GpTestCase):
 
         self.gpArrayMock = MagicMock(spec=GpArray)
         self.gpArrayMock.getDbList.side_effect = [[self.primary0], [self.primary0], [self.primary0]]
+        self.gpArrayMock.segmentPairs = []
         self.gpArrayMock.hasMirrors = True
         self.gpArrayMock.isStandardArray.return_value = (True, None)
         self.gpArrayMock.master = self.gparray.master

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -31,6 +31,7 @@ try:
     from gppylib.heapchecksum import HeapChecksum
     from gppylib.commands.pg import PgControlData
     from gppylib.operations.startSegments import *
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts, mark_segments_down_for_unreachable_hosts
     from gppylib.utils import TableLogger
     from gppylib.gp_era import GpEraFile
 except ImportError, e:
@@ -114,12 +115,13 @@ class GpStart:
                 return 0
 
             num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
+            hosts = set(self.gparray.get_hostlist(includeMaster=False))
             # We check for unreachable segment hosts first thing, because if a host is down but its segments
             # are marked up, later checks can return invalid or misleading results and the cluster may not
             # start in a good state.
-            unreachable_hosts = self.get_unreachable_segment_hosts(num_workers)
+            unreachable_hosts = get_unreachable_segment_hosts(hosts, num_workers)
             if unreachable_hosts:
-                self.mark_segments_down_for_unreachable_hosts(unreachable_hosts)
+                mark_segments_down_for_unreachable_hosts(self.gparray.segmentPairs, unreachable_hosts)
 
             if self.skip_heap_checksum_validation:
                 self.master_checksum_value = None
@@ -295,46 +297,6 @@ class GpStart:
         cmd.run(validateAfter=True)
         logger.info("Master Stopped...")
         raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as master.")
-
-    def get_unreachable_segment_hosts(self, num_workers):
-        hostlist = set(self.gparray.get_hostlist(includeMaster=False))
-
-        pool = base.WorkerPool(numWorkers=num_workers)
-        try:
-            for host in hostlist:
-                cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
-                pool.addCommand(cmd)
-            pool.join()
-        finally:
-            pool.haltWork()
-            pool.joinWorkers()
-
-        # There's no good way to map a CommandResult back to its originating Command so instead
-        # of looping through and finding the hosts that errored out, we remove any hosts that
-        # succeeded from the hostlist and any remaining hosts will be ones that were unreachable.
-        for item in pool.getCompletedItems():
-            result = item.get_results()
-            if result.rc == 0:
-                host = result.stdout.strip()
-                hostlist.remove(host)
-
-        if len(hostlist) > 0:
-            logger.warning("One or more hosts are not reachable via SSH.  Any segments on those hosts will be marked down")
-            for host in sorted(hostlist):
-                logger.warning("Host %s is unreachable" % host)
-            return hostlist
-        return None
-
-    def mark_segments_down_for_unreachable_hosts(self, unreachable_hosts):
-        # We only mark the segment down in gparray for use by later checks, as
-        # setting the actual segment down in gp_segment_configuration leads to
-        # an inconsistent state and may prevent the database from starting.
-        for segmentPair in self.gparray.segmentPairs:
-            for seg in [segmentPair.primaryDB, segmentPair.mirrorDB]:
-                host = seg.getSegmentHostName()
-                if host in unreachable_hosts:
-                    logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
-                    seg.setSegmentStatus(STATUS_DOWN)
 
     ######
     def _recovery_startup(self):

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -150,6 +150,38 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And pg_isready reports all primaries are accepting connections
 
+    @demo_cluster
+    @concourse_cluster
+    Scenario Outline: <scenario> recovery skips unreachable segments
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+
+      And the primary on content 0 is stopped
+      And user can start transactions
+      And the primary on content 1 is stopped
+      And user can start transactions
+      And the status of the primary on content 0 should be "d"
+      And the status of the primary on content 1 should be "d"
+
+      And the host for the primary on content 1 is made unreachable
+
+      And the user runs psql with "-c 'CREATE TABLE IF NOT EXISTS foo (i int)'" against database "postgres"
+      And the user runs psql with "-c 'INSERT INTO foo SELECT generate_series(1, 10000)'" against database "postgres"
+
+      When the user runs "gprecoverseg <args>"
+      Then gprecoverseg should print "Not recovering segment \d because invalid_host is unreachable" to stdout
+      And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "postgres"
+      And the status of the primary on content 0 should be "u"
+      And the status of the primary on content 1 should be "d"
+
+      And the user runs psql with "-c 'DROP TABLE foo'" against database "postgres"
+      And the cluster is returned to a good state
+
+      Examples:
+        | scenario    | args |
+        | incremental | -a   |
+        | full        | -aF  |
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -140,6 +140,7 @@ def set_guc_value(context, guc, value):
 # this can be done to have the test run faster...
 # gpconfig -c gp_fts_mark_mirror_down_grace_period -v 5
 # postgres=# show gp_fts_mark_mirror_down_grace_period;
+@given('the status of the {seg_type} on content {content} should be "{expected_status}"')
 @then('the status of the {seg_type} on content {content} should be "{expected_status}"')
 def impl(context, seg_type, content, expected_status):
     if seg_type == "primary":

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -153,6 +153,7 @@ def impl(context, num_primaries):
 
 
 @given('the user runs psql with "{psql_cmd}" against database "{dbname}"')
+@then('the user runs psql with "{psql_cmd}" against database "{dbname}"')
 def impl(context, dbname, psql_cmd):
     cmd = "psql -d %s %s" % (dbname, psql_cmd)
 
@@ -894,14 +895,28 @@ def _process_exists(pid, host):
 @given('user stops all {segment_type} processes')
 @when('user stops all {segment_type} processes')
 @then('user stops all {segment_type} processes')
-def stop_segments(context, segment_type):
+def stop_all_primary_or_mirror_segments(context, segment_type):
     if segment_type not in ("primary", "mirror"):
         raise Exception("Expected segment_type to be 'primary' or 'mirror', but found '%s'." % segment_type)
 
-    gparray = GpArray.initFromCatalog(dbconn.DbURL())
     role = ROLE_PRIMARY if segment_type == 'primary' else ROLE_MIRROR
+    stop_segments(context, lambda seg: seg.getSegmentRole() == role and seg.content != -1)
 
-    segments = filter(lambda seg: seg.getSegmentRole() == role and seg.content != -1, gparray.getDbList())
+
+@given('the {role} on content {contentID} is stopped')
+def stop_segments_on_contentID(context, role, contentID):
+    if role not in ("primary", "mirror"):
+        raise Exception("Expected segment_type to be 'primary' or 'mirror', but found '%s'." % role)
+
+    role = ROLE_PRIMARY if role == 'primary' else ROLE_MIRROR
+    stop_segments(context, lambda seg: seg.getSegmentRole() == role and seg.content == int(contentID))
+
+
+# where_clause is a lambda that takes a segment to select what segments to stop
+def stop_segments(context, where_clause):
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+
+    segments = filter(where_clause, gparray.getDbList())
     for seg in segments:
         # For demo_cluster tests that run on the CI gives the error 'bash: pg_ctl: command not found'
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.


### PR DESCRIPTION
A clean 6X backport of https://github.com/greenplum-db/gpdb/pull/11395 

Add a check to gprecoverseg to skip attempting recovery of segments that are down and whose hosts are unreachable.

Also extract previous unreachable host logic from gpstart to avoid redundancy.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_gprecoverseg_down_host)