### PR TITLE
gpinitsystem: fix setting DEFAULT_LOCALE_SETTING

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1151,7 +1151,7 @@ case $OS_TYPE in
 		PG_METHOD="ident"
 		HOST_ARCH_TYPE="uname -i"
 		NOLINE_ECHO="$ECHO -e"
-		DEFAULT_LOCALE_SETTING=`locale -a | grep -i en_US.utf*8 | head -1`
+		DEFAULT_LOCALE_SETTING=`locale -a | grep -i en_US.utf.*8 | head -1`
 		PING6=`findCmdInPath ping6`
 		PING_TIME="-c 1"
 		;;


### PR DESCRIPTION
Original PR https://github.com/greenplum-db/gpdb/pull/11397
6X PR: https://github.com/greenplum-db/gpdb/pull/11398

On linux also match locales with a dash such as en_US.UTF-8.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/7X_gpinitsystem_default_locale_fixup)