### PR TITLE
Remove the FIXME label for AOCS specific AM.

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -435,10 +435,8 @@ aoco_beginscan_extractcolumns(Relation rel, Snapshot snapshot,
 	found |= extractcolumns_from_node((Node *)qual, cols, natts);
 
 	/*
-	 * GPDB_12_MERGE_FIXME: is this still true? varattno == 0 is checked inside
-	 * extractcolumns_from_node.
-	 *
-	 * In some cases (for example, count(*)), no columns are specified.
+	 * In some cases (for example, count(*)), targetlist and qual may be null,
+	 * extractcolumns_walker will return immediately, so no columns are specified.
 	 * We always scan the first column.
 	 */
 	if (!found)
@@ -1840,7 +1838,7 @@ static const TableAmRoutine ao_column_methods = {
 	.slot_callbacks = aoco_slot_callbacks,
 
 	/*
-	 * GPDB_12_MERGE_FIXME: it is needed to extract the column information for
+	 * GPDB: it is needed to extract the column information for
 	 * scans before calling beginscan. This can not happen in beginscan because
 	 * the needed information is not available at that time. It is the caller's
 	 * responsibility to choose to call aoco_beginscan_extractcolumns or
@@ -1849,7 +1847,7 @@ static const TableAmRoutine ao_column_methods = {
 	.scan_begin_extractcolumns = aoco_beginscan_extractcolumns,
 
 	/*
-	 * GPDB_12_MERGE_FIXME: Like above but for bitmap scans.
+	 * GPDB: Like above but for bitmap scans.
 	 */
 	.scan_begin_extractcolumns_bm = aoco_beginscan_extractcolumns_bm,
 

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -869,11 +869,9 @@ ExecInitBitmapHeapScan(BitmapHeapScan *node, EState *estate, int eflags)
 	scanstate->ss.ss_currentRelation = currentRelation;
 
 	/*
-	 * GPDB_12_MERGE_FIXME: for AOCO relations, it is needed to extract the
-	 * columns.
-	 *
-	 * This call is equivalent to upstream's table_beginscan_bm() in all other
-	 * cases
+	 * GPDB: This call is equivalent to upstream's table_beginscan_bm() in
+	 * all other cases. We call it here in order to also initialize the
+	 * scan state with the column info needed for AOCO relations.
 	 */
 	scanstate->ss.ss_currentScanDesc = table_beginscan_bm_ecs(currentRelation,
 															  estate->es_snapshot,

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -205,7 +205,8 @@ typedef struct TableAmRoutine
 								 uint32 flags);
 
 	/*
-	 * GPDB_12_MERGE_FIXME: Extract columns for scan from targetlist and quals.
+	 * GPDB: Extract columns for scan from targetlist and quals. This is mainly
+	 * for AOCS tables.
 	 */
 	TableScanDesc	(*scan_begin_extractcolumns) (Relation rel,
 												  Snapshot snapshot,
@@ -214,8 +215,9 @@ typedef struct TableAmRoutine
 												  uint32 flags);
 
 	/*
-	 * GPDB_12_MERGE_FIXME: Extract columns for scan from targetlist and quals,
-	 * stored in key as struct ScanKeyData.
+	 * GPDB: Extract columns for scan from targetlist and quals,
+	 * stored in key as struct ScanKeyData. This is mainly
+	 * for AOCS tables.
 	 */
 	TableScanDesc (*scan_begin_extractcolumns_bm) (Relation rel, Snapshot snapshot,
 												   List *targetList, List *quals,
@@ -762,9 +764,9 @@ table_beginscan(Relation rel, Snapshot snapshot,
 }
 
 /*
- * GPDB_12_MERGE_FIXME: Like table_beginscan(), but first attempt to create a
+ * GPDB: Like table_beginscan(), but first attempt to create a
  * scan key array from the targetList and the quals if the corresponding method
- * is implemented.
+ * is implemented. This is an optimization needed for AOCO relations.
  * Otherwise, it is equivalent as passing the last two arguments as, 0, NULL.
  */
 static inline TableScanDesc
@@ -829,7 +831,7 @@ table_beginscan_bm(Relation rel, Snapshot snapshot,
 }
 
 /*
- * GPDB_12_MERGE_FIXME: Like table_beginscan_bm but with extended information in
+ * GPDB: Like table_beginscan_bm but with extended information in
  * order to extract columns and set up all the needed state for AOCO relations.
  * In case that the access method does not implement the extract function, this
  * defaults to table_beginscan_bm with nkeys and key set to 0 and NULL


### PR DESCRIPTION
These AOCS specific AMs extract column information from targetList
and the quals that used in the scan. This is an optimization for AOCO
relations to avoid fetch extra columns.
Just remove the FIXMEs.

Also, remove a fixme in aoco_beginscan_extractcolumns. If the query
is `count(*)`, targetlist and qual are null. So no columns are specified.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
