### PR TITLE
pg_upgrade: use correct utility mode guc

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -275,9 +275,9 @@ issue_warnings_and_set_wal_level(char *sequence_script_file_name)
 		if (sequence_script_file_name)
 		{
 			prep_status("Adjusting sequences");
-			exec_prog(UTILITY_LOG_FILE, NULL, true,
-					  PG_OPTIONS_UTILITY_MODE
-					  "\"%s/psql\" " EXEC_PSQL_ARGS " %s -f \"%s\"",
+			exec_prog(UTILITY_LOG_FILE, NULL, true, true,
+					  "%s \"%s/psql\" " EXEC_PSQL_ARGS " %s -f \"%s\"",
+					  PG_OPTIONS_UTILITY_MODE_VERSION(new_cluster.major_version),
 					  new_cluster.bindir, cluster_conn_opts(&new_cluster),
 					  sequence_script_file_name);
 			unlink(sequence_script_file_name);

--- a/src/bin/pg_upgrade/dump.c
+++ b/src/bin/pg_upgrade/dump.c
@@ -24,9 +24,9 @@ generate_old_dump(void)
 
 	/* run new pg_dumpall binary for globals */
 	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
-			  PG_OPTIONS_UTILITY_MODE
-			  "\"%s/pg_dumpall\" %s --globals-only --quote-all-identifiers "
+			  "%s \"%s/pg_dumpall\" %s --globals-only --quote-all-identifiers "
 			  "--binary-upgrade %s -f %s",
+			  PG_OPTIONS_UTILITY_MODE_VERSION(old_cluster.major_version),
 			  new_cluster.bindir, cluster_conn_opts(&old_cluster),
 			  log_opts.verbose ? "--verbose" : "",
 			  GLOBALS_DUMP_FILE);
@@ -55,9 +55,9 @@ generate_old_dump(void)
 		snprintf(log_file_name, sizeof(log_file_name), DB_DUMP_LOG_FILE_MASK, old_db->db_oid);
 
 		parallel_exec_prog(log_file_name, NULL,
-						   PG_OPTIONS_UTILITY_MODE
-						   "\"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
+						   "%s \"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
 						   "--binary-upgrade --format=custom %s --file=\"%s\" %s",
+						   PG_OPTIONS_UTILITY_MODE_VERSION(old_cluster.major_version),
 						   new_cluster.bindir, cluster_conn_opts(&old_cluster),
 						   log_opts.verbose ? "--verbose" : "",
 						   sql_file_name, escaped_connstr.data);

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -11,8 +11,10 @@
 #include "pg_upgrade.h"
 
 
-#define PG_OPTIONS_UTILITY_MODE " PGOPTIONS='-c gp_role=utility' "
-
+#define PG_OPTIONS_UTILITY_MODE_VERSION(major_version) \
+	( (GET_MAJOR_VERSION(major_version)) < 1200 ?      \
+		" PGOPTIONS='-c gp_session_role=utility' " :   \
+		" PGOPTIONS='-c gp_role=utility' ")
 
 /*
  * Enumeration for operations in the progress report

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -441,8 +441,8 @@ prepare_new_cluster(void)
 	{
 		prep_status("Analyzing all rows in the new cluster");
 		exec_prog(UTILITY_LOG_FILE, NULL, true, true,
-				  PG_OPTIONS_UTILITY_MODE
-				  "\"%s/vacuumdb\" %s --all --analyze %s",
+				  "%s \"%s/vacuumdb\" %s --all --analyze %s",
+				  PG_OPTIONS_UTILITY_MODE_VERSION(new_cluster.major_version),
 				  new_cluster.bindir, cluster_conn_opts(&new_cluster),
 				  log_opts.verbose ? "--verbose" : "");
 		check_ok();
@@ -457,8 +457,8 @@ prepare_new_cluster(void)
 	 */
 	prep_status("Freezing all rows in the new cluster");
 	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
-			  PG_OPTIONS_UTILITY_MODE
-			  "\"%s/vacuumdb\" %s --all --freeze %s",
+			  "%s \"%s/vacuumdb\" %s --all --freeze %s",
+			  PG_OPTIONS_UTILITY_MODE_VERSION(new_cluster.major_version),
 			  new_cluster.bindir, cluster_conn_opts(&new_cluster),
 			  log_opts.verbose ? "--verbose" : "");
 	check_ok();
@@ -479,8 +479,8 @@ prepare_new_globals(void)
 	prep_status("Restoring global objects in the new cluster");
 
 	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
-			  PG_OPTIONS_UTILITY_MODE
-			  "\"%s/psql\" " EXEC_PSQL_ARGS " %s -f \"%s\"",
+			  "%s \"%s/psql\" " EXEC_PSQL_ARGS " %s -f \"%s\"",
+			  PG_OPTIONS_UTILITY_MODE_VERSION(new_cluster.major_version),
 			  new_cluster.bindir, cluster_conn_opts(&new_cluster),
 			  GLOBALS_DUMP_FILE);
 	check_ok();
@@ -564,10 +564,10 @@ create_new_objects(void)
 
 		parallel_exec_prog(log_file_name,
 						   NULL,
-		 				   PG_OPTIONS_UTILITY_MODE
-						   "\"%s/pg_restore\" %s %s --exit-on-error --verbose "
+						   "%s \"%s/pg_restore\" %s %s --exit-on-error --verbose "
 						   "--binary-upgrade "
 						   "--dbname template1 \"%s\"",
+						   PG_OPTIONS_UTILITY_MODE_VERSION(new_cluster.major_version),
 						   new_cluster.bindir,
 						   cluster_conn_opts(&new_cluster),
 						   create_opts,


### PR DESCRIPTION
For pg_upgrade and pg_dump use correct GUC when connecting in utility mode. For GPDB6 use gp_role and for GPDB7 use gp_session_role. This is needed when performing GPDB6 to GPDB7 upgrades.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/pg_upgrade_connection_guc)