### PR TITLE
Rename write_to_gpfdist_timeout as gpfdist_retry_timeout

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -642,8 +642,8 @@
             <li><xref href="#writable_external_table_bufsize" type="section"
                 >writable_external_table_bufsize</xref>
             </li>
-            <li><xref href="#write_to_gpfdist_timeout" type="section"
-                >write_to_gpfdist_timeout</xref>
+            <li><xref href="#gpfdist_retry_timeout" type="section"
+                >gpfdist_retry_timeout</xref>
             </li>
             <li>
               <xref href="#xid_stop_limit"/>
@@ -9620,11 +9620,11 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       </table>
     </body>
   </topic>
-  <topic id="write_to_gpfdist_timeout">
-    <title>write_to_gpfdist_timeout</title>
+  <topic id="gpfdist_retry_timeout">
+    <title>gpfdist_retry_timeout</title>
     <body>
       <p>Controls the time (in seconds) that Greenplum Database waits before returning an error when
-        Greenplum Database is attempting to write to a <codeph><xref
+        Greenplum Database is attempting to connect or write to a <codeph><xref
             href="../../utility_guide/ref/gpfdist.xml"/></codeph> server and
           <codeph>gpfdist</codeph> does not respond. The default value is 300 (5 minutes). A value
         of 0 disables the timeout.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1212,8 +1212,8 @@
             </p><p>
               <xref href="guc-list.xml#writable_external_table_bufsize" type="section"
                 >writable_external_table_bufsize</xref></p><xref
-              href="guc-list.xml#write_to_gpfdist_timeout" type="section"
-              >write_to_gpfdist_timeout</xref><p><xref href="guc-list.xml#verify_gpfdists_cert"
+              href="guc-list.xml#gpfdist_retry_timeout" type="section"
+              >gpfdist_retry_timeout</xref><p><xref href="guc-list.xml#verify_gpfdists_cert"
                 >verify_gpfdists_cert</xref></p></stentry>
         </strow>
       </simpletable>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -299,7 +299,7 @@
             <topicref href="guc-list.xml#wal_keep_segments"/>
             <topicref href="guc-list.xml#wal_receiver_status_interval"/>
             <topicref href="guc-list.xml#writable_external_table_bufsize"/>
-            <topicref href="guc-list.xml#write_to_gpfdist_timeout"/>
+            <topicref href="guc-list.xml#gpfdist_retry_timeout"/>
             <topicref href="guc-list.xml#xid_stop_limit"/>
             <topicref href="guc-list.xml#xid_warn_limit"/>
         </topicref>

--- a/gpdb-doc/dita/utility_guide/ref/gpfdist.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpfdist.xml
@@ -214,7 +214,7 @@
         <note type="warning">Disabling SSL certificate authentication exposes a security risk by not
           validating the <codeph>gpfdists</codeph> SSL certificate. </note></p>
       <p>You can set the server configuration parameter <codeph><xref
-            href="../../ref_guide/config_params/guc-list.xml#write_to_gpfdist_timeout"/></codeph> to
+            href="../../ref_guide/config_params/guc-list.xml#gpfdist_retry_timeout"/></codeph> to
         control the time that Greenplum Database waits before returning an error when a
           <codeph>gpfdist</codeph> server does not respond while Greenplum Database is attempting to
         write data to <codeph>gpfdist</codeph>. The default is 300 seconds (5 minutes).</p>

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -29,7 +29,7 @@
 
 /* GUC */
 int readable_external_table_timeout = 0;
-int write_to_gpfdist_timeout = 300;
+int gpfdist_retry_timeout = 300;
 
 static void base16_encode(char *raw, int len, char *encoded);
 static char *get_eol_delimiter(List *params);

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -556,10 +556,10 @@ gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
 	/* retry in case server return timeout error */
 	unsigned int wait_time = 1;
 	unsigned int retry_count = 0;
-	/* retry at most 600s by default when any error happens */
+	/* retry at most 300s by default when any error happens */
 	time_t start_time = time(NULL);
 	time_t now;
-	time_t end_time = start_time + write_to_gpfdist_timeout;
+	time_t end_time = start_time + gpfdist_retry_timeout;
 
 	while (true)
 	{
@@ -573,8 +573,8 @@ gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
 		now = time(NULL);
 		if (now >= end_time)
 		{
-			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, write_to_gpfdist_timeout = %d",
-				wait_time, now - start_time, write_to_gpfdist_timeout);
+			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, gpfdist_retry_timeout = %d",
+				wait_time, now - start_time, gpfdist_retry_timeout);
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
 					 errmsg("error when connecting to gpfdist %s, quit after %d tries",
@@ -653,7 +653,7 @@ static bool easy_perform_work(URL_CURL_FILE *file)
 	 * when work load is high:
 	 *	- 'could not connect to server'
 	 *	- gpfdist return timeout (HTTP 408)
-	 * By default it will wait at least write_to_gpfdist_timeout seconds before abort.
+	 * By default it will wait at least gpfdist_retry_timeout seconds before abort.
 	 */
 	CURLcode e = curl_easy_perform(file->curl->handle);
 	if (CURLE_OK != e)
@@ -1202,8 +1202,8 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	{
 		// TIMEOUT for POST only, GET is single HTTP request,
 		// probablity take long time.
-		elog(LOG, "write_to_gpfdist_timeout = %d", write_to_gpfdist_timeout);
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)write_to_gpfdist_timeout);
+		elog(LOG, "gpfdist_retry_timeout = %d", gpfdist_retry_timeout);
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)gpfdist_retry_timeout);
 
 		/*init sequence number*/
 		file->seq_number = 1;

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -551,7 +551,7 @@ get_gpfdist_status(URL_CURL_FILE *file)
 typedef bool (*perform_func)(URL_CURL_FILE *file);
 
 static void
-gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
+gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func perform)
 {
 	/* retry in case server return timeout error */
 	unsigned int wait_time = 1;
@@ -563,7 +563,7 @@ gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func func)
 
 	while (true)
 	{
-		if (!func(file))
+		if (!perform(file))
 		{
 			return;
 		}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2805,12 +2805,12 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"write_to_gpfdist_timeout", PGC_USERSET, EXTERNAL_TABLES,
+		{"gpfdist_retry_timeout", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Timeout (in seconds) for writing data to gpfdist server."),
 			gettext_noop("Default value is 300."),
 			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
 		},
-		&write_to_gpfdist_timeout,
+		&gpfdist_retry_timeout,
 		300, 1, 7200,
 		NULL, NULL, NULL
 	},

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -518,7 +518,7 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
--- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
+-- Test GUC gpfdist_retry_timeout. gpfdist is stopped, insert will retry until timeout
 
 CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
 INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
@@ -526,7 +526,7 @@ INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
 CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
 
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
-set write_to_gpfdist_timeout = 20;
+set gpfdist_retry_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 
 DROP TABLE IF EXISTS test_guc;

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -711,12 +711,12 @@ DROP TABLE IF EXISTS table_multi_locations;
 DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- start_ignore
 -- end_ignore
--- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
+-- Test GUC gpfdist_retry_timeout. gpfdist is stopped, insert will retry until timeout
 CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
 INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
 CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
-set write_to_gpfdist_timeout = 20;
+set gpfdist_retry_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 ERROR:  error when connecting to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
 DROP TABLE IF EXISTS test_guc;

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -122,6 +122,6 @@ extern size_t url_custom_fwrite(void *ptr, size_t size, URL_FILE *file, CopyStat
 
 /* GUC */
 extern int readable_external_table_timeout;
-extern int write_to_gpfdist_timeout;
+extern int gpfdist_retry_timeout;
 
 #endif

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -571,7 +571,7 @@
 		"wal_writer_delay",
 		"wal_writer_flush_after",
 		"writable_external_table_bufsize",
-		"write_to_gpfdist_timeout",
+		"gpfdist_retry_timeout",
 		"xid_stop_limit",
 		"xid_warn_limit",
 		"xmlbinary",


### PR DESCRIPTION
The GUC controls the time that gpdb waits before returning when it
connects or writes to gpfdist. It handles retry times if getting an error from socket/network.
So write_to_gpfdist_timeout is not an exact name and need to be renamed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
