### PR TITLE
Fix initialization of GPDB-specific extra columns for system relations

### DIFF
--- a/src/backend/catalog/Catalog.pm
+++ b/src/backend/catalog/Catalog.pm
@@ -92,6 +92,9 @@ sub Catalogs
 				$bki_values = ProcessDataLine(\%catalog, $bki_values, \%coldefaults, \%extra_values);
 
 				push @{ $catalog{data} }, { oid => $2, bki_values => $bki_values };
+
+				# Clear GPDB_EXTRA_COL settings to further reinitialize their for successive DATA definitions
+				%extra_values = ();
 			}
 			elsif (/^DESCR\(\"(.*)\"\)$/)
 			{


### PR DESCRIPTION
## Problem description
The perl module [catalog/Catalog.pm](https://github.com/greenplum-db/gpdb/blob/6.13.0/src/backend/catalog/Catalog.pm) parses different header files that describe system relations and their predefined system rows and generates corresponding .bki files that are later used for system catalog initialization. Some header's entries, e.g. GPDB_COLUMN_DEFAULT, once established are used later for successive DATA definitions, but others, e.g. GPDB_EXTRA_COL, are assigned only to the next DATA entry. But [Catalog](https://github.com/greenplum-db/gpdb/blob/6.13.0/src/backend/catalog/Catalog.pm#L39-L230) function defined inside catalog/Catalog.pm accounts the second kind of entries as first ones. As a result, some `pg_proc` entries get invalid `prodataaccess` values (this attribute is extensively initialized by GPDB_EXTRA_COL definitions) after cluster initialization. For example, `bitand` function that performs regular bit conjunction is specified as modifying some data (has `prodataaccess` equaled to 'm'):
```sql
# the `bitand` function is defined as modifiable that is kind of absurd
select
    oid, proname,
    pg_get_function_arguments(oid) as "Argument data types",
    pg_get_function_result(oid) as "Result data type",
    obj_description(oid, 'pg_proc'),
    prosrc, prodataaccess
from pg_proc
where oid = 1673;
                                                                 
 oid  | proname | Argument data types | Result data type |       obj_description        | prosrc  | prodataaccess 
------+---------+---------------------+------------------+------------------------------+---------+---------------
 1673 | bitand  | bit, bit            | bit              | implementation of & operator | bit_and | m           
```
This therefore leads to some restrictions in query optimizations, e.g., ORCA inhibits LOJ->Inner Join transformation when function with incorrectly assigned `prodataaccess` value is used inside outer predicate [wrongly marking this function as null-rejecting](https://github.com/greenplum-db/gpdb/blob/6.13.0/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp#L2473-L2481).

## Affected version
Only 6X

## Patch description
The current patch clears GPDB_EXTRA_COL settings after processing of DATA assigned to it in catalog/Catalog.pm file.

Besides of this patch the full fix requires a some SQL script to repair invalid column values in already setup clusters. I see it as bulk update of `prodataaccess` and `proexeclocation` columns of `pg_proc` relation (this columns are affected by GPDB_EXTRA_COL definitions) from initially prepared csv file with correct values of those attributes. Or it could be a single update query with the list of correct attribute values inside VALUES statement. Any thoughts?

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
