### PR TITLE
Add coordinator flag to gpstop gpstart and gpconfig

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -51,13 +51,14 @@ def parseargs():
     parser.add_option('-h', '-?', '--help', action='help')
     parser.add_option('--verbose', action='store_true')
     parser.add_option('--skipvalidation', action='store_true')
-    parser.add_option('--masteronly', dest="coordinatoronly", action='store_true')
+    parser.add_option('--masteronly', '--coordinatoronly', dest="coordinatoronly", action='store_true')
     parser.add_option('--debug', action='store_true')
     parser.add_option('-c', '--change', type='string')
     parser.add_option('-r', '--remove', type='string')
     parser.add_option('-s', '--show', type='string')
     parser.add_option('-v', '--value', type='string')
     parser.add_option('-m', '--mastervalue', dest="coordinatorvalue", type='string')
+    parser.add_option('--coordinatorvalue', dest="newcoordinatorvalue", type='string')
     parser.add_option('-l', '--list', action='store_true')
     parser.add_option('-P', '--primaryvalue', type='string')
     parser.add_option('-M', '--mirrorvalue', type='string')
@@ -66,6 +67,10 @@ def parseargs():
     parser.setHelp([])
 
     (options, _) = parser.parse_args()
+
+    # --coordinatorvalue argument takes precedence over -m/--mastervalue
+    if options.newcoordinatorvalue is not None:
+        options.coordinatorvalue = options.newcoordinatorvalue
 
     options.entry = None
     validate_four_verbs(options)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -731,7 +731,7 @@ class GpStart(Command):
     def __init__(self, name, coordinatorOnly=False, restricted=False, verbose=False,ctxt=LOCAL, remoteHost=None):
         self.cmdStr="$GPHOME/bin/gpstart -a"
         if coordinatorOnly:
-            self.cmdStr += " -m"
+            self.cmdStr += " -c"
             self.propagate_env_map['GPSTART_INTERNAL_COORDINATOR_ONLY'] = 1
         if restricted:
             self.cmdStr += " -R"
@@ -749,7 +749,7 @@ class NewGpStart(Command):
     def __init__(self, name, coordinatorOnly=False, restricted=False, verbose=False,nostandby=False,ctxt=LOCAL, remoteHost=None, coordinatorDirectory=None):
         self.cmdStr="$GPHOME/bin/gpstart -a"
         if coordinatorOnly:
-            self.cmdStr += " -m"
+            self.cmdStr += " -c"
             self.propagate_env_map['GPSTART_INTERNAL_COORDINATOR_ONLY'] = 1
         if restricted:
             self.cmdStr += " -R"

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -774,7 +774,7 @@ class NewGpStop(Command):
     def __init__(self, name, coordinatorOnly=False, restart=False, fast=False, force=False, verbose=False, ctxt=LOCAL, remoteHost=None):
         self.cmdStr="$GPHOME/bin/gpstop -a"
         if coordinatorOnly:
-            self.cmdStr += " -m"
+            self.cmdStr += " -c"
         if verbose or logging_is_verbose():
             self.cmdStr += " -v"
         if fast:
@@ -795,7 +795,7 @@ class GpStop(Command):
     def __init__(self, name, coordinatorOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None, parallel=None, reload=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
         self.cmdStr="$GPHOME/bin/gpstop -a"
         if coordinatorOnly:
-            self.cmdStr += " -m"
+            self.cmdStr += " -c"
         if restart:
             self.cmdStr += " -r"
         if fast:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -100,6 +100,54 @@ class GpStart(GpTestCase):
         self.subject.logger.info.assert_any_call('Coordinator Started...')
         self.assertEqual(return_code, 0)
 
+    def test_new_option_coordinator_success_without_auto_accept(self):
+        sys.argv = ["gpstart", "-c"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+        self.assertEqual(return_code, 0)
+
+    def test_all_short_option_coordinator_success_without_auto_accept(self):
+        sys.argv = ["gpstart", "-c", "-m"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+        self.assertEqual(return_code, 0)
+
+    def test_all_options_coordinator_success_without_auto_accept(self):
+        sys.argv = ["gpstart", "-c", "-m", '--master_only', '--coordinator_only']
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+        self.assertEqual(return_code, 0)
+
     def test_option_coordinator_success_with_auto_accept(self):
         sys.argv = ["gpstart", "-m", "-a"]
         self.mock_userinput.ask_yesno.return_value = True
@@ -115,8 +163,40 @@ class GpStart(GpTestCase):
         self.subject.logger.info.assert_any_call('Coordinator Started...')
         self.assertEqual(return_code, 0)
 
+    def test_new_option_coordinator_success_with_auto_accept(self):
+        sys.argv = ["gpstart", "-c", "-a"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 0)
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+        self.assertEqual(return_code, 0)
+
     def test_output_to_stdout_and_log_for_coordinator_only_happens_before_heap_checksum(self):
         sys.argv = ["gpstart", "-m"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        self.mock_os_path_exists.side_effect = os_exists_check
+        gpstart = self.setup_gpstart()
+
+        return_code = gpstart.run()
+
+        self.assertEqual(return_code, 0)
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+
+        self.assertEqual(self.mock_gplog_log_to_file_only.call_count, 0)
+
+    def test_output_to_stdout_and_log_for_new_coordinator_only_happens_before_heap_checksum(self):
+        sys.argv = ["gpstart", "-c"]
         self.mock_userinput.ask_yesno.return_value = True
         self.subject.unix.PgPortIsActive.local.return_value = False
         self.mock_os_path_exists.side_effect = os_exists_check

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -109,8 +109,65 @@ class GpStop(GpTestCase):
         mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only shutdown', 'N')
 
     @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
+    def test_new_option_coordinator_success_without_auto_accept(self, mock_userinput):
+        sys.argv = ["gpstop", "-c"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        mock_userinput.ask_yesno.return_value = True
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        self.assertEqual(mock_userinput.ask_yesno.call_count, 1)
+        mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only shutdown', 'N')
+
+    @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
+    def test_all_option_coordinator_success_without_auto_accept(self, mock_userinput):
+        sys.argv = ["gpstop", "-c", "-m"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        mock_userinput.ask_yesno.return_value = True
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        self.assertEqual(mock_userinput.ask_yesno.call_count, 1)
+        mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only shutdown', 'N')
+
+    @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
     def test_option_coordinator_success_with_auto_accept(self, mock_userinput):
         sys.argv = ["gpstop", "-m", "-a"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        mock_userinput.ask_yesno.return_value = True
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        self.assertEqual(mock_userinput.ask_yesno.call_count, 0)
+
+    @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
+    def test_new_option_coordinator_success_with_auto_accept(self, mock_userinput):
+        sys.argv = ["gpstop", "-c", "-a"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        mock_userinput.ask_yesno.return_value = True
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        self.assertEqual(mock_userinput.ask_yesno.call_count, 0)
+
+    @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
+    def test_all_short_option_coordinator_success_with_auto_accept(self, mock_userinput):
+        sys.argv = ["gpstop", "-c", "-m", "-a"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        mock_userinput.ask_yesno.return_value = True
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+        self.assertEqual(mock_userinput.ask_yesno.call_count, 0)
+
+    @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
+    def test_all_options_coordinator_success_with_auto_accept(self, mock_userinput):
+        sys.argv = ["gpstop", "-c", "-m", "--coordinator_only", "--master_only", "-a"]
         parser = self.subject.GpStop.createParser()
         options, args = parser.parse_args()
 
@@ -340,7 +397,16 @@ class GpStop(GpTestCase):
         options, args = parser.parse_args()
 
         with self.assertRaisesRegex(ProgramArgumentValidationException, "Incompatible flags. Cannot mix '--host' "
-                                                                         "option with '-m' for coordinator-only."):
+                                                                        "option with stopping coordinator-only."):
+            self.subject.GpStop.createProgram(options, args)
+
+    def test_host_new_option_with_coordinator_option_fails(self):
+        sys.argv = ["gpstop", "--host", "sdw1", "-c"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        with self.assertRaisesRegex(ProgramArgumentValidationException, "Incompatible flags. Cannot mix '--host' "
+                                                                        "option with stopping coordinator-only."):
             self.subject.GpStop.createProgram(options, args)
 
     def test_host_option_with_restart_option_fails(self):

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -757,7 +757,7 @@ class GpStart:
         addTo.add_option('-U', '--specialMode', type='choice', choices=['maintenance'],
                          metavar='maintenance', action='store', default=None,
                          help=SUPPRESS_HELP)
-        addTo.add_option('-m', '--master_only', dest="coordinator_only", action='store_true',
+        addTo.add_option('-m', '--master_only', '-c', '--coordinator_only', dest="coordinator_only", action='store_true',
                          help='start coordinator instance only in maintenance mode')
         addTo.add_option('-y', '--no_standby', dest="start_standby", action='store_false', default=True,
                          help='do not start coordinator standby server')

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -818,7 +818,7 @@ class GpStop:
 
         addTo.add_option('-r', '--restart', action='store_true',
                          help='Restart Greenplum Database instance after successful gpstop.')
-        addTo.add_option('-m', '--master_only', dest='coordinator_only', action='store_true',
+        addTo.add_option('-m', '--master_only', '-c', '--coordinator_only', dest='coordinator_only', action='store_true',
                          help='stop coordinator instance started in maintenance mode')
         addTo.add_option('-y', dest="stop_standby", action='store_false', default=True,
                          help='Do not stop the standby coordinator process.')
@@ -847,7 +847,7 @@ class GpStop:
                 raise ProgramArgumentValidationException("Can not mix --mode options with older deprecated '-f,-i,-s'")
 
         if options.coordinator_only and options.only_this_host:
-            raise ProgramArgumentValidationException("Incompatible flags. Cannot mix '--host' option with '-m' for "
+            raise ProgramArgumentValidationException("Incompatible flags. Cannot mix '--host' option with stopping "
                                                      "coordinator-only.")
 
         if options.restart and options.only_this_host:

--- a/gpMgmt/doc/gpconfig_help
+++ b/gpMgmt/doc/gpconfig_help
@@ -7,8 +7,9 @@ a Greenplum Database system.
 SYNOPSIS
 *****************************************************
 
-gpconfig -c <param_name> -v <value> [-m <coordinator_value> | --masteronly]
-       | -r <param_name> [--masteronly]
+gpconfig -c <param_name> -v <value>
+       [-m <coordinator_value> | --masteronly | --coordinatoronly]
+       | -r <param_name> [--masteronly | --coordinatoronly]
        | -l 
    [--skipvalidation] [--verbose] [--debug]
 
@@ -28,7 +29,7 @@ a parameter, you can also specify a different value for the coordinator if
 necessary. For example, parameters such as max_connections require 
 a different setting on the coordinator than what is used for the segments. 
 If you want to set or unset a global or coordinator only parameter, use 
-the --masteronly option.
+the --masteronly or --coordinatoronly option.
 
 gpconfig can only be used to manage certain parameters. For example, 
 you cannot use it to set parameters such as port, which is required 
@@ -81,7 +82,7 @@ with the -c option. By default, this value is applied to all
 segments, their mirrors, the coordinator, and the standby coordinator.
 
 
--m | --mastervalue coordinator_value
+-m | --mastervalue | --coordinatorvalue coordinator_value
 
 The coordinator value to use for the configuration parameter you 
 specified with the -c option. If specified, this value only 
@@ -89,7 +90,7 @@ applies to the coordinator and standby coordinator. The option can only
 be used with -v. 
 
 
---masteronly
+--masteronly | --coordinatoronly
 
 When specified, gpconfig only edits the coordinator postgresql.conf file.
 
@@ -178,7 +179,7 @@ EXAMPLES
 
 Set the statement_mem setting to 120MB on the coordinator only:
 
-gpconfig -c statement_mem -v 120MB --masteronly
+gpconfig -c statement_mem -v 120MB --coordinatoronly
 
 
 Set the max_connections setting to 100 on all segments 

--- a/gpMgmt/doc/gpstart_help
+++ b/gpMgmt/doc/gpstart_help
@@ -7,8 +7,8 @@ Starts a Greenplum Database system.
 SYNOPSIS
 *****************************************************
 
-gpstart [-d <coordinator_data_directory>] [-B <parallel_processes>] 
-        [-R] [-m] [-y] [-a] [-t <timeout_seconds>] 
+gpstart [-d <coordinator_data_directory>] [-B <parallel_processes>]
+        [-R] [-m | -c] [-y] [-a] [-t <timeout_seconds>]
         [-l logfile_directory] [-v | -q]
 
 gpstart -? | -h | --help
@@ -58,7 +58,7 @@ OPTIONS
   The directory to write the log file. Defaults to ~/gpAdminLogs.
 
 
--m
+-m | -c | --master_only | --coordinator_only
 
   Optional. Starts the coordinator instance only, which may be necessary 
   for maintenance tasks. This mode only allows connections to the coordinator 

--- a/gpMgmt/doc/gpstop_help
+++ b/gpMgmt/doc/gpstop_help
@@ -11,8 +11,8 @@ gpstop [-d <coordinator_data_directory>] [-B <parallel_processes>]
        [-M smart | fast | immediate] [-t <timeout_seconds>]
        [-r] [-y] [-a] [-l <logfile_directory>] [-v | -q]
 
-gpstop -m [-d <coordinator_data_directory>] [-y] [-l <logfile_directory>]
-       [-v | -q]
+gpstop [-m | -c ] [-d <coordinator_data_directory>] [-y]
+       [-l <logfile_directory>] [-v | -q]
 
 gpstop -u [-d <coordinator_data_directory>] [-l <logfile_directory>] 
        [-v | -q]
@@ -93,7 +93,7 @@ OPTIONS
  The directory to write the log file. Defaults to ~/gpAdminLogs.
 
 
--m
+-m | -c | --master_only | --coordinator_only
 
  Optional. Shuts down a Greenplum coordinator instance that was 
  started in maintenance mode.


### PR DESCRIPTION
Add coordinator flag to gpstop gpstart and gpconfig.

Specifically:
- gpstart and gpstop
  - add `-c` and `--coordinator_only`
     - any combination of `[-m,-c,--master_only,--coordinator_only]` means what `-m` by itself means
- gpconfig
  - add `--coordinatoronly`
     -  any combination of `[-m,--masteronly,--coordinatoronly]` means what `-m` by itself means
  - add `--coordinatorvalue`
     - `[-m,--mastervalue]` is as before; only one should be specified; if both are, which is used is unspecified.
     - now , `--coordinatorvalue` has precedence; if specified, its value is used in favor of the existing `-m,--mastervalue`

We are not printing deprecation warnings; these are done at the documentation level.

We are not changing internal uses; this will be done later when we obsolete the existing flags.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-add-gpstart-coordinator-flag)
[CLI only pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-cm-bhuvnesh_add-gpstart-coordinator-flag)