### PR TITLE
Add GUC gp_eager_two_phase_agg to allow user control agg pattern.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -7727,6 +7727,16 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 	{
 		PathTarget *partially_grouped_target;
 
+		if (gp_eager_two_phase_agg)
+		{
+			ListCell *lc;
+			foreach(lc, grouped_rel->pathlist)
+			{
+				Path *path = (Path *) lfirst(lc);
+				path->total_cost += disable_cost;
+			}
+		}
+
 		if (partially_grouped_rel == NULL)
 			partially_grouped_target =
 				make_partial_grouping_target(root, grouped_rel->reltarget,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -258,6 +258,7 @@ bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte = true;
+bool		gp_eager_two_phase_agg = false;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -1742,6 +1743,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_recursive_cte,
 		true, NULL, NULL
+	},
+
+	{
+		{"gp_eager_two_phase_agg", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Eager two stage agg."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_eager_two_phase_agg,
+		false, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -622,6 +622,9 @@ extern bool 	gp_statistics_pullup_from_child_partition;
 /* Extract numdistinct from foreign key relationship */
 extern bool		gp_statistics_use_fkeys;
 
+/* Allow user to force tow stage agg */
+extern bool     gp_eager_two_phase_agg;
+
 /* Analyze tools */
 extern int gp_motion_slice_noop;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -172,6 +172,7 @@
 		"gp_dtx_recovery_interval",
 		"gp_dtx_recovery_prepared_period",
 		"gp_dynamic_partition_pruning",
+		"gp_eager_two_phase_agg",
 		"gp_enable_agg_distinct",
 		"gp_enable_agg_distinct_pruning",
 		"gp_enable_direct_dispatch",

--- a/src/test/regress/expected/gp_aggregates_costs.out
+++ b/src/test/regress/expected/gp_aggregates_costs.out
@@ -71,3 +71,43 @@ explain select avg(b) from cost_agg_t2 group by c;
 drop table cost_agg_t1;
 drop table cost_agg_t2;
 reset statement_mem;
+-- The following case is to test GUC gp_eager_two_phase_agg for planner
+-- When it is set true, planner will choose two stage agg.
+create table t_planner_force_multi_stage(a int, b int) distributed randomly;
+analyze t_planner_force_multi_stage;
+show gp_eager_two_phase_agg;
+ gp_eager_two_phase_agg 
+------------------------
+ off
+(1 row)
+
+-- the GUC gp_eager_two_phase_agg is default false, the table contains no data
+-- so one stage agg will win.
+explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: b
+               ->  Seq Scan on t_planner_force_multi_stage
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+set gp_eager_two_phase_agg = on;
+-- when forcing two stage, it should generate two stage agg plan.
+explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: b
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: b
+               ->  Seq Scan on t_planner_force_multi_stage
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+reset gp_eager_two_phase_agg;
+drop table t_planner_force_multi_stage;

--- a/src/test/regress/expected/gp_aggregates_costs_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_costs_optimizer.out
@@ -67,3 +67,47 @@ explain select avg(b) from cost_agg_t2 group by c;
 drop table cost_agg_t1;
 drop table cost_agg_t2;
 reset statement_mem;
+-- The following case is to test GUC gp_eager_two_phase_agg for planner
+-- When it is set true, planner will choose two stage agg.
+create table t_planner_force_multi_stage(a int, b int) distributed randomly;
+analyze t_planner_force_multi_stage;
+show gp_eager_two_phase_agg;
+ gp_eager_two_phase_agg 
+------------------------
+ off
+(1 row)
+
+-- the GUC gp_eager_two_phase_agg is default false, the table contains no data
+-- so one stage agg will win.
+explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: b
+         ->  Sort
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: b
+                     ->  Seq Scan on t_planner_force_multi_stage
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+set gp_eager_two_phase_agg = on;
+-- when forcing two stage, it should generate two stage agg plan.
+explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: b
+         ->  Sort
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: b
+                     ->  Seq Scan on t_planner_force_multi_stage
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+reset gp_eager_two_phase_agg;
+drop table t_planner_force_multi_stage;

--- a/src/test/regress/sql/gp_aggregates_costs.sql
+++ b/src/test/regress/sql/gp_aggregates_costs.sql
@@ -33,3 +33,17 @@ explain select avg(b) from cost_agg_t2 group by c;
 drop table cost_agg_t1;
 drop table cost_agg_t2;
 reset statement_mem;
+
+-- The following case is to test GUC gp_eager_two_phase_agg for planner
+-- When it is set true, planner will choose two stage agg.
+create table t_planner_force_multi_stage(a int, b int) distributed randomly;
+analyze t_planner_force_multi_stage;
+show gp_eager_two_phase_agg;
+-- the GUC gp_eager_two_phase_agg is default false, the table contains no data
+-- so one stage agg will win.
+explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
+set gp_eager_two_phase_agg = on;
+-- when forcing two stage, it should generate two stage agg plan.
+explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b;
+reset gp_eager_two_phase_agg;
+drop table t_planner_force_multi_stage;


### PR DESCRIPTION
Greenplum planner tries its best to build an accurate cost model
for agg paths. It will generate one-stage or multi-stage agg paths
when adding paths to grouped rel, and it chooses the best path based
on costs. The accuracy of this progress depends on the accuracy of
the previous cost model, like cardinality estimation of all previous
paths which is hard to be accurate. Thus even if the cost model of
agg paths is good, in practical scenario, planner may not choose
the best path for agg. For MPP database to handle big data, two
stage agg may reduce much data in the first stage.

This commit adds a GUC to allow user to force choosing two stage
agg. Set gp_eager_two_phase_agg to true, when we can do two stage
agg, it will add a disable_cost to all the first stage agg paths
thus let two stage agg paths win.
