### PR TITLE
6X: Delay the eager-free of external scan if it's not safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ GRTAGS
 GTAGS
 lib*dll.def
 lib*.pc
+compile_commands.json
 
 # Local excludes in root directory
 /GNUmakefile

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -344,6 +344,11 @@ external_rescan(FileScanDesc scan)
 
 	/* The first call to external_getnext will re-open the scan */
 
+	if (!scan->fs_pstate)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("The file parse state of external scan is invalid")));
+
 	/* reset some parse state variables */
 	scan->fs_pstate->fe_eof = false;
 	scan->fs_pstate->cur_lineno = 0;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2192,6 +2192,8 @@ typedef struct ExternalScanState
 	struct FileScanDescData *ess_ScanDesc;
 	bool		cdb_want_ctid;
 	ItemPointerData cdb_fake_ctid;
+	bool		delayEagerFree;		/* is it safe to free memory used by this node,
+									 * when this node has outputted its last row? */
 } ExternalScanState;
 
 /*

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -48,3 +48,6 @@ dropdb_check_shared_buffer_cache.out
 /oid_wraparound.out
 /gp_tablespace_path_too_long.out
 createdb.out
+/autovacuum-template0-segment.out
+/default_tablespace.out
+/external_table_persistent_error_log.out

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3556,3 +3556,31 @@ CREATE EXTERNAL WEB TABLE web_exec_on_master_with_err_limit_reached (c1 int) EXE
 SELECT * FROM web_exec_on_master_with_err_limit_reached;
 
 DROP EXTERNAL TABLE web_exec_on_master_with_err_limit_reached;
+
+-- Test re-scan the external tables in a subplan
+
+CREATE EXTERNAL WEB TABLE ext_subplan_t1(c1 int) EXECUTE'seq 1 5' ON MASTER FORMAT 'text';
+CREATE EXTERNAL WEB TABLE ext_subplan_t2(c1 int) EXECUTE'seq 1 10' ON MASTER FORMAT 'text';
+
+EXPLAIN SELECT
+     c1,
+     (
+         SELECT c1
+         FROM ext_subplan_t2
+         WHERE ext_subplan_t2.c1 = ext_subplan_t1.c1
+         LIMIT 1
+     )
+FROM ext_subplan_t1;
+
+SELECT
+     c1,
+     (
+         SELECT c1
+         FROM ext_subplan_t2
+         WHERE ext_subplan_t2.c1 = ext_subplan_t1.c1
+         LIMIT 1
+     )
+FROM ext_subplan_t1;
+
+DROP EXTERNAL TABLE ext_subplan_t1;
+DROP EXTERNAL TABLE ext_subplan_t2;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4874,3 +4874,45 @@ ERROR:  segment reject limit reached, aborting operation
 DETAIL:  Last error was: invalid input syntax for integer: "1 3", column c1
 CONTEXT:  External table web_exec_on_master_with_err_limit_reached, line 3 of execute:for i in `seq 1 3`; do echo 1 3;done; echo 22, column c1
 DROP EXTERNAL TABLE web_exec_on_master_with_err_limit_reached;
+-- Test re-scan the external tables in a subplan
+CREATE EXTERNAL WEB TABLE ext_subplan_t1(c1 int) EXECUTE'seq 1 5' ON MASTER FORMAT 'text';
+CREATE EXTERNAL WEB TABLE ext_subplan_t2(c1 int) EXECUTE'seq 1 10' ON MASTER FORMAT 'text';
+EXPLAIN SELECT
+     c1,
+     (
+         SELECT c1
+         FROM ext_subplan_t2
+         WHERE ext_subplan_t2.c1 = ext_subplan_t1.c1
+         LIMIT 1
+     )
+FROM ext_subplan_t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ External Scan on ext_subplan_t1  (cost=0.00..0.00 rows=1 width=4)
+   SubPlan 1
+     ->  Limit  (cost=0.00..0.00 rows=1 width=4)
+           ->  External Scan on ext_subplan_t2  (cost=0.00..0.00 rows=1 width=4)
+                 Filter: (c1 = ext_subplan_t1.c1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+SELECT
+     c1,
+     (
+         SELECT c1
+         FROM ext_subplan_t2
+         WHERE ext_subplan_t2.c1 = ext_subplan_t1.c1
+         LIMIT 1
+     )
+FROM ext_subplan_t1;
+ c1 | c1 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+(5 rows)
+
+DROP EXTERNAL TABLE ext_subplan_t1;
+DROP EXTERNAL TABLE ext_subplan_t2;

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -47,3 +47,7 @@ rpt_tpch.sql
 session_reset.sql
 dropdb_check_shared_buffer_cache.sql
 createdb.sql
+/alter_db_set_tablespace.sql
+/autovacuum-template0-segment.sql
+/default_tablespace.sql
+/external_table_persistent_error_log.sql


### PR DESCRIPTION
```
SubPlan 1
  ->  External Scan
```

A plan snippet like this would trigger SEGV because the state needed by
rescan was freeed when the external table outputted its last row.

It was introduced by the refactor below, only `ExternalNext()` has this
issue.

	commit 6195b96780312d836473b04fd08cc0345999eb9a
        Author: Heikki Linnakangas <hlinnakangas@pivotal.io>
        Date:   Mon Jan 7 12:24:23 2019 +0200

            Refactor executor Squelch and EagerFree functions.

            Merge the two concepts, squelching and eager-freeing. There is now only
            one function, ExecSquelchNode(), that you can call. It recurses to
            children, as before, but it now also performs eager-freeing of resources.
            Previously that was done as a separate call, but that was an unnecessary
            distinction, because all callers of ExecSquelchNode() also called
            ExecEagerFree()

	    ...

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
