### PR TITLE
One Surprising Trick to Massively Increase Cache Hit Rate (a.k.a Converge compiler debug flags with upstream)

### DIFF
--- a/configure
+++ b/configure
@@ -3434,7 +3434,9 @@ $as_echo "#define FAULT_INJECTOR 1" >>confdefs.h
 
 else
   enable_debug_extensions=yes
+
 $as_echo "#define FAULT_INJECTOR 1" >>confdefs.h
+
 fi
 
 

--- a/configure
+++ b/configure
@@ -7204,19 +7204,11 @@ fi
 
 # supply -g if --enable-debug
 if test "$enable_debug" = yes && test "$ac_cv_prog_cc_g" = yes; then
-  if test "$GCC" = yes; then
-    CFLAGS="$CFLAGS -g -ggdb"
-  else
-    CFLAGS="$CFLAGS -g"
-  fi
+  CFLAGS="$CFLAGS -g"
 fi
 
 if test "$enable_debug" = yes && test "$ac_cv_prog_cxx_g" = yes; then
-  if test "$GCC" = yes; then
-    CXXFLAGS="$CXXFLAGS -g3 -ggdb"
-  else
-    CXXFLAGS="$CXXFLAGS -g3"
-  fi
+  CXXFLAGS="$CXXFLAGS -g"
 fi
 
 # enable code coverage if --enable-coverage

--- a/configure.in
+++ b/configure.in
@@ -640,19 +640,11 @@ fi
 
 # supply -g if --enable-debug
 if test "$enable_debug" = yes && test "$ac_cv_prog_cc_g" = yes; then
-  if test "$GCC" = yes; then
-    CFLAGS="$CFLAGS -g -ggdb"
-  else
-    CFLAGS="$CFLAGS -g"
-  fi
+  CFLAGS="$CFLAGS -g"
 fi
 
 if test "$enable_debug" = yes && test "$ac_cv_prog_cxx_g" = yes; then
-  if test "$GCC" = yes; then
-    CXXFLAGS="$CXXFLAGS -g3 -ggdb"
-  else
-    CXXFLAGS="$CXXFLAGS -g3"
-  fi
+  CXXFLAGS="$CXXFLAGS -g"
 fi
 
 # enable code coverage if --enable-coverage

--- a/configure.in
+++ b/configure.in
@@ -229,10 +229,10 @@ AC_SUBST(enable_pxf)
 #
 # include debug extensions in gpcontrib
 #
-PGAC_ARG_BOOL (enable, debug-extensions, yes,
+PGAC_ARG_BOOL(enable, debug-extensions, yes,
               [exclude debug extensions in gpcontrib],
               [AC_DEFINE([FAULT_INJECTOR], 1,
-                         [Define to 1 to build with fault injector. (--enable-faultinjector)])])
+                         [Define to 1 to build with fault injector. (--enable-debug-extensions)])])
 AC_SUBST(enable_debug_extensions)
 
 #


### PR DESCRIPTION
## TL;DR
We converge our configure script a little more to upstream, and we'll see massive speed up on Travis CI GCC compilation due to much improved cache hit rate.

## Long version
This patchset is a combination of two commits (the second one depends on the first):

1. "Typo in configure left from #11112"
2. "Converge compiler debug flags with upstream"

See commit messages for details.

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
