### PR TITLE
Add test after ORCA banned rescans on DPE PartitionSelectors

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.114.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.115.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.114.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.115.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12487,7 +12487,7 @@ int
 main ()
 {
 
-return strncmp("3.114.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.115.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12497,7 +12497,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.114.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.115.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.114.0@gpdb/stable
+orca/v3.115.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.114.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.115.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -2514,3 +2514,71 @@ select * from (select count(*) over (order by a rows between 1 preceding and 1 f
  01-02-2010 |     1 | 1 | 1
 (1 row)
 
+reset all;
+---
+-- DPE: Ensure that a plan with a PartitionSelector in a rescannable position
+-- is never generated.
+---
+create table dpe_foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table dpe_bar(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dpe_bar values (3), (3);
+insert into dpe_foo select 1 from generate_series(1, 9);
+create table dpe_part(i int) partition by range (i) (partition dpe_part1 start (0) inclusive end (100) exclusive);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "dpe_part_1_prt_dpe_part1" for table "dpe_part"
+insert into dpe_part select generate_series(1, 81);
+analyze dpe_foo;
+analyze dpe_bar;
+analyze dpe_part;
+set optimizer_nestloop_factor=1;
+explain select 1 from dpe_bar join (select * from dpe_part join dpe_foo on i = a) t on i + a < c;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.31..7.78 rows=6 width=0)
+   ->  Nested Loop  (cost=2.31..7.78 rows=2 width=0)
+         Join Filter: (public.dpe_part.i + dpe_foo.a) < dpe_bar.c
+         ->  Hash Join  (cost=1.20..5.33 rows=3 width=8)
+               Hash Cond: public.dpe_part.i = dpe_foo.a
+               ->  Append  (cost=0.00..3.81 rows=27 width=4)
+                     ->  Result  (cost=0.00..3.81 rows=27 width=4)
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on dpe_part_1_prt_dpe_part1 dpe_part  (cost=0.00..3.81 rows=27 width=4)
+               ->  Hash  (cost=1.09..1.09 rows=3 width=4)
+                     ->  Partition Selector for dpe_part (dynamic scan id: 1)  (cost=0.00..1.09 rows=3 width=4)
+                           Filter: dpe_foo.a
+                           ->  Seq Scan on dpe_foo  (cost=0.00..1.09 rows=3 width=4)
+         ->  Materialize  (cost=1.11..1.17 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                     ->  Seq Scan on dpe_bar  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_nestloop_factor=1
+ Optimizer status: legacy query optimizer
+(18 rows)
+
+select 1 from dpe_bar join (select * from dpe_part join dpe_foo on i = a) t on i + a < c;
+ ?column?
+----------
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+(18 rows)
+

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -1941,3 +1941,68 @@ select * from (select count(*) over (order by a rows between 1 preceding and 1 f
  01-02-2010 |     1 | 1 | 1
 (1 row)
 
+reset all;
+---
+-- DPE: Ensure that a plan with a PartitionSelector in a rescannable position
+-- is never generated.
+---
+create table dpe_foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table dpe_bar(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dpe_bar values (3), (3);
+insert into dpe_foo select 1 from generate_series(1, 9);
+create table dpe_part(i int) partition by range (i) (partition dpe_part1 start (0) inclusive end (100) exclusive);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "dpe_part_1_prt_dpe_part1" for table "dpe_part"
+insert into dpe_part select generate_series(1, 81);
+analyze dpe_foo;
+analyze dpe_bar;
+analyze dpe_part;
+set optimizer_nestloop_factor=1;
+explain select 1 from dpe_bar join (select * from dpe_part join dpe_foo on i = a) t on i + a < c;
+                                                           QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1724.01 rows=3 width=4)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1724.01 rows=8 width=1)
+         ->  Nested Loop  (cost=0.00..1724.01 rows=3 width=1)
+               Join Filter: (dpe_part.i + dpe_foo.a) < dpe_bar.c
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Table Scan on dpe_bar  (cost=0.00..431.00 rows=1 width=4)
+               ->  Materialize  (cost=0.00..862.01 rows=3 width=8)
+                     ->  Hash Join  (cost=0.00..862.01 rows=3 width=8)
+                           Hash Cond: dpe_part.i = dpe_foo.a
+                           ->  Dynamic Table Scan on dpe_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=27 width=4)
+                           ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                                 ->  Partition Selector for dpe_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                       ->  Table Scan on dpe_foo  (cost=0.00..431.00 rows=3 width=4)
+ Settings:  optimizer=on; optimizer_nestloop_factor=1
+ Optimizer status: PQO version 3.114.0
+(15 rows)
+
+select 1 from dpe_bar join (select * from dpe_part join dpe_foo on i = a) t on i + a < c;
+ ?column?
+----------
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+(18 rows)
+


### PR DESCRIPTION
This adds an ICW test for the ORCA commit: 54769b3025 (https://github.com/greenplum-db/gporca/pull/612)

Bump ORCA version to 3.115