### PR TITLE
Fix GroupingFunc for Plan nodes with SINGLETON flow

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -618,8 +618,6 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 	double current_numGroups;
 	uint64 grouping = 0;
 	double numGroups = *context->p_dNumGroups; /* make a copy of the original number */
-	/* The query has a non-empty set group clause */
-	bool has_groups = (root->parse->groupClause != NIL);
 	bool need_repeat_node = false;
 	List	   *group_pathkeys;
 
@@ -769,11 +767,6 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 			}
 
 			context->aggstrategy = aggstrategy;
-
-			if (current_lefttree->flow != NULL &&
-				current_lefttree->flow->flotype == FLOW_SINGLETON &&
-				has_groups)
-				need_finalagg = false;
 
 			if (!need_finalagg && group_no == last_group_no)
 			{

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -112,32 +112,38 @@ FROM (
 SELECT *
 FROM fin
 WHERE location_id = 1;
-                       QUERY PLAN                        
----------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Subquery Scan on base
    Filter: (COALESCE(base.country_id, base.city_id) = 1)
    ->  Append
-         ->  GroupAggregate
-               Group Key: table1.city_id, (1)
-               ->  Sort
-                     Sort Key: table1.city_id
-                     ->  Subquery Scan on table1
-                           ->  Append
-                                 ->  Result
-                                 ->  Result
-                                 ->  Result
-                                 ->  Result
-         ->  GroupAggregate
-               Group Key: (1), table1_1.city_id
-               ->  Sort
-                     ->  Subquery Scan on table1_1
-                           ->  Append
-                                 ->  Result
-                                 ->  Result
-                                 ->  Result
-                                 ->  Result
+         ->  HashAggregate
+               Group Key: "rollup".city_id, "rollup".prelim_aggref_1, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"
+                     ->  GroupAggregate
+                           Group Key: table1.city_id, (1)
+                           ->  Sort
+                                 Sort Key: table1.city_id
+                                 ->  Subquery Scan on table1
+                                       ->  Append
+                                             ->  Result
+                                             ->  Result
+                                             ->  Result
+                                             ->  Result
+         ->  HashAggregate
+               Group Key: rollup_1.prelim_aggref_1, rollup_1.city_id, rollup_1."grouping", rollup_1."group_id"
+               ->  Subquery Scan on rollup_1
+                     ->  GroupAggregate
+                           Group Key: (1), table1_1.city_id
+                           ->  Sort
+                                 ->  Subquery Scan on table1_1
+                                       ->  Append
+                                             ->  Result
+                                             ->  Result
+                                             ->  Result
+                                             ->  Result
  Optimizer: Postgres query optimizer
-(23 rows)
+(29 rows)
 
 --
 -- Select constant from GROUPING SETS of multiple empty sets

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6095,33 +6095,33 @@ drop table cust_agg;
 select x,y,count(*), grouping(x), grouping(y),grouping(x,y) from generate_series(1,1) x, generate_series(1,1) y group by cube(x,y);
  x | y | count | grouping | grouping | grouping 
 ---+---+-------+----------+----------+----------
- 1 | 1 |     1 |        0 |        0 |        0
+   |   |     1 |        1 |        1 |        3
    | 1 |     1 |        1 |        0 |        2
-   |   |     1 |        1 |        0 |        2
+ 1 | 1 |     1 |        0 |        0 |        0
  1 |   |     1 |        0 |        1 |        1
 (4 rows)
 
 select x,y,count(*), grouping(x,y) from generate_series(1,1) x, generate_series(1,1) y group by grouping sets((x,y),(x),(y),());
  x | y | count | grouping 
 ---+---+-------+----------
- 1 | 1 |     1 |        0
+   |   |     1 |        3
    | 1 |     1 |        2
-   |   |     1 |        2
+ 1 | 1 |     1 |        0
  1 |   |     1 |        1
 (4 rows)
 
 select x,y,count(*), grouping(x,y) from generate_series(1,2) x, generate_series(1,2) y group by cube(x,y);
  x | y | count | grouping 
 ---+---+-------+----------
- 1 | 1 |     1 |        0
- 2 | 1 |     1 |        0
-   | 1 |     2 |        2
- 1 | 2 |     1 |        0
  2 | 2 |     1 |        0
+   |   |     4 |        3
+   | 1 |     2 |        2
+ 1 | 1 |     1 |        0
    | 2 |     2 |        2
-   |   |     4 |        2
- 1 |   |     2 |        1
+ 1 | 2 |     1 |        0
+ 2 | 1 |     1 |        0
  2 |   |     2 |        1
+ 1 |   |     2 |        1
 (9 rows)
 
 create table test_gsets (i int, n numeric);


### PR DESCRIPTION
When creating Agg/Group nodes for rollups, previously we would skip the
final Agg for Plan nodes with Flow of FLOW_SINGLETON. This works fine in
most cases but not for GroupingFunc. As a result, queries such as the
one below would have wrong results for GroupingFunc.

  create table t1(a int, b int) distributed replicated;
  insert into t1 values(1,1);

  select grouping(a, b), a, b from t1 group by grouping sets((a, b),(a));
   grouping | a | b
  ----------+---+---
          0 | 1 | 1
          0 | 1 |
  (2 rows)

As a workaround, this PR just removes that logic and creates final Agg
if needed even for Plan nodes with Flow of FLOW_SINGLETON.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
