### PR TITLE
Remove some GPDB_12_MERGE_FIXMEs and add comments in vacuum.c

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -43,7 +43,7 @@ EXECNAME = 'analyzedb'
 STATEFILE_DIR = 'db_analyze'
 logger = gplog.get_default_logger()
 WRITE_LOCK_FILE_NAME = "write_lock_semaphore"
-ANALYZE_GUCS = "set optimizer_analyze_enable_merge_of_leaf_stats=off; "
+ANALYZE_GUCS = "set optimizer_analyze_root_partition=off; "
 ANALYZE_SQL = """analyze %s"""
 ANALYZE_ROOT_SQL = """analyze rootpartition %s"""
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2726,6 +2726,22 @@ vacuum_params_to_options_list(VacuumParams *params)
 	if (optmask != 0)
 		elog(ERROR, "unrecognized vacuum option %x", optmask);
 
+	/*
+	 * GPDB_12_MERGE_FIXME:
+	 * User-invoked vacuum will never have special values for VacuumParams's
+	 * freeze_min_age, freeze_table_age, multixact_freeze_min_age,
+	 * multixact_freeze_table_age, is_wraparound and log_min_duration. So no need
+	 * to convert them back and dispatch to QEs for now.
+	 * For autovacuum, it may set these values per table. Right now, only
+	 * auto-ANALYZE is enabled which will dispatch analyze from QD, but these vaules
+	 * are not needed for analyze.
+	 * Vacuum through autovacuum is not enabled yet, and if each segment's autovacuum
+	 * launcher take care it's own vacuum process, we don't need to dispatch these
+	 * values as well.
+	 *
+	 * We should consider dispatch these values only if we do vacuum
+	 * as how we do analyze through autovacuum on coordinator.
+	 */
 	if (params->truncate == VACOPT_TERNARY_DISABLED)
 		options = lappend(options, makeDefElem("truncate", (Node *) makeInteger(0), -1));
 	else if (params->truncate == VACOPT_TERNARY_ENABLED)
@@ -2739,9 +2755,6 @@ vacuum_params_to_options_list(VacuumParams *params)
 		options = lappend(options, makeDefElem("index_cleanup", (Node *) makeInteger(1), -1));
 	else
 		elog(ERROR, "unexpected VACUUM 'index_cleanup' option '%d'", (int) params->index_cleanup);
-
-	/* GPDB_12_MERGE_FIXME: Should we do something about 'is_wraparound',
-	 * multixact_freeze ages and other options? */
 
 	return options;
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -382,7 +382,6 @@ bool		optimizer_enable_range_predicate_dpe;
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
 bool		optimizer_analyze_midlevel_partition;
-bool		optimizer_analyze_enable_merge_of_leaf_stats;
 
 /* GUCs for replicated table */
 bool		optimizer_replicated_table_insert;
@@ -2443,17 +2442,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_analyze_midlevel_partition,
 		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"optimizer_analyze_enable_merge_of_leaf_stats", PGC_USERSET, STATS_ANALYZE,
-			gettext_noop("Enable merging of leaf stats into the root stats during ANALYZE when analyzing partitions"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_analyze_enable_merge_of_leaf_stats,
-		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -567,7 +567,6 @@ extern bool optimizer_enable_range_predicate_dpe;
 /* Analyze related GUCs for Optimizer */
 extern bool optimizer_analyze_root_partition;
 extern bool optimizer_analyze_midlevel_partition;
-extern bool optimizer_analyze_enable_merge_of_leaf_stats;
 
 extern bool optimizer_use_gpdb_allocators;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -342,7 +342,6 @@
 		"old_snapshot_threshold",
 		"operator_precedence_warning",
 		"optimizer",
-		"optimizer_analyze_enable_merge_of_leaf_stats",
 		"optimizer_analyze_midlevel_partition",
 		"optimizer_analyze_root_partition",
 		"optimizer_apply_left_outer_to_union_all_disregarding_stats",


### PR DESCRIPTION
Remove these useless FIXMEs, the most of the question logic is still in
use. So add more comments on it.
For the `ANALYZE ROOTPARTITION`, I don't see why we need to discard it.
And `analyzedb` still rely on it.

Add comment to clarify the FIXME why no need to convert back some params
values before dispatch the vacuum to QEs.

Also, do some small refactor to clean code.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
