### PR TITLE
Resurrect logic for optimizer_analyze_enable_merge_of_leaf_stats

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -964,8 +964,10 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 		 * GPDB: If you explicitly ANALYZE a partition, also update the
 		 * parent's stats after the partition has been ANALYZEd. (Thanks to
 		 * the code to merge leaf statistics, it should be fast.)
+		 * If optimizer_analyze_enable_merge_of_leaf_stats is off, do not
+		 * analyze(merge) parent
 		 */
-		if (optimizer_analyze_root_partition || (options & VACOPT_ROOTONLY))
+		if (optimizer_analyze_enable_merge_of_leaf_stats && (optimizer_analyze_root_partition || (options & VACOPT_ROOTONLY)))
 		{
 			Oid			child_relid = relid;
 

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1947,3 +1947,28 @@ FROM pg_statistic WHERE starelid = 'simple_table_no_hll'::regclass;
          1 |        2 |        3 |        0 |        0 |        0 | {1,3,5,7,10} |            |            |            | 
 (1 row)
 
+-- optimizer_analyze_enable_merge_of_leaf_stats GUC works correctly
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo(a int) PARTITION BY RANGE(a) (start (0) INCLUSIVE END (20) EVERY (10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set optimizer_analyze_enable_merge_of_leaf_stats=off;
+INSERT INTO foo values (5),(15);
+ANALYZE foo_1_prt_1;
+ANALYZE foo_1_prt_2;
+-- root should not have stats
+SELECT count(*) from pg_stats where tablename='foo';
+ count 
+-------
+     0
+(1 row)
+
+reset optimizer_analyze_enable_merge_of_leaf_stats;
+-- root should have stats
+ANALYZE foo_1_prt_2;
+SELECT count(*) from pg_stats where tablename='foo';
+ count 
+-------
+     1
+(1 row)
+

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -1961,3 +1961,28 @@ FROM pg_statistic WHERE starelid = 'simple_table_no_hll'::regclass;
          1 |        2 |        3 |        0 |        0 |        0 | {1,3,5,7,10} |            |            |            | 
 (1 row)
 
+-- optimizer_analyze_enable_merge_of_leaf_stats GUC works correctly
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo(a int) PARTITION BY RANGE(a) (start (0) INCLUSIVE END (20) EVERY (10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set optimizer_analyze_enable_merge_of_leaf_stats=off;
+INSERT INTO foo values (5),(15);
+ANALYZE foo_1_prt_1;
+ANALYZE foo_1_prt_2;
+-- root should not have stats
+SELECT count(*) from pg_stats where tablename='foo';
+ count 
+-------
+     0
+(1 row)
+
+reset optimizer_analyze_enable_merge_of_leaf_stats;
+-- root should have stats
+ANALYZE foo_1_prt_2;
+SELECT count(*) from pg_stats where tablename='foo';
+ count 
+-------
+     1
+(1 row)
+

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -833,3 +833,18 @@ ANALYZE simple_table_no_hll;
 SELECT staattnum, stakind1, stakind2, stakind3, stakind4, stakind5,
        stavalues1, stavalues2, stavalues3, stavalues4, stavalues5
 FROM pg_statistic WHERE starelid = 'simple_table_no_hll'::regclass;
+
+-- optimizer_analyze_enable_merge_of_leaf_stats GUC works correctly
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo(a int) PARTITION BY RANGE(a) (start (0) INCLUSIVE END (20) EVERY (10));
+set optimizer_analyze_enable_merge_of_leaf_stats=off;
+INSERT INTO foo values (5),(15);
+ANALYZE foo_1_prt_1;
+ANALYZE foo_1_prt_2;
+-- root should not have stats
+SELECT count(*) from pg_stats where tablename='foo';
+
+reset optimizer_analyze_enable_merge_of_leaf_stats;
+-- root should have stats
+ANALYZE foo_1_prt_2;
+SELECT count(*) from pg_stats where tablename='foo';


### PR DESCRIPTION
When this GUC is set, partition child stats should not be merged to the root.

This GUC is used by analyzedb to prevent unnecessary merging of
statistics for child partitions when analyzing many tables. For example,
if a partitioned table has 100 partitions with data, each analyze will
cause root stats to be merged, a relatively expensive operation.
Analyzedb disables this GUC and makes an explicit call to `analyze
rootpartition <table>` which merges the children.