### PR TITLE
Remove assert in pgstat_combine_from_qe.

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4781,8 +4781,6 @@ pgstat_combine_from_qe(CdbDispatchResults *results, int writerSliceIndex)
 	for (dispatchResult = cdbdisp_resultBegin(results, writerSliceIndex);
 		 dispatchResult < resultEnd; ++dispatchResult)
 	{
-		Assert(dispatchResult->okindex >= 0);
-
 		pgresult = cdbdisp_getPGresult(dispatchResult, dispatchResult->okindex);
 		if (pgresult && !dispatchResult->errcode && pgresult->extraslen > 0 &&
 			pgresult->extraType == PGExtraTypeTableStats)


### PR DESCRIPTION
Remove useless assert.

If `dispatchResult->okindex` is -1 which means we don't receive any
pgresult from a QE, cdbdisp_getPGresult() will return NULL, so no
need to assert dispatchResult->okindex >= 0.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
