### PR TITLE
FTS code cleanup

### DIFF
--- a/src/backend/fts/README
+++ b/src/backend/fts/README
@@ -6,10 +6,9 @@ This document illustrates the mechanism of a GPDB component called
 Fault Tolerance Service (FTS):
 
  - This sections explains how FTS probe process is started. The FTS
-   probe process is running on the Gp_entry_postmaster (master node)
-   only. It starts as a background worker process managed by the
-   BackgroundWorker structure. (see
-   src/include/postmaster/bgworker.h).  Greenplum sets up a group of
+   probe process is running on the master node only. It starts as a
+   background worker process managed by the BackgroundWorker structure
+   (see src/include/postmaster/bgworker.h).  Greenplum sets up a group of
    GP background processes through an array structure PMAuxProcList. A
    entry in that struct represents a GP background process.
 
@@ -22,11 +21,13 @@ Fault Tolerance Service (FTS):
 
       static BackgroundWorker PMAuxProcList[MaxPMAuxProc]
 
-   In Postmaster, we will check the following condition:
+   FtsProbeStartRule() function specifies the following condition under
+   which the FTS probe process should be started by postmaster:
 
-      Gp_entry_postmaster && Gp_role == GP_ROLE_DISPATCH
+      Gp_role == GP_ROLE_DISPATCH
 
-   The FTS probe process is started when the condition is true.
+   That is, the FTS probe process should only be started on the master
+   node in normal cluster mode.
 
    In the initialization phase, we register one BackgroundWorker entry
    for each GP background process into postmaster's private structure

--- a/src/backend/fts/README
+++ b/src/backend/fts/README
@@ -6,7 +6,7 @@ This document illustrates the mechanism of a GPDB component called
 Fault Tolerance Service (FTS):
 
  - This sections explains how FTS probe process is started. The FTS
-   probe process is running on the master node only. It starts as a
+   probe process is running on the coordinator node only. It starts as a
    background worker process managed by the BackgroundWorker structure
    (see src/include/postmaster/bgworker.h).  Greenplum sets up a group of
    GP background processes through an array structure PMAuxProcList. A
@@ -26,7 +26,7 @@ Fault Tolerance Service (FTS):
 
       Gp_role == GP_ROLE_DISPATCH
 
-   That is, the FTS probe process should only be started on the master
+   That is, the FTS probe process should only be started on the coordinator
    node in normal cluster mode.
 
    In the initialization phase, we register one BackgroundWorker entry
@@ -57,13 +57,13 @@ Fault Tolerance Service (FTS):
    the polling. One is timeout on the latch it is waiting for, and the
    other one is that someone sets the latch.
 
-   Certain components running on master node may interrupt FTS from
+   Certain components running on coordinator node may interrupt FTS from
    its wait to trigger a probe immediately. This is referred to as
    notifying FTS. Dispatcher is one such component. As an example, it
    can notify FTS if it encounters an error while creating a gang. The
    reader may check FtsNotifyProber() to find more cases.
 
-3. On the master node, the FTS probe process gets the configuration
+3. On the coordinator node, the FTS probe process gets the configuration
    from catalog table gp_segment_configuration, which describes the
    status of each segment and also reflects if any of them has a
    mirror. For each unique content(or segindex) value, will see a
@@ -84,7 +84,7 @@ Fault Tolerance Service (FTS):
 
    So FTS both read and write the catalog table.
 
-4. On the master node: each round of the polling is done in a chain of
+4. On the coordinator node: each round of the polling is done in a chain of
    calls :
 
 	ftsConnect()
@@ -102,7 +102,7 @@ Fault Tolerance Service (FTS):
    accordingly.
 
 5. On the segment node: in the main loop of PostgresMain(), the
-   requests from the master FTS probe process
+   requests from the coordinator FTS probe process
    received. ProcessStartupPacket() is called first to make sure this
    dialog is for FTS requests and thus the Postgres process spawn for
    it would be a FTS handler(am_ftshandler = true).  Then it accepts

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -35,7 +35,7 @@
  * Check if we can smoothly read and write to data directory.
  *
  * O_DIRECT flag requires buffer to be OS/FS block aligned.
- * Best to have it IO Block alligned henece using BLCKSZ
+ * Best to have it IO Block aligned hence using BLCKSZ
  */
 static bool
 checkIODataDirectory(void)
@@ -46,7 +46,7 @@ checkIODataDirectory(void)
 	char *data = palloc0(size);
 
 	/*
-	 * Buffer needs to be alligned to BLOCK_SIZE for reads and writes if using O_DIRECT
+	 * Buffer needs to be aligned to BLOCK_SIZE for reads and writes if using O_DIRECT
 	 */
 	char* dataAligned = (char *) TYPEALIGN(BLCKSZ, data);
 

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -796,7 +796,7 @@ retryForFtsFailed(fts_segment_info *ftsInfo, pg_time_t now)
 }
 
 /*
- * If retry attempts are available, transition the sgement to the start state
+ * If retry attempts are available, transition the segments to the start state
  * corresponding to their failure state.  If retries have exhausted, leave the
  * segment in the failure state.
  */
@@ -942,7 +942,7 @@ updateConfiguration(CdbComponentDatabaseInfo *primary,
 }
 
 /*
- * Process resonses from primary segments:
+ * Process responses from primary segments:
  * (a) Transition internal state so that segments can be messaged subsequently
  * (e.g. promotion and turning off syncrep).
  * (b) Update gp_segment_configuration catalog table, if needed.
@@ -1140,7 +1140,7 @@ processResponse(fts_context *context)
 			case FTS_PROMOTE_SUCCESS:
 				elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
 					   "FTS mirror (content=%d, dbid=%d) promotion "
-					   "triggerred successfully",
+					   "triggered successfully",
 					   primary->config->segindex, primary->config->dbid);
 				ftsInfo->state = FTS_RESPONSE_PROCESSED;
 				break;

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -39,8 +39,6 @@ typedef struct FtsProbeInfo
 	volatile int32		done_count;
 } FtsProbeInfo;
 
-#define FTS_MAX_TRANSIENT_STATE 100
-
 typedef struct FtsControlBlock
 {
 	LWLockId		ControlLock;


### PR DESCRIPTION
Remove unused variables and macro, and fix typos in FTS code.
Reword notes in src/backend/fts/README.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
