### PR TITLE
[6X Backport] Imporve gpload merge performance

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2769,8 +2769,8 @@ class gpload:
             try:
                 self.db.query(sql.encode('utf-8'))
             except Exception as e:
-                strE = str(str(e), errors = 'ignore')
-                strF = str(str(sql), errors = 'ignore')
+                strE = unicode(str(e), errors = 'ignore')
+                strF = unicode(str(sql), errors = 'ignore')
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
 
         # insert new rows to the target table

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2753,22 +2753,38 @@ class gpload:
         self.rowsInserted = 0 # MPP-13024. No rows inserted yet (only to temp table).
         self.do_update(self.staging_table_name, 0)
 		
+        # delete the updated rows in staging table for merge
+        # so we can directly insert new rows left in staging table
+        # and avoid left outer join when insert new rows which is poor in performance
+
+        match = self.map_stuff('gpload:output:match_columns'
+                            , lambda x,y:'staging_table.%s=into_table.%s' % (x, y)
+                            , 0)
+        sql = 'DELETE FROM %s staging_table '% self.staging_table_name
+        sql += 'USING %s into_table WHERE '% self.get_qualified_tablename()
+        sql += ' %s' % ' AND '.join(match)
+
+        self.log(self.LOG, sql)
+        if not self.options.D:
+            try:
+                self.db.query(sql.encode('utf-8'))
+            except Exception as e:
+                strE = str(str(e), errors = 'ignore')
+                strF = str(str(sql), errors = 'ignore')
+                self.log(self.ERROR, strE + ' encountered while running ' + strF)
+
         # insert new rows to the target table
+
         match = self.map_stuff('gpload:output:match_columns',lambda x,y:'into_table.%s=from_table.%s'%(x,y),0)
         matchColumns = self.getconfig('gpload:output:match_columns',list)
-		
-        cols = filter(lambda a:a[2] != None, self.into_columns)				
+
+        cols = filter(lambda a:a[2] != None, self.into_columns)
         sql = 'INSERT INTO %s ' % self.get_qualified_tablename()
         sql += '(%s) ' % ','.join(map(lambda a:a[0], cols))
         sql += '(SELECT %s ' % ','.join(map(lambda a:'from_table.%s' % a[0], cols))
         sql += 'FROM (SELECT *, row_number() OVER (PARTITION BY %s) AS gpload_row_number ' % ','.join(matchColumns)
         sql += 'FROM %s) AS from_table ' % self.staging_table_name
-        sql += 'LEFT OUTER JOIN %s into_table ' % self.get_qualified_tablename()
-        sql += 'ON %s '%' AND '.join(match)
-        where = self.map_stuff('gpload:output:match_columns',lambda x,y:'(into_table.%s IS NULL OR CAST(into_table.%s AS varchar) = \'\')'%(x,x),0)
-        sql += 'WHERE %s ' % ' AND '.join(where)
-        sql += 'AND gpload_row_number=1)'
-
+        sql += 'WHERE gpload_row_number=1)'
         self.log(self.LOG, sql)
         if not self.options.D:
             try:
@@ -2778,7 +2794,6 @@ class gpload:
                 strE = unicode(str(e), errors = 'ignore')
                 strF = unicode(str(sql), errors = 'ignore')
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
-				
 
     def do_truncate(self, tblname):
         self.log(self.LOG, "Truncate table %s" %(tblname))


### PR DESCRIPTION
In merge mode, when inserting the data from the staging
table into the base table, gpload uses a left join sql
to pick up the data which doesn't exist in the base
table. This leads to poor performance when the base
table is big (more than 1 billion): greenplum will hash
the base table and that generates a lot of spill files.

To improve the performance, we decided not to use the
left join sql. Instead, we delete the rows in staging
table which have already existed in the base table so
we can directly insert new rows left in staging table
and avoid left outer join.

Co-authored-by: XiaoxiaoHe <hxiaoxiao@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
