### PR TITLE
Fix analyze rootpartition and hllscan when used in option list

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -145,9 +145,9 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel)
 		else if (strcmp(opt->defname, "skip_locked") == 0)
 			skip_locked = defGetBoolean(opt);
 		else if (strcmp(opt->defname, "rootpartition") == 0)
-			rootonly = get_vacopt_ternary_value(opt);
+			rootonly = defGetBoolean(opt);
 		else if (strcmp(opt->defname, "fullscan") == 0)
-			fullscan = get_vacopt_ternary_value(opt);
+			fullscan = defGetBoolean(opt);
 		else if (!vacstmt->is_vacuumcmd)
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1947,3 +1947,47 @@ FROM pg_statistic WHERE starelid = 'simple_table_no_hll'::regclass;
          1 |        2 |        3 |        0 |        0 |        0 | {1,3,5,7,10} |            |            |            | 
 (1 row)
 
+-- Make sure analyze rootpartition option works in an option list
+set optimizer_analyze_root_partition to off;
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo(a int) PARTITION BY RANGE(a) (start (0) INCLUSIVE END (20) EVERY (10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO foo values (5),(15);
+ANALYZE (verbose, rootpartition off) foo;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229792, 400, 'f');
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229789, 400, 'f');
+-- root should not have stats
+SELECT count(*) from pg_statistic where starelid='foo'::regclass;
+ count 
+-------
+     0
+(1 row)
+
+-- root should have stats
+ANALYZE (verbose, rootpartition on) foo;
+INFO:  analyzing "public.foo" inheritance tree
+SELECT count(*) from pg_statistic where starelid='foo'::regclass;
+ count 
+-------
+     1
+(1 row)
+
+-- Make sure analyze hll fullscan option works in an option list
+ANALYZE (verbose, fullscan on) foo;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_hyperloglog_accum(a) from public.foo_1_prt_2 as Ta
+INFO:  HLL FULL SCAN
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229792, 400, 'f');
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_hyperloglog_accum(a) from public.foo_1_prt_1 as Ta
+INFO:  HLL FULL SCAN
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229789, 400, 'f');
+ANALYZE (verbose, fullscan off) foo;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229792, 400, 'f');
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229789, 400, 'f');
+reset optimizer_analyze_root_partition;

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -1961,3 +1961,47 @@ FROM pg_statistic WHERE starelid = 'simple_table_no_hll'::regclass;
          1 |        2 |        3 |        0 |        0 |        0 | {1,3,5,7,10} |            |            |            | 
 (1 row)
 
+-- Make sure analyze rootpartition option works in an option list
+set optimizer_analyze_root_partition to off;
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo(a int) PARTITION BY RANGE(a) (start (0) INCLUSIVE END (20) EVERY (10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO foo values (5),(15);
+ANALYZE (verbose, rootpartition off) foo;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230132, 400, 'f');
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230129, 400, 'f');
+-- root should not have stats
+SELECT count(*) from pg_statistic where starelid='foo'::regclass;
+ count 
+-------
+     0
+(1 row)
+
+-- root should have stats
+ANALYZE (verbose, rootpartition on) foo;
+INFO:  analyzing "public.foo" inheritance tree
+SELECT count(*) from pg_statistic where starelid='foo'::regclass;
+ count 
+-------
+     1
+(1 row)
+
+-- Make sure analyze hll fullscan option works in an option list
+ANALYZE (verbose, fullscan on) foo;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_hyperloglog_accum(a) from public.foo_1_prt_2 as Ta
+INFO:  HLL FULL SCAN
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230132, 400, 'f');
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_hyperloglog_accum(a) from public.foo_1_prt_1 as Ta
+INFO:  HLL FULL SCAN
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230129, 400, 'f');
+ANALYZE (verbose, fullscan off) foo;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230132, 400, 'f');
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230129, 400, 'f');
+reset optimizer_analyze_root_partition;


### PR DESCRIPTION
When using `analyze (rootpartition off) <tbl>` or `analyze (hllscan off) <tbl>`,
we didn't properly parse the option value. `rootpartition off` would
have the same effect as `rootpartition on`.

Thanks @d  for finding this