### PR TITLE
Change the default for optimizer_damping_factor_join to 0

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/3WayJoinOnMultiDistributionColumnsTablesNoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/3WayJoinOnMultiDistributionColumnsTablesNoMotion.mdp
@@ -34,7 +34,7 @@ t1.a = t2.a and t2.a = t3.a and t1.b = t3.b and t2.b = t3.b;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
@@ -42,7 +42,7 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
@@ -4649,10 +4649,10 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="102441">
+    <dxl:Plan Id="0" SpaceSize="104185">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1725.860514" Rows="3.473875" Width="44"/>
+          <dxl:Cost StartupCost="0" TotalCost="1725.989618" Rows="129.961520" Width="44"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cs_item_sk">
@@ -4693,7 +4693,7 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1725.859944" Rows="3.473875" Width="44"/>
+            <dxl:Cost StartupCost="0" TotalCost="1725.968308" Rows="129.961520" Width="44"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cs_item_sk">
@@ -4734,13 +4734,17 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
           <dxl:JoinFilter/>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="29" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="20" ColName="sr_ticket_number" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="30" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:TableScan>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.100100" Rows="13000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1294.899130" Rows="129.961520" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cs_item_sk">
@@ -4752,28 +4756,6 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
               <dxl:ProjElem ColId="2" Alias="b">
                 <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.81920.1.0" TableName="cs">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="cs_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="1" Attno="2" ColName="cs_order_number" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="2" Attno="3" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.875914" Rows="8.097602" Width="32"/>
-            </dxl:Properties>
-            <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="i_item_sk">
                 <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
@@ -4789,23 +4771,31 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
               <dxl:ProjElem ColId="21" Alias="b">
                 <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="29" Alias="ss_item_sk">
-                <dxl:Ident ColId="29" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="30" Alias="ss_ticket_number">
-                <dxl:Ident ColId="30" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="31" Alias="b">
-                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="20" ColName="sr_ticket_number" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.874368" Rows="2.699201" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="1294.894791" Rows="129.961520" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="cs_item_sk">
+                  <dxl:Ident ColId="0" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="cs_order_number">
+                  <dxl:Ident ColId="1" ColName="cs_order_number" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="b">
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="i_item_sk">
                   <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
@@ -4821,62 +4811,49 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
                 <dxl:ProjElem ColId="21" Alias="b">
                   <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="29" Alias="ss_item_sk">
-                  <dxl:Ident ColId="29" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="30" Alias="ss_ticket_number">
-                  <dxl:Ident ColId="30" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="31" Alias="b">
-                  <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:JoinFilter/>
               <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="29" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="0" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="30" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="20" ColName="sr_ticket_number" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.002079" Rows="270.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.100100" Rows="13000.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="29" Alias="ss_item_sk">
-                    <dxl:Ident ColId="29" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="0" Alias="cs_item_sk">
+                    <dxl:Ident ColId="0" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="30" Alias="ss_ticket_number">
-                    <dxl:Ident ColId="30" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="1" Alias="cs_order_number">
+                    <dxl:Ident ColId="1" ColName="cs_order_number" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="31" Alias="b">
-                    <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="2" Alias="b">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.81923.1.0" TableName="ss">
+                <dxl:TableDescriptor Mdid="0.81920.1.0" TableName="cs">
                   <dxl:Columns>
-                    <dxl:Column ColId="29" Attno="1" ColName="ss_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="30" Attno="2" ColName="ss_ticket_number" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="31" Attno="3" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="35" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="36" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="0" Attno="1" ColName="cs_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="cs_order_number" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-              <dxl:HashJoin JoinType="Inner">
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.816224" Rows="100.980101" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.852375" Rows="302.940303" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="i_item_sk">
@@ -4896,18 +4873,18 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="19" ColName="sr_item_sk" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:TableScan>
+                <dxl:SortingColumnList/>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.078540" Rows="10200.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.816224" Rows="100.980101" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="i_item_sk">
+                      <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="b">
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="19" Alias="sr_item_sk">
                       <dxl:Ident ColId="19" ColName="sr_item_sk" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
@@ -4919,38 +4896,47 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.81929.1.0" TableName="sr">
-                    <dxl:Columns>
-                      <dxl:Column ColId="19" Attno="1" ColName="sr_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="20" Attno="2" ColName="sr_ticket_number" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="21" Attno="3" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.015513" Rows="300.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="i_item_sk">
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="19" ColName="sr_item_sk" TypeMdid="0.23.1.0"/>
                       <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="11" Alias="b">
-                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.078540" Rows="10200.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="sr_item_sk">
+                        <dxl:Ident ColId="19" ColName="sr_item_sk" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="sr_ticket_number">
+                        <dxl:Ident ColId="20" ColName="sr_ticket_number" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="b">
+                        <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.81929.1.0" TableName="sr">
+                      <dxl:Columns>
+                        <dxl:Column ColId="19" Attno="1" ColName="sr_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="20" Attno="2" ColName="sr_ticket_number" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="21" Attno="3" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.015513" Rows="300.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="i_item_sk">
@@ -4961,24 +4947,70 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.81926.1.0" TableName="it">
-                      <dxl:Columns>
-                        <dxl:Column ColId="10" Attno="1" ColName="i_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:BroadcastMotion>
-              </dxl:HashJoin>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="10" Alias="i_item_sk">
+                          <dxl:Ident ColId="10" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="b">
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.81926.1.0" TableName="it">
+                        <dxl:Columns>
+                          <dxl:Column ColId="10" Attno="1" ColName="i_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:BroadcastMotion>
+                </dxl:HashJoin>
+              </dxl:BroadcastMotion>
             </dxl:HashJoin>
-          </dxl:BroadcastMotion>
+          </dxl:RedistributeMotion>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.002079" Rows="270.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="29" Alias="ss_item_sk">
+                <dxl:Ident ColId="29" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="30" Alias="ss_ticket_number">
+                <dxl:Ident ColId="30" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="b">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.81923.1.0" TableName="ss">
+              <dxl:Columns>
+                <dxl:Column ColId="29" Attno="1" ColName="ss_item_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="30" Attno="2" ColName="ss_ticket_number" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="31" Attno="3" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="35" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-1.mdp
@@ -34,7 +34,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-3.mdp
@@ -42,7 +42,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/Agg-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Agg-Limit.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/AggWithSubqArgs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AggWithSubqArgs.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/AggregateWithSkew.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AggregateWithSkew.mdp
@@ -39,7 +39,7 @@ group by b;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
@@ -8,7 +8,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
@@ -8,7 +8,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/AnySubqueryWithVolatileFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubqueryWithVolatileFunc.mdp
@@ -55,7 +55,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmpAllEmpty.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmpAllEmpty.mdp
@@ -17,7 +17,7 @@ explain  select 1 from foo where foo.a = all('{}');
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmpAnyEmptyLessThan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmpAnyEmptyLessThan.mdp
@@ -17,7 +17,7 @@ explain  select 1 from foo where foo.a < any('{}');
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ArrayCoerceExpr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCoerceExpr.mdp
@@ -7,7 +7,7 @@ explain select * from foo where d in ('a', 'b');
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ArrayRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayRef.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/AvoidConstraintDerivationForLike.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AvoidConstraintDerivationForLike.mdp
@@ -7,7 +7,7 @@ select * from like_error where some_text LIKE ANY (ARRAY['%text1%']);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
@@ -4,7 +4,7 @@
     <dxl:Stacktrace/>
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102004,102024,102025,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
@@ -17,7 +17,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
@@ -8,7 +8,7 @@ SELECT * FROM bitmap_test WHERE a in (1, 47);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
@@ -9,7 +9,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
@@ -13,7 +13,7 @@ select * from x, y where x.i > y.j and y.k = 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -47,7 +47,7 @@ ORDER BY 1 asc ;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102027,102029,102115,102116,102117,102119,102144,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -45,7 +45,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -18,7 +18,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
@@ -22,7 +22,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
@@ -24,7 +24,7 @@ undefined for Bitmap Index Scan. ORCA should find a plan transforming
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
@@ -18,7 +18,7 @@ explain select * from indexonao where a = 21;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
@@ -13,7 +13,7 @@ explain select * from xfoo where j = 1 and k = 2;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ComplexConjDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ComplexConjDisj.mdp
@@ -38,7 +38,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Blocking-Spool-Parallel-Union-All.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Blocking-Spool-Parallel-Union-All.mdp
@@ -20,7 +20,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/BroadcastSkewedHashjoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BroadcastSkewedHashjoin.mdp
@@ -30,7 +30,7 @@ Intent: The join should pick up a Broadcast over Redistribute. The hashjoin is s
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="100">

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
@@ -46,7 +46,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -17,7 +17,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
@@ -12,7 +12,7 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CTE-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-1.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101000,101001,101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-11.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-11.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-6.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-6.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-8.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-8.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-PartTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-PartTbl.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101001,101013,102001,102002,102003,102144,103001,103002,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-with-random-filter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-with-random-filter.mdp
@@ -7,7 +7,7 @@ explain with t as (select * from foo) select count(*) from t where random() < 0.
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp
@@ -9,7 +9,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CTEWithOuterReferences.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithOuterReferences.mdp
@@ -25,7 +25,7 @@
 </dxl:Stacktrace>
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEinlining.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEinlining.mdp
@@ -11,7 +11,7 @@ explain with v as (select x,y from bar) select v1.x from v v1, v v2 where v1.x =
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="1000"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CannotCollapseCascadeProjects.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotCollapseCascadeProjects.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10,7 +10,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102115,102116,102117,102119,102121,102144,103001,103026,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Cascaded-UnionAll-Same-Cols-Order.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Cascaded-UnionAll-Same-Cols-Order.mdp
@@ -9,7 +9,7 @@ select a from foo_hashed union all select b from foo_hashed union all select 1 f
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CastedInClauseWithMCV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CastedInClauseWithMCV.mdp
@@ -11,7 +11,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CheckAsUser.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CheckAsUser.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseCascadeProjects2of2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseCascadeProjects2of2.mdp
@@ -8,7 +8,7 @@ select x.c1 * x.c2, x.c3 from (select a, b, a+b from foo) x(c1,c2,c3);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-With-Agg-Funcs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-With-Agg-Funcs.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
@@ -7,7 +7,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ComputedGroupByCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ComputedGroupByCol.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ConstTblGetUnderSubqUnderProjectWithOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstTblGetUnderSubqUnderProjectWithOuterRef.mdp
@@ -9,7 +9,7 @@ SELECT (SELECT a) FROM foo;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ConstraintIntervalIncludesNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstraintIntervalIncludesNull.mdp
@@ -15,7 +15,7 @@ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ConstraintIntervalWithBoolIncludesNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstraintIntervalWithBoolIncludesNull.mdp
@@ -15,7 +15,7 @@ Rows out:  1 rows at destination with 0.241 ms to first row, 0.242 ms to end.
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ConstraintIntervalWithInIncludesNullArray.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstraintIntervalWithInIncludesNullArray.mdp
@@ -13,7 +13,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ConstraintIntervalWithMultiColumnsIncludeNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstraintIntervalWithMultiColumnsIncludeNull.mdp
@@ -15,7 +15,7 @@ Rows out:  1 rows at destination with 1693 ms to end.
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ConvertBoolConstNullToConstTableFalseFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertBoolConstNullToConstTableFalseFilter.mdp
@@ -8,7 +8,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomSelect.mdp
@@ -8,7 +8,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="6">

--- a/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Const.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Const.mdp
@@ -7,7 +7,7 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="4" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/Correlated-SemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-SemiJoin.mdp
@@ -6,7 +6,7 @@ SQL: select * from t1 where exists(select a from t2 where t2.b<>t1.b group by t2
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
@@ -26,7 +26,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
@@ -27,7 +27,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
@@ -93,7 +93,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSubqueryWithAggWindowFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSubqueryWithAggWindowFunc.mdp
@@ -25,7 +25,7 @@ explain select C.i from C where C.i in (select avg(i) over (partition by i) from
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/CountAny.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CountAny.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
@@ -13,7 +13,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -26,7 +26,7 @@ WHERE  sach_vsnr = 465132477;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="54">

--- a/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
@@ -13,7 +13,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
@@ -14,7 +14,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -10,7 +10,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -16,7 +16,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -32,7 +32,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2010,7 +2010,7 @@
     <dxl:Plan Id="0" SpaceSize="154">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324669.231990" Rows="2560.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324669.270963" Rows="2844.444444" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -2039,7 +2039,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324668.964863" Rows="2560.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324668.974155" Rows="2844.444444" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DPv2QueryOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPv2QueryOnly.mdp
@@ -30,7 +30,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
@@ -16,7 +16,7 @@ drop table if exists foo;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="128">

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
@@ -9,7 +9,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/DeduplicatePredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeduplicatePredicates.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -38,7 +38,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="4">

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
@@ -17,7 +17,7 @@ where a=1 and b>0;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
@@ -13,7 +13,7 @@ where a=1 and b=0;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-MultiCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-MultiCol.mdp
@@ -7,7 +7,7 @@ explain select * from r where a=1 and b=2;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-SingleCol-Disjunction-Negative.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-SingleCol-Disjunction-Negative.mdp
@@ -7,7 +7,7 @@ explain select * from r where a<1 or a=3;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/Distinct-LegacyOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Distinct-LegacyOpfamily.mdp
@@ -12,7 +12,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DonotPushPartConstThruLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DonotPushPartConstThruLimit.mdp
@@ -12,7 +12,7 @@ select * from (select * from h order by j limit 2) x where j = 2;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DqaHavingMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaHavingMax.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DqaMin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaMin.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DuplicateGrpCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DuplicateGrpCol.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -6,7 +6,7 @@ see sql/DynamicBitmapIndexScan.sql
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="64">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
@@ -24,7 +24,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
@@ -114,7 +114,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101001,101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101000,101001,101006,101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101001,101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101001,101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
@@ -17,7 +17,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMinMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMinMax.mdp
@@ -17,7 +17,7 @@
    <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102115,102117,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101001,101013,102001,102002,102003,102024,102025,102115,102117,102144,103001,103027,103033,104002"/>

--- a/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Supported.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Supported.mdp
@@ -32,7 +32,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesIntersect.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesUnion.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Except-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Except-Volatile-Func.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102025,102115,102116,102117,102119,102121,102144,103001,103003,103016,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ExprOnScSubqueryWithOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExprOnScSubqueryWithOuterRef.mdp
@@ -10,7 +10,7 @@ select (select b from bar) + 1 from foo;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ExternalTable1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTable1.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ExternalTable3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalTable3.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -30,7 +30,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102115,102116,102117,102119,102144,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/FilterScalarCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FilterScalarCast.mdp
@@ -10,7 +10,7 @@ EXPLAIN SELECT * FROM foo WHERE b IN ('xyz', 'asds');
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-2PredicateOnDistColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-2PredicateOnDistColumns.mdp
@@ -13,7 +13,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-2PredicateOnDistColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-2PredicateOnDistColumns.mdp
@@ -298,7 +298,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.001120" Rows="5.200000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001103" Rows="5.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -318,7 +318,7 @@
         <dxl:SortingColumnList/>
         <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000810" Rows="5.200000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000805" Rows="5.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-NonDefaultOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-NonDefaultOpfamily.mdp
@@ -73,7 +73,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-NullPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-NullPredicate.mdp
@@ -15,7 +15,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Replicated.mdp
@@ -10,7 +10,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-SubquerySingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-SubquerySingleton.mdp
@@ -10,7 +10,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullOuterJoin-NullRejectingLHS1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullOuterJoin-NullRejectingLHS1.mdp
@@ -15,7 +15,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullOuterJoinLeftMultiplyRightMaxCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullOuterJoinLeftMultiplyRightMaxCard.mdp
@@ -17,7 +17,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/FullOuterJoinZeroMaxCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullOuterJoinZeroMaxCard.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
@@ -21,7 +21,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
@@ -33,7 +33,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Postgis-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Postgis-IndexPlan.mdp
@@ -35,7 +35,7 @@ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..433.00 rows=1 width=24)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-BitmapPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-BitmapPlan.mdp
@@ -29,7 +29,7 @@ Result  (cost=0.00..0.00 rows=1 width=36)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
@@ -31,7 +31,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/GreedyNAryDelayCrossJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GreedyNAryDelayCrossJoin.mdp
@@ -41,7 +41,7 @@ EXPLAIN SELECT * FROM t1, t2, t3, t4 where b = c;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/GreedyNAryJoinWithDisconnectedEdges.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GreedyNAryJoinWithDisconnectedEdges.mdp
@@ -24,7 +24,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
@@ -18,7 +18,7 @@ where t.a in (select count(s.i) from s);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102016,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -38,7 +38,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -828,7 +828,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="828.979625" Rows="22.230000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="828.981560" Rows="35.148716" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -854,7 +854,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="828.977230" Rows="22.230000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="828.977772" Rows="35.148716" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">

--- a/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IDF-NullConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IDF-NullConstant.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102118,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/IN-Numeric.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IN-Numeric.mdp
@@ -8,7 +8,7 @@ explain select * from t_numeric where c5 in (10, 11);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/INDF-NullConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/INDF-NullConstant.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102025,102115,102118,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
@@ -27,7 +27,7 @@ SELECT * FROM foo WHERE 2 IN (SELECT b+1 FROM bar);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -34,7 +34,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
@@ -47,7 +47,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="1" PlanSamples="1" CostThreshold="1"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102025,102029,102144,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnMasterOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnMasterOnlyTable.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102029,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
@@ -21,7 +21,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
@@ -56,7 +56,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -7,7 +7,7 @@ Table X (int i, int j) is distributed by i, column j has index
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102115,102116,102117,102119,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -48,7 +48,7 @@ ORDER BY 1 asc ;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102027,102029,102115,102116,102117,102119,102144,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102027,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply_NestLoopWithNestParamTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply_NestLoopWithNestParamTrue.mdp
@@ -29,7 +29,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
@@ -33,7 +33,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddPartitionToRootWithHomogenousIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddPartitionToRootWithHomogenousIndex.mdp
@@ -18,7 +18,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p3 WHERE c > 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
@@ -16,7 +16,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 12;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
@@ -16,7 +16,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ORPredicate-AO.mdp
@@ -16,7 +16,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c > 11 OR d > 20;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
@@ -16,7 +16,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-HEAP.mdp
@@ -16,7 +16,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-HEAP.mdp
@@ -16,7 +16,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-AndedIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-AndedIn.mdp
@@ -38,7 +38,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102006,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsNonPart.mdp
@@ -34,7 +34,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
@@ -27,7 +27,7 @@ SELECT a FROM y WHERE (a IN (SELECT b FROM bar WHERE b = 2));
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-oid-oid.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-oid-oid.mdp
@@ -28,7 +28,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vc-txt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vc-txt.mdp
@@ -35,7 +35,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
@@ -11,7 +11,7 @@ a < 2 should also be outside the limit but not below.
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForQuantifiedSQ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForQuantifiedSQ.mdp
@@ -48,7 +48,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InnerJoin-With-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoin-With-OuterRefs.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -42,7 +42,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
@@ -31,7 +31,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMasterOnlyTable.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -10,7 +10,7 @@ explain insert into pt2 select * from r;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/InsertNoEnforceConstraints.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNoEnforceConstraints.mdp
@@ -12,7 +12,7 @@ insert into constraints_tab values (NULL, -1);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InsertNotNullCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertNotNullCols.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101001,101013,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertRandomDistr.mdp
@@ -21,7 +21,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/InsertSortDistributed2MasterOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertSortDistributed2MasterOnly.mdp
@@ -8,7 +8,7 @@ explain insert into masteronly select * from distributedtable order by 1;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Int2Predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Int2Predicate.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103003,103016"/>

--- a/src/backend/gporca/data/dxl/minidump/InvalidPlan_IncompatibleDistributionOnJoinBranches.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InvalidPlan_IncompatibleDistributionOnJoinBranches.mdp
@@ -23,7 +23,7 @@
 </dxl:Stacktrace>
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="1200" CostThreshold="1000"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/InvalidPlan_MotionGatherFromMasterToMaster.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InvalidPlan_MotionGatherFromMasterToMaster.mdp
@@ -25,7 +25,7 @@
 </dxl:Stacktrace>
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="1000" CostThreshold="1000"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102024,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-NonRedistributableCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-NonRedistributableCol.mdp
@@ -21,7 +21,7 @@ explain select * from foo, testhstore where foo.b = testhstore.h;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-IDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-IDF.mdp
@@ -19,7 +19,7 @@ select * from foo, bar where foo.a is distinct from c;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Join-INDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-INDF.mdp
@@ -10,7 +10,7 @@ select * from foo, foo2 where foo.a is not distinct from foo2.a;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102025,102115,102116,102117,102119,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
@@ -12,7 +12,7 @@ where e < 10;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,102146,101013,102024,102025,102115,102116,102117,102119,102121,103001,103016"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinAbsEqWithoutOpfamilies.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinAbsEqWithoutOpfamilies.mdp
@@ -63,7 +63,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
@@ -42,7 +42,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/JoinPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinPlan.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="332" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinTinterval.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinTinterval.mdp
@@ -15,7 +15,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-green-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LIKE-Pattern-green-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -42,7 +42,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
@@ -38,7 +38,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
@@ -31,7 +31,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
@@ -35,7 +35,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
@@ -25,7 +25,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
@@ -377,7 +377,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="461.001508" Rows="5.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="461.001661" Rows="5.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -403,7 +403,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="461.001061" Rows="5.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="461.001214" Rows="5.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -488,7 +488,7 @@
           </dxl:RedistributeMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="30.000771" Rows="0.200000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="30.000923" Rows="0.200000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="d">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
@@ -17,7 +17,7 @@ set optimizer_enable_hashjoin = off;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
@@ -22,7 +22,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-With-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-With-Agg.mdp
@@ -17,7 +17,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJNullRejectingPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJNullRejectingPredicates.mdp
@@ -29,7 +29,7 @@ explain select * from t1 left join t2 on t1.a=t2.a left join t3 on t2.a=t3.a lef
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
@@ -1543,7 +1543,7 @@
     <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.153459" Rows="1.199200" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.153459" Rows="1.200000" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1578,7 +1578,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.153298" Rows="1.199200" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.153298" Rows="1.200000" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1618,7 +1618,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Right">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.153232" Rows="2.998000" Width="36"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.153233" Rows="3.000000" Width="36"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
@@ -17,7 +17,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_IDF_no_convert_outer_ref_predicate_with_NULL.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_IDF_no_convert_outer_ref_predicate_with_NULL.mdp
@@ -25,7 +25,7 @@ EXPLAIN SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINC
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -42,7 +42,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5771,7 +5771,7 @@
     <dxl:Plan Id="0" SpaceSize="19655804">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2587.328349" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="2587.327973" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5786,7 +5786,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2587.328325" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="2587.327949" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5806,7 +5806,7 @@
           </dxl:SortingColumnList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2587.328236" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="2587.327860" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5823,7 +5823,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2587.328228" Rows="1.000000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="2587.327852" Rows="1.000000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="110" Alias="count">
@@ -5842,7 +5842,7 @@
               <dxl:LimitOffset/>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2587.328228" Rows="1.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2587.327852" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="1"/>
@@ -5860,7 +5860,7 @@
                 <dxl:Filter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2587.328187" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2587.327811" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -5877,7 +5877,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2587.328134" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2587.327758" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="s_name">
@@ -5896,7 +5896,7 @@
                     <dxl:LimitOffset/>
                     <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2587.328134" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2587.327758" Rows="1.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="s_name">
@@ -5915,7 +5915,7 @@
                       </dxl:HashExprList>
                       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2587.328081" Rows="1.000000" Width="34"/>
+                          <dxl:Cost StartupCost="0" TotalCost="2587.327705" Rows="1.000000" Width="34"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="1"/>
@@ -5932,7 +5932,7 @@
                         <dxl:Filter/>
                         <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2587.328063" Rows="1.000000" Width="34"/>
+                            <dxl:Cost StartupCost="0" TotalCost="2587.327687" Rows="1.000000" Width="34"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="112" Alias="ColRef_0112">
@@ -5951,7 +5951,7 @@
                           <dxl:LimitOffset/>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="2587.328063" Rows="1.000000" Width="34"/>
+                              <dxl:Cost StartupCost="0" TotalCost="2587.327687" Rows="1.000000" Width="34"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="112" Alias="ColRef_0112">
@@ -5972,7 +5972,7 @@
                             <dxl:OneTimeFilter/>
                             <dxl:HashJoin JoinType="Inner">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2587.328052" Rows="1.000000" Width="38"/>
+                                <dxl:Cost StartupCost="0" TotalCost="2587.327676" Rows="1.000000" Width="38"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6088,7 +6088,7 @@
                               </dxl:HashJoin>
                               <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1725.314074" Rows="3.000000" Width="16"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1725.313699" Rows="3.000000" Width="16"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6105,7 +6105,7 @@
                                 <dxl:SortingColumnList/>
                                 <dxl:HashJoin JoinType="Inner">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1725.313788" Rows="1.000000" Width="16"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="1725.313412" Rows="1.000000" Width="16"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6157,7 +6157,7 @@
                                   </dxl:TableScan>
                                   <dxl:HashJoin JoinType="Inner">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1294.225320" Rows="1.000000" Width="16"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="1294.224944" Rows="1.000000" Width="16"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6218,7 +6218,7 @@
                                     </dxl:TableScan>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="862.733991" Rows="1.000000" Width="16"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="862.733615" Rows="1.000000" Width="16"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6239,7 +6239,7 @@
                                       <dxl:OneTimeFilter/>
                                       <dxl:HashJoin JoinType="Left">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="862.712892" Rows="1923.935215" Width="24"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="862.712622" Rows="1914.291369" Width="24"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="41" Alias="l_orderkey">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -24,7 +24,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_dont_convert_to_inner_with_outer_predicate_INDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_dont_convert_to_inner_with_outer_predicate_INDF.mdp
@@ -24,7 +24,7 @@ EXPLAIN SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS NOT DIS
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Lead-Lag-WinFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Lead-Lag-WinFuncs.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-DPv2-With-Select.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-DPv2-With-Select.mdp
@@ -38,7 +38,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -14,7 +14,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102046,102115,102116,102117,102119,102121,102144,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ListPartLossyCastEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartLossyCastEq.mdp
@@ -18,7 +18,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ListPartLossyCastNEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartLossyCastNEq.mdp
@@ -21,7 +21,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -457,7 +457,7 @@ SQL:
     <dxl:Plan Id="0" SpaceSize="3512">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.103418" Rows="10.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.103419" Rows="10.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -472,7 +472,7 @@ SQL:
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.103218" Rows="10.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103219" Rows="10.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -491,7 +491,7 @@ SQL:
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.102320" Rows="10.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.102321" Rows="10.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -506,7 +506,7 @@ SQL:
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.102220" Rows="111.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.102221" Rows="111.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -624,7 +624,7 @@ SQL:
                 </dxl:CTEProducer>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.059504" Rows="110.999992" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.059504" Rows="111.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -8,7 +8,7 @@ SQL:
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -12,7 +12,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -642,7 +642,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
               </dxl:CTEProducer>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.059504" Rows="110.999992" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.059504" Rows="111.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -36,7 +36,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MissingStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MissingStats.mdp
@@ -10,7 +10,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
@@ -46,7 +46,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MultiColumnAggWithDefaultOpfamilies.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiColumnAggWithDefaultOpfamilies.mdp
@@ -10,7 +10,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MultiDistKeyJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiDistKeyJoinCardinality.mdp
@@ -3,23 +3,24 @@
   <dxl:Comment><![CDATA[
      Objective: The join cardinality estimate for multiple distribution keys on the same table should be accurate.
      
-     The query returns around 100 rows when run, and we should estimate around 100 rows when
-     optimizer_damping_factor_join is set to 0. When `optimizer_damping_factor_join` is set
-     to .01 (the default), we estimate ~10K rows returned.
+     The query returns 1000 rows when run. We should estimate around 1000 rows when
+     optimizer_damping_factor_join is set to 0 (the default). When `optimizer_damping_factor_join` is set
+     to .01 (the 5X default), we estimate ~10K rows returned.
 
+     DROP TABLE IF EXISTS foo, bar;
      CREATE TABLE foo (a int, b int) DISTRIBUTED BY (a, b);
      CREATE TABLE bar (c int, d int) DISTRIBUTED BY (c, d);
-     INSERT INTO foo SELECT random() * 100, random() * 100 FROM generate_series(1, 1000);
-     INSERT INTO bar SELECT random() * 100, random() * 100 FROM generate_series(1, 1000);
+     INSERT INTO foo SELECT i/100, i%100 FROM generate_series(1, 1000) i;
+     INSERT INTO bar SELECT i/100, i%100 FROM generate_series(1, 1000) i;
      analyze foo;
      analyze bar;
      set optimizer_damping_factor_join=0;
 
-     explain select * from foo join bar a = c and b = d;
-                                        QUERY PLAN
-     --------------------------------------------------------------------------------
-      Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.28 rows=97 width=16)
-        ->  Hash Join  (cost=0.00..862.27 rows=33 width=16)
+     explain select * from foo join bar on a = c and b = d;
+                                         QUERY PLAN
+     ----------------------------------------------------------------------------------
+      Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.35 rows=1000 width=16)
+        ->  Hash Join  (cost=0.00..862.29 rows=334 width=16)
               Hash Cond: ((foo.a = bar.c) AND (foo.b = bar.d))
               ->  Seq Scan on foo  (cost=0.00..431.01 rows=334 width=8)
               ->  Hash  (cost=431.01..431.01 rows=334 width=8)
@@ -40,9 +41,87 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="102001,102002,102003,102074,102120,102144,103001,103014,103022,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102155,102156,103001,103014,103022,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.379396.1.0" Name="bar" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.379396.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.379393.1.0" Name="foo" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.379393.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -143,437 +222,20 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.681375.1.0.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="55.000000" FreqRemain="0.409000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+      <dxl:ColumnStatistics Mdid="1.379396.1.0.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.017000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.018000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.681375.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="44.000000" FreqRemain="0.297000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-        </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.018000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:ColumnStatistics Mdid="1.681372.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="47.000000" FreqRemain="0.318000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
         </dxl:StatsBucket>
@@ -585,11 +247,11 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
         </dxl:StatsBucket>
@@ -597,19 +259,23 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.016000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
         </dxl:StatsBucket>
@@ -617,233 +283,43 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.017000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.019000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.681372.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="46.000000" FreqRemain="0.314000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
         </dxl:StatsBucket>
@@ -851,23 +327,23 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
         </dxl:StatsBucket>
@@ -875,87 +351,151 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.018000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.014000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
         </dxl:StatsBucket>
@@ -963,11 +503,27 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.012000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.021000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
         </dxl:StatsBucket>
@@ -975,17 +531,37 @@
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.015000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
@@ -996,104 +572,545 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.011000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.013000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:RelationStatistics Mdid="2.681375.1.0" Name="bar" Rows="1000.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.681375.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.681372.1.0" Name="foo" Rows="1000.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.681372.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.379396.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="0.001000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.099000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.379393.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.379393.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="0.001000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.099000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -1121,7 +1138,7 @@
       <dxl:CTEList/>
       <dxl:LogicalJoin JoinType="Inner">
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.681372.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.379393.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -1136,7 +1153,7 @@
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.681375.1.0" TableName="bar">
+          <dxl:TableDescriptor Mdid="0.379396.1.0" TableName="bar">
             <dxl:Columns>
               <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -1165,7 +1182,7 @@
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.276069" Rows="96.116878" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.346837" Rows="1000.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1185,7 +1202,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.270338" Rows="96.116878" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.287211" Rows="1000.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1226,7 +1243,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.681372.1.0" TableName="foo">
+            <dxl:TableDescriptor Mdid="0.379393.1.0" TableName="foo">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -1253,7 +1270,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.681375.1.0" TableName="bar">
+            <dxl:TableDescriptor Mdid="0.379396.1.0" TableName="bar">
               <dxl:Columns>
                 <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -1271,4 +1288,4 @@
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
-</dxl:DXLMessage>	
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-NOT-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-NOT-IN-Subquery.mdp
@@ -40,7 +40,7 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MultipleDampedPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleDampedPredJoinCardinality.mdp
@@ -1,32 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
     <dxl:Comment><![CDATA[
-Objective: The join cardinality estimate for multiple columns on the same table should be accurate.
-The query returns 1-5 rows when run, and we should estimate 50-100 rows or lower when
-optimizer_damping_factor_join is set to 0. When `optimizer_damping_factor_join` is set
-to .01 (the default), we estimate ~1500 rows returned.
+     Objective: The join cardinality estimate for multiple columns on the same table should be reasonable.
 
-create table t1 (a int, b int) distributed by (a);
-create table t2 (a int, b int) distributed by (a);
-insert into t1 select floor(random()*1000),floor(random()*1000) from generate_series(1,1000)i;
-insert into t2 select floor(random()*1000),floor(random()*1000) from generate_series(1,1000)i;
-analyze t1;
-analyze t2;
-set optimizer_damping_factor_join=0;
+     The query returns 1000 rows when run, and we should estimate ~3162 (1000 * sqrt(10)) rows when
+     optimizer_damping_factor_join is set to 0. This is because we damp the t1.b=t2.b predicate
+     from a scale factor of 10 to a scale factor of sqrt(10).
+     When `optimizer_damping_factor_join` is set to .01 (the 5X default), we estimate ~10000 rows
+     returned because we damp the t1.b=t2.b scale factor from 10 to 10 * 0.01**2 = 0.001, which
+     gets rounded up to 1.
 
-explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+     drop table if exists t1, t2;
+     create table t1 (a int, b int) distributed by (a);
+     create table t2 (a int, b int) distributed by (a);
+     insert into t1 select i/10, i%10 from generate_series(1,1000) i;
+     insert into t2 select i/10, i%10 from generate_series(1,1000) i;
+     analyze t1;
+     analyze t2;
+     set optimizer_damping_factor_join=0;
 
-                                   QUERY PLAN
---------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.27 rows=62 width=16)
-   ->  Hash Join  (cost=0.00..862.27 rows=21 width=16)
-         Hash Cond: t1.a = t2.a AND t1.b = t2.b
-         ->  Table Scan on t1  (cost=0.00..431.01 rows=334 width=8)
-         ->  Hash  (cost=431.01..431.01 rows=334 width=8)
-               ->  Table Scan on t2  (cost=0.00..431.01 rows=334 width=8)
- Settings:  optimizer=on; optimizer_damping_factor_join=0
- Optimizer status: PQO version 3.86.0
-(8 rows)
+     explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
+
+                                    QUERY PLAN
+     ----------------------------------------------------------------------------------
+      Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.51 rows=3101 width=16)
+        ->  Hash Join  (cost=0.00..862.33 rows=1034 width=16)
+              Hash Cond: ((t1.a = t2.a) AND (t1.b = t2.b))
+              ->  Seq Scan on t1  (cost=0.00..431.01 rows=334 width=8)
+              ->  Hash  (cost=431.01..431.01 rows=334 width=8)
+                    ->  Seq Scan on t2  (cost=0.00..431.01 rows=334 width=8)
+      Optimizer: Pivotal Optimizer (GPORCA)
 	]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
@@ -34,17 +37,860 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="102001,102002,102003,102074,102113,102120,102144,102147,103001,103014,103015,103022,103027,103029,103033,104003,104004,104005,104006,105000"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102155,102156,103001,103014,103022,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:ColumnStatistics Mdid="1.379414.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.379414.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.379414.1.0" Name="t2" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -59,7 +905,84 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Relation Mdid="0.379414.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.379411.1.0" Name="t1" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.379411.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -74,7 +997,9 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -89,7 +1014,9 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -104,7 +1031,8 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -119,7 +1047,8 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -134,4536 +1063,861 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.5228913.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.000387" DistinctValues="0.129444">
+      <dxl:ColumnStatistics Mdid="1.379411.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003872" DistinctValues="1.294444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000774" DistinctValues="0.258889">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001162" DistinctValues="0.388333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000774" DistinctValues="0.258889">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000290" DistinctValues="0.041667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.125000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.125000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002033" DistinctValues="0.291667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002033" DistinctValues="0.291667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.125000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000804" DistinctValues="0.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001072" DistinctValues="0.153846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001340" DistinctValues="0.192308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000804" DistinctValues="0.115385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000804" DistinctValues="0.115385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000348" DistinctValues="0.066500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001742" DistinctValues="0.332500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002091" DistinctValues="0.399000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002788" DistinctValues="0.532000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000498" DistinctValues="0.095000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000996" DistinctValues="0.190000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003983" DistinctValues="0.760000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001494" DistinctValues="0.285000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="111"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.256154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="111"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="112"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="112"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="112"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003217" DistinctValues="1.536923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="112"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003217" DistinctValues="1.536923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="124"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="124"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="124"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="125"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000581" DistinctValues="0.360833">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="131"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004066" DistinctValues="2.525833">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="131"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="138"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="138"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="138"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.443333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="138"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="142"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.574545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="142"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003168" DistinctValues="1.968182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="151"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="151"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="151"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001267" DistinctValues="0.787273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="151"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="163"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001901" DistinctValues="1.453636">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005069" DistinctValues="3.876364">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.110000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.110000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="195"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001394" DistinctValues="0.666000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="195"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="198"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000929" DistinctValues="0.444000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="198"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001608" DistinctValues="0.999231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="203"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="203"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="203"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005362" DistinctValues="3.330769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="214"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005898" DistinctValues="4.510000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="214"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="225"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="225"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="225"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001072" DistinctValues="0.820000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="225"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="227"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="234"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001267" DistinctValues="0.787273">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="234"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003168" DistinctValues="1.968182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="241"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="241"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="241"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.574545">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="241"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="245"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="245"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="252"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="252"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="258"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="258"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="277"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="277"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="286"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.938182">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="286"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004435" DistinctValues="3.391818">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003485" DistinctValues="2.665000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="303"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="303"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="303"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003485" DistinctValues="2.665000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="303"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="309"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002145" DistinctValues="1.332308">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="309"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="313"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="313"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="313"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001072" DistinctValues="0.666154">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="313"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="315"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="315"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="315"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003753" DistinctValues="2.331538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="315"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="322"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="322"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="329"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004182" DistinctValues="3.198000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="329"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="335"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="335"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="335"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002788" DistinctValues="2.132000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="335"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="339"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="5.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="339"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="344"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="344"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="344"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="345"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="354"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="354"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="363"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="363"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="369"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="369"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="369"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="369"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="371"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003802" DistinctValues="2.907273">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="371"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="377"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="377"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="377"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003168" DistinctValues="2.422727">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="377"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="382"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001162" DistinctValues="0.555000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="382"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="384"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="384"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="384"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.110000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="384"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="388"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003485" DistinctValues="1.665000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="388"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="394"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="394"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="394"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.541250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="395"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006099" DistinctValues="3.788750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="397"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="404"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000465" DistinctValues="0.222000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="404"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="406"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="406"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003253" DistinctValues="1.554000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="406"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="413"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="413"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="413"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003253" DistinctValues="1.554000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="413"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000697" DistinctValues="0.333000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="421"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="421"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="421"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004879" DistinctValues="2.331000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="421"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="428"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="428"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="428"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001394" DistinctValues="0.666000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="428"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="430"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000634" DistinctValues="0.484545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="432"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="432"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="432"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006336" DistinctValues="4.845455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="432"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="442"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="442"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="448"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="448"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="452"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.666250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="452"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="453"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="453"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="453"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006099" DistinctValues="4.663750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="453"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="466"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.938182">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="466"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004435" DistinctValues="3.391818">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="477"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="477"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="483"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="483"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="483"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="483"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="485"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="485"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="492"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000996" DistinctValues="0.761429">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="492"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005974" DistinctValues="4.568571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="499"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000581" DistinctValues="0.360833">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="499"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.082500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004647" DistinctValues="2.886667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="511"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="511"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="522"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="522"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004356" DistinctValues="3.331250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="535"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="535"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="535"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002614" DistinctValues="1.998750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="535"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="538"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001394" DistinctValues="1.066000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="538"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="541"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="541"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="541"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005576" DistinctValues="4.264000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="541"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="553"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003983" DistinctValues="3.045714">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="553"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="557"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="557"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="557"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002987" DistinctValues="2.284286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="557"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.938182">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="567"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="567"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="567"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004435" DistinctValues="3.391818">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="567"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="574"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="574"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="581"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002788" DistinctValues="1.332000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="581"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="585"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="585"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="585"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="586"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="586"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004182" DistinctValues="1.998000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="593"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="593"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="603"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="603"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002614" DistinctValues="1.998750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="613"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="613"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="613"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004356" DistinctValues="3.331250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="613"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="618"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="618"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="628"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="628"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="634"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="634"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="654"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="662"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="662"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001901" DistinctValues="1.453636">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="683"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="683"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="683"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005069" DistinctValues="3.876364">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="683"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005663" DistinctValues="4.330625">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="704"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001307" DistinctValues="0.999375">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="704"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="707"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="707"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="719"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="719"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="738"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="738"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="744"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="744"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.776667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004647" DistinctValues="3.553333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="762"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="762"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="771"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005421" DistinctValues="4.145556">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="771"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001549" DistinctValues="1.184444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="788"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002788" DistinctValues="1.732000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="788"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="792"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="792"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="792"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004182" DistinctValues="2.598000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="792"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="798"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001394" DistinctValues="1.066000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="799"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="801"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="801"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="801"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005576" DistinctValues="4.264000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="801"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="809"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="809"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="814"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="814"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="823"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="823"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="832"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="832"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="832"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="832"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="835"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="835"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="846"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="846"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="856"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="856"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="863"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="863"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="868"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004182" DistinctValues="3.198000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="868"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002788" DistinctValues="2.132000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="878"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000634" DistinctValues="0.211818">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="878"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="879"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="879"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="879"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002535" DistinctValues="0.847273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="879"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="883"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001901" DistinctValues="0.635455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="883"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="886"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="886"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="886"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="887"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="887"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001901" DistinctValues="0.635455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="887"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="896"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005069" DistinctValues="3.876364">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="896"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="904"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="904"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="904"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001901" DistinctValues="1.453636">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="904"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="907"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="907"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="915"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="915"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="925"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="925"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000774" DistinctValues="0.481111">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="936"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="936"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="936"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="937"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="937"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006196" DistinctValues="3.848889">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="937"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="945"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001162" DistinctValues="0.888333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="945"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="946"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="946"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="946"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005808" DistinctValues="4.441667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="946"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="951"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="951"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="958"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="958"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="974"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="974"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="984"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="984"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="999"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.5228913.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004487" DistinctValues="2.815714">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002493" DistinctValues="1.564286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001309" DistinctValues="0.258750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002181" DistinctValues="0.431250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000872" DistinctValues="0.172500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001309" DistinctValues="0.258750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001309" DistinctValues="0.258750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.336923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001611" DistinctValues="1.010769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004832" DistinctValues="3.032308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001904" DistinctValues="0.649091">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003173" DistinctValues="1.081818">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001904" DistinctValues="0.649091">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.260000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.520000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.520000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004295" DistinctValues="2.080000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000776" DistinctValues="0.375556">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006204" DistinctValues="3.004444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005906" DistinctValues="3.706154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.673846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="101"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000332" DistinctValues="0.047619">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="102"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="102"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="102"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001330" DistinctValues="0.190476">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="102"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="106"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="106"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="106"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000665" DistinctValues="0.095238">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="106"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002991" DistinctValues="0.428571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="109"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001662" DistinctValues="0.238095">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="123"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="123"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="123"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005119" DistinctValues="3.212000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="124"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="135"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="135"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="135"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001861" DistinctValues="1.168000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="136"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="147"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="154"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="154"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="162"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="172"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="172"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="181"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="181"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="191"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="191"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="196"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003723" DistinctValues="2.869333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="196"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003257" DistinctValues="2.510667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="211"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004295" DistinctValues="2.695385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="211"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="219"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="219"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="219"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.673846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="219"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001611" DistinctValues="1.010769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="224"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="224"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="237"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="237"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="247"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001662" DistinctValues="1.042857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="247"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="252"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="252"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="252"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003656" DistinctValues="2.294286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="252"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="263"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="263"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="263"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001662" DistinctValues="1.042857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="263"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="278"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="278"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="283"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="283"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="294"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="294"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="307"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="307"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="315"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002792" DistinctValues="2.152000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="315"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="321"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004188" DistinctValues="3.228000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="321"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002538" DistinctValues="1.592727">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004442" DistinctValues="2.787273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="341"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="341"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="341"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="342"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="350"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000997" DistinctValues="0.625714">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="350"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="359"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="359"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="359"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002493" DistinctValues="1.564286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="359"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="368"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="368"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="378"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="378"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="387"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="387"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="397"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="398"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="415"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="415"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="419"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000499" DistinctValues="0.312857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="419"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005484" DistinctValues="3.441429">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000997" DistinctValues="0.625714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="433"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="433"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.751111">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="441"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="443"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="443"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="443"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.751111">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="443"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="445"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="445"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="445"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.751111">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="445"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="447"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="447"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="447"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002327" DistinctValues="1.126667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="447"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000698" DistinctValues="0.438000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004188" DistinctValues="2.628000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.314000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="465"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="465"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002792" DistinctValues="1.352000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="478"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="478"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="478"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000698" DistinctValues="0.338000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="478"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="485"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="485"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="496"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="496"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="496"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="496"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="502"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="502"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="508"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="508"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="508"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="508"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005817" DistinctValues="4.483333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001163" DistinctValues="0.896667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="522"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="522"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="528"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="528"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="536"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003490" DistinctValues="1.690000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="536"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="542"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="542"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="542"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="543"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="543"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="543"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="549"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001163" DistinctValues="0.896667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="549"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005817" DistinctValues="4.483333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="555"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="555"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="567"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="567"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="569"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="569"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="569"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="569"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="575"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="575"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="584"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="584"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="591"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="591"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="596"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005235" DistinctValues="3.285000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="596"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="605"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="605"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="605"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="606"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="606"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.095000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="606"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="609"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.614000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="609"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="612"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="612"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="612"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004886" DistinctValues="3.766000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="612"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="619"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="619"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="628"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="628"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="628"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.260000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="629"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="631"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="631"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002148" DistinctValues="1.040000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="631"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="635"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="635"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="635"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004295" DistinctValues="2.080000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="635"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="643"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="643"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="648"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="648"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="654"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="655"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="655"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="655"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="661"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="661"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="668"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001396" DistinctValues="0.876000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="668"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="671"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000931" DistinctValues="0.584000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="671"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="673"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="673"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="673"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004653" DistinctValues="2.920000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="673"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="683"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="683"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="688"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001396" DistinctValues="0.876000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="688"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="689"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="689"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="689"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002792" DistinctValues="1.752000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="689"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002792" DistinctValues="1.752000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="693"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="693"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="699"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="699"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="705"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="705"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="705"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="705"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="707"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="707"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="714"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001396" DistinctValues="0.876000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="714"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="716"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="716"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="716"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="716"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="721"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="721"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="721"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.314000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="721"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="724"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000776" DistinctValues="0.486667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="724"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="725"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004653" DistinctValues="2.920000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="725"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="731"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="731"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="731"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.973333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="731"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="733"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="733"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="749"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003989" DistinctValues="3.074286">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="749"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002991" DistinctValues="2.305714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="763"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="763"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="773"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="773"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="786"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004886" DistinctValues="3.766000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="786"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="793"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="793"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="793"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.614000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="793"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="796"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="796"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002939" DistinctValues="2.265263">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004041" DistinctValues="3.114737">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="821"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004653" DistinctValues="2.920000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="821"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="829"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="829"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="829"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002327" DistinctValues="1.460000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="834"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="834"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="839"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000872" DistinctValues="0.672500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="839"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006107" DistinctValues="4.707500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="847"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003807" DistinctValues="2.934545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="847"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003173" DistinctValues="2.445455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="863"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="863"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="883"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="884"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="892"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="892"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="899"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000465" DistinctValues="0.358667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="899"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006515" DistinctValues="5.021333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="914"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002617" DistinctValues="2.017500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="914"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="917"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="917"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="917"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004362" DistinctValues="3.362500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="917"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="922"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="922"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="926"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002181" DistinctValues="1.368750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="926"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="931"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="931"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="931"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003926" DistinctValues="2.463750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="931"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000872" DistinctValues="0.547500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="942"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001994" DistinctValues="1.537143">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="942"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="944"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="944"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="944"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004986" DistinctValues="3.842857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="944"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="949"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="949"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="954"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004986" DistinctValues="3.842857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="954"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="959"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="959"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="959"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001994" DistinctValues="1.537143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="959"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="961"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000607" DistinctValues="0.206957">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="961"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="963"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="963"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="963"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000607" DistinctValues="0.206957">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="963"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004249" DistinctValues="1.448696">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="979"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000607" DistinctValues="0.206957">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="979"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="981"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="981"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="981"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000910" DistinctValues="0.310435">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="981"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="984"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="984"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="992"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="992"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="997"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="998"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="998"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:RelationStatistics Mdid="2.5228916.1.0" Name="t2" Rows="1000.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.5228916.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.5228913.1.0" Name="t1" Rows="1000.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.5228913.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.5228916.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.000391" DistinctValues="0.245000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004296" DistinctValues="2.695000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.470000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002460" DistinctValues="0.493500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000703" DistinctValues="0.141000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001054" DistinctValues="0.211500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002812" DistinctValues="0.564000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002460" DistinctValues="0.843500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001054" DistinctValues="0.361500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001054" DistinctValues="0.361500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002460" DistinctValues="0.843500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003835" DistinctValues="2.405455">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003195" DistinctValues="2.004545">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002109" DistinctValues="1.323000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001406" DistinctValues="0.882000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.205000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.117500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="0.352500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.125000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002636" DistinctValues="0.375000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="105"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="0.250000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="105"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="109"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="111"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="111"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.125000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="111"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="113"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="113"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="113"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="114"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="114"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.125000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="114"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="116"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.128182">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="117"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="119"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="119"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="119"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.128182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="119"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="121"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="121"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="121"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003835" DistinctValues="0.769091">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="121"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="133"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="133"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="133"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000959" DistinctValues="0.192273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="133"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000959" DistinctValues="0.192273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="136"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="139"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="139"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="139"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000937" DistinctValues="0.321333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="152"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="152"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="152"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001406" DistinctValues="0.482000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="152"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="155"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="155"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="155"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003281" DistinctValues="1.124667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="155"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="162"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001406" DistinctValues="0.482000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="163"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005113" DistinctValues="3.934545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001917" DistinctValues="1.475455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000370" DistinctValues="0.126842">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="178"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="178"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="178"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003330" DistinctValues="1.141579">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="178"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="187"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="187"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="187"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="188"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="188"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001850" DistinctValues="0.634211">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="188"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="193"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="193"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="193"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001480" DistinctValues="0.507368">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="193"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="197"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="197"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005272" DistinctValues="3.307500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="212"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="212"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="212"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002511" DistinctValues="1.217857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="213"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="218"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="218"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="218"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001506" DistinctValues="0.730714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="218"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.487143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="223"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="223"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="223"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002009" DistinctValues="0.974286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="223"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="227"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="237"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="237"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="250"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="250"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="254"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="5.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="254"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="262"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="262"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="262"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="263"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="276"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="276"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="282"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005468" DistinctValues="4.207778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="282"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="289"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="289"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="289"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001562" DistinctValues="1.202222">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="289"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="291"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="291"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="303"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004474" DistinctValues="3.442727">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="303"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002556" DistinctValues="1.967273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="314"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="314"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.284167">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="321"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="322"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="322"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002929" DistinctValues="1.420833">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="322"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="327"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="1.705000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="327"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="333"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="333"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="343"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001850" DistinctValues="0.897368">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="343"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="348"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="348"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="348"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001480" DistinctValues="0.717895">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="348"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002960" DistinctValues="1.435789">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000740" DistinctValues="0.358947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="362"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="362"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="372"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001562" DistinctValues="1.202222">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="372"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005468" DistinctValues="4.207778">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="381"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="5.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="381"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="388"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="389"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="395"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="395"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="403"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="403"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005272" DistinctValues="3.307500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="411"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002929" DistinctValues="1.420833">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="412"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="417"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="417"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="417"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="0.852500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="417"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.136667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="424"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="424"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="424"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="425"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="439"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="439"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="449"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.630000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="449"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006026" DistinctValues="3.780000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="467"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="467"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="473"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.772857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="473"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="474"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="474"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="474"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006026" DistinctValues="4.637143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="474"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="485"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="485"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="499"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="499"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="507"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="507"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="513"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.470000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="513"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="516"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="516"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="516"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="517"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="517"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004687" DistinctValues="2.940000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="517"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="523"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005624" DistinctValues="4.328000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="523"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="531"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="531"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="531"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001406" DistinctValues="1.082000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="531"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="533"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="533"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="539"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="539"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="544"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.352500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="544"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005272" DistinctValues="4.057500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="552"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="552"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="561"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.735000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="561"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004101" DistinctValues="2.572500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="573"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="573"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="579"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="579"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="601"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="601"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="609"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="609"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="614"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="614"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="623"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="623"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="638"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="638"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="642"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="642"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="642"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="642"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="646"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="646"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.450833">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="651"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="651"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="651"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006444" DistinctValues="4.959167">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="651"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="662"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="662"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="674"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="674"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="682"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="682"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="697"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="697"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="712"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004394" DistinctValues="3.381250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="712"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="717"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="717"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="717"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002636" DistinctValues="2.028750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="717"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="726"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.400909">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="726"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="727"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="727"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="727"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005113" DistinctValues="3.207273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="727"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="735"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="735"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="735"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001278" DistinctValues="0.801818">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="735"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="737"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004687" DistinctValues="2.940000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="737"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.470000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="749"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="749"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="749"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002109" DistinctValues="1.323000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002109" DistinctValues="1.323000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002812" DistinctValues="1.764000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="777"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000781" DistinctValues="0.601111">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="777"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006249" DistinctValues="4.808889">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="786"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="786"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="795"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="795"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.630000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003013" DistinctValues="1.890000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="806"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="806"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="806"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003013" DistinctValues="1.890000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="806"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="809"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006026" DistinctValues="4.637143">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="809"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="821"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="821"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="821"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.772857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="821"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="823"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="823"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="832"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="832"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="841"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003906" DistinctValues="3.005556">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="841"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="846"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="846"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="846"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003124" DistinctValues="2.404444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="846"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="863"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="863"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="873"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001562" DistinctValues="1.202222">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="873"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="875"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="875"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="875"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005468" DistinctValues="4.207778">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="875"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="882"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="882"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="887"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002009" DistinctValues="1.260000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="887"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="891"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.205000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="891"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="898"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="898"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="898"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001506" DistinctValues="0.945000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="898"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.901667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="902"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005858" DistinctValues="4.508333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="902"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="907"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="907"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="919"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="919"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="926"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.400909">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="926"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="927"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="927"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="927"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001917" DistinctValues="1.202727">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="927"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004474" DistinctValues="2.806364">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="937"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.450833">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="937"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="938"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="938"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="938"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006444" DistinctValues="4.959167">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="938"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="949"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="949"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="956"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.551250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="956"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="957"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="957"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="957"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002636" DistinctValues="1.653750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="957"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.205000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="964"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.551250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="964"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="967"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="967"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="967"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004394" DistinctValues="2.756250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="967"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="972"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="972"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="987"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="987"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="999"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.5228916.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000408" DistinctValues="0.058824">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001631" DistinctValues="0.235294">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.379411.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.287500">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.287500">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003032" DistinctValues="1.006250">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001299" DistinctValues="0.431250">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.287500">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001459" DistinctValues="0.694737">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001459" DistinctValues="0.694737">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004012" DistinctValues="1.910526">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000408" DistinctValues="0.058824">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001631" DistinctValues="0.235294">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001631" DistinctValues="0.235294">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003300" DistinctValues="1.571429">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000660" DistinctValues="0.314286">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000660" DistinctValues="0.314286">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.100000">
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
           <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="101"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004851" DistinctValues="3.710000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="115"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="115"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="115"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002079" DistinctValues="1.590000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="115"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004798" DistinctValues="3.669231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="127"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="127"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="127"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.630769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="127"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="143"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="143"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005864" DistinctValues="4.484615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="157"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="157"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="157"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001066" DistinctValues="0.815385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="157"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="159"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="159"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="163"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004764" DistinctValues="2.956250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001299" DistinctValues="0.806250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.537500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="179"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000693" DistinctValues="0.530000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="179"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.007000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006237" DistinctValues="4.770000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="189"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="189"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="199"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004851" DistinctValues="3.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="199"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002079" DistinctValues="1.290000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="209"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="209"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="209"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="222"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="222"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="227"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="233"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003465" DistinctValues="2.650000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="233"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003465" DistinctValues="2.650000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="239"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="239"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="248"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="248"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="255"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002835" DistinctValues="1.759091">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="255"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="264"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="264"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="264"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004095" DistinctValues="2.540909">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="264"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="277"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="278"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="288"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003080" DistinctValues="1.466667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="288"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="292"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="292"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="292"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.100000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="292"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="295"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="295"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="295"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001540" DistinctValues="0.733333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="295"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="297"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="298"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="305"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="305"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="311"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000770" DistinctValues="0.477778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="311"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="312"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="312"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="312"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006160" DistinctValues="3.822222">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="312"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.225000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="327"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="328"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="328"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001732" DistinctValues="1.075000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="328"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.323077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001599" DistinctValues="0.992308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="337"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="337"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="337"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003198" DistinctValues="1.984615">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="337"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="343"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.758824">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="343"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="346"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="346"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="346"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002446" DistinctValues="1.517647">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="346"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003261" DistinctValues="2.023529">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="366"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="366"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="373"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000577" DistinctValues="0.358333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="373"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.225000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="383"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="383"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="383"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001155" DistinctValues="0.716667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="383"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="385"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="385"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="393"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002599" DistinctValues="1.987500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="393"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004331" DistinctValues="3.312500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="396"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="401"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="401"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="5.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="411"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="412"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="416"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="416"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="416"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="416"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="418"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="418"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="423"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="423"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="433"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="433"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="447"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003080" DistinctValues="1.911111">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="447"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="452"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="452"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003850" DistinctValues="2.388889">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="452"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="466"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003960" DistinctValues="3.028571">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="466"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002970" DistinctValues="2.271429">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="473"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="473"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="479"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="479"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="487"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004158" DistinctValues="3.180000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="487"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002772" DistinctValues="2.120000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="497"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="497"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="501"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="501"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="511"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="511"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="518"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="518"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="519"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="519"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="519"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="519"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="523"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005864" DistinctValues="4.484615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="523"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="534"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="534"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="534"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001066" DistinctValues="0.815385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="534"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="536"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000577" DistinctValues="0.358333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="536"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="537"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="537"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="537"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001732" DistinctValues="1.075000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="537"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004620" DistinctValues="2.866667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="548"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="548"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="555"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="555"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="565"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.662500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="565"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006064" DistinctValues="4.637500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="573"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="573"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="578"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000533" DistinctValues="0.330769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="578"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="579"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="579"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="579"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004265" DistinctValues="2.646154">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="579"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.323077">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="591"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="591"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="602"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="602"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="608"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="608"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="617"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="617"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="622"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="622"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="625"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="625"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="625"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="625"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="631"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="631"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="642"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005775" DistinctValues="4.416667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="642"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="652"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="652"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="652"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001155" DistinctValues="0.883333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="652"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="654"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002599" DistinctValues="1.987500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="657"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="657"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="657"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004331" DistinctValues="3.312500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="657"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="662"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="662"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="668"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001980" DistinctValues="1.514286">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="668"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004950" DistinctValues="3.785714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="675"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.537500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="675"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="677"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="677"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="677"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.537500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="677"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="679"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="679"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="679"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.225000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="679"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="703"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="703"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="733"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004158" DistinctValues="3.180000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="733"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="739"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="739"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="739"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002772" DistinctValues="2.120000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="739"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="743"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001732" DistinctValues="1.325000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="743"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.975000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="751"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003080" DistinctValues="2.355556">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="751"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="755"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="755"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="755"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003850" DistinctValues="2.944444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="755"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002772" DistinctValues="1.320000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="764"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="764"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="764"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="765"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="765"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="766"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="766"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004158" DistinctValues="1.980000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="766"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="772"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001299" DistinctValues="0.993750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="772"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="775"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="775"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="775"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005631" DistinctValues="4.306250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="775"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="788"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="3.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="788"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="798"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="799"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="799"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001155" DistinctValues="0.883333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="801"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005775" DistinctValues="4.416667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="813"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="813"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="827"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="827"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="834"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="834"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="848"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.433333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="848"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="851"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="851"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="851"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001540" DistinctValues="0.955556">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="851"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003080" DistinctValues="1.911111">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="857"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="857"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="864"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="864"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="872"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="872"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="872"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="872"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001260" DistinctValues="0.600000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="876"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="876"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="876"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001260" DistinctValues="0.600000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="876"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="878"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="878"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="878"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004410" DistinctValues="2.100000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="878"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="885"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="885"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="885"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="886"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="896"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="896"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="909"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="909"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="919"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001066" DistinctValues="0.661538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="919"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="921"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="921"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="921"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003732" DistinctValues="2.315385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="921"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="928"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="928"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="928"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.323077">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="928"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="932"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="932"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="942"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="942"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="952"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="952"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.006930" DistinctValues="5.300000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="969"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="969"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="969"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001260" DistinctValues="0.963636">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="972"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="972"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="972"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005670" DistinctValues="4.336364">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="972"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="981"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.001540" DistinctValues="1.177778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="981"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="983"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="983"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="983"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.005390" DistinctValues="4.122222">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="983"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="993"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="993"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="993"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="993"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000100" DistinctValues="0.030000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.65.1.0"/>
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
@@ -4677,7 +1931,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
       <dxl:CTEList/>
       <dxl:LogicalJoin JoinType="Inner">
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.5228913.1.0" TableName="t1">
+          <dxl:TableDescriptor Mdid="0.379411.1.0" TableName="t1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -4692,7 +1946,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.5228916.1.0" TableName="t2">
+          <dxl:TableDescriptor Mdid="0.379414.1.0" TableName="t2">
             <dxl:Columns>
               <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -4721,7 +1975,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.273354" Rows="61.435742" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.511275" Rows="3100.272216" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -4741,7 +1995,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.269691" Rows="61.435742" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.326416" Rows="3100.272216" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -4782,7 +2036,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.5228913.1.0" TableName="t1">
+            <dxl:TableDescriptor Mdid="0.379411.1.0" TableName="t1">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -4809,7 +2063,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.5228916.1.0" TableName="t2">
+            <dxl:TableDescriptor Mdid="0.379414.1.0" TableName="t2">
               <dxl:Columns>
                 <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleIndependentPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleIndependentPredJoinCardinality.mdp
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
 	    <dxl:Comment><![CDATA[
-Objective: The join cardinality estimate for multiple columns on different tables should be accurate.
-The query returns ~0 rows when run, and we should estimate ~0 rows when
-optimizer_damping_factor_join is set to 0. When `optimizer_damping_factor_join` is set
-to .01 (the default), we estimate ~2500 rows returned.
+Objective: The join cardinality estimate for multiple columns on different tables should be reasonable.
 
+The query returns ~1 rows when run, but we should estimate ~1000 rows
+for optimizer_damping_factor_join 0 and ~2300 rows for the previous 0.01 value.
+The reason for the estimate is that we assume referential integrity constraints
+for the joins, which is not the case in this example.
+
+drop table if exists t1, t2, t3;
 create table t1 (a int, b int) distributed by (a);
 create table t2 (a int, b int) distributed by (a);
 create table t3 (a int, b int) distributed by (a);
@@ -21,21 +24,19 @@ analyze t3;
 set optimizer_join_order=query;
 explain select * from t1, t2, t3 where t1.a = t2.a and t2.a = t3.a and t1.b = t3.b;
 
-                                      QUERY PLAN
---------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.53 rows=4 width=24)
-   ->  Hash Join  (cost=0.00..1293.53 rows=2 width=24)
-         Hash Cond: t2.a = t3.a AND t1.b = t3.b
-         ->  Hash Join  (cost=0.00..862.21 rows=527 width=16)
-               Hash Cond: t1.a = t2.a
-               ->  Table Scan on t1  (cost=0.00..431.01 rows=334 width=8)
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.64 rows=1000 width=24)
+   ->  Hash Join  (cost=0.00..1293.55 rows=334 width=24)
+         Hash Cond: ((t2.a = t3.a) AND (t1.b = t3.b))
+         ->  Hash Join  (cost=0.00..862.21 rows=505 width=16)
+               Hash Cond: (t1.a = t2.a)
+               ->  Seq Scan on t1  (cost=0.00..431.01 rows=334 width=8)
                ->  Hash  (cost=431.01..431.01 rows=334 width=8)
-                     ->  Table Scan on t2  (cost=0.00..431.01 rows=334 width=8)
+                     ->  Seq Scan on t2  (cost=0.00..431.01 rows=334 width=8)
          ->  Hash  (cost=431.01..431.01 rows=334 width=8)
-               ->  Table Scan on t3  (cost=0.00..431.01 rows=334 width=8)
- Settings:  optimizer=on; optimizer_damping_factor_join=0; optimizer_join_order=query
- Optimizer status: PQO version 3.88.0
-(12 rows)
+               ->  Seq Scan on t3  (cost=0.00..431.01 rows=334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
 	]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
@@ -5756,7 +5757,7 @@ explain select * from t1, t2, t3 where t1.a = t2.a and t2.a = t3.a and t1.b = t3
     <dxl:Plan Id="0" SpaceSize="29">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.534444" Rows="3.933771" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.651422" Rows="1000.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -5782,7 +5783,7 @@ explain select * from t1, t2, t3 where t1.a = t2.a and t2.a = t3.a and t1.b = t3
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.534092" Rows="3.933771" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.561982" Rows="1000.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/MultipleIndexPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleIndexPredicate.mdp
@@ -67,7 +67,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-3.mdp
@@ -6,7 +6,7 @@ explain select generate_series(0,2) x, generate_series(0,3) y from (select gener
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp
@@ -15,7 +15,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NLJ-DistCol-No-Broadcast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-DistCol-No-Broadcast.mdp
@@ -20,7 +20,7 @@ explain select * from a1,b1 where a1.a = b1.a;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NLJ-EqDistCol-InEqNonDistCol-No-Broadcast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-EqDistCol-InEqNonDistCol-No-Broadcast.mdp
@@ -20,7 +20,7 @@ explain select * from a1,b1 where a1.a = b1.a and a1.a != b1.b;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-NullInner.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-NullInner.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Name-Cardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Name-Cardinality.mdp
@@ -13,7 +13,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
@@ -23,7 +23,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
@@ -42,7 +42,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
@@ -36,7 +36,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NoDistKeyMultiPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoDistKeyMultiPredJoinCardinality.mdp
@@ -1587,7 +1587,7 @@
     <dxl:Plan Id="0" SpaceSize="26">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.445092" Rows="970.732885" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.448529" Rows="1000.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1613,7 +1613,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.358270" Rows="970.732885" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.359089" Rows="1000.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/NoMissingStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoMissingStats.mdp
@@ -9,7 +9,7 @@ explain select count(*) from foo where c = 1;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NoMissingStatsAskingForSystemColFOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoMissingStatsAskingForSystemColFOJ.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NoPartConstraint-WhenNoDefaultPartsAndIndices.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPartConstraint-WhenNoDefaultPartsAndIndices.mdp
@@ -24,7 +24,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
@@ -85,7 +85,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,103001,103002"/>

--- a/src/backend/gporca/data/dxl/minidump/NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NotExists-SuperflousOuterRefWithGbAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NotExists-SuperflousOuterRefWithGbAgg.mdp
@@ -25,7 +25,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/NullConstant-INDF-Col.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NullConstant-INDF-Col.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102025,102115,102118,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/OR.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OR.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/OneDistKeyMultiPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneDistKeyMultiPredJoinCardinality.mdp
@@ -1223,7 +1223,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.420052" Rows="970.732885" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.423489" Rows="1000.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1249,7 +1249,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.333230" Rows="970.732885" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.334049" Rows="1000.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/OneSegmentGather.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneSegmentGather.mdp
@@ -112,7 +112,7 @@ WHERE filter_col = 'TEST'
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="54">

--- a/src/backend/gporca/data/dxl/minidump/OrderByOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderByOuterRef.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
@@ -16,7 +16,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-ConstArray-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-ConstArray-2.mdp
@@ -15,7 +15,7 @@ select * from P where a > ALL ('{1,2,3}'::integer[]);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-NOT-IN.mdp
@@ -15,7 +15,7 @@ Select * from P where P.a NOT IN (1,2);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WithOnlyDefaultPartInfo.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WithOnlyDefaultPartInfo.mdp
@@ -27,7 +27,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
@@ -41,7 +41,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
@@ -9,7 +9,7 @@ WHERE b in (1,2);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102144,103001,103026,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -43,7 +43,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
@@ -9,7 +9,7 @@ explain select * from foo where b = 25 or b = 35;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate3.mdp
@@ -9,7 +9,7 @@ explain select * from foo where (b = 25 and a > 10) or (b<15 and a>5);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
@@ -12,7 +12,7 @@ select (select h.i from t2) from h where h.j = 1;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-PartitionSelectorRewindability.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-PartitionSelectorRewindability.mdp
@@ -37,7 +37,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="7" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102029,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102144,103001,103012,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-EqPredicateWithCastRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-EqPredicateWithCastRange.mdp
@@ -7,7 +7,7 @@ explain select * from R where b::int8=5::int8;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFList.mdp
@@ -14,7 +14,7 @@ EXPLAIN SELECT * FROM listfoo WHERE b IS DISTINCT FROM 2;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFWithCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFWithCast.mdp
@@ -12,7 +12,7 @@ explain select * from L where 2::numeric is distinct from b::numeric;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
@@ -9,7 +9,7 @@ explain select * from dd_part_singlecol where a is null and b is null;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -23,7 +23,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
@@ -13,7 +13,7 @@ select * from foo where b is not null;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -57,7 +57,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultipleEqPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultipleEqPredicates.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NonConstSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NonConstSelect.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,102,101001,101013,103001,103002"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCastMultiLevelList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCastMultiLevelList.mdp
@@ -12,7 +12,7 @@ EXPLAIN SELECT * FROM pt_complex WHERE  k::numeric = 2::numeric AND j::numeric =
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
@@ -33,7 +33,7 @@ explain select * from t1 where a = 1 and b in (select b from t2);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsOfDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsOfDisjuncts.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc1.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Preds-Over-WinFunc4.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -8,7 +8,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ProjectOutsideCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectOutsideCountStar.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ProjectRepeatedColumn2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectRepeatedColumn2.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101000,101001,101013,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/ProjectWithConstant.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectWithConstant.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Push-Subplan-Below-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Push-Subplan-Below-Union.mdp
@@ -68,7 +68,7 @@ union
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-1.mdp
@@ -15,7 +15,7 @@ select id from uav1 union select val from uav4 union select id from uav2;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnionAll.mdp
@@ -14,7 +14,7 @@ explain select id from uav group by id;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -10,7 +10,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqOnEndPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqOnEndPartitionRange.mdp
@@ -19,7 +19,7 @@
 <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTEqOnEndPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTEqOnEndPartitionRange.mdp
@@ -19,7 +19,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Remove-Distinct-From-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Remove-Distinct-From-Subquery.mdp
@@ -58,7 +58,7 @@ select * from bar where c not in (select distinct a from foo);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/RemoveUnusedProjElements.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RemoveUnusedProjElements.mdp
@@ -7,7 +7,7 @@ select sum(a) from (select a, b*c, c||d from woo) as too;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJReplicated.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTable-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTable-CTAS.mdp
@@ -6,7 +6,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableGroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableGroupBy.mdp
@@ -9,7 +9,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableInsert.mdp
@@ -8,7 +8,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/RightJoinBothReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinBothReplicated.mdp
@@ -27,7 +27,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/RightJoinHashed.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinHashed.mdp
@@ -25,7 +25,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/RightJoinReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinReplicated.mdp
@@ -25,7 +25,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/RollupNoAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RollupNoAgg.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
@@ -26,7 +26,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -16,7 +16,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/SelectOnBpchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectOnBpchar.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103002,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Self-Comparison.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Self-Comparison.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2InnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2InnerJoin.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp
@@ -24,7 +24,7 @@ explain select * from x where x.i in (select x.y from y);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103021,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,102016,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
@@ -15,7 +15,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -15,7 +15,7 @@ AND
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/Stats-For-Select-With-Outer-Refs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stats-For-Select-With-Outer-Refs.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103002,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-NoParams.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-NoParams.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -35,7 +35,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -576,7 +576,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.004858" Rows="19.999995" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.004858" Rows="20.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -595,7 +595,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
               <dxl:LimitOffset/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.004030" Rows="19.999995" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.004030" Rows="20.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
@@ -27,7 +27,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
@@ -45,7 +45,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-To-ScalarSubq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-To-ScalarSubq.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqEnforceSubplan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqEnforceSubplan.mdp
@@ -9,7 +9,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/SubqOuterReferenceInClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqOuterReferenceInClause.mdp
@@ -9,7 +9,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -49,7 +49,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
@@ -6,7 +6,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/SubqueryOuterRefLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryOuterRefLimit.mdp
@@ -13,7 +13,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
@@ -6497,10 +6497,10 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11166015676">
+    <dxl:Plan Id="0" SpaceSize="9016323952">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="527997.396320" Rows="25.000000" Width="34"/>
+          <dxl:Cost StartupCost="0" TotalCost="505295.883530" Rows="25.000000" Width="34"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="69" Alias="n_name">
@@ -6516,7 +6516,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="527997.392503" Rows="25.000000" Width="34"/>
+            <dxl:Cost StartupCost="0" TotalCost="505295.879713" Rows="25.000000" Width="34"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="69" Alias="n_name">
@@ -6534,7 +6534,7 @@
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="527997.383723" Rows="25.000000" Width="34"/>
+              <dxl:Cost StartupCost="0" TotalCost="505295.870932" Rows="25.000000" Width="34"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="69"/>
@@ -6552,7 +6552,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="527997.381937" Rows="25.000000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="505295.869146" Rows="25.000000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="69" Alias="n_name">
@@ -6571,7 +6571,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="527997.380606" Rows="25.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="505295.867816" Rows="25.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="69" Alias="n_name">
@@ -6585,7 +6585,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="527997.380606" Rows="25.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="505295.867816" Rows="25.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="69"/>
@@ -6609,7 +6609,7 @@
                   <dxl:Filter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="516749.583045" Rows="168702200.194000" Width="42"/>
+                      <dxl:Cost StartupCost="0" TotalCost="504845.955799" Rows="6748088.007760" Width="42"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="36" Alias="l_extendedprice">

--- a/src/backend/gporca/data/dxl/minidump/TVFAnyelement.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFAnyelement.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/TVFGenerateSeries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFGenerateSeries.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedAgg.mdp
@@ -20,7 +20,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/TaintedReplicatedLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TaintedReplicatedLimit.mdp
@@ -21,7 +21,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/TextMCVCardinalityGreaterThan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TextMCVCardinalityGreaterThan.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102007,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctDistrCol.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102007,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/TimeStamp-Date-HashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TimeStamp-Date-HashJoin.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,102001,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -21,7 +21,7 @@ select  i_item_id
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="96"/>

--- a/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
@@ -69,7 +69,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/TypeModifierArrayRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TypeModifierArrayRef.mdp
@@ -7,7 +7,7 @@ SELECT b[1] AS typmod_in_array_ref FROM foo;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/TypeModifierConst.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TypeModifierConst.mdp
@@ -6,7 +6,7 @@ select '5'::varchar(10);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/UDA-AnyArray.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UDA-AnyArray.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,103001"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-Distributed-Table-With-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Distributed-Table-With-Const-Table.mdp
@@ -7,7 +7,7 @@ Table X (int i, int j) is distributed by i
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102115,102116,102117,102119,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-On-HJNs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-On-HJNs.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Output.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Output.mdp
@@ -8,7 +8,7 @@ select * from x where a in (select a from y union select 1);
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Volatile-Func.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103003,103016"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionWithCTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionWithCTE.mdp
@@ -14,7 +14,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103002,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
@@ -40,7 +40,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="4">

--- a/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithOids.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithOids.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102007,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102016,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingNonDistColSameTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingNonDistColSameTable.mdp
@@ -23,7 +23,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/UseDistributionSatisfactionForUniversalInnerChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UseDistributionSatisfactionForUniversalInnerChild.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="102001,102002,102003,102024,102144,103001,103027,103033"/>

--- a/src/backend/gporca/data/dxl/minidump/VarcharMCVCardinalityGreaterThan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/VarcharMCVCardinalityGreaterThan.mdp
@@ -11,7 +11,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
@@ -10,7 +10,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">

--- a/src/backend/gporca/data/dxl/minidump/WindowFrame-SingleEdged.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WindowFrame-SingleEdged.mdp
@@ -3,7 +3,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>

--- a/src/backend/gporca/data/dxl/minidump/cte-duplicate-columns-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/cte-duplicate-columns-2.mdp
@@ -12,7 +12,7 @@ where x1.b = x2.b;
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -17,7 +17,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102116,102117,102119,102121,103001,103016"/>

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CScaleFactorUtils.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CScaleFactorUtils.h
@@ -100,7 +100,8 @@ public:
 	// calculate the cumulative join scaling factor
 	static CDouble CumulativeJoinScaleFactor(
 		CMemoryPool *mp, const CStatisticsConfig *stats_config,
-		SJoinConditionArray *join_conds_scale_factors);
+		SJoinConditionArray *join_conds_scale_factors,
+		CDouble limit_for_result_scale_factor);
 
 	// return scaling factor of the join predicate after apply damping
 	static CDouble DampedJoinScaleFactor(const CStatisticsConfig *stats_config,

--- a/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -473,9 +473,12 @@ CJoinStatsProcessor::CalcJoinCardinality(
 {
 	GPOS_ASSERT(NULL != stats_config);
 	GPOS_ASSERT(NULL != join_conds_scale_factors);
+	CDouble limit_for_result_scale_factor(
+		std::max(left_num_rows.Get(), right_num_rows.Get()));
 
 	CDouble scale_factor = CScaleFactorUtils::CumulativeJoinScaleFactor(
-		mp, stats_config, join_conds_scale_factors);
+		mp, stats_config, join_conds_scale_factors,
+		limit_for_result_scale_factor);
 	CDouble cartesian_product_num_rows = left_num_rows * right_num_rows;
 
 	if (IStatistics::EsjtLeftAntiSemiJoin == join_type ||

--- a/src/backend/gporca/libnaucrates/src/statistics/CScaleFactorUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CScaleFactorUtils.cpp
@@ -200,7 +200,8 @@ CScaleFactorUtils::CalcCumulativeScaleFactorSqrtAlg(
 CDouble
 CScaleFactorUtils::CumulativeJoinScaleFactor(
 	CMemoryPool *mp, const CStatisticsConfig *stats_config,
-	SJoinConditionArray *join_conds_scale_factors)
+	SJoinConditionArray *join_conds_scale_factors,
+	CDouble limit_for_result_scale_factor)
 {
 	GPOS_ASSERT(NULL != stats_config);
 	GPOS_ASSERT(NULL != join_conds_scale_factors);
@@ -240,6 +241,8 @@ CScaleFactorUtils::CumulativeJoinScaleFactor(
 	//    is not correlated with any other predicate. This assumption comes from the idea that distribution
 	//    cols are ideally unique for each record to gain the best possible performance. This is a best
 	//    guess since we do not have a way to support correlated columns at this time.
+	//
+
 	CDouble cumulative_scale_factor(1.0);
 	if (stats_config->DDampingFactorJoin() > 0)
 	{
@@ -267,6 +270,21 @@ CScaleFactorUtils::CumulativeJoinScaleFactor(
 		cumulative_scale_factor =
 			CScaleFactorUtils::CalcCumulativeScaleFactorSqrtAlg(
 				scale_factor_hashmap, independent_join_preds);
+
+		// Limit the scale factor, usually to the cardinality of the larger of
+		// the joined tables. The reason for this is that we want to assume
+		// a referential integrity constraint between the two joined tables, so
+		// a row in one table will match with at least one row in the other
+		// table. This makes multi-predicate joins more similar to single
+		// predicates, where we make the same assumption. This assumption is
+		// baked in the formula itself: When we divide the cartesian product
+		// by the max of the NDVs that means that every one of these NDVs will
+		// have a match in the other table. Another way to look at it is that
+		// 'cumulative_scale_factor' represents the NDV of the combined equi-join
+		// columns (ignore non-equi joins for a moment). We know that this NDV
+		// cannot exceed the cardinality of the larger of the tables.
+		cumulative_scale_factor = std::min(cumulative_scale_factor.Get(),
+										   limit_for_result_scale_factor.Get());
 
 		independent_join_preds->Release();
 		scale_factor_hashmap->Release();

--- a/src/backend/gporca/libnaucrates/src/statistics/CScaleFactorUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CScaleFactorUtils.cpp
@@ -271,10 +271,11 @@ CScaleFactorUtils::CumulativeJoinScaleFactor(
 			CScaleFactorUtils::CalcCumulativeScaleFactorSqrtAlg(
 				scale_factor_hashmap, independent_join_preds);
 
-		// Limit the scale factor, usually to the cardinality of the larger of
-		// the joined tables. The reason for this is that we want to assume
-		// a referential integrity constraint between the two joined tables, so
-		// a row in one table will match with at least one row in the other
+		// Limit the scale factor, usually to the cardinality of the larger of the
+		// joined tables. This causes the resulting join cardinality to be at least
+		// the size of the smaller table. The reason for this is that we want to
+		// assume a referential integrity constraint between the two joined tables,
+		// so a row in one table will match with at least one row in the other
 		// table. This makes multi-predicate joins more similar to single
 		// predicates, where we make the same assumption. This assumption is
 		// baked in the formula itself: When we divide the cartesian product

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4415,12 +4415,12 @@ struct config_real ConfigureNamesReal_gp[] =
 
 	{
 		{"optimizer_damping_factor_join", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("join predicate damping factor in optimizer, 1.0 means no damping"),
+			gettext_noop("join predicate damping factor in optimizer, 1.0 means no damping, 0.0 means square root method"),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_damping_factor_join,
-		0.01, 0.0, 1.0,
+		0.0, 0.0, 1.0,
 		NULL, NULL, NULL
 	},
 	{


### PR DESCRIPTION
This PR has 3 parts:

1. Change the default for goc optimizer_damping_factor_join to 0
2. Limit the scale factor when using the new algorithm to avoid under-estimations.
3. MDP file changes, updated some test cases to use an RI constraint between the tables, since this is what we assume in the estimation.

See the individual commit messages for more details.

Some historical info on the code for damping factor 0:

- https://github.com/greenplum-db/gporca/pull/567: Initial implementation
- https://github.com/greenplum-db/gpdb/pull/10479 (6X backport: https://github.com/greenplum-db/gpdb/pull/10549): Improve the damping algorithm for predicates on distribution keys


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
