### PR TITLE
Remove FtsControlBlock->ControlLock.

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -925,7 +925,6 @@ updateConfiguration(CdbComponentDatabaseInfo *primary,
 		 * dispatcher, now that changes has been persisted to catalog.
 		 */
 		Assert(ftsProbeInfo);
-		ftsLock();
 		if (IsPrimaryAlive)
 			FTS_STATUS_SET_UP(ftsProbeInfo->status[primary->config->dbid]);
 		else
@@ -935,7 +934,6 @@ updateConfiguration(CdbComponentDatabaseInfo *primary,
 			FTS_STATUS_SET_UP(ftsProbeInfo->status[mirror->config->dbid]);
 		else
 			FTS_STATUS_SET_DOWN(ftsProbeInfo->status[mirror->config->dbid]);
-		ftsUnlock();
 	}
 
 	return UpdateNeeded;

--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -194,8 +194,6 @@ PrimaryOrMirrorWillBeUpdated(int count)
 	will_be_called_count(StartTransactionCommand, count);
 	will_be_called_count(GetTransactionSnapshot, count);
 	will_be_called_count(CommitTransactionCommand, count);
-	will_be_called_count(ftsLock, count);
-	will_be_called_count(ftsUnlock, count);
 }
 
 /*

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -43,7 +43,6 @@ typedef struct FtsProbeInfo
 
 typedef struct FtsControlBlock
 {
-	LWLockId		ControlLock;
 	FtsProbeInfo	fts_probe_info;
 	pid_t			fts_probe_pid;
 }	FtsControlBlock;
@@ -56,8 +55,6 @@ extern void FtsShmemInit(void);
 extern bool FtsIsSegmentDown(CdbComponentDatabaseInfo *dBInfo);
 extern bool FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **, int);
 
-extern void ftsLock(void);
-extern void ftsUnlock(void);
 extern void FtsNotifyProber(void);
 extern uint8 getFtsVersion(void);
 #endif   /* CDBFTS_H */


### PR DESCRIPTION
Remove FtsControlBlock->ControlLock (the LWLock for guarding ftsProbeInfo->status)
and related ftsLock()/ftsUnlock() functions.

FtsControlBlock->ControlLock is intended to guard concurrent access to
ftsProbeInfo->status array. In the original code implementation, only the writer
(FTS probe process) acquires this lock before updating ftsProbeInfo->status, but
readers (query dispatcher processes) reads ftsProbeInfo->status without locking
(see function FtsIsSegmentDown()).

ftsProbeInfo->status is a volatile uint8 array. Because accessing unaligned byte
in memory is not atomic and a reader does not acquire the LWLock before reading,
the original implementation poses race condition to readers. That is, a QD may
not see the correct ftsProbeInfo->status values when calling FtsIsSegmentDown().
However, the consequence is actually harmless: at worst, a QD may decide a QE on a
failed segment to be still re-usable when recycling a gang (see the call chain
cdbcomponent_recycleIdleQE-->cleanupQE-->FtsIsSegmentDown), and gets an error
when dispatching the next command/statement.

Therefore, we can keep the reader side logic unchanged, i.e., a QD can still read
ftsProbeInfo->status without acquiring FtsControlBlock->ControlLock.

Given that, there is no point for the writer (i.e. FTS probe process) to acquire
this lock either. So we can just remove this lock.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
