### PR TITLE
Speed up ORCA's Relcache translation

### DIFF
--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -66,4 +66,16 @@ CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	return str;
 }
 
+// return the requested metadata object
+IMDCacheObject *
+CMDProviderRelcache::GetMDObj(CMemoryPool *mp, CMDAccessor *md_accessor,
+							  IMDId *mdid) const
+{
+	IMDCacheObject *md_obj =
+		CTranslatorRelcacheToDXL::RetrieveObject(mp, md_accessor, mdid);
+	GPOS_ASSERT(nullptr != md_obj);
+
+	return md_obj;
+}
+
 // EOF

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -518,14 +518,22 @@ CMDAccessor::GetImdObj(IMDId *mdid)
 				timerFetch.Restart();
 			}
 
+			// Any object to be inserted into the MD cache must be allocated in the
+			// different memory pool, so that it is not destroyed at the end of the
+			// query. Since the mdid passed to GetMDObj() may be saved in the object,
+			// make a copy of it here in the right memory pool.
+			// An exception is made for CTAS (see below).
 			CMemoryPool *mp = m_mp;
+			IMDId *mdidCopy = mdid;
 			if (IMDId::EmdidGPDBCtas != mdid->MdidType())
 			{
 				// create the accessor memory pool
 				mp = a_pmdcacc->Pmp();
+				mdidCopy = mdid->Copy(mp);
+				GPOS_ASSERT(mdidCopy->Equals(mdid));
 			}
 
-			pmdobjNew = pmdp->GetMDObj(mp, this, mdid);
+			pmdobjNew = pmdp->GetMDObj(mp, this, mdidCopy);
 			GPOS_ASSERT(nullptr != pmdobjNew);
 
 			if (fPrintOptStats)

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -517,20 +517,15 @@ CMDAccessor::GetImdObj(IMDId *mdid)
 			{
 				timerFetch.Restart();
 			}
-			CAutoP<CWStringBase> a_pstr;
-			a_pstr = pmdp->GetMDObjDXLStr(m_mp, this, mdid);
 
-			GPOS_ASSERT(nullptr != a_pstr.Value());
 			CMemoryPool *mp = m_mp;
-
 			if (IMDId::EmdidGPDBCtas != mdid->MdidType())
 			{
 				// create the accessor memory pool
 				mp = a_pmdcacc->Pmp();
 			}
 
-			pmdobjNew = gpdxl::CDXLUtils::ParseDXLToIMDIdCacheObj(
-				mp, a_pstr.Value(), nullptr /* XSD path */);
+			pmdobjNew = pmdp->GetMDObj(mp, this, mdid);
 			GPOS_ASSERT(nullptr != pmdobjNew);
 
 			if (fPrintOptStats)

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdCast.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdCast.h
@@ -126,6 +126,15 @@ public:
 
 		return dynamic_cast<CMDIdCast *>(mdid);
 	}
+
+	// make a copy in the given memory pool
+	IMDId *
+	Copy(CMemoryPool *mp) const override
+	{
+		CMDIdGPDB *mdid_src = CMDIdGPDB::CastMdid(m_mdid_src->Copy(mp));
+		CMDIdGPDB *mdid_dest = CMDIdGPDB::CastMdid(m_mdid_dest->Copy(mp));
+		return GPOS_NEW(mp) CMDIdCast(mdid_src, mdid_dest);
+	}
 };
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdColStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdColStats.h
@@ -124,6 +124,14 @@ public:
 
 		return dynamic_cast<CMDIdColStats *>(mdid);
 	}
+
+	// make a copy in the given memory pool
+	IMDId *
+	Copy(CMemoryPool *mp) const override
+	{
+		CMDIdGPDB *mdid_rel = CMDIdGPDB::CastMdid(m_rel_mdid->Copy(mp));
+		return GPOS_NEW(mp) CMDIdColStats(mdid_rel, m_attr_pos);
+	}
 };
 
 }  // namespace gpmd

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdGPDB.h
@@ -141,6 +141,12 @@ public:
 		return dynamic_cast<CMDIdGPDB *>(mdid);
 	}
 
+	IMDId *
+	Copy(CMemoryPool *mp) const override
+	{
+		return GPOS_NEW(mp) CMDIdGPDB(*this);
+	}
+
 	// invalid mdid
 	static CMDIdGPDB m_mdid_invalid_key;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdRelStats.h
@@ -119,6 +119,14 @@ public:
 
 		return dynamic_cast<CMDIdRelStats *>(mdid);
 	}
+
+	// make a copy in the given memory pool
+	IMDId *
+	Copy(CMemoryPool *mp) const override
+	{
+		CMDIdGPDB *mdid_rel = CMDIdGPDB::CastMdid(m_rel_mdid->Copy(mp));
+		return GPOS_NEW(mp) CMDIdRelStats(mdid_rel);
+	}
 };
 
 }  // namespace gpmd

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdScCmp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdScCmp.h
@@ -127,6 +127,17 @@ public:
 
 		return dynamic_cast<CMDIdScCmp *>(mdid);
 	}
+
+	// make a copy in the given memory pool
+	IMDId *
+	Copy(CMemoryPool *mp) const override
+	{
+		CMDIdGPDB *mdid_left = CMDIdGPDB::CastMdid(m_mdid_left->Copy(mp));
+		CMDIdGPDB *mdid_right = CMDIdGPDB::CastMdid(m_mdid_right->Copy(mp));
+
+		return GPOS_NEW(mp)
+			CMDIdScCmp(mdid_left, mdid_right, m_comparision_type);
+	}
 };
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDProviderMemory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDProviderMemory.h
@@ -66,6 +66,10 @@ public:
 	CWStringBase *GetMDObjDXLStr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								 IMDId *mdid) const override;
 
+	// returns the requested metadata object
+	IMDCacheObject *GetMDObj(CMemoryPool *mp, CMDAccessor *md_accessor,
+							 IMDId *mdid) const override;
+
 	// return the mdid for the specified system id and type
 	IMDId *MDId(CMemoryPool *mp, CSystemId sysid,
 				IMDType::ETypeInfo type_info) const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -163,6 +163,9 @@ public:
 	}
 
 	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
+
+	// make a copy in the given memory pool
+	virtual IMDId *Copy(CMemoryPool *mp) const = 0;
 };
 
 // common structures over metadata id elements

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDProvider.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDProvider.h
@@ -50,6 +50,10 @@ public:
 										 CMDAccessor *md_accessor,
 										 IMDId *mdid) const = 0;
 
+	// return the requested metadata object
+	virtual IMDCacheObject *GetMDObj(CMemoryPool *mp, CMDAccessor *md_accessor,
+									 IMDId *mdid) const = 0;
+
 	// return the mdid for the specified system id and type
 	virtual IMDId *MDId(CMemoryPool *mp, CSystemId sysid,
 						IMDType::ETypeInfo type_info) const = 0;

--- a/src/backend/gporca/libnaucrates/src/md/CMDProviderMemory.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDProviderMemory.cpp
@@ -225,4 +225,21 @@ CMDProviderMemory::MDId(CMemoryPool *mp, CSystemId sysid,
 	return GetGPDBTypeMdid(mp, sysid, type_info);
 }
 
+// return the requested metadata object
+IMDCacheObject *
+CMDProviderMemory::GetMDObj(CMemoryPool *mp, CMDAccessor *md_accessor,
+							IMDId *mdid) const
+{
+	CAutoP<CWStringBase> a_pstr;
+	a_pstr = GetMDObjDXLStr(mp, md_accessor, mdid);
+
+	GPOS_ASSERT(nullptr != a_pstr.Value());
+
+	IMDCacheObject *pmdobjNew = gpdxl::CDXLUtils::ParseDXLToIMDIdCacheObj(
+		mp, a_pstr.Value(), nullptr /* XSD path */);
+	GPOS_ASSERT(nullptr != pmdobjNew);
+
+	return pmdobjNew;
+}
+
 // EOF

--- a/src/include/gpopt/relcache/CMDProviderRelcache.h
+++ b/src/include/gpopt/relcache/CMDProviderRelcache.h
@@ -61,6 +61,10 @@ public:
 	CWStringBase *GetMDObjDXLStr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								 IMDId *md_id) const override;
 
+	// return the requested metadata object
+	IMDCacheObject *GetMDObj(CMemoryPool *mp, CMDAccessor *md_accessor,
+							 IMDId *mdid) const override;
+
 	// return the mdid for the requested type
 	IMDId *
 	MDId(CMemoryPool *mp, CSystemId sysid,


### PR DESCRIPTION
For every object that is requested from GPDB, ORCA currently constructs
and MD object, serializes it completely to a string, and then
de-serializes it back to an MD object before inserting it into the MD
Cache.
Although this needs to be done only once per session for every unique
object, it is very wasteful of resources, and can be skipped entirely
for faster total optimization time.
For instance, this commit brings down the total optimization time for
the following query down from 5.3s to 2.5s (over 2X speed up) by speeding
up metadata retrieval.

```
set statement_mem = "4096MB";
select * from foo_4k;
```
* foo_4k is a partitioned table with 4000 partitions.
* the memory limits are increased to accommodate the larger query plan &
  metadata requirements