### PR TITLE
Do not wait for synchronous replication if QD WAL sender is not for HA

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -201,7 +201,8 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 			syncStandbyPresent = (walsnd->pid != 0)
 				&& ((walsnd->state == WALSNDSTATE_STREAMING)
 					|| (walsnd->state == WALSNDSTATE_CATCHUP &&
-						walsnd->caughtup_within_range));
+						walsnd->caughtup_within_range))
+				&& walsnd->is_for_gp_walreceiver;
 			SpinLockRelease(&walsnd->mutex);
 
 			if (syncStandbyPresent)


### PR DESCRIPTION
In GPDB, the coordinator segment does not follow the usual rules for
synchronous replication. It just assumes that all WAL streaming
connections are synchronous no matter if the synchronous_standby_names
GUC is set or not (to allow the coordinator to skip blocking if the
standby coordinator crashes). To allow asynchronous connections to the
coordinator segment, we should check for the is_for_gp_walreceiver
flag that we label our High Availability mirror connections with. If
it's not set to true, we should not consider the WAL stream to be
synchronous.

I am fully aware that this SyncRepWaitForLSN coordinator segment hack may be removed with the implementation of a coordinator/standby autofailover... but there hasn't been much talk on how that would look (e.g. do we need to keep the hack for users who do not want to use the coordinator/standby autofailover feature but still wants a standby coordinator?).  Hence the need for this PR.