### PR TITLE
docs - remove refs to gp_fts_probe_threadcount guc

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -1146,13 +1146,10 @@
                 <p>
                   <codeph>gp_set_read_only</codeph>
                 </p>
-                <p>
-                  <codeph>gp_fts_probe_interval</codeph>
-                </p>
               </stentry>
               <stentry>
                 <p>
-                  <codeph>gp_fts_probe_threadcount</codeph>
+                  <codeph>gp_fts_probe_interval</codeph>
                 </p>
               </stentry>
             </strow>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -253,9 +253,6 @@
               <xref href="#gp_fts_probe_retries"/>
             </li>
             <li>
-              <xref href="#gp_fts_probe_threadcount"/>
-            </li>
-            <li>
               <xref href="#gp_fts_probe_timeout"/>
             </li>
             <li>
@@ -3276,34 +3273,6 @@
             <row>
               <entry colname="col1">integer</entry>
               <entry colname="col2">5</entry>
-              <entry colname="col3">master<p>system</p><p>restart</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="gp_fts_probe_threadcount">
-    <title>gp_fts_probe_threadcount</title>
-    <body>
-      <p>Specifies the number of <codeph>ftsprobe</codeph> threads to create. This parameter should
-        be set to a value equal to or greater than the number of segments per host. </p>
-      <table id="gp_fts_probe_threadcount_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">1 - 128</entry>
-              <entry colname="col2">16</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1428,10 +1428,6 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_fts_probe_threadcount" type="section"
-                  >gp_fts_probe_threadcount</xref>
-              </p>
-              <p>
                 <xref href="guc-list.xml#gp_fts_probe_timeout" format="dita"/>
               </p>
               <p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -107,7 +107,6 @@
             <topicref href="guc-list.xml#gp_external_enable_filter_pushdown"/>
             <topicref href="guc-list.xml#gp_fts_probe_interval"/>
             <topicref href="guc-list.xml#gp_fts_probe_retries"/>
-            <topicref href="guc-list.xml#gp_fts_probe_threadcount"/>
             <topicref href="guc-list.xml#gp_fts_probe_timeout"/>
             <topicref href="guc-list.xml#gp_fts_replication_attempt_count"/>
             <topicref href="guc-list.xml#gp_global_deadlock_detector_period"/>


### PR DESCRIPTION
the gp_fts_probe_threadcount guc was removed in 6, clean up the docs.
