### PR TITLE
Fix the remaining occurrences of NULL

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalRightOuterJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalRightOuterJoin.h
@@ -115,7 +115,7 @@ public:
 	static CLogicalRightOuterJoin *
 	PopConvert(COperator *pop)
 	{
-		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalRightOuterJoin == pop->Eopid());
 
 		return dynamic_cast<CLogicalRightOuterJoin *>(pop);

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
@@ -39,7 +39,7 @@ public:
 	CPhysicalRightOuterHashJoin(CMemoryPool *mp,
 								CExpressionArray *pdrgpexprOuterKeys,
 								CExpressionArray *pdrgpexprInnerKeys,
-								IMdIdArray *hash_opfamilies = NULL);
+								IMdIdArray *hash_opfamilies = nullptr);
 
 	// dtor
 	~CPhysicalRightOuterHashJoin() override;
@@ -62,7 +62,7 @@ public:
 	static CPhysicalRightOuterHashJoin *
 	PopConvert(COperator *pop)
 	{
-		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalRightOuterHashJoin == pop->Eopid());
 
 		return dynamic_cast<CPhysicalRightOuterHashJoin *>(pop);

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalRightOuterJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalRightOuterJoin.cpp
@@ -31,7 +31,7 @@ using namespace gpopt;
 CLogicalRightOuterJoin::CLogicalRightOuterJoin(CMemoryPool *mp)
 	: CLogicalJoin(mp)
 {
-	GPOS_ASSERT(NULL != mp);
+	GPOS_ASSERT(nullptr != mp);
 }
 
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformLeftJoin2RightJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformLeftJoin2RightJoin.cpp
@@ -86,7 +86,7 @@ CXformLeftJoin2RightJoin::Transform(CXformContext *pxfctxt,
 									CXformResult *pxfres,
 									CExpression *pexpr) const
 {
-	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(nullptr != pxfctxt);
 	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
 	GPOS_ASSERT(FCheckPattern(pexpr));
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformRightOuterJoin2HashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformRightOuterJoin2HashJoin.cpp
@@ -74,7 +74,7 @@ CXformRightOuterJoin2HashJoin::Transform(CXformContext *pxfctxt,
 										 CXformResult *pxfres,
 										 CExpression *pexpr) const
 {
-	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(nullptr != pxfctxt);
 	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
 	GPOS_ASSERT(FCheckPattern(pexpr));
 


### PR DESCRIPTION
Commit be71386dd0c4a902 was the result of "rebase and merge" of
greenplum-db/gpdb#11462. This means that while it passed the check it
introduced, the result of the rebase would fail the test (due to
greenplum-db/gpdb#11461), as evidenced by a red Travis CI.

This commit fixes the remaining occurrences of "NULL".