### PR TITLE
Resolve several FIXMEs of hash aggregations

### DIFF
--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -2835,6 +2835,12 @@ typedef struct JoinPathExtraData
 #define GROUPING_CAN_USE_SORT       0x0001
 #define GROUPING_CAN_USE_HASH       0x0002
 #define GROUPING_CAN_PARTIAL_AGG	0x0004
+/*
+ * PostgreSQL's executor doesn't support hashed aggregation
+ * with DISTINCT, because it's supposed to be "a certain loser",
+ * which is not that certion in Greenplum MPP architecture.
+ */
+#define GROUPING_CAN_USE_MPP_HASH   0x0008
 
 /*
  * What kind of partitionwise aggregation is in use?

--- a/src/include/optimizer/tlist.h
+++ b/src/include/optimizer/tlist.h
@@ -45,11 +45,6 @@ extern bool grouping_is_hashable(List *groupClause);
 extern void get_sortgroupclauses_tles(List *clauses, List *targetList,
 									  List **tles, List **sortops, List **eqops);
 
-extern Oid *extract_grouping_ops(List *groupClause);
-extern AttrNumber *extract_grouping_cols(List *groupClause, List *tlist);
-extern bool grouping_is_sortable(List *groupClause);
-extern bool grouping_is_hashable(List *groupClause);
-
 extern Index maxSortGroupRef(List *targetlist, bool include_orderedagg);
 
 extern int get_row_width(List *tlist);


### PR DESCRIPTION
1, make can_mpp_hash a bitmask bit.
2, remove the hasNonCombine check because Greenplum now spills tuples
instead, not the transdata.
3, remove several duplicated declaration.
