### PR TITLE
Use OID of pg_aoseg same as used for gpdb6 and gpdb5

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302101081
+#define CATALOG_VERSION_NO	302102091
 
 #endif

--- a/src/include/catalog/pg_namespace.dat
+++ b/src/include/catalog/pg_namespace.dat
@@ -25,7 +25,12 @@
 # GPDB-specific built-in namespaces.
 # NOTE: pg_dump has BM_BITMAPINDEX_NAMESPACE's value hard-coded in the
 # getTables() query.
-{ oid => '7014', oid_symbol => 'PG_AOSEGMENT_NAMESPACE',
+# OIDs for these built-in namespaces can't be changed. pg_upgrade
+# fails if OID for these schemas mismatch between old and new
+# cluster. Mainly preassigned lookup uses these oids in key hence
+# object lookup fails if it differs between source and destination
+# cluster
+{ oid => '6104', oid_symbol => 'PG_AOSEGMENT_NAMESPACE',
   descr => 'Reserved schema for Append Only segment list and eof tables',
   nspname => 'pg_aoseg', nspowner => 'PGUID', nspacl => '_null_' },
 { oid => '7012', oid_symbol => 'PG_BITMAPINDEX_NAMESPACE',

--- a/src/include/catalog/pg_publication.h
+++ b/src/include/catalog/pg_publication.h
@@ -27,7 +27,7 @@
  *		typedef struct FormData_pg_publication
  * ----------------
  */
-CATALOG(pg_publication,6104,PublicationRelationId)
+CATALOG(pg_publication,6107,PublicationRelationId)
 {
 	Oid			oid;			/* oid */
 

--- a/src/test/regress/expected/namespace_gp.out
+++ b/src/test/regress/expected/namespace_gp.out
@@ -98,8 +98,23 @@ WHERE nspname ~ 'test_schema_[12]';
 
 SELECT rolname
 FROM pg_authid a
-WHERE rolname ~ 'tmp_test_schema_role'
+WHERE rolname ~ 'tmp_test_schema_role';
  rolname 
 ---------
 (0 rows)
+
+-- OIDs for these built-in namespaces should not change. pg_upgrade
+-- fails if OID for these schemas mismatch across major versions.
+-- Mainly preassigned oid lookup uses these oids in key hence object
+-- lookup fails if it differs between source and destination cluster.
+SELECT oid, nspname FROM pg_namespace
+WHERE nspname IN ('pg_catalog', 'pg_toast', 'pg_aoseg', 'pg_bitmapindex')
+ORDER BY oid;
+ oid  |    nspname     
+------+----------------
+   11 | pg_catalog
+   99 | pg_toast
+ 6104 | pg_aoseg
+ 7012 | pg_bitmapindex
+(4 rows)
 

--- a/src/test/regress/sql/namespace_gp.sql
+++ b/src/test/regress/sql/namespace_gp.sql
@@ -67,4 +67,12 @@ WHERE nspname ~ 'test_schema_[12]';
 
 SELECT rolname
 FROM pg_authid a
-WHERE rolname ~ 'tmp_test_schema_role'
+WHERE rolname ~ 'tmp_test_schema_role';
+
+-- OIDs for these built-in namespaces should not change. pg_upgrade
+-- fails if OID for these schemas mismatch across major versions.
+-- Mainly preassigned oid lookup uses these oids in key hence object
+-- lookup fails if it differs between source and destination cluster.
+SELECT oid, nspname FROM pg_namespace
+WHERE nspname IN ('pg_catalog', 'pg_toast', 'pg_aoseg', 'pg_bitmapindex')
+ORDER BY oid;


### PR DESCRIPTION
pg_upgrade via pg_dump and pg_restore binary upgrade mode in functions
to preassign oids (like
pg_catalog.binary_upgrade_set_next_array_pg_type_oid()) use schema
OIDs from old cluster for built-in schemas. Namespace oid is part of
key for preassgined oid search. If the OID is different between source
and destination cluster for pg_aoseg (built-in schema), then can't
find preassigned oid. That results in attempt to allocate new oid for
objects in pg_aoseg schema and fails. This restriction doesn't
exist for user schemas as during restore user schema is created with
the OID from old cluster.

For fun played with pg_toast schema to have OID different between
source and destination cluster. On restore it skips creating toast
table for this case, as decision to create toast table or not during
binary upgrade is based on OID lookup. Due to difference in OIDs
lookup fails and it considers no toast table is needed.

Co-authored-by: David Krieger <dkrieger@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
