### PR TITLE
Optimize pg_get_expr to avoid unnecessary lock on relation. 

### DIFF
--- a/src/test/isolation2/expected/query_gp_partitions_view.out
+++ b/src/test/isolation2/expected/query_gp_partitions_view.out
@@ -1,0 +1,29 @@
+-- Test that pg_partitions view does not lock a table.
+-- 6X used to acquire lock on partition tables when query
+-- gp_partitons view. See `expr_has_vars` in ruleutils.c
+-- for more details.
+create table pg_partitions_ddl_tab(a int, b int) distributed by (a) partition by range (b) ( start (1) end (20) every(5::float) );
+CREATE
+
+1: begin;
+BEGIN
+1: lock pg_partitions_ddl_tab in access exclusive mode;
+LOCK
+1: lock pg_partitions_ddl_tab_1_prt_2 in access exclusive mode;
+LOCK
+
+
+-- The following query should not be blocked by session 1 because no
+-- locks should be held by pg_partitions view.
+select tablename, partitiontablename, partitionboundary from pg_partitions where tablename like 'pg_partitions_ddl%';
+ tablename             | partitiontablename            | partitionboundary                               
+-----------------------+-------------------------------+-------------------------------------------------
+ pg_partitions_ddl_tab | pg_partitions_ddl_tab_1_prt_1 | START (1) END (6) EVERY (5::double precision)   
+ pg_partitions_ddl_tab | pg_partitions_ddl_tab_1_prt_2 | START (6) END (11) EVERY (5::double precision)  
+ pg_partitions_ddl_tab | pg_partitions_ddl_tab_1_prt_3 | START (11) END (16) EVERY (5::double precision) 
+ pg_partitions_ddl_tab | pg_partitions_ddl_tab_1_prt_4 | START (16) END (20) EVERY (5::double precision) 
+(4 rows)
+
+1: end;
+END
+1q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -5,7 +5,7 @@ test: lockmodes
 # cluster during testing. Usually the 2nd reboot should be faster.
 test: prepare_limit
 test: prepared_xact_deadlock_pg_rewind
-test: ao_partition_lock
+test: ao_partition_lock query_gp_partitions_view
 test: dml_on_root_locks_all_parts
 
 test: select_dropped_table

--- a/src/test/isolation2/sql/query_gp_partitions_view.sql
+++ b/src/test/isolation2/sql/query_gp_partitions_view.sql
@@ -1,0 +1,19 @@
+-- Test that pg_partitions view does not lock a table.
+-- 6X used to acquire lock on partition tables when query
+-- gp_partitons view. See `expr_has_vars` in ruleutils.c
+-- for more details.
+create table pg_partitions_ddl_tab(a int, b int)
+distributed by (a) partition by range (b)
+( start (1) end (20) every(5::float) );
+
+1: begin;
+1: lock pg_partitions_ddl_tab in access exclusive mode;
+1: lock pg_partitions_ddl_tab_1_prt_2 in access exclusive mode;
+
+
+-- The following query should not be blocked by session 1 because no
+-- locks should be held by pg_partitions view.
+select tablename, partitiontablename, partitionboundary from pg_partitions where tablename like 'pg_partitions_ddl%';
+
+1: end;
+1q:


### PR DESCRIPTION
This interface is designed to parse a generic rule expression and rule
expressions contain references to relations. Acquiring AccessShareLock
on a relation encountered while deparsing a rule expression seems
logical.
For partition tables, the RANGE and LIST expressions are much simpler -
they cannot contain any references to relations.
So we decide to optimize out the lock when the expression contains
no Var nodes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
