### PR TITLE
gprecoverseg: rebalance all possible segments

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -447,6 +447,19 @@ class SegmentPair:
             hosts.append(self.mirrorDB.hostname)
         return hosts
 
+    def balanced(self):
+        return self.primaryDB.preferred_role == self.primaryDB.role and \
+               self.mirrorDB.preferred_role == self.mirrorDB.role
+
+    def reachable(self):
+        return not self.primaryDB.unreachable and not self.mirrorDB.unreachable
+
+    def up(self):
+        return self.primaryDB.isSegmentUp() and self.mirrorDB.isSegmentUp()
+
+    def synchronized(self):
+        return self.primaryDB.isSegmentModeSynchronized() and self.mirrorDB.isSegmentModeSynchronized()
+
     def is_segment_pair_valid(self):
         """Validates that the primary/mirror pair are in a valid state"""
         prim_status = self.primaryDB.getSegmentStatus()

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -592,17 +592,6 @@ class GpRecoverSegmentProgram:
                 raise ProgramArgumentValidationException( \
                     "Invalid value for recover hosts: %s" % ex)
 
-        # If it's a rebalance operation, make sure we are in an acceptable state to do that
-        # Acceptable state is:
-        #    - No segments down
-        #    - No segments in change tracking or unsynchronized state
-        if self.__options.rebalanceSegments:
-            if len(gpArray.get_invalid_segdbs()) > 0:
-                raise Exception("Down segments still exist.  All segments must be up to rebalance.")
-            if len(gpArray.get_synchronized_segdbs()) != len(gpArray.getSegDbList()):
-                raise Exception(
-                    "Some segments are not yet synchronized.  All segments must be synchronized to rebalance.")
-
         # retain list of hosts that were existing in the system prior to getRecoverActions...
         # this will be needed for later calculations that determine whether
         # new hosts were added into the system

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -62,11 +62,11 @@ class RebalanceSegmentsTestCase(GpTestCase):
         coordinator = Segment.initFromString(
             "1|-1|p|p|s|u|cdw|cdw|5432|/data/coordinator")
         self.primary0 = Segment.initFromString(
-            "2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+            "2|0|p|m|s|u|sdw1|sdw1|40000|/data/primary0")
         primary1 = Segment.initFromString(
             "3|1|p|p|s|u|sdw2|sdw2|40001|/data/primary1")
         self.mirror0 = Segment.initFromString(
-            "4|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+            "4|0|m|p|s|u|sdw2|sdw2|50000|/data/mirror0")
         mirror1 = Segment.initFromString(
             "5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
         return GpArray([coordinator, self.primary0, primary1, self.mirror0, mirror1])

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -174,6 +174,13 @@ Feature: gprecoverseg tests
       And the status of the primary on content 0 should be "u"
       And the status of the primary on content 1 should be "d"
 
+      # Rebalance all possible segments and skip unreachable segment pairs.
+      When the user runs "gprecoverseg -ar"
+      Then gprecoverseg should return a return code of 0
+      And gprecoverseg should print "Not rebalancing primary segment dbid \d with its mirror dbid \d because one is either down, unreachable, or not synchronized" to stdout
+      And content 0 is balanced
+      And content 1 is unbalanced
+
       And the user runs psql with "-c 'DROP TABLE foo'" against database "postgres"
       And the cluster is returned to a good state
 


### PR DESCRIPTION
Don't bail out early if some segments can not be rebalanced. Rather rebalance all possible segments, and skip those that are down. Down segments can occur for hosts that are unreachable.

Rebalance segment pairs that are swapped, status is up, host is reachable, and synchronized.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/7X_rebalance)