### PR TITLE
Skip the pg data directory fsync step in startup after gprecoverseg.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -224,6 +224,8 @@ class PgBaseBackup(Command):
         if logfile:
             cmd_tokens.append('> %s 2>&1' % pipes.quote(logfile))
 
+        cmd_tokens.append(' && touch %s/gp_recovery_sync_done' % pgdata)
+
         cmd_str = ' '.join(cmd_tokens)
 
         self.command_tokens = cmd_tokens

--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -340,4 +340,10 @@ extern bool XLogArchiveIsReady(const char *xlog);
 extern bool XLogArchiveIsReadyOrDone(const char *xlog);
 extern void XLogArchiveCleanup(const char *xlog);
 
+/*
+ * GPDB specific: implies pg_basebackup or pg_rewind has done fsync on the
+ * whole pg data directory so startup could skip the unnecessary pg data fsync.
+ */
+#define RECOVERY_SYNC_DONE      "gp_recovery_sync_done"
+
 #endif							/* XLOG_INTERNAL_H */


### PR DESCRIPTION
gprecoverseg calls pg_basebackup or pg_rewind to do recovery on the failed
nodes and we force the pg data directory fsync in those commands so we could
skip the pg data directory fsync during startup since the recovered database
is not in cleanly shutdown states.

This could save some time if the recovered databases include a lot of table
files. It's implemented by writing a new file recovery_sync_done in the pg
data directory after pg_basebackup/pg_rewind finishes.