### PR TITLE
ic-proxy: limit max size of packet cache.

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.h
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.h
@@ -14,6 +14,8 @@
 
 #include <uv.h>
 
+#define IC_PROXY_PKT_CACHE_MAX_SIZE 20000
+
 extern void ic_proxy_pkt_cache_init(uint32 pkt_size);
 extern void ic_proxy_pkt_cache_uninit(void);
 extern void *ic_proxy_pkt_cache_alloc(size_t *pkt_size);


### PR DESCRIPTION
icproxy's flow control is based on the PAUSE/RESUME, which needs to
route to a remote client. This asynchronous flow control may result
in the size of packet cache increase rapidly but packet returned to
free list slowly.

Packet cache should have a maximum size to limit the total memory
used by icproxy background worker. When limit is reached, the packet
should be freed instead putting to free list.

Note that this patch could not fix the flow control issue, but only
helps to avoid the bloating of packet cache.

Manually tested on a Azure big cluster, this cannot be reproduced in
small cluster.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
