### PR TITLE
Fall back for queries with nested window functions

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2131,6 +2131,17 @@ gpdb::FindNodes(Node *node, List *nodeTags)
 	return -1;
 }
 
+bool
+gpdb::FindNestedNodes(Node *node, NodeTag nodeTag)
+{
+	GP_WRAP_START;
+	{
+		return find_nested_nodes(node, nodeTag);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
 Node *
 gpdb::CoerceToCommonType(ParseState *pstate, Node *node, Oid target_type,
 						 const char *context)

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -449,6 +449,22 @@ CQueryMutators::NeedsLevelsUpCorrection(SContextIncLevelsupMutator *context,
 	return cte_levels_up >= context->m_current_query_level;
 }
 
+BOOL
+CQueryMutators::HasNestedWindowFunctions(const Query *query)
+{
+	ListCell *lc = NULL;
+	ForEach(lc, query->targetList)
+	{
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+
+		if (gpdb::FindNestedNodes((Node *) target_entry->expr, T_WindowRef) > 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CQueryMutators::RunGroupingColMutator
@@ -1471,6 +1487,16 @@ CQueryMutators::NeedsProjListWindowNormalization(const Query *query)
 	if (!query->hasWindFuncs)
 	{
 		return false;
+	}
+
+	// The GPDB side does not check for (unsupported) nested window
+	// functions and in 5X the executor will abort with an internal
+	// error if it finds those.
+	// Example: sum(rank(a) over(order by a)) over(order by a)
+	if (HasNestedWindowFunctions(query))
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+				   GPOS_WSZ_LIT("Nested window functions"));
 	}
 
 	ListCell *lc = NULL;

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -612,6 +612,9 @@ void AppendStringInfo(StringInfo str, const char *str1, const char *str2);
 // the first one found, or -1 if there are none
 int FindNodes(Node *node, List *nodeTags);
 
+// look for a given node tag nested within the same tag (don't descend into subqueries)
+bool FindNestedNodes(Node *node, NodeTag nodeTag);
+
 Node *CoerceToCommonType(ParseState *pstate, Node *node, Oid target_type,
 						 const char *context);
 

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -155,6 +155,9 @@ private:
 	static BOOL NeedsLevelsUpCorrection(SContextIncLevelsupMutator *context,
 										Index cte_levels_up);
 
+	// check one query scope for nested window functions
+	static BOOL HasNestedWindowFunctions(const Query *query);
+
 public:
 	// fall back during since the target list refers to a attribute which algebrizer at this point cannot resolve
 	static BOOL ShouldFallback(Node *node, SContextTLWalker *context);

--- a/src/include/optimizer/walkers.h
+++ b/src/include/optimizer/walkers.h
@@ -74,6 +74,7 @@ extern List *extract_nodes(PlannerGlobal *glob, Node *node, int nodeTag);
 extern List *extract_nodes_plan(Plan *pl, int nodeTag, bool descendIntoSubqueries);
 extern List *extract_nodes_expression(Node *node, int nodeTag, bool descendIntoSubqueries);
 extern int find_nodes(Node *node, List *nodeTags);
+extern bool find_nested_nodes(Node *node, NodeTag nodeTag);
 
 #ifdef __cplusplus
 }

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11908,4 +11908,18 @@ select * from tcorr1 where a < coalesce((select tcorr1.a from tcorr2 where a = 1
  1 | 99
 (1 row)
 
+-- make sure nested window functions give a reasonable error
+select max(count(*) over (order by a)) over (partition by a) from tcorr1;
+ERROR:  Window function calls may not be nested.
+select 1+max(count(*) over (order by a)) over (partition by a) from tcorr1;
+ERROR:  Window function calls may not be nested.
+select * from tcorr1 where a > (select 1+max(count(*) over (order by a)) over (partition by a) from tcorr1);
+ERROR:  Window function calls may not be nested.
+-- this one should work, no nesting
+select max(a) over(order by a) + min(a) over(order by a) from tcorr1;
+ ?column? 
+----------
+        2
+(1 row)
+
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11965,4 +11965,21 @@ select * from tcorr1 where a < coalesce((select tcorr1.a from tcorr2 where a = 1
  1 | 99
 (1 row)
 
+-- make sure nested window functions give a reasonable error
+select max(count(*) over (order by a)) over (partition by a) from tcorr1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ERROR:  Window function calls may not be nested.
+select 1+max(count(*) over (order by a)) over (partition by a) from tcorr1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ERROR:  Window function calls may not be nested.
+select * from tcorr1 where a > (select 1+max(count(*) over (order by a)) over (partition by a) from tcorr1);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ERROR:  Window function calls may not be nested.
+-- this one should work, no nesting
+select max(a) over(order by a) + min(a) over(order by a) from tcorr1;
+ ?column? 
+----------
+        2
+(1 row)
+
 reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2071,6 +2071,14 @@ select * from tcorr1 where b = (select tcorr1.b from tcorr2 where b=33);
 -- expect 1 row, subquery returns nothing, so a < 22 is true
 select * from tcorr1 where a < coalesce((select tcorr1.a from tcorr2 where a = 11), 22);
 
+-- make sure nested window functions give a reasonable error
+select max(count(*) over (order by a)) over (partition by a) from tcorr1;
+select 1+max(count(*) over (order by a)) over (partition by a) from tcorr1;
+select * from tcorr1 where a > (select 1+max(count(*) over (order by a)) over (partition by a) from tcorr1);
+
+-- this one should work, no nesting
+select max(a) over(order by a) + min(a) over(order by a) from tcorr1;
+
 reset optimizer_trace_fallback;
 
 -- start_ignore


### PR DESCRIPTION
GPDB does not support nested window functions like
select sum(rank(a) over(order by a)) over(order by a)

In 5X_STABLE, this check is done in the planner code path and
then again in the executor. The executor check will cause gpdb
to abort with an internal error.

Since ORCA does not go through the planner syntax check (function
window_tlist_mutator), queries with nested window functions will
abort.

This commit adds a check similar to the one in window_tlist_mutator
to the ORCA code path. To be more precise, to the algebrizer that
is part of the DXL generation.

I tried nested window functions on Postgres, MySQL and Oracle and
those engines don't support them, either.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
