### PR TITLE
Properly end minidump filename with a NULL byte

### DIFF
--- a/src/backend/gporca/libgpopt/src/minidump/CMinidumperUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/minidump/CMinidumperUtils.cpp
@@ -188,7 +188,7 @@ CMinidumperUtils::GenerateMinidumpFileName(
 
 		ulNameLength = clib::Strlen(szMinidumpFileName + ulNameStart);
 		clib::Strncpy(buf + ulPrefixLength, szMinidumpFileName + ulNameStart,
-					  ulNameLength);
+					  ulNameLength + 1);
 	}
 }
 


### PR DESCRIPTION
[Fixes #11494]