### PR TITLE
Fix multiple definition linker error

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -74,7 +74,7 @@ bool		Debug_print_prelim_plan;	/* Shall we log argument of
 
 bool		Debug_print_slice_table;	/* Shall we log the slice table? */
 
-bool		Debug_resource_group;	/* Shall we log the resource group? */
+bool		Debug_resource_group = false;	/* Shall we log the resource group? */
 
 bool		gp_backup_directIO = false; /* disable\enable direct I/O dump */
 

--- a/src/backend/tcop/test/postgres_test.c
+++ b/src/backend/tcop/test/postgres_test.c
@@ -39,7 +39,6 @@ int errfinish_impl(int dummy __attribute__((unused)),...)
 		will_return(errstart, true);\
     } \
 
-const char *progname = "postgres";
 
 /* List with multiple elements, return FALSE. */
 void

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -163,7 +163,6 @@ int			Debug_appendonly_bad_header_print_level = ERROR;
 bool		Debug_appendonly_print_datumstream = false;
 bool		Debug_appendonly_print_visimap = false;
 bool		Debug_appendonly_print_compaction = false;
-bool		Debug_resource_group = false;
 bool		gp_crash_recovery_abort_suppress_fatal = false;
 bool		gp_persistent_statechange_suppress_error = false;
 bool		Debug_bitmap_print_insert = false;
@@ -298,9 +297,6 @@ int			Debug_dtm_action_protocol = DEBUG_DTM_ACTION_PROTOCOL_DEFAULT;
 
 int			Debug_dtm_action_segment = DEBUG_DTM_ACTION_SEGMENT_DEFAULT;
 int			Debug_dtm_action_nestinglevel = DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT;
-
-/* Enable check for compatibility of encoding and locale in createdb */
-bool		gp_encoding_check_locale_compatibility;
 
 int			gp_connection_send_timeout;
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -871,6 +871,9 @@ extern bool	gp_setwith_alter_storage;
 /* MPP-9772, MPP-9773: remove support for CREATE INDEX CONCURRENTLY */
 extern bool	gp_create_index_concurrently;
 
+/* Enable check for compatibility of encoding and locale in createdb */
+extern bool gp_encoding_check_locale_compatibility;
+
 /* Priority for the segworkers relative to the postmaster's priority */
 extern int gp_segworker_relative_priority;
 


### PR DESCRIPTION
I recently had to build 5X_STABLE with GCC 10, and this old annoyance sprung up. These are backports of #10085 and #11152.
