### PR TITLE
CLI: update logging and help text

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -656,11 +656,9 @@ class GpRecoverSegmentProgram:
 
             self.trigger_fts_probe(port=gpEnv.getCoordinatorPort())
 
-            self.logger.info("******************************************************************")
-            self.logger.info("Updating segments for streaming is completed.")
-            self.logger.info("For segments updated successfully, streaming will continue in the background.")
-            self.logger.info("Use  gpstate -s  to check the streaming progress.")
-            self.logger.info("******************************************************************")
+            self.logger.info("********************************")
+            self.logger.info("Segments successfully recovered.")
+            self.logger.info("********************************")
 
         sys.exit(0)
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -91,10 +91,7 @@ The recovery process marks the segment as up again in the Greenplum
 Database system catalog, and then initiates the resyncronization 
 process to bring the transactional state of the segment 
 up-to-date with the latest changes. The system is online 
-and available during resyncronization. To check the status 
-of the resyncronization process run:
-
-gpstate -m
+and available during resyncronization.
 
 If you do not have mirroring enabled or if you have both a 
 primary and its mirror down, you must take manual steps to 

--- a/gpMgmt/doc/gpstate_help
+++ b/gpMgmt/doc/gpstate_help
@@ -193,6 +193,12 @@ SEGMENT OUTPUT DATA
                 Resynchronizing = data is currently being copied from one to the other
                 Change Tracking = segment down and active segment is logging changes
 
+* WAL sent location - last write-ahead log location sent
+
+* WAL flush location - last write-ahead log location flushed to disk on the replica
+
+* WAL replay location - last write-ahead log location replayed on the replica
+
 * Change tracking data size - when in Change Tracking mode, the size of the change 
                             log file (may grow and shrink as compression is applied)
 
@@ -202,25 +208,12 @@ SEGMENT OUTPUT DATA
 * Data synchronized - when in Resynchronization mode, the estimated size of data 
                     that has already been synchronized
 
-* Estimated resync progress with mirror - when in Resynchronization mode, the 
-                                        estimated percentage of completion
-
-* Estimated resync end time - when in Resynchronization mode, the estimated 
-                            time to complete
-
-* File postmaster.pid - status of postmaster.pid lock file: Found or Missing
-
-* PID from postmaster.pid file - PID found in the postmaster.pid file
-
-* Lock files in /tmp - a segment port lock file for its postgres process is 
-                       created in /tmp (file is removed when a segment shuts down)
-
 * Active PID - active process ID of a segment
 
-* Coordinator reports status as - segment status as reported in the system catalog: 
+* Coordinator reports status as - segment status as reported in the system catalog:
                            Up or Down
 
-Database status - status of Greenplum Database to incoming requests: 
+* Database status - status of Greenplum Database to incoming requests:
                 Up, Down, or Suspended. A Suspended state means database 
                 activity is temporarily paused while a segment transitions from 
                 one state to another.
@@ -263,4 +256,4 @@ Display the Greenplum software version information:
 SEE ALSO
 *****************************************************
 
-gpstart, gplogfilter
+gpstart, gplogfilter, gprecoverseg


### PR DESCRIPTION
Now that gprecoverseg blocks and shows progress update logging. Also, gpstate does not show recovery progress so remove references to that.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gprecoverseg_logging)