### PR TITLE
[6X backport] CLI: update logging and help text

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -693,11 +693,9 @@ class GpRecoverSegmentProgram:
 
             self.trigger_fts_probe(port=gpEnv.getMasterPort())
 
-            self.logger.info("******************************************************************")
-            self.logger.info("Updating segments for streaming is completed.")
-            self.logger.info("For segments updated successfully, streaming will continue in the background.")
-            self.logger.info("Use  gpstate -s  to check the streaming progress.")
-            self.logger.info("******************************************************************")
+            self.logger.info("********************************")
+            self.logger.info("Segments successfully recovered.")
+            self.logger.info("********************************")
 
         sys.exit(0)
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -91,10 +91,7 @@ The recovery process marks the segment as up again in the Greenplum
 Database system catalog, and then initiates the resyncronization 
 process to bring the transactional state of the segment 
 up-to-date with the latest changes. The system is online 
-and available during resyncronization. To check the status 
-of the resyncronization process run:
-
-gpstate -m
+and available during resyncronization.
 
 If you do not have mirroring enabled or if you have both a 
 primary and its mirror down, you must take manual steps to 
@@ -221,14 +218,14 @@ be cancelled and rolled back.
 
 -s
 
-Show pg_basebackup progress sequentially instead of inplace. Useful when
-writing to a file, or if a tty does not support escape sequences. Defaults to
-showing the progress inplace.
+Show pg_rewind/pg_basebackup progress sequentially instead of inplace. Useful
+when writing to a file, or if a tty does not support escape sequences. Defaults
+to showing the progress inplace.
 
 
 --no-progress
 
-Do not show pg_basebackup progress. Useful when writing to a
+Do not show pg_rewind/pg_basebackup progress. Useful when writing to a
 file. Defaults to showing the progress.
 
 

--- a/gpMgmt/doc/gpstate_help
+++ b/gpMgmt/doc/gpstate_help
@@ -7,7 +7,7 @@ Shows the status of a running Greenplum Database system.
 SYNOPSIS
 *****************************************************
 
-gpstate [-d <master_data_directory>] [-B <parallel_processes>] 
+gpstate [-d <master_data_directory>] [-B <parallel_processes>]
         [-s | -b | -Q | -e] [-m | -c] [-p] [-i] [-f] 
         [-v | -q] [-l <log_directory>]
 
@@ -26,7 +26,7 @@ spanning multiple machines. The gpstate utility provides
 additional status information for a Greenplum Database system, 
 such as:
 * Which segments are down.
-* Master and segment configuration information (hosts, 
+* Master and segment configuration information (hosts,
   data directories, etc.).
 * The ports used by the system.
 * A mapping of primary segments to their corresponding 
@@ -57,7 +57,7 @@ OPTIONS
 
 -d <master_data_directory>
 
-  Optional. The master data directory. If not specified, the 
+  Optional. The master data directory. If not specified, the
   value set for $MASTER_DATA_DIRECTORY will be used.
 
 
@@ -145,14 +145,14 @@ MASTER OUTPUT DATA
 
 * Master host - host name of the master
 
-* Master postgres process ID - PID of the master postgres database 
+* Master postgres process ID - PID of the master postgres database
                                listener process
 
 * Master data directory - file system location of the master data directory
 
 * Master port - port of the master database listener process
 
-* Master current role - dispatch = regular operating mode 
+* Master current role - dispatch = regular operating mode
                         utility = maintenance mode 
 
 * Greenplum array configuration type - Standard = one NIC per host 
@@ -193,7 +193,13 @@ SEGMENT OUTPUT DATA
                 Resynchronizing = data is currently being copied from one to the other
                 Change Tracking = segment down and active segment is logging changes
 
-* Change tracking data size - when in Change Tracking mode, the size of the change 
+* WAL sent location - last write-ahead log location sent
+
+* WAL flush location - last write-ahead log location flushed to disk on the replica
+
+* WAL replay location - last write-ahead log location replayed on the replica
+
+* Change tracking data size - when in Change Tracking mode, the size of the change
                             log file (may grow and shrink as compression is applied)
 
 * Estimated total data to synchronize - when in Resynchronization mode, the estimated 
@@ -202,25 +208,12 @@ SEGMENT OUTPUT DATA
 * Data synchronized - when in Resynchronization mode, the estimated size of data 
                     that has already been synchronized
 
-* Estimated resync progress with mirror - when in Resynchronization mode, the 
-                                        estimated percentage of completion
-
-* Estimated resync end time - when in Resynchronization mode, the estimated 
-                            time to complete
-
-* File postmaster.pid - status of postmaster.pid lock file: Found or Missing
-
-* PID from postmaster.pid file - PID found in the postmaster.pid file
-
-* Lock files in /tmp - a segment port lock file for its postgres process is 
-                       created in /tmp (file is removed when a segment shuts down)
-
 * Active PID - active process ID of a segment
 
-* Master reports status as - segment status as reported in the system catalog: 
+* Master reports status as - segment status as reported in the system catalog:
                            Up or Down
 
-Database status - status of Greenplum Database to incoming requests: 
+* Database status - status of Greenplum Database to incoming requests:
                 Up, Down, or Suspended. A Suspended state means database 
                 activity is temporarily paused while a segment transitions from 
                 one state to another.
@@ -263,4 +256,4 @@ Display the Greenplum software version information:
 SEE ALSO
 *****************************************************
 
-gpstart, gplogfilter
+gpstart, gplogfilter, gprecoverseg


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/11501

Now that gprecoverseg blocks and shows progress update logging. Also, gpstate does not show recovery progress so remove references to that.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gprecoverseg_logging_6X)
