### PR TITLE
Renanme the duplicated symbol of backend libpq

### DIFF
--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -20,7 +20,10 @@ OBJS = be-fsstubs.o be-secure.o be-secure-common.o auth.o crypt.o hba.o ifaddr.o
 
 ifeq ($(with_openssl),yes)
 OBJS += be-secure-openssl.o
-OBJS += fe-secure-openssl.o
+endif
+
+ifeq ($(with_gssapi),yes)
+OBJS += be-gssapi-common.o be-secure-gssapi.o
 endif
 
 # Greenplum objects follow
@@ -29,9 +32,14 @@ OBJS += fe-protocol3.o fe-connect.o \
 	fe-auth-scram.o \
         $(filter getpeereid.o, $(LIBOBJS))
 
-# Greenplum OPENSSL objects follow
+# Greenplum OpenSSL objects follow
 ifeq ($(with_openssl),yes)
-OBJS += fe-secure-common.o
+OBJS += fe-secure-common.o fe-secure-openssl.o
+endif
+
+# Greenplum GSSAPI objects follow
+ifeq ($(with_gssapi),yes)
+OBJS += fe-gssapi-common.o fe-secure-gssapi.o
 endif
 
 fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-auth-scram.c fe-misc.c fe-protocol2.c fe-secure.c fe-secure-openssl.c fe-secure-common.c fe-secure-gssapi.c fe-gssapi-common.c: % : $(top_srcdir)/src/interfaces/libpq/%
@@ -48,11 +56,7 @@ $(top_builddir)/src/port/pg_config_paths.h:
 clean distclean: clean-symlinks
 
 clean-symlinks:
-	rm -f fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-misc.c fe-protocol2.c fe-secure.c getpeereid.c fe-auth-scram.c fe-gssapi-common.c fe-secure-common.c fe-secure-gssapi.c
-
-ifeq ($(with_gssapi),yes)
-OBJS += be-gssapi-common.o be-secure-gssapi.o
-OBJS += fe-gssapi-common.o fe-secure-gssapi.o
-endif
+	rm -f fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-auth-scram.c fe-misc.c fe-protocol2.c fe-secure.c fe-secure-openssl.c fe-secure-common.c fe-secure-gssapi.c fe-gssapi-common.c
+	rm -f getpeereid.c
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -1392,7 +1392,7 @@ pg_GSS_recvauth(Port *port)
 		if (maj_stat != GSS_S_COMPLETE && maj_stat != GSS_S_CONTINUE_NEEDED)
 		{
 			gss_delete_sec_context(&lmin_s, &port->gss->ctx, GSS_C_NO_BUFFER);
-			pg_GSS_error(ERROR,
+			pg_GSS_error_be(ERROR,
 						 _("accepting GSS security context failed"),
 						 maj_stat, min_stat);
 		}
@@ -1431,7 +1431,7 @@ pg_GSS_checkauth(Port *port)
 	 */
 	maj_stat = gss_display_name(&min_stat, port->gss->name, &gbuf, NULL);
 	if (maj_stat != GSS_S_COMPLETE)
-		pg_GSS_error(ERROR,
+		pg_GSS_error_be(ERROR,
 					 _("retrieving GSS user name failed"),
 					 maj_stat, min_stat);
 

--- a/src/backend/libpq/be-gssapi-common.c
+++ b/src/backend/libpq/be-gssapi-common.c
@@ -20,7 +20,6 @@
  * Helper function for getting all strings of a GSSAPI error (of specified
  * stat).  Call once for GSS_CODE and once for MECH_CODE.
  */
-#if 0
 static void
 pg_GSS_error_int(char *s, size_t len, OM_uint32 stat, int type)
 {
@@ -46,7 +45,6 @@ pg_GSS_error_int(char *s, size_t len, OM_uint32 stat, int type)
 		ereport(WARNING,
 				(errmsg_internal("incomplete GSS error report")));
 }
-#endif
 
 /*
  * Fetch and report all error messages from GSSAPI.  To avoid allocation,
@@ -55,11 +53,10 @@ pg_GSS_error_int(char *s, size_t len, OM_uint32 stat, int type)
  */
 /*
  * In GPDB backend, we also link with fe-gssapi-common.o, which contains
- * this same function. Disable it here to avoid linker error.
+ * this same function. Rename it with a "_be" suffix here to avoid linker error.
  */
-#if 0
 void
-pg_GSS_error(int severity, const char *errmsg,
+pg_GSS_error_be(int severity, const char *errmsg,
 			 OM_uint32 maj_stat, OM_uint32 min_stat)
 {
 	char		msg_major[128],
@@ -79,4 +76,3 @@ pg_GSS_error(int severity, const char *errmsg,
 			(errmsg_internal("%s", errmsg),
 			 errdetail_internal("%s: %s", msg_major, msg_minor)));
 }
-#endif

--- a/src/backend/libpq/be-secure-gssapi.c
+++ b/src/backend/libpq/be-secure-gssapi.c
@@ -174,7 +174,7 @@ be_gssapi_write(Port *port, void *ptr, size_t len)
 		major = gss_wrap(&minor, gss->ctx, 1, GSS_C_QOP_DEFAULT,
 						 &input, &conf, &output);
 		if (major != GSS_S_COMPLETE)
-			pg_GSS_error(FATAL, gettext_noop("GSSAPI wrap error"), major, minor);
+			pg_GSS_error_be(FATAL, gettext_noop("GSSAPI wrap error"), major, minor);
 
 		if (conf == 0)
 			ereport(FATAL,
@@ -340,7 +340,7 @@ be_gssapi_read(Port *port, void *ptr, size_t len)
 
 		major = gss_unwrap(&minor, gss->ctx, &input, &output, &conf, NULL);
 		if (major != GSS_S_COMPLETE)
-			pg_GSS_error(FATAL, gettext_noop("GSSAPI unwrap error"),
+			pg_GSS_error_be(FATAL, gettext_noop("GSSAPI unwrap error"),
 						 major, minor);
 
 		if (conf == 0)
@@ -518,7 +518,7 @@ secure_open_gssapi(Port *port)
 									   NULL, NULL);
 		if (GSS_ERROR(major))
 		{
-			pg_GSS_error(ERROR, gettext_noop("GSSAPI context error"),
+			pg_GSS_error_be(ERROR, gettext_noop("GSSAPI context error"),
 						 major, minor);
 			gss_release_buffer(&minor, &output);
 			return -1;
@@ -590,7 +590,7 @@ secure_open_gssapi(Port *port)
 								PQ_GSS_SEND_BUFFER_SIZE - sizeof(uint32), &max_packet_size);
 
 	if (GSS_ERROR(major))
-		pg_GSS_error(FATAL, gettext_noop("GSSAPI size check error"),
+		pg_GSS_error_be(FATAL, gettext_noop("GSSAPI size check error"),
 					 major, minor);
 
 	port->gss->enc = true;

--- a/src/include/libpq/be-gssapi-common.h
+++ b/src/include/libpq/be-gssapi-common.h
@@ -20,7 +20,7 @@
 #include <gssapi/gssapi.h>
 #endif
 
-void		pg_GSS_error(int severity, const char *errmsg,
+void		pg_GSS_error_be(int severity, const char *errmsg,
 						 OM_uint32 maj_stat, OM_uint32 min_stat);
 
 #endif							/* BE_GSSAPI_COMMON_H */


### PR DESCRIPTION
In GPDB backend, we also link with some objects of the frontend for
inter-communicating. Rename the duplicated `pg_GSS_error()` with a "_be"
suffix to avoid linker error.
