### PR TITLE
[Backport] ic-proxy: limit max size of packet cache. (#11489)

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -18,8 +18,6 @@
  * - many libuv requests, such as uv_write(), needs us to allocate the request
  *   buffer, they are not reused, too, we could consider saving them in a
  *   free list similarly, or even share the same free list with packets;
- * - we need to limit the size of the free list, currently packets are never
- *   freed;
  *
  *
  * Copyright (c) 2020-Present Pivotal Software, Inc.
@@ -149,10 +147,19 @@ ic_proxy_pkt_cache_free(void *pkt)
 		Assert(iter != cpkt);
 #endif
 
-	cpkt->next = ic_proxy_pkt_cache.freelist;
-	ic_proxy_pkt_cache.freelist = cpkt;
-	ic_proxy_pkt_cache.n_free++;
+	/* need to limit the size of the free list */
+	if (ic_proxy_pkt_cache.n_total > IC_PROXY_PKT_CACHE_MAX_SIZE)
+	{
+		ic_proxy_free(pkt);
+		ic_proxy_pkt_cache.n_total--;
+	}
+	else
+	{
+		cpkt->next = ic_proxy_pkt_cache.freelist;
+		ic_proxy_pkt_cache.freelist = cpkt;
+		ic_proxy_pkt_cache.n_free++;
 
-	ic_proxy_log(LOG, "pkt-cache: recycled, %d free, %d total",
-				 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
+		ic_proxy_log(LOG, "pkt-cache: recycled, %d free, %d total",
+					 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
+	}
 }

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.h
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.h
@@ -14,6 +14,8 @@
 
 #include <uv.h>
 
+#define IC_PROXY_PKT_CACHE_MAX_SIZE 20000
+
 extern void ic_proxy_pkt_cache_init(uint32 pkt_size);
 extern void ic_proxy_pkt_cache_uninit(void);
 extern void *ic_proxy_pkt_cache_alloc(size_t *pkt_size);


### PR DESCRIPTION
icproxy's flow control is based on the PAUSE/RESUME, which needs to
route to a remote client. This asynchronous flow control may result
in the size of packet cache increase rapidly but packet returned to
free list slowly.

Packet cache should have a maximum size to limit the total memory
used by icproxy background worker. When limit is reached, the packet
should be freed instead putting to free list.

Note that this patch could not fix the flow control issue, but only
helps to avoid the bloating of packet cache.

Reviewed-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
