### PR TITLE
Limit anyarray coercion to INSERT statements

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -212,12 +212,15 @@ coerce_type(ParseState *pstate, Node *node,
 		 */
 
 		/*
-		 * BUG BUG 
-		 * JIRA MPP-3786
+		 * GPDB: Special handling for ANYARRAY type. This enables INSERTs into
+		 * catalog tables having anyarray columns.
 		 *
-		 * Special handling for ANYARRAY type.  
+		 * Restrict the type coercion to INSERT statements as this hack was only
+		 * meant to fix INSERTs for dumping/restoring pg_statistic tuples by
+		 * external utilities such as gpsd, minirepro, gpbackup/gprestore.
 		 */
-		if(targetTypeId == ANYARRAYOID && IsA(node, Const) && inputTypeId != UNKNOWNOID)
+		if(targetTypeId == ANYARRAYOID && IsA(node, Const) && inputTypeId != UNKNOWNOID
+		   && (pstate != NULL && pstate->p_expr_kind == EXPR_KIND_INSERT_TARGET))
 		{
 			Const	   *con = (Const *) node;
 			Const	   *newcon = makeNode(Const);

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -52,7 +52,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
 
 -- change stats manually so that MCV and MCF numbers do not match
 set allow_system_table_mods=true;
-update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='bfv_statistics_foo2'::regclass;
+update pg_statistic set stavalues1=array_in('{6,3,1,5,4,2}', 'int'::regtype::oid, -1) where starelid='bfv_statistics_foo2'::regclass;
 -- excercise the translator
 explain select a from bfv_statistics_foo2 where a > 1 order by a;
                                  QUERY PLAN                                  
@@ -346,12 +346,12 @@ SET allow_system_table_mods=true;
 -- s/\(selfuncs\.c:\d+\)//
 -- end_matchsubs
 -- Broken MCVs
-UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
+UPDATE pg_statistic SET stavalues1=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 ERROR:  invalid MCV array of type integer, for attribute of type text (selfuncs.c:4700)
 -- Broken histogram
 UPDATE pg_statistic SET stakind2=2 WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
-UPDATE pg_statistic SET stavalues2='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
+UPDATE pg_statistic SET stavalues2=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 ERROR:  invalid histogram of type integer, for attribute of type text (selfuncs.c:4661)
 RESET allow_system_table_mods;

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -54,7 +54,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
 
 -- change stats manually so that MCV and MCF numbers do not match
 set allow_system_table_mods=true;
-update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='bfv_statistics_foo2'::regclass;
+update pg_statistic set stavalues1=array_in('{6,3,1,5,4,2}', 'int'::regtype::oid, -1) where starelid='bfv_statistics_foo2'::regclass;
 -- excercise the translator
 explain select a from bfv_statistics_foo2 where a > 1 order by a;
 NOTICE:  The number of most common values and frequencies do not match on column a of table bfv_statistics_foo2.
@@ -353,7 +353,7 @@ SET allow_system_table_mods=true;
 -- s/\(selfuncs\.c:\d+\)//
 -- end_matchsubs
 -- Broken MCVs
-UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
+UPDATE pg_statistic SET stavalues1=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 NOTICE:  Type mismatch between attribute b of table test_broken_stats having type 25 and statistic having type 23, please ANALYZE the table again
 NOTICE:  One or more columns in the following table(s) do not have statistics: test_broken_stats
@@ -364,7 +364,7 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
 
 -- Broken histogram
 UPDATE pg_statistic SET stakind2=2 WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
-UPDATE pg_statistic SET stavalues2='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
+UPDATE pg_statistic SET stavalues2=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 NOTICE:  Type mismatch between attribute b of table test_broken_stats having type 25 and statistic having type 23, please ANALYZE the table again
 NOTICE:  Type mismatch between attribute b of table test_broken_stats having type 25 and statistic having type 23, please ANALYZE the table again

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -127,3 +127,12 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table "schema_view\'.gp_dist_random"."foo\'.bar"
 drop cascades to view view_with_gp_dist_random_special_chars
+-- Check that views containing operator expressions involving arrays have the
+-- correct internal representation
+CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
+SELECT pg_get_viewdef('view_with_array_op_expr');
+                 pg_get_viewdef                 
+------------------------------------------------
+  SELECT ('{1}'::integer[] = '{2}'::integer[]);
+(1 row)
+

--- a/src/test/regress/sql/bfv_statistic.sql
+++ b/src/test/regress/sql/bfv_statistic.sql
@@ -28,7 +28,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
 
 -- change stats manually so that MCV and MCF numbers do not match
 set allow_system_table_mods=true;
-update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='bfv_statistics_foo2'::regclass;
+update pg_statistic set stavalues1=array_in('{6,3,1,5,4,2}', 'int'::regtype::oid, -1) where starelid='bfv_statistics_foo2'::regclass;
 
 -- excercise the translator
 explain select a from bfv_statistics_foo2 where a > 1 order by a;
@@ -280,12 +280,12 @@ SET allow_system_table_mods=true;
 -- end_matchsubs
 
 -- Broken MCVs
-UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
+UPDATE pg_statistic SET stavalues1=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 
 -- Broken histogram
 UPDATE pg_statistic SET stakind2=2 WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
-UPDATE pg_statistic SET stavalues2='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
+UPDATE pg_statistic SET stavalues2=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 
 RESET allow_system_table_mods;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -74,3 +74,8 @@ CREATE TABLE "schema_view\'.gp_dist_random"."foo\'.bar" (a int);
 CREATE TEMP VIEW view_with_gp_dist_random_special_chars AS SELECT * FROM gp_dist_random(E'"schema_view\\''.gp_dist_random"."foo\\''.bar"');
 SELECT pg_get_viewdef('view_with_gp_dist_random_special_chars');
 DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
+
+-- Check that views containing operator expressions involving arrays have the
+-- correct internal representation
+CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
+SELECT pg_get_viewdef('view_with_array_op_expr');


### PR DESCRIPTION
The anyarray coercion hack was added circa 2008 to accommodate INSERT
statements into catalog tables such as pg_statistic, which sport the
anyarray type - a pseudo-type that does not handle insertions.

However, coerce_type() is a very low level function that has a variety
of callsites. The logic added has an adverse effect on views, for e.g.
that have an OpExpr with array types:

```
CREATE VIEW fooview AS SELECT '{1}'::int[] = '{2}'::int[];

\d+ fooview
                 View "public.fooview"
  Column  |  Type   | Modifiers | Storage | Description
----------+---------+-----------+---------+-------------
 ?column? | boolean |           | plain   |
View definition:
 SELECT '{1}'::anyarray = '{2}'::anyarray;
```

We can see that the view definition includes incorrect downcasts to the
pseudo-type anyarray. (It should have been
SELECT '{1}'::integer = '{2}'::integer;)

Running the view definition inevitably yields:

```
ERROR:  cannot accept a value of type anyarray
LINE 1: SELECT '{1}'::anyarray = '{2}'::anyarray;
```

We fix this issue by restricting the scope of the type coercion logic to
INSERTs only, in line with what was originally intended.

This is not the ideal fix - ideally, we should rip out the hack from
coerce_type() completely and adapt our utilities to emit array_in
expressions to insert/update columns with anyarray types (as
demonstrated in the changes to bfv_statistic.sql). This is what we will
be doing in future versions of GPDB.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>