### PR TITLE
Use NDV to calculate CBucket::MakeBucketSingleton frequency

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -692,7 +692,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.061244" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.061257" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -709,7 +709,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.061154" Rows="1.748262" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.061166" Rows="1.766098" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -750,7 +750,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
           </dxl:PartitionSelector>
           <dxl:DynamicBitmapTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.061154" Rows="1.748262" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.061166" Rows="1.766098" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
@@ -610,7 +610,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="387.962523" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="387.962241" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="hi_ndv">
@@ -624,7 +624,7 @@
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="387.962493" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="387.962211" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="hi_ndv">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
@@ -285,7 +285,7 @@ explain select * from indexonao where a = 21;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="392.963271" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="392.963331" Rows="1.000012" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -296,7 +296,7 @@ explain select * from indexonao where a = 21;
         <dxl:SortingColumnList/>
         <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="392.963250" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="392.963310" Rows="1.000012" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CArrayExpansionTest/JoinWithInListExpand.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CArrayExpansionTest/JoinWithInListExpand.mdp
@@ -558,7 +558,7 @@ select a,b from foo, bar where foo.a in (1,2,3,4,5,6) and foo.a = bar.c;
     <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.004932" Rows="9.333333" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.004821" Rows="8.166667" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -572,7 +572,7 @@ select a,b from foo, bar where foo.a in (1,2,3,4,5,6) and foo.a = bar.c;
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.004654" Rows="9.333333" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.004577" Rows="8.166667" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -659,7 +659,7 @@ select a,b from foo, bar where foo.a in (1,2,3,4,5,6) and foo.a = bar.c;
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.001813" Rows="8.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001811" Rows="7.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/DPv2QueryOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPv2QueryOnly.mdp
@@ -5924,7 +5924,7 @@
     <dxl:Plan Id="0" SpaceSize="58">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="300474.732026" Rows="205294544.272930" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="300474.867137" Rows="205295483.329566" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a1">
@@ -5956,7 +5956,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="275992.673306" Rows="205294544.272930" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="275992.696431" Rows="205295483.329566" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a1">
@@ -5994,7 +5994,7 @@
           </dxl:HashCondList>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="140279.642853" Rows="2031954610.973613" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="140279.636652" Rows="2031954519.701040" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a1">
@@ -6026,7 +6026,7 @@
             </dxl:HashCondList>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="20742.170705" Rows="1016128073.489710" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="20742.169853" Rows="1016128027.846651" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a1">

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
@@ -424,7 +424,7 @@ where a=1 and b=0;
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.010614" Rows="1.000001" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.010614" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -441,7 +441,7 @@ where a=1 and b=0;
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.010560" Rows="1.000001" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.010560" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+    <dxl:Comment><![CDATA[
+        CREATE TABLE mytable(a bigint) WITH (appendonly=true, orientation=row);
+        CREATE INDEX idx_mytable_a ON mytable USING btree (a);
+        SET allow_system_table_mods=ON;
+        UPDATE pg_class SET relpages = 800000::int, reltuples = 150000000.0::real WHERE relname = 'mytable';
+
+        INSERT INTO pg_statistic VALUES (
+            'mytable'::regclass,
+            1::smallint,
+            False::boolean,
+            0.33333::real,
+            8::integer,
+            1000.0::real,
+            2::smallint,
+            0::smallint,
+            0::smallint,
+            0::smallint,
+            0::smallint,
+            0::oid,
+            0::oid,
+            0::oid,
+            0::oid,
+            0::oid,
+            NULL::real[],
+            NULL::real[],
+            NULL::real[],
+            NULL::real[],
+            NULL::real[],
+            E'{500000000,700000000}'::int8[],
+            NULL::int8[],
+            NULL::int8[],
+            NULL::int8[],
+            NULL::anyarray);
+
+
+        EXPLAIN SELECT * FROM mytable WHERE a=600000000;
+    ]]>
+    </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102155,102156,103001,103014,103022,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.212992.1.0" Name="mytable" Rows="141140992.000000" RelPages="743257" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.212992.1.0" Name="mytable" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Hash" DistributionColumns="0" Keys="3,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.20.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="0.213016.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.212992.1.0.0" Name="a" Width="8.000000" NullFreq="0.351972" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.648028" DistinctValues="54315.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" Value="5100000000130082751"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" Value="5200000000000097561"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Index Mdid="0.213016.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.20.1.0"/>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="5100000000133138764"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.212992.1.0" TableName="mytable">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.20.1.0" ColWidth="8"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="391.714832" Rows="1683.942093" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:BitmapTableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="391.656275" Rows="1683.942093" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:RecheckCond>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.20.1.0"/>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="5100000000133138764"/>
+            </dxl:Comparison>
+          </dxl:RecheckCond>
+          <dxl:BitmapIndexProbe>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="5100000000133138764"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.213016.1.0" IndexName="idx_mytable_a"/>
+          </dxl:BitmapIndexProbe>
+          <dxl:TableDescriptor Mdid="0.212992.1.0" TableName="mytable">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.20.1.0" ColWidth="8"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="2" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:BitmapTableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.20.1.0" Value="5100000000133138764"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -711,7 +711,7 @@
     <dxl:Plan Id="1" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.029301" Rows="20.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.029275" Rows="19.607843" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -728,7 +728,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.028223" Rows="20.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.028219" Rows="19.607843" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -764,7 +764,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.028223" Rows="20.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.028219" Rows="19.607843" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -536,7 +536,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="437.000538" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000538" Rows="1.000012" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -550,7 +550,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="437.000502" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000502" Rows="1.000012" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/EqualityPredicateOverDate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EqualityPredicateOverDate.mdp
@@ -301,7 +301,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="482.634091" Rows="984.924062" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="482.634262" Rows="989.898435" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="d">
@@ -312,7 +312,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="482.607379" Rows="984.924062" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="482.607416" Rows="989.898435" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="d">

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
@@ -1479,7 +1479,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="888838.914903" Rows="42.017982" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="888838.913054" Rows="42.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c">
@@ -1505,7 +1505,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="888838.911145" Rows="42.017982" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="888838.909298" Rows="42.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c">
@@ -1542,7 +1542,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.001150" Rows="3.001349" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.001150" Rows="3.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -1559,7 +1559,7 @@
             <dxl:SortingColumnList/>
             <dxl:IndexScan IndexScanDirection="Forward">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000484" Rows="1.000450" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000484" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
@@ -1957,7 +1957,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1765474.708805" Rows="4.000000" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="1765474.620713" Rows="4.000000" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1992,7 +1992,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1765474.708268" Rows="4.000000" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="1765474.620176" Rows="4.000000" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -2037,7 +2037,7 @@
           <dxl:OneTimeFilter/>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1765474.708129" Rows="4.220000" Width="36"/>
+              <dxl:Cost StartupCost="0" TotalCost="1765474.620045" Rows="4.000000" Width="36"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -2187,7 +2187,7 @@
             </dxl:HashJoin>
             <dxl:Materialize Eager="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.019401" Rows="3.330000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.019327" Rows="3.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
@@ -2203,7 +2203,7 @@
               <dxl:Filter/>
               <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.019388" Rows="3.330000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.019315" Rows="3.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">
@@ -2220,7 +2220,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.018673" Rows="1.110000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.018670" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
@@ -4175,7 +4175,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="555.842504" Rows="12606.449785" Width="156"/>
+          <dxl:Cost StartupCost="0" TotalCost="4220.745632" Rows="2284199.908555" Width="156"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -4252,7 +4252,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="548.513619" Rows="12606.449785" Width="156"/>
+            <dxl:Cost StartupCost="0" TotalCost="2892.803173" Rows="2284199.908555" Width="156"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -4331,7 +4331,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="535.500127" Rows="3.816909" Width="49"/>
+              <dxl:Cost StartupCost="0" TotalCost="535.708176" Rows="691.597064" Width="49"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -4366,7 +4366,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="535.499011" Rows="1.272303" Width="49"/>
+                <dxl:Cost StartupCost="0" TotalCost="535.505976" Rows="230.532355" Width="49"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="id">
@@ -4427,7 +4427,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="10.434215" Rows="9908.370184" Width="107"/>
+              <dxl:Cost StartupCost="0" TotalCost="1890.606295" Rows="9908.370184" Width="107"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="16" Alias="id">
@@ -4496,7 +4496,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
             </dxl:PartitionSelector>
             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="10.434215" Rows="9908.370184" Width="107"/>
+                <dxl:Cost StartupCost="0" TotalCost="1890.606295" Rows="9908.370184" Width="107"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="id">

--- a/src/backend/gporca/data/dxl/minidump/NoBroadcastUnderGatherForWindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoBroadcastUnderGatherForWindowFunction.mdp
@@ -457,7 +457,7 @@ WHERE buyer_name = 'ABC'
         <dxl:OneTimeFilter/>
         <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.008953" Rows="1.000000" Width="25"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.008953" Rows="1.000012" Width="25"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="curr_bidrate">
@@ -472,7 +472,7 @@ WHERE buyer_name = 'ABC'
           <dxl:Filter/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.008953" Rows="1.000000" Width="21"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.008953" Rows="1.000012" Width="21"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="curr_bidcnt">
@@ -492,7 +492,7 @@ WHERE buyer_name = 'ABC'
             </dxl:HashCondList>
             <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.008369" Rows="1.000000" Width="21"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.008369" Rows="1.000012" Width="21"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="network_id">
@@ -506,7 +506,7 @@ WHERE buyer_name = 'ABC'
               <dxl:SortingColumnList/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.008321" Rows="1.000000" Width="21"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.008321" Rows="1.000012" Width="21"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="3" Alias="network_id">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -1199,7 +1199,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
     <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000001" Width="17"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000000" Width="17"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="col1">
@@ -1217,7 +1217,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000122" Rows="1.000001" Width="17"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000122" Rows="1.000000" Width="17"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="col1">
@@ -1240,7 +1240,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000001" Width="17"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="col1">
@@ -1265,7 +1265,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
             <dxl:LimitOffset/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000001" Width="17"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="col1">
@@ -1309,7 +1309,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
               </dxl:PartitionSelector>
               <dxl:DynamicTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000001" Width="17"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="col1">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -888,7 +888,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1294.709910" Rows="5356.953432" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1294.717330" Rows="5431.276543" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -908,7 +908,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1294.325066" Rows="5356.953432" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1294.327147" Rows="5431.276543" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -3258,7 +3258,7 @@
     <dxl:Plan Id="0" SpaceSize="55653">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1784762.484108" Rows="371185706.953630" Width="355"/>
+          <dxl:Cost StartupCost="0" TotalCost="1548280.515894" Rows="321694266.492042" Width="355"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3490,7 +3490,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1313165.628414" Rows="539984.658212" Width="339"/>
+            <dxl:Cost StartupCost="0" TotalCost="1138306.731315" Rows="467986.685065" Width="339"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3699,7 +3699,7 @@
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1312343.712366" Rows="539984.658212" Width="339"/>
+              <dxl:Cost StartupCost="0" TotalCost="1137594.404102" Rows="467986.685065" Width="339"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3914,7 +3914,7 @@
             </dxl:HashCondList>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1311504.590863" Rows="539984.658212" Width="232"/>
+                <dxl:Cost StartupCost="0" TotalCost="1136809.698814" Rows="467986.685065" Width="232"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -4112,7 +4112,7 @@
               </dxl:BroadcastMotion>
               <dxl:DynamicTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="246169.243168" Rows="3885189615.297647" Width="200"/>
+                  <dxl:Cost StartupCost="0" TotalCost="213404.135560" Rows="3367164198.571393" Width="200"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -4378,7 +4378,7 @@
               </dxl:PrintableFilter>
               <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="432.429157" Rows="967.490176" Width="107"/>
+                  <dxl:Cost StartupCost="0" TotalCost="432.238603" Rows="838.491452" Width="107"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -4470,7 +4470,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.074320" Rows="483.745088" Width="107"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.064411" Rows="419.245726" Width="107"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -4586,7 +4586,7 @@
                   </dxl:PartitionSelector>
                   <dxl:DynamicTableScan PartIndexId="3">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.074320" Rows="483.745088" Width="107"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.064411" Rows="419.245726" Width="107"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="d_date_sk">

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-1.mdp
@@ -1695,7 +1695,7 @@ select id from uav1 union select val from uav4 union select id from uav2;
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1308.061661" Rows="100.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1308.061666" Rows="100.333333" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -1706,7 +1706,7 @@ select id from uav1 union select val from uav4 union select id from uav2;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1308.060170" Rows="100.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1308.060171" Rows="100.333333" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-2.mdp
@@ -2331,7 +2331,7 @@
     <dxl:Plan Id="0" SpaceSize="812">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1307.986960" Rows="199.009901" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1307.986991" Rows="201.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -2342,7 +2342,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1307.983993" Rows="199.009901" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1307.983995" Rows="201.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -652,7 +652,7 @@
     <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.005848" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.005845" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -672,7 +672,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.005789" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.005786" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -762,7 +762,7 @@
             </dxl:PrintableFilter>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.005395" Rows="3.030300" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.005395" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/RightJoinDPS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinDPS.mdp
@@ -357,7 +357,7 @@
     <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="863.499554" Rows="10008.889880" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="863.499563" Rows="10009.000991" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -377,7 +377,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Right">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.902757" Rows="10008.889880" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.902759" Rows="10009.000991" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
@@ -762,7 +762,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.162545" Rows="1008.888980" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.162553" Rows="1009.000091" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -782,7 +782,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Right">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.102388" Rows="1008.888980" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.102390" Rows="1009.000091" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -2651,7 +2651,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9093.143836" Rows="11530621.000000" Width="123"/>
+          <dxl:Cost StartupCost="0" TotalCost="9093.176214" Rows="11530621.000000" Width="123"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="inv_date_sk">
@@ -2817,7 +2817,7 @@
         </dxl:GatherMotion>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="435.150680" Rows="350.629208" Width="107"/>
+            <dxl:Cost StartupCost="0" TotalCost="435.156720" Rows="361.043926" Width="107"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="d_date_sk">
@@ -2909,7 +2909,7 @@
           <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="434.982227" Rows="350.629208" Width="107"/>
+              <dxl:Cost StartupCost="0" TotalCost="434.983264" Rows="361.043926" Width="107"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="d_date_sk">

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -14870,7 +14870,7 @@ with results as
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="21559.317591" Rows="20.062500" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="21949.250066" Rows="20.062500" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="842" Alias="total_sum">
@@ -14893,7 +14893,7 @@ with results as
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="21559.317591" Rows="20.062500" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="21949.250066" Rows="20.062500" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="842" Alias="sum">
@@ -14923,7 +14923,7 @@ with results as
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="21559.315523" Rows="20.062500" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="21949.247997" Rows="20.062500" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="842" Alias="sum">
@@ -14955,7 +14955,7 @@ with results as
             <dxl:LimitOffset/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="21559.315523" Rows="20.062500" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="21949.247997" Rows="20.062500" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="842" Alias="sum">
@@ -14979,7 +14979,7 @@ with results as
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="0" Columns="204,89,88,205,206">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20266.314944" Rows="14.062500" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="20656.247418" Rows="14.062500" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="204" Alias="sum">
@@ -15000,7 +15000,7 @@ with results as
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="20266.314943" Rows="14.062500" Width="32"/>
+                    <dxl:Cost StartupCost="0" TotalCost="20656.247418" Rows="14.062500" Width="32"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="204" Alias="sum">
@@ -15023,7 +15023,7 @@ with results as
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="20266.314929" Rows="14.062500" Width="26"/>
+                      <dxl:Cost StartupCost="0" TotalCost="20656.247404" Rows="14.062500" Width="26"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="89"/>
@@ -15045,7 +15045,7 @@ with results as
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="20266.314897" Rows="14.062500" Width="26"/>
+                        <dxl:Cost StartupCost="0" TotalCost="20656.247371" Rows="14.062500" Width="26"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15067,7 +15067,7 @@ with results as
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="20266.314897" Rows="14.062500" Width="26"/>
+                          <dxl:Cost StartupCost="0" TotalCost="20656.247371" Rows="14.062500" Width="26"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15092,7 +15092,7 @@ with results as
                         </dxl:HashExprList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="20266.314849" Rows="14.062500" Width="26"/>
+                            <dxl:Cost StartupCost="0" TotalCost="20656.247324" Rows="14.062500" Width="26"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15109,7 +15109,7 @@ with results as
                           <dxl:OneTimeFilter/>
                           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="20266.314849" Rows="14.062500" Width="26"/>
+                              <dxl:Cost StartupCost="0" TotalCost="20656.247324" Rows="14.062500" Width="26"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="89"/>
@@ -15131,7 +15131,7 @@ with results as
                             <dxl:Filter/>
                             <dxl:HashJoin JoinType="Inner">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="19782.739138" Rows="61135453.777721" Width="26"/>
+                                <dxl:Cost StartupCost="0" TotalCost="20119.800634" Rows="67819601.064540" Width="26"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="22" Alias="ss_net_profit">
@@ -15154,7 +15154,7 @@ with results as
                               </dxl:HashCondList>
                               <dxl:HashJoin JoinType="Inner">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="8119.513997" Rows="152838634.444302" Width="12"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="8141.454737" Rows="169549002.661349" Width="12"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="7" Alias="ss_store_sk">
@@ -15207,7 +15207,7 @@ with results as
                                 </dxl:TableScan>
                                 <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.251673" Rows="12092.239264" Width="4"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.252171" Rows="13414.324949" Width="4"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -15218,7 +15218,7 @@ with results as
                                   <dxl:SortingColumnList/>
                                   <dxl:TableScan>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.247287" Rows="377.882477" Width="4"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.247306" Rows="419.197655" Width="4"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -15249,7 +15249,7 @@ with results as
                               </dxl:HashJoin>
                               <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="10624.284156" Rows="4147.200000" Width="22"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="10825.822451" Rows="4147.200000" Width="22"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="65" Alias="s_store_sk">
@@ -15266,7 +15266,7 @@ with results as
                                 <dxl:SortingColumnList/>
                                 <dxl:HashJoin JoinType="In">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="10624.275883" Rows="129.600000" Width="22"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="10825.814178" Rows="129.600000" Width="22"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="65" Alias="s_store_sk">
@@ -15320,7 +15320,7 @@ with results as
                                   </dxl:TableScan>
                                   <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="10193.268682" Rows="64.000000" Width="3"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="10394.806977" Rows="64.000000" Width="3"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15331,7 +15331,7 @@ with results as
                                     <dxl:SortingColumnList/>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="10193.268404" Rows="2.000000" Width="3"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="10394.806698" Rows="2.000000" Width="3"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15347,7 +15347,7 @@ with results as
                                       <dxl:OneTimeFilter/>
                                       <dxl:Window PartitionColumns="155">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="10193.268371" Rows="5.000000" Width="11"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="10394.806665" Rows="5.000000" Width="11"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="203" Alias="ranking">
@@ -15363,7 +15363,7 @@ with results as
                                         <dxl:Filter/>
                                         <dxl:Sort SortDiscardDuplicates="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="10193.268360" Rows="5.000000" Width="11"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="10394.806654" Rows="5.000000" Width="11"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="202" Alias="att_2">
@@ -15382,7 +15382,7 @@ with results as
                                           <dxl:LimitOffset/>
                                           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="10193.268360" Rows="5.000000" Width="11"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="10394.806654" Rows="5.000000" Width="11"/>
                                             </dxl:Properties>
                                             <dxl:GroupingColumns>
                                               <dxl:GroupingColumn ColId="155"/>
@@ -15400,7 +15400,7 @@ with results as
                                             <dxl:Filter/>
                                             <dxl:Sort SortDiscardDuplicates="false">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="10193.268342" Rows="5.000000" Width="11"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="10394.806637" Rows="5.000000" Width="11"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15418,7 +15418,7 @@ with results as
                                               <dxl:LimitOffset/>
                                               <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="10193.268342" Rows="5.000000" Width="11"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="10394.806637" Rows="5.000000" Width="11"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
                                                   <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15437,7 +15437,7 @@ with results as
                                                 </dxl:HashExprList>
                                                 <dxl:Result>
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="10193.268330" Rows="5.000000" Width="11"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="10394.806624" Rows="5.000000" Width="11"/>
                                                   </dxl:Properties>
                                                   <dxl:ProjList>
                                                     <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15451,7 +15451,7 @@ with results as
                                                   <dxl:OneTimeFilter/>
                                                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                                     <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="10193.268330" Rows="5.000000" Width="11"/>
+                                                      <dxl:Cost StartupCost="0" TotalCost="10394.806624" Rows="5.000000" Width="11"/>
                                                     </dxl:Properties>
                                                     <dxl:GroupingColumns>
                                                       <dxl:GroupingColumn ColId="155"/>
@@ -15469,7 +15469,7 @@ with results as
                                                     <dxl:Filter/>
                                                     <dxl:HashJoin JoinType="Inner">
                                                       <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="9599.502175" Rows="152838634.444302" Width="11"/>
+                                                        <dxl:Cost StartupCost="0" TotalCost="9736.121994" Rows="169549002.661349" Width="11"/>
                                                       </dxl:Properties>
                                                       <dxl:ProjList>
                                                         <dxl:ProjElem ColId="123" Alias="ss_net_profit">
@@ -15489,7 +15489,7 @@ with results as
                                                       </dxl:HashCondList>
                                                       <dxl:HashJoin JoinType="Inner">
                                                         <dxl:Properties>
-                                                          <dxl:Cost StartupCost="0" TotalCost="8119.513997" Rows="152838634.444302" Width="12"/>
+                                                          <dxl:Cost StartupCost="0" TotalCost="8141.454737" Rows="169549002.661349" Width="12"/>
                                                         </dxl:Properties>
                                                         <dxl:ProjList>
                                                           <dxl:ProjElem ColId="108" Alias="ss_store_sk">
@@ -15542,7 +15542,7 @@ with results as
                                                         </dxl:TableScan>
                                                         <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                                           <dxl:Properties>
-                                                            <dxl:Cost StartupCost="0" TotalCost="431.251673" Rows="12092.239264" Width="4"/>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.252171" Rows="13414.324949" Width="4"/>
                                                           </dxl:Properties>
                                                           <dxl:ProjList>
                                                             <dxl:ProjElem ColId="167" Alias="d_date_sk">
@@ -15553,7 +15553,7 @@ with results as
                                                           <dxl:SortingColumnList/>
                                                           <dxl:TableScan>
                                                             <dxl:Properties>
-                                                              <dxl:Cost StartupCost="0" TotalCost="431.247287" Rows="377.882477" Width="4"/>
+                                                              <dxl:Cost StartupCost="0" TotalCost="431.247306" Rows="419.197655" Width="4"/>
                                                             </dxl:Properties>
                                                             <dxl:ProjList>
                                                               <dxl:ProjElem ColId="167" Alias="d_date_sk">

--- a/src/backend/gporca/data/dxl/statistics/NestedPred-Output-9.xml
+++ b/src/backend/gporca/data/dxl/statistics/NestedPred-Output-9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Statistics>
-    <dxl:DerivedRelationStats Rows="5437.698850" EmptyRelation="false">
+    <dxl:DerivedRelationStats Rows="2718.849425" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="592" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2001"/>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-E-MaxBoundary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Statistics>
-    <dxl:DerivedRelationStats Rows="2416.638336" EmptyRelation="false">
+    <dxl:DerivedRelationStats Rows="1208.440000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GT-MinBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GT-MinBoundary.xml
@@ -1,105 +1,105 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Statistics>
-    <dxl:DerivedRelationStats Rows="60421.879156" EmptyRelation="false">
+    <dxl:DerivedRelationStats Rows="59213.560000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.039998" DistinctValues="1.999900">
+        <dxl:StatsBucket Frequency="0.020408" DistinctValues="1.000000">
           <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
         </dxl:StatsBucket>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-GTE-MaxBoundary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Statistics>
-    <dxl:DerivedRelationStats Rows="2416.638336" EmptyRelation="false">
+    <dxl:DerivedRelationStats Rows="1208.440000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>

--- a/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LT-MaxBoundary.xml
+++ b/src/backend/gporca/data/dxl/statistics/Numeric-Output-2-LT-MaxBoundary.xml
@@ -1,105 +1,105 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Statistics>
-    <dxl:DerivedRelationStats Rows="60421.758336" EmptyRelation="false">
+    <dxl:DerivedRelationStats Rows="59213.560000" EmptyRelation="false">
       <dxl:DerivedColumnStats ColId="1" Width="7.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgABAA==" DoubleValue="1.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgADAA==" DoubleValue="3.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAFAA==" DoubleValue="5.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAHAA==" DoubleValue="7.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAJAA==" DoubleValue="9.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgALAA==" DoubleValue="11.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgANAA==" DoubleValue="13.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAPAA==" DoubleValue="15.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgARAA==" DoubleValue="17.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgATAA==" DoubleValue="19.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAVAA==" DoubleValue="21.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAXAA==" DoubleValue="23.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAYAA==" DoubleValue="24.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAaAA==" DoubleValue="26.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAcAA==" DoubleValue="28.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAeAA==" DoubleValue="30.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAgAA==" DoubleValue="32.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAiAA==" DoubleValue="34.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAkAA==" DoubleValue="36.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAmAA==" DoubleValue="38.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgApAA==" DoubleValue="41.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAqAA==" DoubleValue="42.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAtAA==" DoubleValue="45.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.040000" DistinctValues="2.000000">
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="2.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAuAA==" DoubleValue="46.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
         </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.039996" DistinctValues="1.999800">
+        <dxl:StatsBucket Frequency="0.020408" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAxAA==" DoubleValue="49.000000"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" Value="AAAACgAAAgAyAA==" DoubleValue="50.000000"/>
         </dxl:StatsBucket>

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -415,14 +415,11 @@ CBucket::MakeBucketSingleton(CMemoryPool *mp, CPoint *point_singleton) const
 	// if the bucket is not already singleton, scale accordingly
 	if (!this->IsSingleton())
 	{
-		CDouble ratio =
-			CDouble(1.0) / m_bucket_upper_bound->Width(m_bucket_lower_bound,
-													   m_is_lower_closed,
-													   m_is_upper_closed);
-		frequency_new =
-			std::min(DOUBLE(1.0), (this->m_frequency * ratio).Get());
-		;
-		distinct_new = CDouble(1.0);
+		// scale NDV down to 1 (or take the entire NDV if it's less than 1),
+		// then scale the frequency by the same ratio
+		CDouble ratio = 1 / std::max(1.0, m_distinct.Get());
+		distinct_new = m_distinct * ratio;
+		frequency_new = m_frequency * ratio;
 	}
 
 	// singleton point is both lower and upper

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -202,14 +202,6 @@ CBucket::GetOverlapPercentage(const CPoint *point, BOOL include_point) const
 	CDouble res = 1 / distance_upper;
 	res = res * distance_middle;
 
-	// TODO: When calculating the overlap percentage for doubles, we're
-	// using a different method than when calculating the frequency. This
-	// causes the frequency of singleton Double buckets to be inconsistent
-	// -- the frequency of the split bucket exceeds the frequency of the
-	// original bucket.  Instead, we should have a consistent method of
-	// calculating singleton frequency, either through NDV or assuming a
-	// small epsilon (using the NDV in GetOverlapPercentage is probably
-	// safer)
 	return CDouble(std::min(res.Get(), DOUBLE(1.0)));
 }
 
@@ -1217,6 +1209,9 @@ CBucket::SplitAndMergeBuckets(
 													 true /*include_lower*/);
 			this_overlap =
 				this->GetOverlapPercentage(minUpper, false /*include_point*/);
+			GPOS_ASSERT(this_overlap * this->GetFrequency() +
+							upper_third->GetFrequency() <=
+						this->GetFrequency() + CStatistics::Epsilon);
 		}
 		else
 		{
@@ -1225,6 +1220,9 @@ CBucket::SplitAndMergeBuckets(
 				mp, minUpper, true /*include_lower*/);
 			bucket_other_overlap = bucket_other->GetOverlapPercentage(
 				minUpper, false /*include_point*/);
+			GPOS_ASSERT(bucket_other_overlap * bucket_other->GetFrequency() +
+							upper_third->GetFrequency() <=
+						bucket_other->GetFrequency() + CStatistics::Epsilon);
 		}
 	}
 	else
@@ -1238,6 +1236,9 @@ CBucket::SplitAndMergeBuckets(
 													 true /*include_lower*/);
 			this_overlap =
 				this->GetOverlapPercentage(minUpper, false /*include_point*/);
+			GPOS_ASSERT(this_overlap * this->GetFrequency() +
+							upper_third->GetFrequency() <=
+						this->GetFrequency() + CStatistics::Epsilon);
 		}
 		else if (bucket_other->IsUpperClosed() && !this->IsUpperClosed())
 		{
@@ -1245,6 +1246,9 @@ CBucket::SplitAndMergeBuckets(
 				mp, minUpper, true /*include_lower*/);
 			bucket_other_overlap = bucket_other->GetOverlapPercentage(
 				minUpper, false /*include_point*/);
+			GPOS_ASSERT(bucket_other_overlap * bucket_other->GetFrequency() +
+							upper_third->GetFrequency() <=
+						bucket_other->GetFrequency() + CStatistics::Epsilon);
 		}
 		// the buckets are completely identical
 		// [1,5) & [1,5) OR (1,5] & (1,5] OR [1,5] & [1,5]

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -71,7 +71,7 @@ Join-With-Subq-Preds-1 Non-Hashjoinable-Pred Non-Hashjoinable-Pred-2 Factorized-
 NLJ-DistCol-No-Broadcast NLJ-EqAllCol-No-Broadcast NLJ-EqDistCol-InEqNonDistCol-No-Broadcast
 NLJ-InEqDistCol-EqNonDistCol-Redistribute CorrelatedNLJWithTrueCondition InferPredicatesInnerOfLOJ
 InferredPredicatesConstraintSimplification NoPushdownPredicateWithCTEAnchor
-InferPredicatesForPartSQ InferPredicatesForQuantifiedSQ;
+InferPredicatesForPartSQ InferPredicatesForQuantifiedSQ DoubleNDVCardinalityEquals;
 
 CLikeIDFTest:
 LIKE-Pattern-green LIKE-Pattern-green-2 LIKE-Pattern-Empty Nested-Or-Predicates Join-IDF

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -833,25 +833,24 @@ select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order 
 --q32
 --
 explain select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
-                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324032.85 rows=2 width=4)
-   Filter: (SubPlan 1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
-         ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
-   SubPlan 1  (slice0)
-     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.79 rows=4 width=4)
+   ->  Seq Scan on t1  (cost=0.00..1324032.79 rows=2 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
            ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 Filter: ((CASE WHEN ((sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                               ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
-                                                     Filter: ((c2 > (-1)) AND (c2 <= 1))
+                       Filter: ((CASE WHEN ((sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                     ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                                           Filter: ((c2 > (-1)) AND (c2 <= 1))
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(15 rows)
 
 select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
  c1 

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -289,19 +289,18 @@ select c1 from t1 where c1 not in
 --
 explain select c1 from t1 where c1 > 6 and c1 not in 
 	(select c2 from t2) and c1 < 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
-   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: t1.c1 = t2.c2
-         ->  Seq Scan on t1  (cost=0.00..431.00 rows=2 width=4)
-               Filter: c1 > 6 AND c1 < 10
-         ->  Hash  (cost=431.00..431.00 rows=5 width=4)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
-                     ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(10 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
+   Hash Cond: (t1.c1 = t2.c2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               Filter: ((c1 > 6) AND (c1 < 10))
+   ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
+               ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select c1 from t1 where c1 > 6 and c1 not in 
 	(select c2 from t2) and c1 < 10;


### PR DESCRIPTION
Currently in CBucket::MakeBucketSingleton(), we use a width based approach to
calculate the resultant singleton bucket frequency. At the same time the NDV in
the returned bucket is assumed to be 1.  This is problematic because it means
that NDV and frequency were not scaled evenly.  If we want to guarantee the NDV
of the resultant bucket is 1, then we must adjust the frequency of the new
bucket using same ratio. Change uses NDV ratio to calculate the new frequency.

Similar update in CBucket.cpp::GetOverlapPercentage().

Testing:
Ran explain pipelines and sanity checked the plan changes.
Checked that it produced the desired plan on a known customer query.