### PR TITLE
CI: gen_pipeline.py should use python3

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ----------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The master of gpdb should be using python3 everywhere, including here.

I am not sure how to test this as it is not called anywhere in the repo, but it does work locally on my machine.
