### PR TITLE
readability: const-qualify pointer parameters

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: |
   modernize-use-equals-delete,
   modernize-use-nullptr,
   modernize-use-default-member-init,
+  readability-non-const-parameter,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'gpdbcost|gpopt|gpos|naucrates'

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1382,8 +1382,8 @@ CTranslatorRelcacheToDXL::ComputeIncludedCols(CMemoryPool *mp,
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorRelcacheToDXL::GetAttributePosition(INT attno,
-											   ULONG *GetAttributePosition)
+CTranslatorRelcacheToDXL::GetAttributePosition(
+	INT attno, const ULONG *GetAttributePosition)
 {
 	ULONG idx = (ULONG)(GPDXL_SYSTEM_COLUMNS + attno);
 	ULONG pos = GetAttributePosition[idx];

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1240,7 +1240,7 @@ ULongPtrArray *
 CTranslatorUtils::GenerateColIds(
 	CMemoryPool *mp, List *target_list, IMdIdArray *input_mdid_arr,
 	ULongPtrArray *input_colids,
-	BOOL *
+	const BOOL *
 		is_outer_ref,  // array of flags indicating if input columns are outer references
 	CIdGenerator *colid_generator)
 {

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDBLegacy.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDBLegacy.h
@@ -90,7 +90,7 @@ private:
 								  ICostModelParams *pcp);
 
 	// add up array of costs
-	static CCost CostSum(DOUBLE *pdCost, ULONG size);
+	static CCost CostSum(const DOUBLE *pdCost, ULONG size);
 
 	// check if given operator is unary
 	static BOOL FUnary(COperator::EOperatorId op_id);

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDBLegacy.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDBLegacy.cpp
@@ -249,7 +249,7 @@ CCostModelGPDBLegacy::FUnary(COperator::EOperatorId op_id)
 //
 //---------------------------------------------------------------------------
 CCost
-CCostModelGPDBLegacy::CostSum(DOUBLE *pdCost, ULONG size)
+CCostModelGPDBLegacy::CostSum(const DOUBLE *pdCost, ULONG size)
 {
 	GPOS_ASSERT(nullptr != pdCost);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CEnumeratorConfig.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CEnumeratorConfig.h
@@ -320,9 +320,9 @@ public:
 	void PrintPlanSample() const;
 
 	// compute Gaussian kernel density
-	static void GussianKernelDensity(DOUBLE *pdObervationX,
-									 DOUBLE *pdObervationY,
-									 ULONG ulObservations, DOUBLE *pdX,
+	static void GussianKernelDensity(const DOUBLE *pdObervationX,
+									 const DOUBLE *pdObervationY,
+									 ULONG ulObservations, const DOUBLE *pdX,
 									 DOUBLE *pdY, ULONG size);
 
 	// generate default enumerator configurations

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -158,7 +158,8 @@ private:
 
 	// check if given xform id is in the given array of xforms
 	static BOOL FXformInArray(CXform::EXformId exfid,
-							  CXform::EXformId rgXforms[], ULONG ulXforms);
+							  const CXform::EXformId rgXforms[],
+							  ULONG ulXforms);
 
 #ifdef GPOS_DEBUG
 	// check whether the given join type is swapable

--- a/src/backend/gporca/libgpopt/src/engine/CEnumeratorConfig.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEnumeratorConfig.cpp
@@ -206,10 +206,11 @@ CEnumeratorConfig::InitCostDistrSize()
 //---------------------------------------------------------------------------
 void
 CEnumeratorConfig::GussianKernelDensity(
-	DOUBLE *pdObervationX, DOUBLE *pdObervationY, ULONG ulObservations,
-	DOUBLE *pdX,  // input: X-values we need to compute estimates for
-	DOUBLE *pdY,  // output: estimated Y-values for given X-values
-	ULONG size	  // number of input X-values
+	const DOUBLE *pdObervationX, const DOUBLE *pdObervationY,
+	ULONG ulObservations,
+	const DOUBLE *pdX,	// input: X-values we need to compute estimates for
+	DOUBLE *pdY,		// output: estimated Y-values for given X-values
+	ULONG size			// number of input X-values
 )
 {
 	GPOS_ASSERT(nullptr != pdObervationX);

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalUnionAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalUnionAll.cpp
@@ -19,7 +19,7 @@ static BOOL Equals(ULongPtrArray *pdrgpulFst, ULongPtrArray *pdrgpulSnd);
 // helper to assert distribution delivered by UnionAll children
 static void AssertValidChildDistributions(
 	CMemoryPool *mp, CExpressionHandle &exprhdl,
-	CDistributionSpec::EDistributionType
+	const CDistributionSpec::EDistributionType
 		*pedt,		 // array of distribution types to check
 	ULONG ulDistrs,	 // number of distribution types to check
 	const CHAR *szAssertMsg);
@@ -849,7 +849,7 @@ CPhysicalUnionAll::MapOutputColRefsToInput(CMemoryPool *mp,
 void
 AssertValidChildDistributions(
 	CMemoryPool *mp, CExpressionHandle &exprhdl,
-	CDistributionSpec::EDistributionType
+	const CDistributionSpec::EDistributionType
 		*pedt,		 // array of distribution types to check
 	ULONG ulDistrs,	 // number of distribution types to check
 	const CHAR *szAssertMsg)

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2012,8 +2012,8 @@ CXformUtils::AddMinAggs(CMemoryPool *mp, CMDAccessor *md_accessor,
 //
 //---------------------------------------------------------------------------
 BOOL
-CXformUtils::FXformInArray(CXform::EXformId exfid, CXform::EXformId rgXforms[],
-						   ULONG ulXforms)
+CXformUtils::FXformInArray(CXform::EXformId exfid,
+						   const CXform::EXformId rgXforms[], ULONG ulXforms)
 {
 	for (ULONG ul = 0; ul < ulXforms; ul++)
 	{

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
@@ -84,7 +84,7 @@ private:
 	// return the LINT value of byte array
 	static LINT Value(CDXLMemoryManager *dxl_memory_manager,
 					  const Attributes &attrs, Edxltoken target_elem,
-					  BYTE *data);
+					  const BYTE *data);
 
 	// parses a byte array representation of the datum
 	static BYTE *GetByteArray(CDXLMemoryManager *dxl_memory_manager,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -2742,7 +2742,7 @@ CDXLOperatorFactory::GetDatumStatsLintMappable(
 LINT
 CDXLOperatorFactory::Value(CDXLMemoryManager *dxl_memory_manager,
 						   const Attributes &attrs, Edxltoken target_elem,
-						   BYTE *data)
+						   const BYTE *data)
 {
 	if (nullptr == data)
 	{

--- a/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
@@ -697,7 +697,7 @@ public:
 	// create Equivalence Class based on the breakpoints
 	static CColRefSetArray *createEquivalenceClasses(CMemoryPool *mp,
 													 CColRefSet *pcrs,
-													 INT setBoundary[]);
+													 const INT setBoundary[]);
 };	// class CTestUtils
 
 

--- a/src/backend/gporca/server/include/unittest/gpopt/search/CTreeMapTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/search/CTreeMapTest.h
@@ -45,7 +45,7 @@ class CTreeMapTest
 		CNode(const CNode &) = delete;
 
 		// ctor
-		CNode(CMemoryPool *mp, ULONG *pulData, CNodeArray *pdrgpnd);
+		CNode(CMemoryPool *mp, const ULONG *pulData, CNodeArray *pdrgpnd);
 
 		// dtor
 		~CNode() override;

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -4165,7 +4165,7 @@ CTestUtils::EresUnittest_RunTestsWithoutAdditionalTraceFlags(
 // Create Equivalence Class based on the breakpoints
 CColRefSetArray *
 CTestUtils::createEquivalenceClasses(CMemoryPool *mp, CColRefSet *pcrs,
-									 INT setBoundary[])
+									 const INT setBoundary[])
 {
 	INT i = 0;
 	ULONG bpIndex = 0;

--- a/src/backend/gporca/server/src/unittest/gpopt/search/CTreeMapTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/search/CTreeMapTest.cpp
@@ -99,7 +99,7 @@ CTreeMapTest::CNode::OsPrintWithIndent(IOstream &os, ULONG ulIndent) const
 //
 //---------------------------------------------------------------------------
 CTreeMapTest::CNode::CNode(CMemoryPool *,  // mp
-						   ULONG *pulData, CNodeArray *pdrgpnd)
+						   const ULONG *pulData, CNodeArray *pdrgpnd)
 	: m_ulData(gpos::ulong_max), m_pdrgpnd(pdrgpnd)
 {
 	if (nullptr != pulData)

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -383,7 +383,7 @@ public:
 										   ULONG size);
 
 	// return the position of a given attribute number
-	static ULONG GetAttributePosition(INT attno, ULONG *attno_mapping);
+	static ULONG GetAttributePosition(INT attno, const ULONG *attno_mapping);
 
 	// retrieve a type from the relcache
 	static IMDType *RetrieveType(CMemoryPool *mp, IMDId *mdid);

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -207,7 +207,7 @@ public:
 	static ULongPtrArray *GenerateColIds(CMemoryPool *mp, List *target_list,
 										 IMdIdArray *input_mdids,
 										 ULongPtrArray *input_nums,
-										 BOOL *is_outer_ref,
+										 const BOOL *is_outer_ref,
 										 CIdGenerator *colid_generator);
 
 	// construct an array of DXL column descriptors for a target list


### PR DESCRIPTION
This patch adds the "readability-non-const-parameter" check to clang-tidy and it also fixes all the warnings that it produces (in both the translator and gporca proper).

[1] https://clang.llvm.org/extra/clang-tidy/checks/readability-non-const-parameter.html
