### PR TITLE
[ORCA] Fix improper uses of reinterpret_cast

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtPlan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtPlan.h
@@ -83,7 +83,7 @@ public:
 	{
 		GPOS_ASSERT(nullptr != pdpctxt);
 
-		return reinterpret_cast<CDrvdPropCtxtPlan *>(pdpctxt);
+		return dynamic_cast<CDrvdPropCtxtPlan *>(pdpctxt);
 	}
 
 };	// class CDrvdPropCtxtPlan

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtRelational.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtRelational.h
@@ -79,7 +79,7 @@ public:
 	{
 		GPOS_ASSERT(nullptr != pdpctxt);
 
-		return reinterpret_cast<CDrvdPropCtxtRelational *>(pdpctxt);
+		return dynamic_cast<CDrvdPropCtxtRelational *>(pdpctxt);
 	}
 
 };	// class CDrvdPropCtxtRelational

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -322,7 +322,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(pop->FLogical());
 
-		return reinterpret_cast<CLogical *>(pop);
+		return dynamic_cast<CLogical *>(pop);
 	}
 
 	// returns the table descriptor for (Dynamic)(BitmapTable)Get operators

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalAssert.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalAssert.h
@@ -113,7 +113,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalAssert == pop->Eopid());
 
-		return reinterpret_cast<CLogicalAssert *>(pop);
+		return dynamic_cast<CLogicalAssert *>(pop);
 	}
 
 	// derive statistics

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDifference.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDifference.h
@@ -116,7 +116,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalDifference == pop->Eopid());
 
-		return reinterpret_cast<CLogicalDifference *>(pop);
+		return dynamic_cast<CLogicalDifference *>(pop);
 	}
 
 };	// class CLogicalDifference

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDifferenceAll.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDifferenceAll.h
@@ -114,7 +114,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalDifferenceAll == pop->Eopid());
 
-		return reinterpret_cast<CLogicalDifferenceAll *>(pop);
+		return dynamic_cast<CLogicalDifferenceAll *>(pop);
 	}
 
 };	// class CLogicalDifferenceAll

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIntersect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIntersect.h
@@ -117,7 +117,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalIntersect == pop->Eopid());
 
-		return reinterpret_cast<CLogicalIntersect *>(pop);
+		return dynamic_cast<CLogicalIntersect *>(pop);
 	}
 
 };	// class CLogicalIntersect

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIntersectAll.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIntersectAll.h
@@ -121,7 +121,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalIntersectAll == pop->Eopid());
 
-		return reinterpret_cast<CLogicalIntersectAll *>(pop);
+		return dynamic_cast<CLogicalIntersectAll *>(pop);
 	}
 
 	// derive statistics

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalMaxOneRow.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalMaxOneRow.h
@@ -161,7 +161,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalMaxOneRow == pop->Eopid());
 
-		return reinterpret_cast<CLogicalMaxOneRow *>(pop);
+		return dynamic_cast<CLogicalMaxOneRow *>(pop);
 	}
 
 	// derive statistics

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -133,7 +133,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalSelect == pop->Eopid());
 
-		return reinterpret_cast<CLogicalSelect *>(pop);
+		return dynamic_cast<CLogicalSelect *>(pop);
 	}
 
 	// derive statistics

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUnion.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUnion.h
@@ -117,7 +117,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalUnion == pop->Eopid());
 
-		return reinterpret_cast<CLogicalUnion *>(pop);
+		return dynamic_cast<CLogicalUnion *>(pop);
 	}
 
 };	// class CLogicalUnion

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUnionAll.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUnionAll.h
@@ -125,7 +125,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopLogicalUnionAll == pop->Eopid());
 
-		return reinterpret_cast<CLogicalUnionAll *>(pop);
+		return dynamic_cast<CLogicalUnionAll *>(pop);
 	}
 
 	// derive statistics based on union all semantics

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPattern.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPattern.h
@@ -76,7 +76,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(pop->FPattern());
 
-		return reinterpret_cast<CPattern *>(pop);
+		return dynamic_cast<CPattern *>(pop);
 	}
 
 	// helper to check multi-node pattern

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalAssert.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalAssert.h
@@ -183,7 +183,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalAssert == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalAssert *>(pop);
+		return dynamic_cast<CPhysicalAssert *>(pop);
 	}
 
 	// debug print

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalExternalScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalExternalScan.h
@@ -87,7 +87,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalExternalScan == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalExternalScan *>(pop);
+		return dynamic_cast<CPhysicalExternalScan *>(pop);
 	}
 
 };	// class CPhysicalExternalScan

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFilter.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFilter.h
@@ -149,7 +149,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalFilter == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalFilter *>(pop);
+		return dynamic_cast<CPhysicalFilter *>(pop);
 	}
 
 };	// class CPhysicalFilter

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashAgg.h
@@ -104,7 +104,7 @@ public:
 		GPOS_ASSERT(EopPhysicalHashAgg == pop->Eopid() ||
 					EopPhysicalHashAggDeduplicate == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalHashAgg *>(pop);
+		return dynamic_cast<CPhysicalHashAgg *>(pop);
 	}
 
 };	// class CPhysicalHashAgg

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashAggDeduplicate.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashAggDeduplicate.h
@@ -110,7 +110,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalHashAggDeduplicate == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalHashAggDeduplicate *>(pop);
+		return dynamic_cast<CPhysicalHashAggDeduplicate *>(pop);
 	}
 
 };	// class CPhysicalHashAggDeduplicate

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalScalarAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalScalarAgg.h
@@ -97,7 +97,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalScalarAgg == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalScalarAgg *>(pop);
+		return dynamic_cast<CPhysicalScalarAgg *>(pop);
 	}
 
 };	// class CPhysicalScalarAgg

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalStreamAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalStreamAgg.h
@@ -130,7 +130,7 @@ public:
 		GPOS_ASSERT(EopPhysicalStreamAgg == pop->Eopid() ||
 					EopPhysicalStreamAggDeduplicate == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalStreamAgg *>(pop);
+		return dynamic_cast<CPhysicalStreamAgg *>(pop);
 	}
 
 };	// class CPhysicalStreamAgg

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalStreamAggDeduplicate.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalStreamAggDeduplicate.h
@@ -122,7 +122,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopPhysicalStreamAggDeduplicate == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalStreamAggDeduplicate *>(pop);
+		return dynamic_cast<CPhysicalStreamAggDeduplicate *>(pop);
 	}
 
 };	// class CPhysicalStreamAggDeduplicate

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalTableScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalTableScan.h
@@ -73,7 +73,7 @@ public:
 		GPOS_ASSERT(EopPhysicalTableScan == pop->Eopid() ||
 					EopPhysicalExternalScan == pop->Eopid());
 
-		return reinterpret_cast<CPhysicalTableScan *>(pop);
+		return dynamic_cast<CPhysicalTableScan *>(pop);
 	}
 
 	// statistics derivation during costing

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalar.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalar.h
@@ -172,7 +172,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(pop->FScalar());
 
-		return reinterpret_cast<CScalar *>(pop);
+		return dynamic_cast<CScalar *>(pop);
 	}
 
 	// the type of the scalar expression

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarAggFunc.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarAggFunc.h
@@ -129,7 +129,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarAggFunc == pop->Eopid());
 
-		return reinterpret_cast<CScalarAggFunc *>(pop);
+		return dynamic_cast<CScalarAggFunc *>(pop);
 	}
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArray.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArray.h
@@ -106,7 +106,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarArray == pop->Eopid());
 
-		return reinterpret_cast<CScalarArray *>(pop);
+		return dynamic_cast<CScalarArray *>(pop);
 	}
 
 	// element type id

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArrayCmp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArrayCmp.h
@@ -126,7 +126,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarArrayCmp == pop->Eopid());
 
-		return reinterpret_cast<CScalarArrayCmp *>(pop);
+		return dynamic_cast<CScalarArrayCmp *>(pop);
 	}
 
 	// name of the comparison operator

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarBoolOp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarBoolOp.h
@@ -112,7 +112,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarBoolOp == pop->Eopid());
 
-		return reinterpret_cast<CScalarBoolOp *>(pop);
+		return dynamic_cast<CScalarBoolOp *>(pop);
 	}
 
 	// boolean expression evaluation

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarConst.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarConst.h
@@ -97,7 +97,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarConst == pop->Eopid());
 
-		return reinterpret_cast<CScalarConst *>(pop);
+		return dynamic_cast<CScalarConst *>(pop);
 	}
 
 	// the type of the scalar expression

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarFunc.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarFunc.h
@@ -130,7 +130,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarFunc == pop->Eopid());
 
-		return reinterpret_cast<CScalarFunc *>(pop);
+		return dynamic_cast<CScalarFunc *>(pop);
 	}
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarIdent.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarIdent.h
@@ -104,7 +104,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarIdent == pop->Eopid());
 
-		return reinterpret_cast<CScalarIdent *>(pop);
+		return dynamic_cast<CScalarIdent *>(pop);
 	}
 
 	// the type of the scalar expression

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarNullIf.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarNullIf.h
@@ -112,7 +112,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarNullIf == pop->Eopid());
 
-		return reinterpret_cast<CScalarNullIf *>(pop);
+		return dynamic_cast<CScalarNullIf *>(pop);
 	}
 
 };	// class CScalarNullIf

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarOp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarOp.h
@@ -116,7 +116,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarOp == pop->Eopid());
 
-		return reinterpret_cast<CScalarOp *>(pop);
+		return dynamic_cast<CScalarOp *>(pop);
 	}
 
 	// helper function

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectElement.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectElement.h
@@ -104,7 +104,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarProjectElement == pop->Eopid());
 
-		return reinterpret_cast<CScalarProjectElement *>(pop);
+		return dynamic_cast<CScalarProjectElement *>(pop);
 	}
 
 	IMDId *

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectList.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectList.h
@@ -77,7 +77,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarProjectList == pop->Eopid());
 
-		return reinterpret_cast<CScalarProjectList *>(pop);
+		return dynamic_cast<CScalarProjectList *>(pop);
 	}
 
 	IMDId *

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubquery.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubquery.h
@@ -119,7 +119,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarSubquery == pop->Eopid());
 
-		return reinterpret_cast<CScalarSubquery *>(pop);
+		return dynamic_cast<CScalarSubquery *>(pop);
 	}
 
 	// print

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryAll.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryAll.h
@@ -68,7 +68,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarSubqueryAll == pop->Eopid());
 
-		return reinterpret_cast<CScalarSubqueryAll *>(pop);
+		return dynamic_cast<CScalarSubqueryAll *>(pop);
 	}
 
 };	// class CScalarSubqueryAll

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryAny.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryAny.h
@@ -68,7 +68,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarSubqueryAny == pop->Eopid());
 
-		return reinterpret_cast<CScalarSubqueryAny *>(pop);
+		return dynamic_cast<CScalarSubqueryAny *>(pop);
 	}
 
 };	// class CScalarSubqueryAny

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryExists.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryExists.h
@@ -62,7 +62,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarSubqueryExists == pop->Eopid());
 
-		return reinterpret_cast<CScalarSubqueryExists *>(pop);
+		return dynamic_cast<CScalarSubqueryExists *>(pop);
 	}
 
 };	// class CScalarSubqueryExists

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryNotExists.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryNotExists.h
@@ -62,7 +62,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarSubqueryNotExists == pop->Eopid());
 
-		return reinterpret_cast<CScalarSubqueryNotExists *>(pop);
+		return dynamic_cast<CScalarSubqueryNotExists *>(pop);
 	}
 
 };	// class CScalarSubqueryNotExists

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryQuantified.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSubqueryQuantified.h
@@ -107,7 +107,7 @@ public:
 		GPOS_ASSERT(EopScalarSubqueryAny == pop->Eopid() ||
 					EopScalarSubqueryAll == pop->Eopid());
 
-		return reinterpret_cast<CScalarSubqueryQuantified *>(pop);
+		return dynamic_cast<CScalarSubqueryQuantified *>(pop);
 	}
 
 	// print

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarWindowFunc.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarWindowFunc.h
@@ -111,7 +111,7 @@ public:
 		GPOS_ASSERT(nullptr != pop);
 		GPOS_ASSERT(EopScalarWindowFunc == pop->Eopid());
 
-		return reinterpret_cast<CScalarWindowFunc *>(pop);
+		return dynamic_cast<CScalarWindowFunc *>(pop);
 	}
 
 	// does window function definition include Distinct?

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
@@ -562,7 +562,7 @@ CLogicalGbAgg::Matches(COperator *pop) const
 		return false;
 	}
 
-	CLogicalGbAgg *popAgg = reinterpret_cast<CLogicalGbAgg *>(pop);
+	CLogicalGbAgg *popAgg = dynamic_cast<CLogicalGbAgg *>(pop);
 
 	return FGeneratesDuplicates() == popAgg->FGeneratesDuplicates() &&
 		   popAgg->Egbaggtype() == m_egbaggtype &&

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -530,7 +530,7 @@ CPhysicalAgg::Matches(COperator *pop) const
 		return false;
 	}
 
-	CPhysicalAgg *popAgg = reinterpret_cast<CPhysicalAgg *>(pop);
+	CPhysicalAgg *popAgg = dynamic_cast<CPhysicalAgg *>(pop);
 
 	if (FGeneratesDuplicates() != popAgg->FGeneratesDuplicates())
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CScalarIsDistinctFrom.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarIsDistinctFrom.cpp
@@ -25,7 +25,7 @@ CScalarIsDistinctFrom::PopConvert(COperator *pop)
 	GPOS_ASSERT(nullptr != pop);
 	GPOS_ASSERT(EopScalarIsDistinctFrom == pop->Eopid());
 
-	return reinterpret_cast<CScalarIsDistinctFrom *>(pop);
+	return dynamic_cast<CScalarIsDistinctFrom *>(pop);
 }
 
 // perform boolean expression evaluation

--- a/src/backend/gporca/libgpos/src/error/CErrorContext.cpp
+++ b/src/backend/gporca/libgpos/src/error/CErrorContext.cpp
@@ -168,7 +168,7 @@ CErrorContext::CopyPropErrCtxt(const IErrorContext *err_ctxt)
 	// copy error message
 	m_static_buffer.Reset();
 	m_static_buffer.Append(
-		&(reinterpret_cast<const CErrorContext *>(err_ctxt)->m_static_buffer));
+		&(dynamic_cast<const CErrorContext *>(err_ctxt)->m_static_buffer));
 
 	// copy severity
 	m_severity = err_ctxt->GetSeverity();


### PR DESCRIPTION
We should use a `dynamic_cast` (and in some narrow circumstances, `static_cast`) for downcasting a polymorphic type. These uses of `reinterpret_cast` are improper (and highly discouraged [1]), and even if they work now, it will be brittle (e.g. when a derived class changes layout to no longer align with a base class that happens to be convertible through `reinterpret_cast`, a problem that `static_cast` doesn't have).

The sites of improper casts are found using the following command in clang-query:

`match cxxReinterpretCastExpr(hasSourceExpression(ignoringParenImpCasts(declRefExpr(to(parmVarDecl(hasType(pointsTo(cxxRecordDecl().bind("base")))))))),hasDestinationType(pointsTo(cxxRecordDecl(isDerivedFrom(equalsBoundNode("base")))))).bind("cast")`

[1] https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast

