### PR TITLE
[Backport] Use CColRef Id for hash/equal comparisons in Orca

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEInfo.h
@@ -25,9 +25,8 @@ namespace gpopt
 class CLogicalCTEConsumer;
 
 // hash map: CColRef -> ULONG
-typedef CHashMap<CColRef, ULONG, gpos::HashValue<CColRef>,
-				 gpos::Equals<CColRef>, CleanupNULL<CColRef>,
-				 CleanupDelete<ULONG> >
+typedef CHashMap<CColRef, ULONG, CColRef::HashValue, CColRef::Equals,
+				 CleanupNULL<CColRef>, CleanupDelete<ULONG> >
 	ColRefToUlongMap;
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
@@ -28,9 +28,8 @@ class CColRefSet;
 typedef CDynamicPtrArray<CColRefSet, CleanupRelease> CColRefSetArray;
 
 // hash map mapping CColRef -> CColRefSet
-typedef CHashMap<CColRef, CColRefSet, gpos::HashValue<CColRef>,
-				 gpos::Equals<CColRef>, CleanupNULL<CColRef>,
-				 CleanupRelease<CColRefSet> >
+typedef CHashMap<CColRef, CColRefSet, CColRef::HashValue, CColRef::Equals,
+				 CleanupNULL<CColRef>, CleanupRelease<CColRefSet> >
 	ColRefToColRefSetMap;
 
 // hash map mapping INT -> CColRef

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -32,9 +32,8 @@ class CConstraint;
 typedef CDynamicPtrArray<CConstraint, CleanupRelease> CConstraintArray;
 
 // hash map mapping CColRef -> CConstraintArray
-typedef CHashMap<CColRef, CConstraintArray, gpos::HashValue<CColRef>,
-				 gpos::Equals<CColRef>, CleanupNULL<CColRef>,
-				 CleanupRelease<CConstraintArray> >
+typedef CHashMap<CColRef, CConstraintArray, CColRef::HashValue, CColRef::Equals,
+				 CleanupNULL<CColRef>, CleanupRelease<CConstraintArray> >
 	ColRefToConstraintArrayMap;
 
 // mapping CConstraint -> BOOL to cache previous containment queries,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -50,9 +50,8 @@ using namespace gpdxl;
 using namespace gpnaucrates;
 
 // hash map mapping CColRef -> CDXLNode
-typedef CHashMap<CColRef, CDXLNode, gpos::HashValue<CColRef>,
-				 gpos::Equals<CColRef>, CleanupNULL<CColRef>,
-				 CleanupRelease<CDXLNode> >
+typedef CHashMap<CColRef, CDXLNode, CColRef::HashValue, CColRef::Equals,
+				 CleanupNULL<CColRef>, CleanupRelease<CDXLNode> >
 	ColRefToDXLNodeMap;
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Replacing an unstable hash function in maps that used CColRef as the key

I got SIGSEGV in production. 
After investigating the bug, I found that the internal structures of the map contain a lost key (CColRef), but cannot find the value for this key.
I think that the reason for this behavior lies in the fact that the hash function used CColRef as a value, which means that any change in CColRef led to a change in the hash value and broke the map.

When I tried to apply the merge to the master, I found that a similar fix was already there. 
https://github.com/greenplum-db/gpdb/commit/65276acb0fd8f6f860d017c1fe5bf6aca7220731
But this fix is not in 6X

Main problem HashMap was ColRefToConstraintArrayMap in CConstraint.h


GP 6.12.1 SIGSEGV Stack (if need i can give core dump):
```
#0  0x00007f0fe05e249b in raise () from /lib64/libpthread.so.0
#1  0x0000000000bdba76 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5548
#2  <signal handler called>
#3  0x0000000000dcfb1f in Release (this=0x0) at ../../../../../../src/backend/gporca/libgpos/include/gpos/common/CRefCount.h:106
#4  gpopt::CConstraint::Contains (this=0x1866ebc0, pcnstr=0x1869f070) at CConstraint.cpp:974
#5  0x0000000000dcc5a1 in gpopt::CConstraint::Equals (this=0x1866ebc0, pcnstr=0x1869f070) at CConstraint.cpp:1010
#6  0x0000000000e304b5 in gpopt::CPartConstraint::FEqualConstrMaps (phmulcnstrFst=0x1866f060, phmulcnstrSnd=0x18671d20, ulLevels=2) at CPartConstraint.cpp:252
#7  0x0000000000e3063a in gpopt::CPartConstraint::FEquivalent (this=this@entry=0x1866dd70, ppartcnstr=ppartcnstr@entry=0x18670d60) at CPartConstraint.cpp:221
#8  0x0000000000df30ef in gpopt::CPartIndexMap::CPartTableInfo::FDefinesPartialScans (ppartcnstrmap=ppartcnstrmap@entry=0x329afcf0, ppartcnstrRel=ppartcnstrRel@entry=0x1866dd70)
    at CPartIndexMap.cpp:162
#9  0x0000000000df41e3 in CPartTableInfo (ulPropagators=0, ppartcnstrRel=0x1866dd70, pdrgppartkeys=0x329ad570, mdid=0x49b16f8, epim=gpopt::CPartIndexMap::EpimConsumer, 
    ppartcnstrmap=0x329afcf0, scan_id=<optimized out>, this=0x329ac3b0) at CPartIndexMap.cpp:55
#10 gpopt::CPartIndexMap::Insert (this=this@entry=0x329adb40, scan_id=scan_id@entry=1, ppartcnstrmap=ppartcnstrmap@entry=0x329afcf0, epim=epim@entry=gpopt::CPartIndexMap::EpimConsumer, 
    ulExpectedPropagators=ulExpectedPropagators@entry=0, mdid=mdid@entry=0x49b16f8, pdrgppartkeys=pdrgppartkeys@entry=0x329ad570, ppartcnstrRel=ppartcnstrRel@entry=0x1866dd70)
    at CPartIndexMap.cpp:240
#11 0x0000000000e97fb8 in gpopt::CPhysicalScan::PpimDeriveFromDynamicScan (mp=<optimized out>, part_idx_id=1, rel_mdid=0x49b16f8, pdrgpdrgpcrPart=<optimized out>, 
    ulSecondaryPartIndexId=<optimized out>, ppartcnstr=<optimized out>, ppartcnstrRel=0x1866dd70, ulExpectedPropagators=0) at CPhysicalScan.cpp:242
#12 0x0000000000e860d4 in gpopt::CPhysicalDynamicScan::PpimDerive (this=<optimized out>, mp=<optimized out>, pdpctxt=<optimized out>) at CPhysicalDynamicScan.cpp:120
#13 0x0000000000de5263 in gpopt::CDrvdPropPlan::Derive (this=0x329ae320, mp=0x27e2a68, exprhdl=..., pdpctxt=0x329afca0) at CDrvdPropPlan.cpp:107

