### PR TITLE
Use switch cases instead of for-loops over array-of-function pointers

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -95,7 +95,6 @@ CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt(
 {
 	m_translator_dxl_to_scalar = GPOS_NEW(m_mp)
 		CTranslatorDXLToScalar(m_mp, m_md_accessor, m_num_of_segments);
-	InitTranslators();
 }
 
 //---------------------------------------------------------------------------
@@ -109,100 +108,6 @@ CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt(
 CTranslatorDXLToPlStmt::~CTranslatorDXLToPlStmt()
 {
 	GPOS_DELETE(m_translator_dxl_to_scalar);
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorDXLToPlStmt::InitTranslators
-//
-//	@doc:
-//		Initialize index of translators
-//
-//---------------------------------------------------------------------------
-void
-CTranslatorDXLToPlStmt::InitTranslators()
-{
-	for (ULONG idx = 0;
-		 idx < GPOS_ARRAY_SIZE(m_dxlop_translator_func_mapping_array); idx++)
-	{
-		m_dxlop_translator_func_mapping_array[idx] = nullptr;
-	}
-
-	// array mapping operator type to translator function
-	static const STranslatorMapping dxlop_translator_func_mapping_array[] = {
-		{EdxlopPhysicalTableScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
-		{EdxlopPhysicalExternalScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
-		{EdxlopPhysicalIndexScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexScan},
-		{EdxlopPhysicalIndexOnlyScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan},
-		{EdxlopPhysicalHashJoin,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLHashJoin},
-		{EdxlopPhysicalNLJoin,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLNLJoin},
-		{EdxlopPhysicalMergeJoin,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLMergeJoin},
-		{EdxlopPhysicalMotionGather,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
-		{EdxlopPhysicalMotionBroadcast,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
-		{EdxlopPhysicalMotionRedistribute,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion},
-		{EdxlopPhysicalMotionRandom,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLDuplicateSensitiveMotion},
-		{EdxlopPhysicalMotionRoutedDistribute,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLMotion},
-		{EdxlopPhysicalLimit,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLLimit},
-		{EdxlopPhysicalAgg, &gpopt::CTranslatorDXLToPlStmt::TranslateDXLAgg},
-		{EdxlopPhysicalWindow,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLWindow},
-		{EdxlopPhysicalSort, &gpopt::CTranslatorDXLToPlStmt::TranslateDXLSort},
-		{EdxlopPhysicalSubqueryScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan},
-		{EdxlopPhysicalResult,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLResult},
-		{EdxlopPhysicalAppend,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLAppend},
-		{EdxlopPhysicalMaterialize,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLMaterialize},
-		{EdxlopPhysicalSequence,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLSequence},
-		{EdxlopPhysicalDynamicTableScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLDynTblScan},
-		/* {EdxlopPhysicalDynamicIndexScan,		&gpopt::CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan}, */
-		{EdxlopPhysicalTVF, &gpopt::CTranslatorDXLToPlStmt::TranslateDXLTvf},
-		{EdxlopPhysicalDML, &gpopt::CTranslatorDXLToPlStmt::TranslateDXLDml},
-		{EdxlopPhysicalSplit,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLSplit},
-		// GPDB_12_MERGE_FIXME: stop generating AssertOp from ORCA
-		//			{EdxlopPhysicalAssert,					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLAssert},
-		{EdxlopPhysicalCTEProducer,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan},
-		{EdxlopPhysicalCTEConsumer,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan},
-		{EdxlopPhysicalBitmapTableScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan},
-		{EdxlopPhysicalDynamicBitmapTableScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan},
-		{EdxlopPhysicalCTAS, &gpopt::CTranslatorDXLToPlStmt::TranslateDXLCtas},
-		{EdxlopPhysicalPartitionSelector,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLPartSelector},
-		{EdxlopPhysicalValuesScan,
-		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLValueScan},
-	};
-
-	const ULONG num_of_translators =
-		GPOS_ARRAY_SIZE(dxlop_translator_func_mapping_array);
-
-	for (ULONG idx = 0; idx < num_of_translators; idx++)
-	{
-		STranslatorMapping elem = dxlop_translator_func_mapping_array[idx];
-		m_dxlop_translator_func_mapping_array[elem.dxl_op_id] =
-			elem.dxlnode_to_logical_funct;
-	}
 }
 
 //---------------------------------------------------------------------------
@@ -359,23 +264,195 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 	GPOS_ASSERT(nullptr != dxlnode);
 	GPOS_ASSERT(nullptr != ctxt_translation_prev_siblings);
 
-	CDXLOperator *dxlop = dxlnode->GetOperator();
-	ULONG ulOpId = (ULONG) dxlop->GetDXLOperator();
+	Plan *plan;
 
-	PfPplan dxlnode_to_logical_funct =
-		m_dxlop_translator_func_mapping_array[ulOpId];
+	const CDXLOperator *dxlop = dxlnode->GetOperator();
+	gpdxl::Edxlopid ulOpId = dxlop->GetDXLOperator();
 
-	if (nullptr == dxlnode_to_logical_funct)
+	switch (ulOpId)
+	{
+		default:
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
+					   dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
+		}
+		case EdxlopPhysicalTableScan:
+		case EdxlopPhysicalExternalScan:
+		{
+			plan = TranslateDXLTblScan(dxlnode, output_context,
+									   ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalIndexScan:
+		{
+			plan = TranslateDXLIndexScan(dxlnode, output_context,
+										 ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalIndexOnlyScan:
+		{
+			plan = TranslateDXLIndexOnlyScan(dxlnode, output_context,
+											 ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalHashJoin:
+		{
+			plan = TranslateDXLHashJoin(dxlnode, output_context,
+										ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalNLJoin:
+		{
+			plan = TranslateDXLNLJoin(dxlnode, output_context,
+									  ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalMergeJoin:
+		{
+			plan = TranslateDXLMergeJoin(dxlnode, output_context,
+										 ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalMotionGather:
+		case EdxlopPhysicalMotionBroadcast:
+		case EdxlopPhysicalMotionRoutedDistribute:
+		{
+			plan = TranslateDXLMotion(dxlnode, output_context,
+									  ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalMotionRedistribute:
+		case EdxlopPhysicalMotionRandom:
+		{
+			plan = TranslateDXLDuplicateSensitiveMotion(
+				dxlnode, output_context, ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalLimit:
+		{
+			plan = TranslateDXLLimit(dxlnode, output_context,
+									 ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalAgg:
+		{
+			plan = TranslateDXLAgg(dxlnode, output_context,
+								   ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalWindow:
+		{
+			plan = TranslateDXLWindow(dxlnode, output_context,
+									  ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalSort:
+		{
+			plan = TranslateDXLSort(dxlnode, output_context,
+									ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalSubqueryScan:
+		{
+			plan = TranslateDXLSubQueryScan(dxlnode, output_context,
+											ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalResult:
+		{
+			plan = TranslateDXLResult(dxlnode, output_context,
+									  ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalAppend:
+		{
+			plan = TranslateDXLAppend(dxlnode, output_context,
+									  ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalMaterialize:
+		{
+			plan = TranslateDXLMaterialize(dxlnode, output_context,
+										   ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalSequence:
+		{
+			plan = TranslateDXLSequence(dxlnode, output_context,
+										ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalDynamicTableScan:
+		{
+			plan = TranslateDXLDynTblScan(dxlnode, output_context,
+										  ctxt_translation_prev_siblings);
+			break;
+		}
+		/* case EdxlopPhysicalDynamicIndexScan: { plan = TranslateDXLDynIdxScan(dxlnode, output_context, ctxt_translation_prev_siblings); break;} */
+		case EdxlopPhysicalTVF:
+		{
+			plan = TranslateDXLTvf(dxlnode, output_context,
+								   ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalDML:
+		{
+			plan = TranslateDXLDml(dxlnode, output_context,
+								   ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalSplit:
+		{
+			plan = TranslateDXLSplit(dxlnode, output_context,
+									 ctxt_translation_prev_siblings);
+			break;
+		}
+		// GPDB_12_MERGE_FIXME: stop generating AssertOp from ORCA
+		//			case EdxlopPhysicalAssert: { plan = TranslateDXLAssert(dxlnode, output_context, ctxt_translation_prev_siblings); break;}
+		case EdxlopPhysicalCTEProducer:
+		{
+			plan = TranslateDXLCTEProducerToSharedScan(
+				dxlnode, output_context, ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalCTEConsumer:
+		{
+			plan = TranslateDXLCTEConsumerToSharedScan(
+				dxlnode, output_context, ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalBitmapTableScan:
+		case EdxlopPhysicalDynamicBitmapTableScan:
+		{
+			plan = TranslateDXLBitmapTblScan(dxlnode, output_context,
+											 ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalCTAS:
+		{
+			plan = TranslateDXLCtas(dxlnode, output_context,
+									ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalPartitionSelector:
+		{
+			plan = TranslateDXLPartSelector(dxlnode, output_context,
+											ctxt_translation_prev_siblings);
+			break;
+		}
+		case EdxlopPhysicalValuesScan:
+		{
+			plan = TranslateDXLValueScan(dxlnode, output_context,
+										 ctxt_translation_prev_siblings);
+			break;
+		}
+	}
+
+	if (nullptr == plan)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
 				   dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
 	}
-
-	Plan *const plan = (this->*dxlnode_to_logical_funct)(
-		dxlnode, output_context, ctxt_translation_prev_siblings);
-	if (nullptr == plan)
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-				   dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
 	return plan;
 }
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -80,95 +80,131 @@ Expr *
 CTranslatorDXLToScalar::TranslateDXLToScalar(const CDXLNode *dxlnode,
 											 CMappingColIdVar *colid_var)
 {
-	static const STranslatorElem translators[] = {
-		{EdxlopScalarIdent,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar},
-		{EdxlopScalarCmp,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarCmpToScalar},
-		{EdxlopScalarDistinct,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarDistinctToScalar},
-		{EdxlopScalarOpExpr,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar},
-		{EdxlopScalarArrayComp,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarArrayCompToScalar},
-		{EdxlopScalarCoalesce,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarCoalesceToScalar},
-		{EdxlopScalarMinMax,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarMinMaxToScalar},
-		{EdxlopScalarConstValue,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarConstToScalar},
-		{EdxlopScalarBoolExpr,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarBoolExprToScalar},
-		{EdxlopScalarBooleanTest,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarBooleanTestToScalar},
-		{EdxlopScalarNullTest,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarNullTestToScalar},
-		{EdxlopScalarNullIf,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarNullIfToScalar},
-		{EdxlopScalarIfStmt,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarIfStmtToScalar},
-		{EdxlopScalarSwitch,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarSwitchToScalar},
-		{EdxlopScalarCaseTest,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarCaseTestToScalar},
-		{EdxlopScalarFuncExpr,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarFuncExprToScalar},
-		{EdxlopScalarAggref,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarAggrefToScalar},
-		{EdxlopScalarWindowRef,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarWindowRefToScalar},
-		{EdxlopScalarCast,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarCastToScalar},
-		{EdxlopScalarCoerceToDomain,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarCoerceToDomainToScalar},
-		{EdxlopScalarCoerceViaIO,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOToScalar},
-		{EdxlopScalarArrayCoerceExpr,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarArrayCoerceExprToScalar},
-		{EdxlopScalarSubPlan,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar},
-		{EdxlopScalarArray,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarArrayToScalar},
-		{EdxlopScalarArrayRef,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarArrayRefToScalar},
-		{EdxlopScalarDMLAction,
-		 &CTranslatorDXLToScalar::TranslateDXLScalarDMLActionToScalar},
+	GPOS_ASSERT(nullptr != dxlnode);
+	Edxlopid eopid = dxlnode->GetOperator()->GetDXLOperator();
+	switch (eopid)
+	{
+		default:
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
+					   dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
+		}
+		case EdxlopScalarIdent:
+		{
+			return TranslateDXLScalarIdentToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarCmp:
+		{
+			return TranslateDXLScalarCmpToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarDistinct:
+		{
+			return TranslateDXLScalarDistinctToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarOpExpr:
+		{
+			return TranslateDXLScalarOpExprToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarArrayComp:
+		{
+			return TranslateDXLScalarArrayCompToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarCoalesce:
+		{
+			return TranslateDXLScalarCoalesceToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarMinMax:
+		{
+			return TranslateDXLScalarMinMaxToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarConstValue:
+		{
+			return TranslateDXLScalarConstToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarBoolExpr:
+		{
+			return TranslateDXLScalarBoolExprToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarBooleanTest:
+		{
+			return TranslateDXLScalarBooleanTestToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarNullTest:
+		{
+			return TranslateDXLScalarNullTestToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarNullIf:
+		{
+			return TranslateDXLScalarNullIfToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarIfStmt:
+		{
+			return TranslateDXLScalarIfStmtToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarSwitch:
+		{
+			return TranslateDXLScalarSwitchToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarCaseTest:
+		{
+			return TranslateDXLScalarCaseTestToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarFuncExpr:
+		{
+			return TranslateDXLScalarFuncExprToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarAggref:
+		{
+			return TranslateDXLScalarAggrefToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarWindowRef:
+		{
+			return TranslateDXLScalarWindowRefToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarCast:
+		{
+			return TranslateDXLScalarCastToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarCoerceToDomain:
+		{
+			return TranslateDXLScalarCoerceToDomainToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarCoerceViaIO:
+		{
+			return TranslateDXLScalarCoerceViaIOToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarArrayCoerceExpr:
+		{
+			return TranslateDXLScalarArrayCoerceExprToScalar(dxlnode,
+															 colid_var);
+		}
+		case EdxlopScalarSubPlan:
+		{
+			return TranslateDXLScalarSubplanToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarArray:
+		{
+			return TranslateDXLScalarArrayToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarArrayRef:
+		{
+			return TranslateDXLScalarArrayRefToScalar(dxlnode, colid_var);
+		}
+		case EdxlopScalarDMLAction:
+		{
+			return TranslateDXLScalarDMLActionToScalar(dxlnode, colid_var);
+		}
 #if 0
 		// GPDB_12_MERGE_FIXME: These were removed from the server with the v12 merge
 		// of upstream partitioning. Need something to replace? Need to rip out from GPORCA?
-		{EdxlopScalarPartDefault, &CTranslatorDXLToScalar::TranslateDXLScalarPartDefaultToScalar},
-		{EdxlopScalarPartBound, &CTranslatorDXLToScalar::TranslateDXLScalarPartBoundToScalar},
-		{EdxlopScalarPartBoundInclusion, &CTranslatorDXLToScalar::TranslateDXLScalarPartBoundInclusionToScalar},
-		{EdxlopScalarPartBoundOpen, &CTranslatorDXLToScalar::TranslateDXLScalarPartBoundOpenToScalar},
-		{EdxlopScalarPartListValues, &CTranslatorDXLToScalar::TranslateDXLScalarPartListValuesToScalar},
-		{EdxlopScalarPartListNullTest, &CTranslatorDXLToScalar::TranslateDXLScalarPartListNullTestToScalar},
+		case EdxlopScalarPartDefault: { return TranslateDXLScalarPartDefaultToScalar(dxlnode, colid_var); }
+		case EdxlopScalarPartBound: { return TranslateDXLScalarPartBoundToScalar(dxlnode, colid_var); }
+		case EdxlopScalarPartBoundInclusion: { return TranslateDXLScalarPartBoundInclusionToScalar(dxlnode, colid_var); }
+		case EdxlopScalarPartBoundOpen: { return TranslateDXLScalarPartBoundOpenToScalar(dxlnode, colid_var); }
+		case EdxlopScalarPartListValues: { return TranslateDXLScalarPartListValuesToScalar(dxlnode, colid_var); }
+		case EdxlopScalarPartListNullTest: { return TranslateDXLScalarPartListNullTestToScalar(dxlnode, colid_var); }
 #endif
-	};
-
-	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
-
-	GPOS_ASSERT(nullptr != dxlnode);
-	Edxlopid eopid = dxlnode->GetOperator()->GetDXLOperator();
-
-	// find translator for the node type
-	expr_func_ptr translate_func = nullptr;
-	for (ULONG ul = 0; ul < num_translators; ul++)
-	{
-		STranslatorElem elem = translators[ul];
-		if (eopid == elem.eopid)
-		{
-			translate_func = elem.translate_func;
-			break;
-		}
 	}
-
-	if (nullptr == translate_func)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-				   dxlnode->GetOperator()->GetOpNameStr()->GetBuffer());
-	}
-
-	return (this->*translate_func)(dxlnode, colid_var);
 }
 
 //---------------------------------------------------------------------------
@@ -1541,47 +1577,43 @@ Expr *
 CTranslatorDXLToScalar::TranslateDXLDatumToScalar(CDXLDatum *datum_dxl)
 {
 	GPOS_ASSERT(nullptr != datum_dxl);
-	static const SDatumTranslatorElem translators[] = {
-		{CDXLDatum::EdxldatumInt2,
-		 &CTranslatorDXLToScalar::ConvertDXLDatumToConstInt2},
-		{CDXLDatum::EdxldatumInt4,
-		 &CTranslatorDXLToScalar::ConvertDXLDatumToConstInt4},
-		{CDXLDatum::EdxldatumInt8,
-		 &CTranslatorDXLToScalar::ConvertDXLDatumToConstInt8},
-		{CDXLDatum::EdxldatumBool,
-		 &CTranslatorDXLToScalar::ConvertDXLDatumToConstBool},
-		{CDXLDatum::EdxldatumOid,
-		 &CTranslatorDXLToScalar::ConvertDXLDatumToConstOid},
-		{CDXLDatum::EdxldatumGeneric,
-		 &CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar},
-		{CDXLDatum::EdxldatumStatsDoubleMappable,
-		 &CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar},
-		{CDXLDatum::EdxldatumStatsLintMappable,
-		 &CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar}};
 
-	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
 	CDXLDatum::EdxldatumType edxldatumtype = datum_dxl->GetDatumType();
-
-	// find translator for the node type
-	const_func_ptr translate_func = nullptr;
-	for (ULONG i = 0; i < num_translators; i++)
+	switch (edxldatumtype)
 	{
-		SDatumTranslatorElem elem = translators[i];
-		if (edxldatumtype == elem.edxldt)
+		default:
 		{
-			translate_func = elem.translate_func;
-			break;
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
+					   CDXLTokens::GetDXLTokenStr(EdxltokenScalarConstValue)
+						   ->GetBuffer());
+		}
+		case CDXLDatum::EdxldatumInt2:
+		{
+			return (Expr *) ConvertDXLDatumToConstInt2(datum_dxl);
+		}
+		case CDXLDatum::EdxldatumInt4:
+		{
+			return (Expr *) ConvertDXLDatumToConstInt4(datum_dxl);
+		}
+		case CDXLDatum::EdxldatumInt8:
+		{
+			return (Expr *) ConvertDXLDatumToConstInt8(datum_dxl);
+		}
+		case CDXLDatum::EdxldatumBool:
+		{
+			return (Expr *) ConvertDXLDatumToConstBool(datum_dxl);
+		}
+		case CDXLDatum::EdxldatumOid:
+		{
+			return (Expr *) ConvertDXLDatumToConstOid(datum_dxl);
+		}
+		case CDXLDatum::EdxldatumGeneric:
+		case CDXLDatum::EdxldatumStatsDoubleMappable:
+		case CDXLDatum::EdxldatumStatsLintMappable:
+		{
+			return (Expr *) TranslateDXLDatumGenericToScalar(datum_dxl);
 		}
 	}
-
-	if (nullptr == translate_func)
-	{
-		GPOS_RAISE(
-			gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-			CDXLTokens::GetDXLTokenStr(EdxltokenScalarConstValue)->GetBuffer());
-	}
-
-	return (Expr *) (this->*translate_func)(datum_dxl);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
@@ -39,28 +39,6 @@ using namespace gpmd;
 class CCostModelGPDB : public ICostModel
 {
 private:
-	// definition of operator processor
-	typedef CCost(FnCost)(CMemoryPool *, CExpressionHandle &,
-						  const CCostModelGPDB *, const SCostingInfo *);
-
-	//---------------------------------------------------------------------------
-	//	@struct:
-	//		SCostMapping
-	//
-	//	@doc:
-	//		Mapping of operator to a cost function
-	//
-	//---------------------------------------------------------------------------
-	struct SCostMapping
-	{
-		// physical operator id
-		COperator::EOperatorId m_eopid;
-
-		// pointer to cost function
-		FnCost *m_pfnc;
-
-	};	// struct SCostMapping
-
 	// memory pool
 	CMemoryPool *m_mp;
 
@@ -69,9 +47,6 @@ private:
 
 	// cost model parameters
 	CCostModelParamsGPDB *m_cost_model_params;
-
-	// array of mappings
-	static const SCostMapping m_rgcm[];
 
 	// return cost of processing the given number of rows
 	static CCost CostTupleProcessing(DOUBLE rows, DOUBLE width,

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -39,73 +39,6 @@ using namespace gpos;
 using namespace gpdbcost;
 
 
-// initialization of cost functions
-const CCostModelGPDB::SCostMapping CCostModelGPDB::m_rgcm[] = {
-	{COperator::EopPhysicalTableScan, CostScan},
-	{COperator::EopPhysicalDynamicTableScan, CostScan},
-	{COperator::EopPhysicalExternalScan, CostScan},
-
-	{COperator::EopPhysicalFilter, CostFilter},
-
-	{COperator::EopPhysicalIndexOnlyScan, CostIndexOnlyScan},
-	{COperator::EopPhysicalIndexScan, CostIndexScan},
-	{COperator::EopPhysicalDynamicIndexScan, CostIndexScan},
-	{COperator::EopPhysicalBitmapTableScan, CostBitmapTableScan},
-	{COperator::EopPhysicalDynamicBitmapTableScan, CostBitmapTableScan},
-
-	{COperator::EopPhysicalSequenceProject, CostSequenceProject},
-
-	{COperator::EopPhysicalCTEProducer, CostCTEProducer},
-	{COperator::EopPhysicalCTEConsumer, CostCTEConsumer},
-	{COperator::EopPhysicalConstTableGet, CostConstTableGet},
-	{COperator::EopPhysicalDML, CostDML},
-
-	{COperator::EopPhysicalHashAgg, CostHashAgg},
-	{COperator::EopPhysicalHashAggDeduplicate, CostHashAgg},
-	{COperator::EopPhysicalScalarAgg, CostScalarAgg},
-	{COperator::EopPhysicalStreamAgg, CostStreamAgg},
-	{COperator::EopPhysicalStreamAggDeduplicate, CostStreamAgg},
-
-	{COperator::EopPhysicalSequence, CostSequence},
-
-	{COperator::EopPhysicalSort, CostSort},
-
-	{COperator::EopPhysicalTVF, CostTVF},
-
-	{COperator::EopPhysicalSerialUnionAll, CostUnionAll},
-	{COperator::EopPhysicalParallelUnionAll, CostUnionAll},
-
-	{COperator::EopPhysicalInnerHashJoin, CostHashJoin},
-	{COperator::EopPhysicalLeftSemiHashJoin, CostHashJoin},
-	{COperator::EopPhysicalLeftAntiSemiHashJoin, CostHashJoin},
-	{COperator::EopPhysicalLeftAntiSemiHashJoinNotIn, CostHashJoin},
-	{COperator::EopPhysicalLeftOuterHashJoin, CostHashJoin},
-	{COperator::EopPhysicalRightOuterHashJoin, CostHashJoin},
-
-	{COperator::EopPhysicalInnerIndexNLJoin, CostIndexNLJoin},
-	{COperator::EopPhysicalLeftOuterIndexNLJoin, CostIndexNLJoin},
-
-	{COperator::EopPhysicalMotionGather, CostMotion},
-	{COperator::EopPhysicalMotionBroadcast, CostMotion},
-	{COperator::EopPhysicalMotionHashDistribute, CostMotion},
-	{COperator::EopPhysicalMotionRandom, CostMotion},
-	{COperator::EopPhysicalMotionRoutedDistribute, CostMotion},
-
-	{COperator::EopPhysicalInnerNLJoin, CostNLJoin},
-	{COperator::EopPhysicalLeftSemiNLJoin, CostNLJoin},
-	{COperator::EopPhysicalLeftAntiSemiNLJoin, CostNLJoin},
-	{COperator::EopPhysicalLeftAntiSemiNLJoinNotIn, CostNLJoin},
-	{COperator::EopPhysicalLeftOuterNLJoin, CostNLJoin},
-	{COperator::EopPhysicalCorrelatedInnerNLJoin, CostNLJoin},
-	{COperator::EopPhysicalCorrelatedLeftOuterNLJoin, CostNLJoin},
-	{COperator::EopPhysicalCorrelatedLeftSemiNLJoin, CostNLJoin},
-	{COperator::EopPhysicalCorrelatedInLeftSemiNLJoin, CostNLJoin},
-	{COperator::EopPhysicalCorrelatedLeftAntiSemiNLJoin, CostNLJoin},
-	{COperator::EopPhysicalCorrelatedNotInLeftAntiSemiNLJoin, CostNLJoin},
-
-	{COperator::EopPhysicalFullMergeJoin, CostMergeJoin},
-};
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CCostModelGPDB::CCostModelGPDB
@@ -2013,20 +1946,147 @@ CCostModelGPDB::Cost(
 		return CostUnary(m_mp, exprhdl, pci, m_cost_model_params);
 	}
 
-	FnCost *pfnc = nullptr;
-	const ULONG size = GPOS_ARRAY_SIZE(m_rgcm);
-
-	// find the cost function corresponding to the given operator
-	for (ULONG ul = 0; pfnc == nullptr && ul < size; ul++)
+	switch (op_id)
 	{
-		if (op_id == m_rgcm[ul].m_eopid)
+		default:
 		{
-			pfnc = m_rgcm[ul].m_pfnc;
+			// FIXME: macro this?
+			__builtin_unreachable();
+		}
+		case COperator::EopPhysicalTableScan:
+		case COperator::EopPhysicalDynamicTableScan:
+		case COperator::EopPhysicalExternalScan:
+		{
+			return CostScan(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalFilter:
+		{
+			return CostFilter(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalIndexOnlyScan:
+		{
+			return CostIndexOnlyScan(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalIndexScan:
+		case COperator::EopPhysicalDynamicIndexScan:
+		{
+			return CostIndexScan(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalBitmapTableScan:
+		case COperator::EopPhysicalDynamicBitmapTableScan:
+		{
+			return CostBitmapTableScan(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalSequenceProject:
+		{
+			return CostSequenceProject(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalCTEProducer:
+		{
+			return CostCTEProducer(m_mp, exprhdl, this, pci);
+		}
+		case COperator::EopPhysicalCTEConsumer:
+		{
+			return CostCTEConsumer(m_mp, exprhdl, this, pci);
+		}
+		case COperator::EopPhysicalConstTableGet:
+		{
+			return CostConstTableGet(m_mp, exprhdl, this, pci);
+		}
+		case COperator::EopPhysicalDML:
+		{
+			return CostDML(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalHashAgg:
+		case COperator::EopPhysicalHashAggDeduplicate:
+		{
+			return CostHashAgg(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalScalarAgg:
+		{
+			return CostScalarAgg(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalStreamAgg:
+		case COperator::EopPhysicalStreamAggDeduplicate:
+		{
+			return CostStreamAgg(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalSequence:
+		{
+			return CostSequence(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalSort:
+		{
+			return CostSort(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalTVF:
+		{
+			return CostTVF(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalSerialUnionAll:
+		case COperator::EopPhysicalParallelUnionAll:
+		{
+			return CostUnionAll(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalInnerHashJoin:
+		case COperator::EopPhysicalLeftSemiHashJoin:
+		case COperator::EopPhysicalLeftAntiSemiHashJoin:
+		case COperator::EopPhysicalLeftAntiSemiHashJoinNotIn:
+		case COperator::EopPhysicalLeftOuterHashJoin:
+		case COperator::EopPhysicalRightOuterHashJoin:
+		{
+			return CostHashJoin(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalInnerIndexNLJoin:
+		case COperator::EopPhysicalLeftOuterIndexNLJoin:
+		{
+			return CostIndexNLJoin(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalMotionGather:
+		case COperator::EopPhysicalMotionBroadcast:
+		case COperator::EopPhysicalMotionHashDistribute:
+		case COperator::EopPhysicalMotionRandom:
+		case COperator::EopPhysicalMotionRoutedDistribute:
+		{
+			return CostMotion(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalInnerNLJoin:
+		case COperator::EopPhysicalLeftSemiNLJoin:
+		case COperator::EopPhysicalLeftAntiSemiNLJoin:
+		case COperator::EopPhysicalLeftAntiSemiNLJoinNotIn:
+		case COperator::EopPhysicalLeftOuterNLJoin:
+		case COperator::EopPhysicalCorrelatedInnerNLJoin:
+		case COperator::EopPhysicalCorrelatedLeftOuterNLJoin:
+		case COperator::EopPhysicalCorrelatedLeftSemiNLJoin:
+		case COperator::EopPhysicalCorrelatedInLeftSemiNLJoin:
+		case COperator::EopPhysicalCorrelatedLeftAntiSemiNLJoin:
+		case COperator::EopPhysicalCorrelatedNotInLeftAntiSemiNLJoin:
+		{
+			return CostNLJoin(m_mp, exprhdl, this, pci);
+		}
+
+		case COperator::EopPhysicalFullMergeJoin:
+		{
+			return CostMergeJoin(m_mp, exprhdl, this, pci);
 		}
 	}
-	GPOS_ASSERT(nullptr != pfnc);
-
-	return pfnc(m_mp, exprhdl, this, pci);
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CNormalizer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CNormalizer.h
@@ -31,32 +31,6 @@ using namespace gpos;
 class CNormalizer
 {
 private:
-	// definition of push through function
-	typedef void(FnPushThru)(CMemoryPool *mp, CExpression *pexprLogical,
-							 CExpression *pexprConj,
-							 CExpression **ppexprResult);
-
-	//---------------------------------------------------------------------------
-	//	@struct:
-	//		SPushThru
-	//
-	//	@doc:
-	//		Mapping of a logical operator to a push through function
-	//
-	//---------------------------------------------------------------------------
-	struct SPushThru
-	{
-		// logical operator id
-		COperator::EOperatorId m_eopid;
-
-		// pointer to push through function
-		FnPushThru *m_pfnpt;
-
-	};	// struct SPushThru
-
-	// array of mappings
-	static const SPushThru m_rgpt[];
-
 	//  return true if second expression is a child of first expression
 	static BOOL FChild(CExpression *pexpr, CExpression *pexprChild);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -69,20 +69,6 @@ typedef CHashMapIter<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
 //---------------------------------------------------------------------------
 class CTranslatorDXLToExpr
 {
-	// shorthand for functions for translating DXL operator nodes into expression trees
-	typedef CExpression *(CTranslatorDXLToExpr::*PfPexpr)(
-		const CDXLNode *dxlnode);
-
-	// pair of DXL operator type and the corresponding translator
-	struct STranslatorMapping
-	{
-		// type
-		Edxlopid edxlopid;
-
-		// translator function pointer
-		PfPexpr pf;
-	};
-
 private:
 	// memory pool
 	CMemoryPool *m_mp;
@@ -109,9 +95,6 @@ private:
 
 	// id of CTE that we are currently processing (gpos::ulong_max for main query)
 	ULONG m_ulCTEId;
-
-	// DXL operator translators indexed by the operator id
-	PfPexpr m_rgpfTranslators[EdxlopSentinel];
 
 	// a copy of the pointer to column factory, obtained at construction time
 	CColumnFactory *m_pcf;
@@ -231,7 +214,7 @@ private:
 		const CDXLNode *pdxlnSubqueryAny);
 
 	// translate a DXL scalar into an expr scalar
-	CExpression *PexprScalar(const CDXLNode *pdxlnCond);
+	CExpression *PexprScalar(const CDXLNode *dxlnode);
 
 	// translate a DXL scalar if stmt into a scalar if
 	CExpression *PexprScalarIf(const CDXLNode *pdxlnIf);
@@ -349,9 +332,6 @@ private:
 	void AddDistributionColumns(CTableDescriptor *ptabdesc,
 								const IMDRelation *pmdrel,
 								IntToUlongMap *phmiulAttnoColMapping);
-
-	// initialize index of operator translators
-	void InitTranslators();
 
 	// main translation routine for DXL tree -> Expr tree
 	CExpression *Pexpr(const CDXLNode *dxlnode,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -66,40 +66,6 @@ typedef CHashMap<CColRef, CDXLNode, CColRef::HashValue, CColRef::Equals,
 class CTranslatorExprToDXL
 {
 private:
-	// shorthand for functions for translating scalar expressions
-	typedef CDXLNode *(CTranslatorExprToDXL::*PfPdxlnScalar)(
-		CExpression *pexpr);
-
-	// shorthand for functions for translating physical expressions
-	typedef CDXLNode *(CTranslatorExprToDXL::*PfPdxlnPhysical)(
-		CExpression *pexpr, CColRefArray *colref_array,
-		CDistributionSpecArray *
-			pdrgpdsBaseTables,	// output: array of base table hash distributions
-		ULONG
-			*pulNonGatherMotions,  // output: number of non-Gather motion nodes
-		BOOL *pfDML				   // output: is this a DML operation
-	);
-
-	// pair of scalar operator type and the corresponding translator
-	struct SScTranslatorMapping
-	{
-		// type
-		COperator::EOperatorId op_id;
-
-		// translator function pointer
-		PfPdxlnScalar pf;
-	};
-
-	// pair of physical operator type and the corresponding translator
-	struct SPhTranslatorMapping
-	{
-		// type
-		COperator::EOperatorId op_id;
-
-		// translator function pointer
-		PfPdxlnPhysical pf;
-	};
-
 	// memory pool
 	CMemoryPool *m_mp;
 
@@ -128,20 +94,8 @@ private:
 	// id of master node
 	INT m_iMasterId;
 
-	// scalar expression translators indexed by the operator id
-	PfPdxlnScalar m_rgpfScalarTranslators[COperator::EopSentinel];
-
-	// physical expression translators indexed by the operator id
-	PfPdxlnPhysical m_rgpfPhysicalTranslators[COperator::EopSentinel];
-
 	// private copy ctor
 	CTranslatorExprToDXL(const CTranslatorExprToDXL &);
-
-	// initialize index of scalar translators
-	void InitScalarTranslators();
-
-	// initialize index of physical translators
-	void InitPhysicalTranslators();
 
 	EdxlBoolExprType Edxlbooltype(
 		const CScalarBoolOp::EBoolOperator eboolop) const;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSimplifySubquery.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSimplifySubquery.h
@@ -38,27 +38,6 @@ private:
 	// definition of matching function
 	typedef BOOL(FnMatch)(COperator *);
 
-	//---------------------------------------------------------------------------
-	//	@struct:
-	//		SSimplifySubqueryMapping
-	//
-	//	@doc:
-	//		Mapping of a simplify function to matching function
-	//
-	//---------------------------------------------------------------------------
-	struct SSimplifySubqueryMapping
-	{
-		// simplification function
-		FnSimplify *m_pfnsimplify;
-
-		// matching function
-		FnMatch *m_pfnmatch;
-
-	};	// struct SSimplifySubqueryMapping
-
-	// array of mappings
-	static const SSimplifySubqueryMapping m_rgssm[];
-
 	// transform existential subqueries to count(*) subqueries
 	static BOOL FSimplifyExistential(CMemoryPool *mp, CExpression *pexprScalar,
 									 CExpression **ppexprNewScalar);
@@ -68,9 +47,16 @@ private:
 									CExpression **ppexprNewScalar);
 
 	// main driver, transform existential/quantified subqueries to count(*) subqueries
-	static BOOL FSimplify(CMemoryPool *mp, CExpression *pexprScalar,
-						  CExpression **ppexprNewScalar,
-						  FnSimplify *pfnsimplify, FnMatch *pfnmatch);
+	static BOOL FSimplifySubqueryRecursive(CMemoryPool *mp,
+										   CExpression *pexprScalar,
+										   CExpression **ppexprNewScalar,
+										   FnSimplify *pfnsimplify,
+										   FnMatch *pfnmatch);
+
+	static CExpression *FSimplifySubquery(CMemoryPool *mp,
+										  CExpression *pexprInput,
+										  FnSimplify *pfnsimplify,
+										  FnMatch *pfnmatch);
 
 public:
 	CXformSimplifySubquery(const CXformSimplifySubquery &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -71,22 +71,6 @@ private:
 		EicIncluded
 	};
 
-	typedef CLogical *(*PDynamicIndexOpConstructor)(
-		CMemoryPool *mp, const IMDIndex *pmdindex, CTableDescriptor *ptabdesc,
-		ULONG ulOriginOpId, CName *pname, ULONG ulPartIndex,
-		CColRefArray *pdrgpcrOutput, CColRef2dArray *pdrgpdrgpcrPart);
-
-	typedef CLogical *(*PStaticIndexOpConstructor)(
-		CMemoryPool *mp, const IMDIndex *pmdindex, CTableDescriptor *ptabdesc,
-		ULONG ulOriginOpId, CName *pname, CColRefArray *pdrgpcrOutput);
-
-	typedef CExpression *(PRewrittenIndexPath)(CMemoryPool *mp,
-											   CExpression *pexprIndexCond,
-											   CExpression *pexprResidualCond,
-											   const IMDIndex *pmdindex,
-											   CTableDescriptor *ptabdesc,
-											   COperator *popLogical);
-
 	// private copy ctor
 	CXformUtils(const CXformUtils &);
 
@@ -209,14 +193,12 @@ private:
 
 	// construct an expression representing a new access path using the given functors for
 	// operator constructors and rewritten access path
-	static CExpression *PexprBuildIndexPlan(
+	static CExpression *PexprBuildBtreeIndexPlan(
 		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprGet,
 		ULONG ulOriginOpId, CExpressionArray *pdrgpexprConds,
 		CColRefSet *pcrsReqd, CColRefSet *pcrsScalarExpr,
 		CColRefSet *outer_refs, const IMDIndex *pmdindex,
-		const IMDRelation *pmdrel, CPartConstraint *ppcForPartialIndexes,
-		IMDIndex::EmdindexType emdindtype, PDynamicIndexOpConstructor pdiopc,
-		PStaticIndexOpConstructor psiopc, PRewrittenIndexPath prip);
+		const IMDRelation *pmdrel, CPartConstraint *ppcForPartialIndexes);
 
 	// create a dynamic operator for a btree index plan
 	static CLogical *
@@ -528,11 +510,9 @@ public:
 						 const IMDIndex *pmdindex, const IMDRelation *pmdrel,
 						 CPartConstraint *ppcartcnstrIndex)
 	{
-		return PexprBuildIndexPlan(
+		return PexprBuildBtreeIndexPlan(
 			mp, md_accessor, pexprGet, ulOriginOpId, pdrgpexprConds, pcrsReqd,
-			pcrsScalarExpr, outer_refs, pmdindex, pmdrel, ppcartcnstrIndex,
-			IMDIndex::EmdindBtree, PopDynamicBtreeIndexOpConstructor,
-			PopStaticBtreeIndexOpConstructor, PexprRewrittenBtreeIndexPath);
+			pcrsScalarExpr, outer_refs, pmdindex, pmdrel, ppcartcnstrIndex);
 	}
 
 	// helper for creating bitmap bool op expressions

--- a/src/backend/gporca/libgpopt/src/operators/CNormalizer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CNormalizer.cpp
@@ -31,36 +31,6 @@
 using namespace gpopt;
 
 
-// initialization of push through handler
-const CNormalizer::SPushThru CNormalizer::m_rgpt[] = {
-	{COperator::EopLogicalSelect, PushThruSelect},
-	{COperator::EopLogicalProject, PushThruUnaryWithScalarChild},
-	{COperator::EopLogicalSequenceProject, PushThruSeqPrj},
-	{COperator::EopLogicalGbAgg, PushThruUnaryWithScalarChild},
-	{COperator::EopLogicalCTEAnchor, PushThruUnaryWithoutScalarChild},
-	{COperator::EopLogicalUnion, PushThruSetOp},
-	{COperator::EopLogicalUnionAll, PushThruSetOp},
-	{COperator::EopLogicalIntersect, PushThruSetOp},
-	{COperator::EopLogicalIntersectAll, PushThruSetOp},
-	{COperator::EopLogicalDifference, PushThruSetOp},
-	{COperator::EopLogicalDifferenceAll, PushThruSetOp},
-	{COperator::EopLogicalInnerJoin, PushThruJoin},
-	{COperator::EopLogicalNAryJoin, PushThruJoin},
-	{COperator::EopLogicalInnerApply, PushThruJoin},
-	{COperator::EopLogicalInnerCorrelatedApply, PushThruJoin},
-	{COperator::EopLogicalLeftOuterJoin, PushThruJoin},
-	{COperator::EopLogicalLeftOuterApply, PushThruJoin},
-	{COperator::EopLogicalLeftOuterCorrelatedApply, PushThruJoin},
-	{COperator::EopLogicalLeftSemiApply, PushThruJoin},
-	{COperator::EopLogicalLeftSemiApplyIn, PushThruJoin},
-	{COperator::EopLogicalLeftSemiCorrelatedApplyIn, PushThruJoin},
-	{COperator::EopLogicalLeftAntiSemiApply, PushThruJoin},
-	{COperator::EopLogicalLeftAntiSemiApplyNotIn, PushThruJoin},
-	{COperator::EopLogicalLeftAntiSemiCorrelatedApplyNotIn, PushThruJoin},
-	{COperator::EopLogicalLeftSemiJoin, PushThruJoin},
-};
-
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CNormalizer::FPushThruOuterChild
@@ -1070,32 +1040,68 @@ CNormalizer::PushThru(CMemoryPool *mp, CExpression *pexprLogical,
 		return;
 	}
 
-	FnPushThru *pfnpt = nullptr;
-	COperator::EOperatorId op_id = pexprLogical->Pop()->Eopid();
-	const ULONG size = GPOS_ARRAY_SIZE(m_rgpt);
 	// find the push thru function corresponding to the given operator
-	for (ULONG ul = 0; pfnpt == nullptr && ul < size; ul++)
+	switch (pexprLogical->Pop()->Eopid())
 	{
-		if (op_id == m_rgpt[ul].m_eopid)
+		case COperator::EopLogicalSelect:
+			PushThruSelect(mp, pexprLogical, pexprConj, ppexprResult);
+			break;
+
+		case COperator::EopLogicalProject:
+		case COperator::EopLogicalGbAgg:
+			PushThruUnaryWithScalarChild(mp, pexprLogical, pexprConj,
+										 ppexprResult);
+			break;
+
+		case COperator::EopLogicalSequenceProject:
+			PushThruSeqPrj(mp, pexprLogical, pexprConj, ppexprResult);
+			break;
+
+		case COperator::EopLogicalCTEAnchor:
+			PushThruUnaryWithoutScalarChild(mp, pexprLogical, pexprConj,
+											ppexprResult);
+			break;
+
+		case COperator::EopLogicalUnion:
+		case COperator::EopLogicalUnionAll:
+		case COperator::EopLogicalIntersect:
+		case COperator::EopLogicalIntersectAll:
+		case COperator::EopLogicalDifference:
+		case COperator::EopLogicalDifferenceAll:
+			PushThruSetOp(mp, pexprLogical, pexprConj, ppexprResult);
+			break;
+
+		case COperator::EopLogicalInnerJoin:
+		case COperator::EopLogicalNAryJoin:
+		case COperator::EopLogicalInnerApply:
+		case COperator::EopLogicalInnerCorrelatedApply:
+		case COperator::EopLogicalLeftOuterJoin:
+		case COperator::EopLogicalLeftOuterApply:
+		case COperator::EopLogicalLeftOuterCorrelatedApply:
+		case COperator::EopLogicalLeftSemiApply:
+		case COperator::EopLogicalLeftSemiApplyIn:
+		case COperator::EopLogicalLeftSemiCorrelatedApplyIn:
+		case COperator::EopLogicalLeftAntiSemiApply:
+		case COperator::EopLogicalLeftAntiSemiApplyNotIn:
+		case COperator::EopLogicalLeftAntiSemiCorrelatedApplyNotIn:
+		case COperator::EopLogicalLeftSemiJoin:
+			PushThruJoin(mp, pexprLogical, pexprConj, ppexprResult);
+			break;
+
+		default:
 		{
-			pfnpt = m_rgpt[ul].m_pfnpt;
+			// can't push predicates through, start a new normalization path
+			CExpression *pexprNormalized =
+				PexprRecursiveNormalize(mp, pexprLogical);
+			*ppexprResult = pexprNormalized;
+			if (!FChild(pexprLogical, pexprConj))
+			{
+				// add select node on top of the result for the given predicate
+				pexprConj->AddRef();
+				*ppexprResult =
+					CUtils::PexprSafeSelect(mp, pexprNormalized, pexprConj);
+			}
 		}
-	}
-
-	if (nullptr != pfnpt)
-	{
-		pfnpt(mp, pexprLogical, pexprConj, ppexprResult);
-		return;
-	}
-
-	// can't push predicates through, start a new normalization path
-	CExpression *pexprNormalized = PexprRecursiveNormalize(mp, pexprLogical);
-	*ppexprResult = pexprNormalized;
-	if (!FChild(pexprLogical, pexprConj))
-	{
-		// add select node on top of the result for the given predicate
-		pexprConj->AddRef();
-		*ppexprResult = CUtils::PexprSafeSelect(mp, pexprNormalized, pexprConj);
 	}
 }
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -83,14 +83,6 @@ CTranslatorDXLToExpr::CTranslatorDXLToExpr(CMemoryPool *mp,
 	// initialize hash tables
 	m_phmululCTE = GPOS_NEW(m_mp) UlongToUlongMap(m_mp);
 
-	const ULONG size = GPOS_ARRAY_SIZE(m_rgpfTranslators);
-	for (ULONG ul = 0; ul < size; ul++)
-	{
-		m_rgpfTranslators[ul] = nullptr;
-	}
-
-	InitTranslators();
-
 	if (fInitColumnFactory)
 	{
 		// get column factory from optimizer context object
@@ -114,97 +106,6 @@ CTranslatorDXLToExpr::~CTranslatorDXLToExpr()
 	m_phmululCTE->Release();
 	CRefCount::SafeRelease(m_pdrgpulOutputColRefs);
 	CRefCount::SafeRelease(m_pdrgpmdname);
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorDXLToExpr::InitTranslators
-//
-//	@doc:
-//		Initialize index of scalar translators
-//
-//---------------------------------------------------------------------------
-void
-CTranslatorDXLToExpr::InitTranslators()
-{
-	// array mapping operator type to translator function
-	STranslatorMapping translators_mapping[] = {
-		{EdxlopLogicalGet, &gpopt::CTranslatorDXLToExpr::PexprLogicalGet},
-		{EdxlopLogicalExternalGet,
-		 &gpopt::CTranslatorDXLToExpr::PexprLogicalGet},
-		{EdxlopLogicalTVF, &gpopt::CTranslatorDXLToExpr::PexprLogicalTVF},
-		{EdxlopLogicalSelect, &gpopt::CTranslatorDXLToExpr::PexprLogicalSelect},
-		{EdxlopLogicalProject,
-		 &gpopt::CTranslatorDXLToExpr::PexprLogicalProject},
-		{EdxlopLogicalCTEAnchor,
-		 &gpopt::CTranslatorDXLToExpr::PexprLogicalCTEAnchor},
-		{EdxlopLogicalCTEProducer,
-		 &gpopt::CTranslatorDXLToExpr::PexprLogicalCTEProducer},
-		{EdxlopLogicalCTEConsumer,
-		 &gpopt::CTranslatorDXLToExpr::PexprLogicalCTEConsumer},
-		{EdxlopLogicalGrpBy, &gpopt::CTranslatorDXLToExpr::PexprLogicalGroupBy},
-		{EdxlopLogicalLimit, &gpopt::CTranslatorDXLToExpr::PexprLogicalLimit},
-		{EdxlopLogicalJoin, &gpopt::CTranslatorDXLToExpr::PexprLogicalJoin},
-		{EdxlopLogicalConstTable,
-		 &gpopt::CTranslatorDXLToExpr::PexprLogicalConstTableGet},
-		{EdxlopLogicalSetOp, &gpopt::CTranslatorDXLToExpr::PexprLogicalSetOp},
-		{EdxlopLogicalWindow, &gpopt::CTranslatorDXLToExpr::PexprLogicalSeqPr},
-		{EdxlopLogicalInsert, &gpopt::CTranslatorDXLToExpr::PexprLogicalInsert},
-		{EdxlopLogicalDelete, &gpopt::CTranslatorDXLToExpr::PexprLogicalDelete},
-		{EdxlopLogicalUpdate, &gpopt::CTranslatorDXLToExpr::PexprLogicalUpdate},
-		{EdxlopLogicalCTAS, &gpopt::CTranslatorDXLToExpr::PexprLogicalCTAS},
-		{EdxlopScalarIdent, &gpopt::CTranslatorDXLToExpr::PexprScalarIdent},
-		{EdxlopScalarCmp, &gpopt::CTranslatorDXLToExpr::PexprScalarCmp},
-		{EdxlopScalarOpExpr, &gpopt::CTranslatorDXLToExpr::PexprScalarOp},
-		{EdxlopScalarDistinct,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarIsDistinctFrom},
-		{EdxlopScalarConstValue,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarConst},
-		{EdxlopScalarBoolExpr, &gpopt::CTranslatorDXLToExpr::PexprScalarBoolOp},
-		{EdxlopScalarFuncExpr, &gpopt::CTranslatorDXLToExpr::PexprScalarFunc},
-		{EdxlopScalarMinMax, &gpopt::CTranslatorDXLToExpr::PexprScalarMinMax},
-		{EdxlopScalarAggref, &gpopt::CTranslatorDXLToExpr::PexprAggFunc},
-		{EdxlopScalarWindowRef, &gpopt::CTranslatorDXLToExpr::PexprWindowFunc},
-		{EdxlopScalarNullTest,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarNullTest},
-		{EdxlopScalarNullIf, &gpopt::CTranslatorDXLToExpr::PexprScalarNullIf},
-		{EdxlopScalarBooleanTest,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarBooleanTest},
-		{EdxlopScalarIfStmt, &gpopt::CTranslatorDXLToExpr::PexprScalarIf},
-		{EdxlopScalarSwitch, &gpopt::CTranslatorDXLToExpr::PexprScalarSwitch},
-		{EdxlopScalarSwitchCase,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarSwitchCase},
-		{EdxlopScalarCaseTest,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarCaseTest},
-		{EdxlopScalarCoalesce,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarCoalesce},
-		{EdxlopScalarArrayCoerceExpr,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarArrayCoerceExpr},
-		{EdxlopScalarCast, &gpopt::CTranslatorDXLToExpr::PexprScalarCast},
-		{EdxlopScalarCoerceToDomain,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarCoerceToDomain},
-		{EdxlopScalarCoerceViaIO,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarCoerceViaIO},
-		{EdxlopScalarSubquery,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarSubquery},
-		{EdxlopScalarSubqueryAny,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarSubqueryQuantified},
-		{EdxlopScalarSubqueryAll,
-		 &gpopt::CTranslatorDXLToExpr::PexprScalarSubqueryQuantified},
-		{EdxlopScalarArray, &gpopt::CTranslatorDXLToExpr::PexprArray},
-		{EdxlopScalarArrayComp, &gpopt::CTranslatorDXLToExpr::PexprArrayCmp},
-		{EdxlopScalarArrayRef, &gpopt::CTranslatorDXLToExpr::PexprArrayRef},
-		{EdxlopScalarArrayRefIndexList,
-		 &gpopt::CTranslatorDXLToExpr::PexprArrayRefIndexList},
-	};
-
-	const ULONG translators_mapping_len = GPOS_ARRAY_SIZE(translators_mapping);
-
-	for (ULONG ul = 0; ul < translators_mapping_len; ul++)
-	{
-		STranslatorMapping elem = translators_mapping[ul];
-		m_rgpfTranslators[elem.edxlopid] = elem.pf;
-	}
 }
 
 //---------------------------------------------------------------------------
@@ -435,17 +336,50 @@ CTranslatorDXLToExpr::PexprLogical(const CDXLNode *dxlnode)
 				dxlnode->GetOperator()->GetDXLOperatorType());
 	CDXLOperator *dxl_op = dxlnode->GetOperator();
 
-	ULONG ulOpId = (ULONG) dxl_op->GetDXLOperator();
-	PfPexpr pf = m_rgpfTranslators[ulOpId];
-
-	if (nullptr == pf)
+	switch (dxl_op->GetDXLOperator())
 	{
-		GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
-				   dxl_op->GetOpNameStr()->GetBuffer());
+		case EdxlopLogicalGet:
+		case EdxlopLogicalExternalGet:
+			return CTranslatorDXLToExpr::PexprLogicalGet(dxlnode);
+		case EdxlopLogicalTVF:
+			return CTranslatorDXLToExpr::PexprLogicalTVF(dxlnode);
+		case EdxlopLogicalSelect:
+			return CTranslatorDXLToExpr::PexprLogicalSelect(dxlnode);
+		case EdxlopLogicalProject:
+			return CTranslatorDXLToExpr::PexprLogicalProject(dxlnode);
+		case EdxlopLogicalCTEAnchor:
+			return CTranslatorDXLToExpr::PexprLogicalCTEAnchor(dxlnode);
+		case EdxlopLogicalCTEProducer:
+			return CTranslatorDXLToExpr::PexprLogicalCTEProducer(dxlnode);
+		case EdxlopLogicalCTEConsumer:
+			return CTranslatorDXLToExpr::PexprLogicalCTEConsumer(dxlnode);
+		case EdxlopLogicalGrpBy:
+			return CTranslatorDXLToExpr::PexprLogicalGroupBy(dxlnode);
+		case EdxlopLogicalLimit:
+			return CTranslatorDXLToExpr::PexprLogicalLimit(dxlnode);
+		case EdxlopLogicalJoin:
+			return CTranslatorDXLToExpr::PexprLogicalJoin(dxlnode);
+		case EdxlopLogicalConstTable:
+			return CTranslatorDXLToExpr::PexprLogicalConstTableGet(dxlnode);
+		case EdxlopLogicalSetOp:
+			return CTranslatorDXLToExpr::PexprLogicalSetOp(dxlnode);
+		case EdxlopLogicalWindow:
+			return CTranslatorDXLToExpr::PexprLogicalSeqPr(dxlnode);
+		case EdxlopLogicalInsert:
+			return CTranslatorDXLToExpr::PexprLogicalInsert(dxlnode);
+		case EdxlopLogicalDelete:
+			return CTranslatorDXLToExpr::PexprLogicalDelete(dxlnode);
+		case EdxlopLogicalUpdate:
+			return CTranslatorDXLToExpr::PexprLogicalUpdate(dxlnode);
+		case EdxlopLogicalCTAS:
+			return CTranslatorDXLToExpr::PexprLogicalCTAS(dxlnode);
+		default:
+			GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
+					   dxl_op->GetOpNameStr()->GetBuffer());
+			return nullptr;
 	}
-
-	return (this->*pf)(dxlnode);
 }
+
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -2534,28 +2468,85 @@ CTranslatorDXLToExpr::PexprScalarSubqueryQuantified(
 //
 //---------------------------------------------------------------------------
 CExpression *
-CTranslatorDXLToExpr::PexprScalar(const CDXLNode *pdxlnOp)
+CTranslatorDXLToExpr::PexprScalar(const CDXLNode *dxlnode)
 {
-	GPOS_ASSERT(nullptr != pdxlnOp);
-	CDXLOperator *dxl_op = pdxlnOp->GetOperator();
+	GPOS_ASSERT(nullptr != dxlnode);
+	GPOS_ASSERT(EdxloptypeScalar ==
+				dxlnode->GetOperator()->GetDXLOperatorType());
+	CDXLOperator *dxl_op = dxlnode->GetOperator();
 	ULONG ulOpId = (ULONG) dxl_op->GetDXLOperator();
 
 	if (EdxlopScalarSubqueryExists == ulOpId ||
 		EdxlopScalarSubqueryNotExists == ulOpId)
 	{
 		return PexprScalarSubqueryExistential(
-			pdxlnOp->GetOperator()->GetDXLOperator(), (*pdxlnOp)[0]);
+			dxlnode->GetOperator()->GetDXLOperator(), (*dxlnode)[0]);
 	}
 
-	PfPexpr pf = m_rgpfTranslators[ulOpId];
-
-	if (nullptr == pf)
+	switch (dxl_op->GetDXLOperator())
 	{
-		GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
-				   dxl_op->GetOpNameStr()->GetBuffer());
+		case EdxlopScalarIdent:
+			return CTranslatorDXLToExpr::PexprScalarIdent(dxlnode);
+		case EdxlopScalarCmp:
+			return CTranslatorDXLToExpr::PexprScalarCmp(dxlnode);
+		case EdxlopScalarOpExpr:
+			return CTranslatorDXLToExpr::PexprScalarOp(dxlnode);
+		case EdxlopScalarDistinct:
+			return CTranslatorDXLToExpr::PexprScalarIsDistinctFrom(dxlnode);
+		case EdxlopScalarConstValue:
+			return CTranslatorDXLToExpr::PexprScalarConst(dxlnode);
+		case EdxlopScalarBoolExpr:
+			return CTranslatorDXLToExpr::PexprScalarBoolOp(dxlnode);
+		case EdxlopScalarFuncExpr:
+			return CTranslatorDXLToExpr::PexprScalarFunc(dxlnode);
+		case EdxlopScalarMinMax:
+			return CTranslatorDXLToExpr::PexprScalarMinMax(dxlnode);
+		case EdxlopScalarAggref:
+			return CTranslatorDXLToExpr::PexprAggFunc(dxlnode);
+		case EdxlopScalarWindowRef:
+			return CTranslatorDXLToExpr::PexprWindowFunc(dxlnode);
+		case EdxlopScalarNullTest:
+			return CTranslatorDXLToExpr::PexprScalarNullTest(dxlnode);
+		case EdxlopScalarNullIf:
+			return CTranslatorDXLToExpr::PexprScalarNullIf(dxlnode);
+		case EdxlopScalarBooleanTest:
+			return CTranslatorDXLToExpr::PexprScalarBooleanTest(dxlnode);
+		case EdxlopScalarIfStmt:
+			return CTranslatorDXLToExpr::PexprScalarIf(dxlnode);
+		case EdxlopScalarSwitch:
+			return CTranslatorDXLToExpr::PexprScalarSwitch(dxlnode);
+		case EdxlopScalarSwitchCase:
+			return CTranslatorDXLToExpr::PexprScalarSwitchCase(dxlnode);
+		case EdxlopScalarCaseTest:
+			return CTranslatorDXLToExpr::PexprScalarCaseTest(dxlnode);
+		case EdxlopScalarCoalesce:
+			return CTranslatorDXLToExpr::PexprScalarCoalesce(dxlnode);
+		case EdxlopScalarArrayCoerceExpr:
+			return CTranslatorDXLToExpr::PexprScalarArrayCoerceExpr(dxlnode);
+		case EdxlopScalarCast:
+			return CTranslatorDXLToExpr::PexprScalarCast(dxlnode);
+		case EdxlopScalarCoerceToDomain:
+			return CTranslatorDXLToExpr::PexprScalarCoerceToDomain(dxlnode);
+		case EdxlopScalarCoerceViaIO:
+			return CTranslatorDXLToExpr::PexprScalarCoerceViaIO(dxlnode);
+		case EdxlopScalarSubquery:
+			return CTranslatorDXLToExpr::PexprScalarSubquery(dxlnode);
+		case EdxlopScalarSubqueryAny:
+		case EdxlopScalarSubqueryAll:
+			return CTranslatorDXLToExpr::PexprScalarSubqueryQuantified(dxlnode);
+		case EdxlopScalarArray:
+			return CTranslatorDXLToExpr::PexprArray(dxlnode);
+		case EdxlopScalarArrayComp:
+			return CTranslatorDXLToExpr::PexprArrayCmp(dxlnode);
+		case EdxlopScalarArrayRef:
+			return CTranslatorDXLToExpr::PexprArrayRef(dxlnode);
+		case EdxlopScalarArrayRefIndexList:
+			return CTranslatorDXLToExpr::PexprArrayRefIndexList(dxlnode);
+		default:
+			GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
+					   dxl_op->GetOpNameStr()->GetBuffer());
+			return nullptr;
 	}
-
-	return (this->*pf)(pdxlnOp);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
@@ -65,10 +65,6 @@ XERCES_CPP_NAMESPACE_USE
 class CDXLMemoryManager;
 class CDXLDatum;
 
-// shorthand for functions for translating a DXL datum
-typedef CDXLDatum *(PfPdxldatum)(CDXLMemoryManager *, const Attributes &,
-								 Edxltoken, IMDId *, BOOL);
-
 //---------------------------------------------------------------------------
 //	@class:
 //		CDXLOperatorFactory
@@ -92,13 +88,6 @@ private:
 							  ULONG *length);
 
 public:
-	// pair of oid for datums and the factory function
-	struct SDXLDatumFactoryElem
-	{
-		OID oid;
-		PfPdxldatum *pf;
-	};
-
 	static CDXLDatum *GetDatumOid(CDXLMemoryManager *dxl_memory_manager,
 								  const Attributes &attrs,
 								  Edxltoken target_elem, IMDId *mdid,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerDXL.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerDXL.h
@@ -27,11 +27,6 @@ using namespace gpmd;
 
 XERCES_CPP_NAMESPACE_USE
 
-// shorthand for functions for translating GPDB expressions into DXL nodes
-typedef void (CParseHandlerDXL::*ParseHandler)(
-	CParseHandlerBase *parse_handler_base);
-
-
 //---------------------------------------------------------------------------
 //	@class:
 //		CParseHandlerDXL
@@ -44,13 +39,6 @@ typedef void (CParseHandlerDXL::*ParseHandler)(
 class CParseHandlerDXL : public CParseHandlerBase
 {
 private:
-	// pair of parse handler type and parse handler function
-	struct SParseElem
-	{
-		EDxlParseHandlerType parse_handler_type;  // parse handler type
-		ParseHandler parse_handler_func;  // pointer to corresponding function
-	};
-
 	// traceflags
 	CBitSet *m_trace_flags_bitset;
 
@@ -113,9 +101,6 @@ private:
 		const XMLCh *const element_local_name,	// local part of element's name
 		const XMLCh *const element_qname		// element's qname
 		) override;
-
-	// find the parse handler function for the given type
-	ParseHandler FindParseHandler(EDxlParseHandlerType parse_handler_type);
 
 	// extract traceflags
 	void ExtractTraceFlags(CParseHandlerBase *parse_handler_base);

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerDXL.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerDXL.cpp
@@ -433,57 +433,45 @@ CParseHandlerDXL::endDocument()
 		EDxlParseHandlerType parse_handler_type =
 			parse_handler_base->GetParseHandlerType();
 
-		// find parse handler for the current type
-		ParseHandler parse_handler_func = FindParseHandler(parse_handler_type);
-
-		if (nullptr != parse_handler_func)
+		switch (parse_handler_type)
 		{
-			(this->*parse_handler_func)(parse_handler_base);
+			case EdxlphTraceFlags:
+				CParseHandlerDXL::ExtractTraceFlags(parse_handler_base);
+				break;
+			case EdxlphOptConfig:
+				CParseHandlerDXL::ExtractOptimizerConfig(parse_handler_base);
+				break;
+			case EdxlphPlan:
+				CParseHandlerDXL::ExtractDXLPlan(parse_handler_base);
+				break;
+			case EdxlphMetadata:
+				CParseHandlerDXL::ExtractMetadataObjects(parse_handler_base);
+				break;
+			case EdxlphStatistics:
+				CParseHandlerDXL::ExtractStats(parse_handler_base);
+				break;
+			case EdxlphQuery:
+				CParseHandlerDXL::ExtractDXLQuery(parse_handler_base);
+				break;
+			case EdxlphMetadataRequest:
+				CParseHandlerDXL::ExtractMDRequest(parse_handler_base);
+				break;
+			case EdxlphSearchStrategy:
+				CParseHandlerDXL::ExtractSearchStrategy(parse_handler_base);
+				break;
+			case EdxlphCostParams:
+				CParseHandlerDXL::ExtractCostParams(parse_handler_base);
+				break;
+			case EdxlphScalarExpr:
+				CParseHandlerDXL::ExtractScalarExpr(parse_handler_base);
+				break;
+			default:
+				// do nothing
+				break;
 		}
 	}
 
 	m_parse_handler_mgr->DeactivateHandler();
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CParseHandlerDXL::FindParseHandler
-//
-//	@doc:
-//		Find the parse handler function for the given type
-//
-//---------------------------------------------------------------------------
-ParseHandler
-CParseHandlerDXL::FindParseHandler(EDxlParseHandlerType parse_handler_type)
-{
-	SParseElem parse_element_type_func_map[] = {
-		{EdxlphTraceFlags, &CParseHandlerDXL::ExtractTraceFlags},
-		{EdxlphOptConfig, &CParseHandlerDXL::ExtractOptimizerConfig},
-		{EdxlphPlan, &CParseHandlerDXL::ExtractDXLPlan},
-		{EdxlphMetadata, &CParseHandlerDXL::ExtractMetadataObjects},
-		{EdxlphStatistics, &CParseHandlerDXL::ExtractStats},
-		{EdxlphQuery, &CParseHandlerDXL::ExtractDXLQuery},
-		{EdxlphMetadataRequest, &CParseHandlerDXL::ExtractMDRequest},
-		{EdxlphSearchStrategy, &CParseHandlerDXL::ExtractSearchStrategy},
-		{EdxlphCostParams, &CParseHandlerDXL::ExtractCostParams},
-		{EdxlphScalarExpr, &CParseHandlerDXL::ExtractScalarExpr},
-	};
-
-	const ULONG num_of_parse_handler =
-		GPOS_ARRAY_SIZE(parse_element_type_func_map);
-	ParseHandler parse_handler_func = nullptr;
-	for (ULONG idx = 0; idx < num_of_parse_handler; idx++)
-	{
-		SParseElem elem = parse_element_type_func_map[idx];
-		if (parse_handler_type == elem.parse_handler_type)
-		{
-			parse_handler_func = elem.parse_handler_func;
-			break;
-		}
-	}
-
-	return parse_handler_func;
 }
 
 //---------------------------------------------------------------------------

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -86,22 +86,7 @@ class CDXLDirectDispatchInfo;
 //---------------------------------------------------------------------------
 class CTranslatorDXLToPlStmt
 {
-	// shorthand for functions for translating DXL operator nodes into planner trees
-	typedef Plan *(CTranslatorDXLToPlStmt::*PfPplan)(
-		const CDXLNode *dxlnode, CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *ctxt_translation_prev_siblings);
-
 private:
-	// pair of DXL operator type and the corresponding translator
-	struct STranslatorMapping
-	{
-		// type
-		Edxlopid dxl_op_id;
-
-		// translator function pointer
-		PfPplan dxlnode_to_logical_funct;
-	};
-
 	// context for fixing index var attno
 	struct SContextIndexVarAttno
 	{
@@ -126,9 +111,6 @@ private:
 
 	// meta data accessor
 	CMDAccessor *m_md_accessor;
-
-	// DXL operator translators indexed by the operator id
-	PfPplan m_dxlop_translator_func_mapping_array[EdxlopSentinel];
 
 	CContextDXLToPlStmt *m_dxl_to_plstmt_context;
 
@@ -182,9 +164,6 @@ public:
 	static JoinType GetGPDBJoinTypeFromDXLJoinType(EdxlJoinType join_type);
 
 private:
-	// initialize index of operator translators
-	void InitTranslators();
-
 	// Set the bitmapset of a plan to the list of param_ids defined by the plan
 	void SetParamIds(Plan *);
 

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -72,28 +72,7 @@ using namespace gpmd;
 //---------------------------------------------------------------------------
 class CTranslatorDXLToScalar
 {
-	// shorthand for functions for translating DXL nodes to GPDB expressions
-	typedef Expr *(CTranslatorDXLToScalar::*expr_func_ptr)(
-		const CDXLNode *dxlnode, CMappingColIdVar *colid_var);
-
 private:
-	// pair of DXL op id and translator function
-	struct STranslatorElem
-	{
-		Edxlopid eopid;
-		expr_func_ptr translate_func;
-	};
-
-	// shorthand for functions for translating DXL nodes to GPDB expressions
-	typedef Const *(CTranslatorDXLToScalar::*const_func_ptr)(CDXLDatum *);
-
-	// pair of DXL datum type and translator function
-	struct SDatumTranslatorElem
-	{
-		CDXLDatum::EdxldatumType edxldt;
-		const_func_ptr translate_func;
-	};
-
 	CMemoryPool *m_mp;
 
 	// meta data accessor

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -63,22 +63,11 @@ class CTranslatorQueryToDXL
 {
 	friend class CTranslatorScalarToDXL;
 
-	// shorthand for functions for translating DXL nodes to GPDB expressions
-	typedef CDXLNode *(CTranslatorQueryToDXL::*DXLNodeToLogicalFunc)(
-		const RangeTblEntry *rte, ULONG rti, ULONG current_query_level);
-
 	// mapping RTEKind to WCHARs
 	struct SRTENameElem
 	{
 		RTEKind m_rtekind;
 		const WCHAR *m_rte_name;
-	};
-
-	// pair of RTEKind and its translators
-	struct SRTETranslator
-	{
-		RTEKind m_rtekind;
-		DXLNodeToLogicalFunc dxlnode_to_logical_funct;
 	};
 
 	// mapping CmdType to WCHARs
@@ -280,7 +269,7 @@ private:
 	);
 
 	// throws an exception when RTE kind not yet supported
-	void UnsupportedRTEKind(RTEKind rtekind) const;
+	[[noreturn]] void UnsupportedRTEKind(RTEKind rtekind) const;
 
 	// translate an entry of the from clause (this can either be FromExpr or JoinExpr)
 	CDXLNode *TranslateFromClauseToDXL(Node *node);

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -59,25 +59,9 @@ class CDXLDatum;
 
 class CTranslatorScalarToDXL
 {
-	// shorthand for functions for translating GPDB expressions into DXL nodes
-	typedef CDXLNode *(CTranslatorScalarToDXL::*ExprToDXLFn)(
-		const Expr *expr, const CMappingVarColId *var_colid_mapping);
-
-	// shorthand for functions for translating DXL nodes to GPDB expressions
-	typedef CDXLDatum *(DxlDatumFromDatum)(CMemoryPool *mp,
-										   const IMDType *md_type, BOOL is_null,
-										   ULONG len, Datum datum);
-
 private:
 	// private constructor for TranslateStandaloneExprToDXL
 	CTranslatorScalarToDXL(CMemoryPool *mp, CMDAccessor *mda);
-
-	// pair of node tag and translator function
-	struct STranslatorElem
-	{
-		NodeTag tag;
-		ExprToDXLFn func_ptr;
-	};
 
 	// context for the whole query being translated, or NULL if this is
 	// standalone expression (e.g. the DEFAULT expression of a column).
@@ -323,13 +307,6 @@ public:
 	// extract the long int value of a datum
 	static LINT ExtractLintValueFromDatum(const IMDType *md_type, BOOL is_null,
 										  BYTE *bytes, ULONG len);
-
-	// pair of DXL datum type and translator function
-	struct SDXLDatumTranslatorElem
-	{
-		IMDType::ETypeInfo type_info;
-		DxlDatumFromDatum *func_ptr;
-	};
 
 	// datum to oid CDXLDatum
 	static CDXLDatum *TranslateOidDatumToDXL(CMemoryPool *mp,


### PR DESCRIPTION
This patch is inspired by a change in #11285 but we've wholesale applied it to all of ORCA codebase. See each commit for more topical details.

## To reviewers
* The patch is organized into topical commits for convenience of review, but we plan to land the change as one squashed commit

* Most of the changes are fairly mundane, each "mundane" change roughly consists of 3 parts:
  1. Replace the look-up logic from a for-loop-over-array-of-function pointers to a straightforward switch case
  2. At every site of such a for-loop, there's always an array and a struct defined (with the lookup key and a function pointer). Remove the array, the "init" function, and the struct.
  3. This leaves behind a `typedef` that defines a shorthand of the function pointer. Remove the `typedef`.

* "Interesting" changes that require some nontrivial amount of braincells:
  1. "CXformSimplifySubquery": the logic is actually a lot more clear if you unnest the little array of 3 function pointers and express them in procedural code.
  2. "Remove unnecessary func ptrs in `CXformUtils::PexprBuildIndexPlan`": we have some uncalled-for complexity here passing around enums and function pointers, but the call sites always pass one constant value.

We validate that we leave no dead function pointer `typedef`s behind by sweeping the code base using the following query in `clang-query`:

```
match typedefNameDecl(hasType(anyOf(qualType(memberPointerType()),unless(qualType()))),unless(isExpansionInSystemHeader())).bind("typedef")
```

This is joint work with @chrishajas and @hardikar , the "interesting" logic is courtesy of @hardikar .