### PR TITLE
Travis CI: set LC_* enviornment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,11 @@ matrix:
     fast_finish: true
     include:
         # OS and Compiler variations
+        # 
+        # NOTE: Some of the docker containers set LC_ALL and LC_CTYPE to 
+        # values that are not specified on the system's locale as found 
+        # via "locale -a". This causes gpinitsystem and possibly initdb 
+        # to fail. Set these environment variables to the system's locale.
         # ----------------------------------------------------------------
         #
         # Ubuntu Bionic, gcc 8
@@ -48,6 +53,7 @@ matrix:
           env:
               - T=debug C=""
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+              - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
           addons:
               apt:
                   sources:
@@ -61,6 +67,7 @@ matrix:
           env:
               - T=debug C=""
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+              - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
           addons:
               apt:
                   sources:
@@ -90,6 +97,7 @@ matrix:
           env:
               - T=debug C="--without-zlib --without-libbz2 --without-zstd --without-quicklz"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+              - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
           addons:
               apt:
                   sources: *common_sources
@@ -103,6 +111,7 @@ matrix:
           env:
               - tests=unit T=debug C="--disable-orca"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+              - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
           addons:
               apt:
                   sources: *common_sources
@@ -115,6 +124,7 @@ matrix:
           env:
               - tests=installcheck T=debug C="--disable-orca"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+              - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
           addons:
               apt:
                   sources: *common_sources

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -481,7 +481,7 @@ CHK_PARAMS () {
 		# Note: This check is performed on the coordinator only.  There is an assumption
 		# being made that the locales available on the coordinator are available on the
 		# segment hosts.
-		LOCALE_SETTING=$REQ_LOCALE_SETTING
+		LOCALE_SETTING=$(USE_FIRST_SET_ARG $REQ_LOCALE_SETTING $LC_ALL)
 		if [ x"" != x"$LOCALE_SETTING" ]; then
 			IN_ARRAY $LOCALE_SETTING "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -489,7 +489,7 @@ CHK_PARAMS () {
 			fi
 		fi
 
-		LCCOLLATE=$(USE_FIRST_SET_ARG $LCCOLLATE $LOCALE_SETTING)
+		LCCOLLATE=$(USE_FIRST_SET_ARG $LCCOLLATE $LC_COLLATE $LOCALE_SETTING)
 		if [ x"" != x"$LCCOLLATE" ]; then
 			IN_ARRAY $LCCOLLATE "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -497,7 +497,7 @@ CHK_PARAMS () {
 			fi	
 		fi
 
-		LCCTYPE=$(USE_FIRST_SET_ARG $LCCTYPE $LOCALE_SETTING)
+		LCCTYPE=$(USE_FIRST_SET_ARG $LCCTYPE $LC_CTYPE $LOCALE_SETTING)
 		if [ x"" != x"$LCCTYPE" ]; then
 			IN_ARRAY $LCCTYPE "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -505,7 +505,7 @@ CHK_PARAMS () {
 			fi
 		fi
 
-		LCMESSAGES=$(USE_FIRST_SET_ARG $LCMESSAGES $LOCALE_SETTING)
+		LCMESSAGES=$(USE_FIRST_SET_ARG $LCMESSAGES $LC_MESSAGES $LOCALE_SETTING)
 		if [ x"" != x"$LCMESSAGES" ]; then
 			IN_ARRAY $LCMESSAGES "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -513,7 +513,7 @@ CHK_PARAMS () {
 			fi
 		fi
 		
-		LCMONETARY=$(USE_FIRST_SET_ARG $LCMONETARY $LOCALE_SETTING)
+		LCMONETARY=$(USE_FIRST_SET_ARG $LCMONETARY $LC_MONETARY $LOCALE_SETTING)
 		if [ x"" != x"$LCMONETARY" ]; then
 			IN_ARRAY $LCMONETARY "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -521,7 +521,7 @@ CHK_PARAMS () {
 			fi
 		fi
 		
-		LCNUMERIC=$(USE_FIRST_SET_ARG $LCNUMERIC $LOCALE_SETTING)
+		LCNUMERIC=$(USE_FIRST_SET_ARG $LCNUMERIC $LC_NUMERIC $LOCALE_SETTING)
 		if [ x"" != x"$LCNUMERIC" ]; then
 			IN_ARRAY $LCNUMERIC "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -529,7 +529,7 @@ CHK_PARAMS () {
 			fi
 		fi
 		
-		LCTIME=$(USE_FIRST_SET_ARG $LCTIME $LOCALE_SETTING)
+		LCTIME=$(USE_FIRST_SET_ARG $LCTIME $LC_TIME $LOCALE_SETTING)
 		if [ x"" != x"$LCTIME" ]; then
 			IN_ARRAY $LCTIME "`locale -a`"
 			if [ $? -eq 0 ]; then

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -206,17 +206,14 @@ Feature: gpinitsystem tests
         Then the database locales are saved
         And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the locale "C"
 
-    @foo
-    # TODO: Re-enable the environment variable checks once we decide how to handle flags defaulting to variables
     Scenario: gpinitsystem uses multiple locales if multiple are specified
         Given the database is not running
-        #And the environment variable "LC_COLLATE" is set to "C"
-        #And the environment variable "LC_CTYPE" is set to "C"
+        And the environment variable "LC_COLLATE" is set to "C"
+        And the environment variable "LC_CTYPE" is set to "C"
         And the system locale is saved
         When a demo cluster is created using the installed UTF locale
         And gpinitsystem should return a return code of 0
         Then the database locales are saved
-        #And the database locales "lc_collate" match the locale "C"
-        And the database locales "lc_collate" match the system locale
+        And the database locales "lc_collate" match the locale "C"
         And the database locales "lc_ctype" match the installed UTF locale
         And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale


### PR DESCRIPTION
Followup to https://github.com/greenplum-db/gpdb/pull/11483

1. Reverts the gpinitsystem Travis CI workaround
2. Set LC_* enviornment variables in Travis CI. Some of the docker containers set LC_ALL and LC_CTYPE to values that are not specified on the system's locale as found via "locale -a". This causes gpinitsystem and possibly initdb to fail. Set these environment variables to the system's locale.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/travisCIDebug)