### PR TITLE
Add analyzedb option to skip analyze rootstats

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -274,6 +274,7 @@ class AnalyzeDb(Operation):
         self.verbose = options.verbose
         self.clean_last = options.clean_last
         self.clean_all = options.clean_all
+        self.orca_rootstats = options.orca_rootstats
         self.gen_profile_only = options.gen_profile_only
         self.analyze_gucs = ANALYZE_GUCS
 
@@ -414,7 +415,10 @@ class AnalyzeDb(Operation):
             # and its corresponding columns to be analyzed
             # key: name of the root partition whose stats needs to be refreshed
             # value: a set of column names to be analyzed, or '-1' meaning all columns of that table
-            root_partition_col_dict = self._get_root_partition_col_dict(candidates, input_col_dict)
+            # this can be suppressed with a flag if ORCA is not used
+            # (performance improvement when there are many partitions and columns)
+            if self.orca_rootstats:
+                root_partition_col_dict = self._get_root_partition_col_dict(candidates, input_col_dict)
 
             ordered_candidates = self._get_ordered_candidates(candidates, root_partition_col_dict)
             target_list = []
@@ -1290,6 +1294,8 @@ def create_parser():
                       help="Parallel level, i.e. the number of tables to be analyzed in parallel. Valid numbers are between 1 and 10. Default value is 5.")
     parser.add_option('--skip_root_stats', action='store_false', dest='rootstats', default=True,
                       help="This option is no longer used. Please remove it from your scripts.")
+    parser.add_option('--skip_orca_root_stats', action='store_false', dest='orca_rootstats', default=True,
+                      help="Suppress generation of root partition stats for ORCA.")
     parser.add_option('--gen_profile_only', action='store_true', dest='gen_profile_only', default=False,
                       help="Create cached state files to indicate specified table or all tables have been analyzed.")
     parser.add_option('--full', action='store_true', dest='full_analyze', default=False,
@@ -1372,7 +1378,10 @@ class AnalyzeWorker(Worker):
                     self.pool.markTaskDone()
                     self.cmd = None
                 else:
-                    self.logger.info("[%s] started  %s" % (self.name, self.cmd.name))
+                    # run the command
+                    # get rid of the gucs for displaying in the log
+                    cmd_display = re.sub(r'set .*;\s*', '', self.cmd.name)
+                    self.logger.info("[%s] started  %s" % (self.name, cmd_display))
                     start_time = time.time()
                     self.cmd.run()
                     end_time = time.time()
@@ -1380,7 +1389,7 @@ class AnalyzeWorker(Worker):
                     if len(stderr) > 0:  # emit stderr if there is any
                         self.logger.warning('\n'.join(stderr))
                     if self.cmd.was_successful():
-                        self.logger.info("[%s] finished %s. Elapsed time: %d seconds." % (self.name, self.cmd.name,
+                        self.logger.info("[%s] finished %s. Elapsed time: %d seconds." % (self.name, cmd_display,
                                                                                           int(end_time - start_time)))
                     self.pool.addFinishedWorkItem(self.cmd)
                     self.cmd = None

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1411,7 +1411,8 @@ Feature: Incrementally analyze the database
         And the row "1,'2008-01-01'" is inserted into "public.sales" in "incr_analyze"
         And the row "2,'2008-01-02'" is inserted into "public.sales" in "incr_analyze"
         When the user runs "analyzedb -a -d incr_analyze -t public.sales --skip_orca_root_stats"
-        Then output should not contain "rootpartition"
+        Then analyzedb should return a return code of 0
+        And output should not contain "rootpartition"
 
     # entries exist for some parts in state files for partition tables
 

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1401,8 +1401,17 @@ Feature: Incrementally analyze the database
         And output should not contain "-public.sales_1_prt_3"
         And output should not contain "-public.sales_1_prt_4"
         And analyzedb should print "-public.sales_1_prt_2" to stdout
+        And analyzedb should print "rootpartition" to stdout
         And "public.sales_1_prt_2" should appear in the latest state files
         And "public.sales_1_prt_4" should appear in the latest state files
+
+    Scenario: Partition tables, (entries for all parts, dml on all parts, root), skip root stats
+        Given no state files exist for database "incr_analyze"
+        And the user runs "analyzedb -a -d incr_analyze -t public.sales"
+        And the row "1,'2008-01-01'" is inserted into "public.sales" in "incr_analyze"
+        And the row "2,'2008-01-02'" is inserted into "public.sales" in "incr_analyze"
+        When the user runs "analyzedb -a -d incr_analyze -t public.sales --skip_orca_root_stats"
+        Then output should not contain "rootpartition"
 
     # entries exist for some parts in state files for partition tables
 


### PR DESCRIPTION
Added a new option --skip_orca_root_stats to suppress the final
ANALYZE ROOTPARTITION command.

Recommendation: Use this option only if
a) The analyze rootpartition commands take up a lot of time, and
b) You are not using ORCA

Also made the analyzedb log output more readable by suppressing
the SET commands.

NOTE 1: If you use this option, a subsequent analyzedb without the option
will NOT update the root-level stats, unless there have been additional
changes in the table. Example:

analyzedb -d sampledb -s public --skip_orca_root_stats

This analyzes tables but does not create root-level stats for partitioned tables.

analyzedb -d sampledb -s public

This will NOT create the root-level stats of partitioned AO tables, unless
the tables were updated between the two analyzedb runs.

NOTE 2: We have a deprecated option --skip_root_stats. Using a different name
for this PR avoids the following problem:

- A user is currently using the --skip_root_stats option. It does nothing,
  so things work just fine (suprisingly, this is a fairly common situation).
- The user upgrades to the latest version of 6X. Now, if we were re-using
  the same name for the option, this user would no longer get good ORCA
  stats and would be forced to update their scripts.

For some history on analyzedb and analyze rootstats, see 5X PRs
https://github.com/greenplum-db/gpdb/pull/8912 and
https://github.com/greenplum-db/gpdb/pull/8984
(these changes were also merged to 6X and master).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
