### PR TITLE
Emit query stmt for duration log messages

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1474,7 +1474,7 @@ exec_mpp_query(const char *query_string,
 		case 1:
 			ereport(LOG,
 					(errmsg("duration: %s ms", msec_str),
-					 errhidestmt(true)));
+					 errhidestmt(false)));
 			break;
 		case 2:
 			ereport(LOG,
@@ -1975,7 +1975,7 @@ exec_simple_query(const char *query_string)
 		case 1:
 			ereport(LOG,
 					(errmsg("duration: %s ms", msec_str),
-					 errhidestmt(true)));
+					 errhidestmt(false)));
 			break;
 		case 2:
 			ereport(LOG,
@@ -2877,7 +2877,7 @@ exec_execute_message(const char *portal_name, int64 max_rows)
 		case 1:
 			ereport(LOG,
 					(errmsg("duration: %s ms", msec_str),
-					 errhidestmt(true)));
+					 errhidestmt(false)));
 			break;
 		case 2:
 			ereport(LOG,


### PR DESCRIPTION
Commit 59da71 fixed elog infrastrucutre to correctly handle
errhidestmt(). As side effect of that, case 1 query "duration" log
messages no more contain query stmt. In GPDB, it becomes very
difficult and it's highly desirable to have query stmt associated with
message to understand the context for message. One can always look at
previous message for session to find the query stmt but that
unnecessarity complicates the debugging.

Hence, marking `errhidestmt(false)` for such duration log messages.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
