### PR TITLE
Fix external table escape off bug

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6633,7 +6633,7 @@ static int
 CopyReadAttributesText(CopyState cstate, int stop_processing_at_field)
 {
 	char		delimc = cstate->delim[0];
-	char		escapec = cstate->escape_off ? delimc : cstate->escape[0];
+	char		escapec = cstate->escape[0];
 	bool		delim_off = cstate->delim_off;
 	int			fieldno;
 	char	   *output_ptr;

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6725,7 +6725,7 @@ CopyReadAttributesText(CopyState cstate, int stop_processing_at_field)
 				found_delim = true;
 				break;
 			}
-			if (c == escapec)
+			if (c == escapec && !cstate->escape_off)
 			{
 				if (cur_ptr >= line_end_ptr)
 					break;

--- a/src/test/isolation2/input/external_table.source
+++ b/src/test/isolation2/input/external_table.source
@@ -144,3 +144,15 @@ CREATE EXTERNAL WEB TABLE ext_delimiter_off_csv
 (a text) EXECUTE E'echo O' ON COORDINATOR FORMAT 'csv' (delimiter 'OFF') ENCODING 'UTF8';
 
 SELECT * FROM ext_delimiter_off_csv;
+
+-- start_ignore
+DROP EXTERNAL TABLE IF EXISTS exttab_delimiter_escape_off;
+-- end_ignore
+
+-- Create external table(text format) with both delimiter and escape off
+CREATE EXTERNAL WEB TABLE exttab_delimiter_escape_off(a text)
+EXECUTE E'cat @abs_srcdir@/data/exttab_escape_off.data' ON SEGMENT 0
+format 'TEXT' (delimiter 'OFF' escape 'OFF') encoding 'UTF8'
+LOG ERRORS  SEGMENT REJECT LIMIT 10;
+
+SELECT * FROM exttab_delimiter_escape_off ORDER BY a;

--- a/src/test/isolation2/output/external_table.source
+++ b/src/test/isolation2/output/external_table.source
@@ -234,3 +234,22 @@ SELECT * FROM ext_delimiter_off_csv;
 ---
  O 
 (1 row)
+
+-- start_ignore
+DROP EXTERNAL TABLE IF EXISTS exttab_delimiter_escape_off;
+DROP
+-- end_ignore
+
+-- Create external table(text format) with both delimiter and escape off
+CREATE EXTERNAL WEB TABLE exttab_delimiter_escape_off(a text) EXECUTE E'cat @abs_srcdir@/data/exttab_escape_off.data' ON SEGMENT 0 format 'TEXT' (delimiter 'OFF' escape 'OFF') encoding 'UTF8' LOG ERRORS  SEGMENT REJECT LIMIT 10;
+CREATE
+
+SELECT * FROM exttab_delimiter_escape_off ORDER BY a;
+ a                                
+----------------------------------
+ correct record in lower          
+ CORRECT RECORD IN UPPER          
+ line with backslash 3\1001300102 
+ Value off                        
+ Value OFF                        
+(5 rows)

--- a/src/test/regress/data/exttab_escape_off.data
+++ b/src/test/regress/data/exttab_escape_off.data
@@ -1,0 +1,5 @@
+line with backslash 3\1001300102
+CORRECT RECORD IN UPPER
+correct record in lower
+Value OFF
+Value off


### PR DESCRIPTION
escape char will be set as delimiter char if escape is 'OFF' for text
format external table. That should not be expected behavior.
So fix it by checking escape_off flag in CopyReadAttributesText().

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
