### PR TITLE
Follow-up: pg_upgrade check to detect views with anyarray casts

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -33,6 +33,7 @@ static void check_large_objects(void);
 static void check_invalid_indexes(void);
 static void check_foreign_key_constraints_on_root_partition(void);
 static void check_views_with_unsupported_lag_lead_function(void);
+static void check_views_with_fabricated_anyarray_casts(void);
 
 
 /*
@@ -61,6 +62,7 @@ check_greenplum(void)
 	check_large_objects();
 	check_invalid_indexes();
 	check_views_with_unsupported_lag_lead_function();
+	check_views_with_fabricated_anyarray_casts();
 }
 
 /*
@@ -1254,6 +1256,82 @@ check_views_with_unsupported_lag_lead_function(void)
 		pg_fatal("Your installation contains views using lag or lead \n"
 				 "functions with the second parameter as bigint. These views \n"
 				 "need to be dropped before proceeding to upgrade. \n"
+				 "A list of views is in the file:\n"
+				 "\t%s\n\n", output_path);
+	}
+	else
+		check_ok();
+}
+
+static void
+check_views_with_fabricated_anyarray_casts()
+{
+	char		output_path[MAXPGPATH];
+	FILE		*script = NULL;
+	bool		found = false;
+	int			dbnum;
+	int			i_viewname;
+
+	prep_status("Checking for non-dumpable views with anyarray casts");
+
+	snprintf(output_path, sizeof(output_path), "view_anyarray_casts.txt");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		int			rowno;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn;
+		bool		db_used = false;
+
+		conn = connectToServer(&old_cluster, active_db->db_name);
+		PQclear(executeQueryOrDie(conn, "SET search_path TO 'public';"));
+
+		/* Install check support function */
+		PQclear(executeQueryOrDie(conn,
+									 "CREATE OR REPLACE FUNCTION "
+									 "view_has_anyarray_casts(OID) "
+									 "RETURNS BOOL "
+									 "AS '$libdir/pg_upgrade_support' "
+									 "LANGUAGE C STRICT;"));
+		res = executeQueryOrDie(conn,
+								"SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS badviewname "
+								"FROM pg_class c JOIN pg_namespace n on c.relnamespace=n.oid "
+								"WHERE c.relkind = 'v' AND "
+								"view_has_anyarray_casts(c.oid) = TRUE;");
+
+		PQclear(executeQueryOrDie(conn, "DROP FUNCTION view_has_anyarray_casts(OID);"));
+		PQclear(executeQueryOrDie(conn, "SET search_path to '';"));
+
+		ntups = PQntuples(res);
+		i_viewname = PQfnumber(res, "badviewname");
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
+				pg_fatal("Could not create necessary file:  %s\n", output_path);
+			if (!db_used)
+			{
+				fprintf(script, "Database: %s\n", active_db->db_name);
+				db_used = true;
+			}
+			fprintf(script, "  %s \n",
+					PQgetvalue(res, rowno, i_viewname));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		fclose(script);
+		pg_log(PG_REPORT, "fatal\n");
+		pg_fatal("Your installation contains views having anyarray\n"
+				 "casts. Drop the view or recreate the view without explicit \n"
+				 "array-type type casts before running the upgrade. Alternatively, drop the view \n"
+				 "before the upgrade and recreate the view after the upgrade. \n"
 				 "A list of views is in the file:\n"
 				 "\t%s\n\n", output_path);
 	}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/greenplum-db/gpdb/pull/11506

This commit introduces a new Greenplum check to see if there are any
views with corrupted view definitions (having anyarray casts), which
could arise from the special GPDB specific ANYARRAY coercion logic added
in parse_coerce.c: coerce_type() circa 2008.

The check makes use of a new support UDF that invokes a walker to figure
out if there are any anyarray casts in the view's query tree.

Since, the pg_node_tree type (column type of pg_rewrite.ev_action), does
not allow input, it is hard to bust the catalog in order to perform an
automated test. So we performed a manual test by creating the following busted
views created with server binaries not having the fix.

```sql
         View "public.v_anyarray_in_cte"
 Column | Type | Modifiers | Storage  | Description
--------+------+-----------+----------+-------------
 foo    | text |           | extended |
View definition:
 WITH cte AS (
         SELECT 'foo'::text AS foo
           FROM pg_class
          WHERE '{1}'::anyarray = '{2}'::anyarray
        )
 SELECT cte.foo
   FROM cte;

         View "public.v_anyarray_in_func_expr"
  Column  |  Type   | Modifiers | Storage | Description
----------+---------+-----------+---------+-------------
 ?column? | boolean |           | plain   |
View definition:
 SELECT array_agg(pg_database.oid)::integer[] OPERATOR(pg_catalog.=) '{1}'::anyarray
   FROM pg_database;

         View "public.v_anyarray_in_subselect"
  Column  |  Type   | Modifiers | Storage | Description
----------+---------+-----------+---------+-------------
 ?column? | integer |           | plain   |
View definition:
 SELECT 1
   FROM ( SELECT '{1}'::anyarray = '{1}'::anyarray) sub;

           View "public.v_anyarray_in_tlist"
  Column  |  Type   | Modifiers | Storage | Description
----------+---------+-----------+---------+-------------
 ?column? | boolean |           | plain   |
View definition:
 SELECT '{1}'::anyarray = '{1}'::anyarray;

           View "public.v_anyarray_in_where"
  Column  |  Type   | Modifiers | Storage | Description
----------+---------+-----------+---------+-------------
 ?column? | integer |           | plain   |
View definition:
 SELECT 1
   FROM pg_class
  WHERE '{1}'::anyarray = '{1}'::anyarray;

```

False positive test case (should not be flagged as a bad view by
pg_upgrade):
```sql
       View "public.v_anyarray_in_text_expr"
 Column  | Type | Modifiers | Storage  | Description
---------+------+-----------+----------+-------------
 textcol | text |           | extended |
View definition:
 SELECT 'blah::anyarray'::text AS textcol;
```

Co-authored-by: Kevin Yeap <kyeap@vmware.com>