### PR TITLE
Analyzedb works for schema and table names containing ":", "," or "\\n"

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -626,10 +626,6 @@ class AnalyzeDb(Operation):
         for can in candidates:
             schema = can[0]
             table = can[1]
-            if '\n' in schema or ',' in schema or ':' in schema:
-                raise Exception('Schema name has an invalid character "\\n", ":", "," : "%s"' % schema)
-            if '\n' in table or ',' in table or ':' in table:
-                raise Exception('Table name has an invalid character "\\n", ":", "," : "%s"' % table)
             if can in mid_level_partitions:
                 logger.warning("Skipping mid-level partition %s.%s" % (schema, table))
             else:
@@ -1260,7 +1256,7 @@ def create_parser():
                           "as having stale stats every time analyzedb is run. This is because we use AO metadata to check for DML or "
                           "DDL events, which is not available to heap tables.  "
                           "2. Views, indices and external tables are automatically skipped.  "
-                          "3. Table names or schema names containing comma or period is not supported yet."
+                          "3. Table names or schema names containing period is not supported yet."
                           )
     parser.set_usage('%prog [options] ')
     parser.remove_option('-h')

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -164,6 +164,17 @@ Feature: Incrementally analyze the database
         When the user runs "analyzedb -l -d incr_analyze -t '"my schema"."my ao"'"
         Then analyzedb should print "-"my schema"."my ao" to stdout
 
+    Scenario: Table and schema name with a colon, comma and newline
+        Given no state files exist for database "incr_analyze"
+        And schema ""my:schema"" exists in "incr_analyze"
+        And there is a regular "ao" table ""my:ao"" with column name list ""my,col","My:Col",z" and column type list "int,text,real" in schema ""my:schema""
+        And there is a regular "heap" table ""my,heap"" with column name list ""my\\ncol","My:Col",z" and column type list "int,text,real" in schema ""my:schema""
+        When the user runs "analyzedb -l -d incr_analyze -s 'my:schema'"
+        Then analyzedb should print "-"my:schema"."my:ao" to stdout
+	And analyzedb should print "-"my:schema"."my,heap" to stdout
+        When the user runs "analyzedb -l -d incr_analyze -t '"my:schema"."my:ao"'"
+        Then analyzedb should print "-"my:schema"."my:ao" to stdout
+
     Scenario: Incremental analyze, no dirty tables
         Given no state files exist for database "incr_analyze"
         And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"


### PR DESCRIPTION
Analyzedb seems to work fine for schema and table names containing
characters like ":", "," or "\\n". Hence, removing the check code for
these and adding behave test for it.

Fixes https://github.com/greenplum-db/gpdb/issues/11299

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
