### PR TITLE
[6X] gpinitsystem: update default locale on linux

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -387,28 +387,20 @@ if [ "${BLDWRAP_POSTGRES_CONF_ADDONS}" != "__none__" ]  && \
     echo ""
 fi
 
-# photon requires explicitly setting locale during gpinitsystem
-# TODO: This hack will go away when gpinitsystem automatically using default system locale.
-if [ -f /etc/os-release ]; then
-    if grep -q photon /etc/os-release; then
-        LOCALE_OPTS="-n en_US.UTF-8"
-    fi
-fi
-
 if [ -f "${CLUSTER_CONFIG_POSTGRES_ADDONS}" ]; then
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} "$@"
 else
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} ${LOCALE_OPTS:-} "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs ${STANDBY_INIT_OPTS} "$@"
 fi
 RETURN=$?
 

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1426,7 +1426,14 @@ case $OS_TYPE in
 		PG_METHOD="ident"
 		HOST_ARCH_TYPE="uname -i"
 		NOLINE_ECHO="$ECHO -e"
-		DEFAULT_LOCALE_SETTING=en_US.utf8
+		# Using `$HEAD -1` protects from the unlikely scenario of there being two
+		# utf8 variants on the system and grabbing only one, rather than passing
+		# both values to initdb causing a failure.
+		DEFAULT_LOCALE_SETTING=$($LOCALE -a | $GREP -i "^en_US\.utf.*8$" | $HEAD -1)
+    # If no utf8 variant is found on the system default to "en_US.utf8" to
+    # prevent future checks and code within gpinitsystem from failing, and a
+    # friendly error message returned.
+		DEFAULT_LOCALE_SETTING=${DEFAULT_LOCALE_SETTING:-"en_US.utf8"}
 		PING6=`findCmdInPath ping6`
 		PING_TIME="-c 1"
 		DF="`findCmdInPath df` -P"


### PR DESCRIPTION
On linux gpinitsystem was defaulting to the hard coded value of "en_US.utf8". Photon3 uses the value en_US.UTF-8. Later checks in gpinitsystem would fail due to this discrepancy. Thus, query the system for the correct utf-8 variation to use as the default.

Note, we use `$HEAD -1` protects from the unlikely scenario of there being two utf8 variants on the system and grabbing only one, rather than passing both values to initdb causing a failure.

If no utf8 variant is found on the system default to "en_US.utf8" to prevent future checks and code within gpinitsystem from failing, and a friendly error message returned.


[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6X_gpinitsystem_default_locale)

For reference:
- previous 6X PR https://github.com/greenplum-db/gpdb/pull/11500
- 7X PRs https://github.com/greenplum-db/gpdb/pull/11483 https://github.com/greenplum-db/gpdb/pull/11531 https://github.com/greenplum-db/gpdb/pull/11528