### PR TITLE
Add a gp_switch_wal() catalog function to system_views.sql

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1630,6 +1630,25 @@ AS
    SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_tablespace_location($1)'
 LANGUAGE SQL EXECUTE ON COORDINATOR;
 
+-- pg_switch_wal wrapper functions to switch WAL segment files on Greenplum cluster-wide
+CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+AS 'SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_switch_wal()'
+LANGUAGE SQL EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+RETURNS SETOF RECORD
+AS
+  'SELECT * FROM pg_catalog.gp_switch_wal_on_all_segments()
+   UNION ALL
+   SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_switch_wal()'
+LANGUAGE SQL EXECUTE ON COORDINATOR;
+
+COMMENT ON FUNCTION pg_catalog.gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
+COMMENT ON FUNCTION pg_catalog.gp_switch_wal() IS 'Switch WAL segment files on all segments';
+
+REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
+REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
+
 CREATE OR REPLACE FUNCTION
   parse_ident(str text, strict boolean DEFAULT true)
 RETURNS text[]

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302102091
+#define CATALOG_VERSION_NO	302102221
 
 #endif

--- a/src/test/gpdb_pitr/.gitignore
+++ b/src/test/gpdb_pitr/.gitignore
@@ -4,6 +4,9 @@ regression.out
 # Local symbolic links
 sql_isolation_testcase.py
 
+expected/setup.out
+sql/setup.sql
+
 # Generated subdirectories
 /results/
 /temp_test/

--- a/src/test/gpdb_pitr/Makefile
+++ b/src/test/gpdb_pitr/Makefile
@@ -5,14 +5,21 @@
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
+setup:
+	cp $(top_builddir)/src/test/isolation2/sql/setup.sql ./sql/setup.sql
+	cp $(top_builddir)/src/test/isolation2/expected/setup.out ./expected/setup.out
+
 sql_isolation_testcase.py:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/isolation2/sql_isolation_testcase.py
 
-install: sql_isolation_testcase.py
+install: sql_isolation_testcase.py setup
 	$(MAKE) -C $(top_builddir)/src/test/isolation2 install
 
 installcheck: install
 	./test_gpdb_pitr.sh
 
 clean:
+	rm -f sql_isolation_testcase.py
+	rm -f ./sql/setup.sql
+	rm -f ./expected/setup.out
 	./test_gpdb_pitr_cleanup.sh

--- a/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
+++ b/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
@@ -146,20 +146,16 @@ SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
  10  
 (10 rows)
 
--- Run pg_switch_wal() so that the WAL segment files with the restore
+-- Run gp_switch_wal() so that the WAL segment files with the restore
 -- points are archived to the WAL Archive directories.
-SELECT true FROM pg_switch_wal();
- bool 
-------
- t    
-(1 row)
-SELECT (SELECT true FROM pg_switch_wal()) FROM gp_dist_random('gp_id');
+SELECT true FROM gp_switch_wal();
  bool 
 ------
  t    
  t    
  t    
-(3 rows)
+ t    
+(4 rows)
 
 -- Call a checkpoint to flush buffers (including the switch xlog record)
 CHECKPOINT;

--- a/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
+++ b/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
@@ -60,10 +60,9 @@ SELECT * FROM gpdb_two_phase_commit_after_acquire_share_lock;
 SELECT * FROM gpdb_one_phase_commit;
 SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
 
--- Run pg_switch_wal() so that the WAL segment files with the restore
+-- Run gp_switch_wal() so that the WAL segment files with the restore
 -- points are archived to the WAL Archive directories.
-SELECT true FROM pg_switch_wal();
-SELECT (SELECT true FROM pg_switch_wal()) FROM gp_dist_random('gp_id');
+SELECT true FROM gp_switch_wal();
 
 -- Call a checkpoint to flush buffers (including the switch xlog record)
 CHECKPOINT;


### PR DESCRIPTION
When calling pg_switch_wal, it will only execute on the coordinator
segment. To run pg_switch_wal on the primary segments, we would need
to use gp_dist_random or use utility-mode connections. To make things
easier for end-users and help with external WAL archiving projects,
this commit introduces a new catalog function that switches WAL
segment files on all seegments by using the GPDB-specific EXECUTE ON
[COORDINATOR | ALL SEGMENTS] feature of CREATE FUNCTION (a less hacky
way compared to using gp_dist_random for function calls).

Co-authored-by: Jimmy Yih <jyih@pivotal.io>
