### PR TITLE
Make member functions const (or better)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,9 @@ Checks: |
   modernize-use-equals-delete,
   modernize-use-nullptr,
   modernize-use-default-member-init,
+  readability-make-member-function-const,
   readability-non-const-parameter,
+  readability-static-accessed-through-instance,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'gpdbcost|gpopt|gpos|naucrates'

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3599,8 +3599,8 @@ CTranslatorDXLToPlStmt::TranslateDXLFilterList(
 	{
 		CDXLNode *child_filter_dxlnode = (*filter_list_dxlnode)[ul];
 
-		if (m_translator_dxl_to_scalar->HasConstTrue(child_filter_dxlnode,
-													 m_md_accessor))
+		if (gpdxl::CTranslatorDXLToScalar::HasConstTrue(child_filter_dxlnode,
+														m_md_accessor))
 		{
 			filters_list = gpdb::LAppend(filters_list, nullptr /*datum*/);
 			continue;

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2723,7 +2723,7 @@ CTranslatorQueryToDXL::CreateDXLSetOpFromColumns(
 //---------------------------------------------------------------------------
 BOOL
 CTranslatorQueryToDXL::SetOpNeedsCast(List *target_list,
-									  IMdIdArray *input_col_mdids) const
+									  IMdIdArray *input_col_mdids)
 {
 	GPOS_ASSERT(nullptr != input_col_mdids);
 	GPOS_ASSERT(nullptr != target_list);
@@ -3059,7 +3059,7 @@ CTranslatorQueryToDXL::TranslateFromClauseToDXL(Node *node)
 //		Raise exception for unsupported RangeTblEntries of a particular kind
 //---------------------------------------------------------------------------
 void
-CTranslatorQueryToDXL::UnsupportedRTEKind(RTEKind rtekind) const
+CTranslatorQueryToDXL::UnsupportedRTEKind(RTEKind rtekind)
 {
 	GPOS_ASSERT(!(RTE_RELATION == rtekind || RTE_CTE == rtekind ||
 				  RTE_FUNCTION == rtekind || RTE_SUBQUERY == rtekind ||
@@ -4638,7 +4638,7 @@ IntToUlongMap *
 CTranslatorQueryToDXL::RemapColIds(CMemoryPool *mp,
 								   IntToUlongMap *attno_to_colid_mapping,
 								   ULongPtrArray *from_list_colids,
-								   ULongPtrArray *to_list_colids) const
+								   ULongPtrArray *to_list_colids)
 {
 	GPOS_ASSERT(nullptr != attno_to_colid_mapping);
 	GPOS_ASSERT(nullptr != from_list_colids && nullptr != to_list_colids);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -137,8 +137,7 @@ CTranslatorScalarToDXL::TranslateStandaloneExprToDXL(
 //		Return the EdxlBoolExprType for a given GPDB BoolExprType
 //---------------------------------------------------------------------------
 EdxlBoolExprType
-CTranslatorScalarToDXL::EdxlbooltypeFromGPDBBoolType(
-	BoolExprType boolexprtype) const
+CTranslatorScalarToDXL::EdxlbooltypeFromGPDBBoolType(BoolExprType boolexprtype)
 {
 	static ULONG mapping[][2] = {
 		{NOT_EXPR, Edxlnot},

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -105,7 +105,7 @@ SOptContext::SOptContext() = default;
 //
 //---------------------------------------------------------------------------
 void
-SOptContext::Free(SOptContext::EPin input, SOptContext::EPin output)
+SOptContext::Free(SOptContext::EPin input, SOptContext::EPin output) const
 {
 	if (nullptr != m_query_dxl && epinQueryDXL != input &&
 		epinQueryDXL != output)
@@ -145,7 +145,7 @@ SOptContext::Free(SOptContext::EPin input, SOptContext::EPin output)
 //
 //---------------------------------------------------------------------------
 CHAR *
-SOptContext::CloneErrorMsg(MemoryContext context)
+SOptContext::CloneErrorMsg(MemoryContext context) const
 {
 	if (nullptr == context || nullptr == m_error_msg)
 	{

--- a/src/backend/gporca/libgpdbcost/src/ICostModel.cpp
+++ b/src/backend/gporca/libgpdbcost/src/ICostModel.cpp
@@ -44,7 +44,7 @@ ICostModel::PcmDefault(CMemoryPool *mp)
 //
 //---------------------------------------------------------------------------
 void
-ICostModel::SetParams(ICostModelParamsArray *pdrgpcp)
+ICostModel::SetParams(ICostModelParamsArray *pdrgpcp) const
 {
 	if (nullptr == pdrgpcp)
 	{

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -143,8 +143,8 @@ protected:
 												   EConstraintType ect);
 
 	// mapping between columns and arrays of constraints
-	ColRefToConstraintArrayMap *Phmcolconstr(
-		CMemoryPool *mp, CColRefSet *pcrs, CConstraintArray *pdrgpcnstr) const;
+	static ColRefToConstraintArrayMap *Phmcolconstr(
+		CMemoryPool *mp, CColRefSet *pcrs, CConstraintArray *pdrgpcnstr);
 
 	// return a copy of the conjunction/disjunction constraint for a different column
 	static CConstraint *PcnstrConjDisjRemapForColumn(

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -57,18 +57,20 @@ private:
 
 	// adds ranges from a source array to a destination array, starting
 	// at the range with the given index
-	void AddRemainingRanges(CMemoryPool *mp, CRangeArray *pdrgprngSrc,
-							ULONG ulStart, CRangeArray *pdrgprngDest);
+	static void AddRemainingRanges(CMemoryPool *mp, CRangeArray *pdrgprngSrc,
+								   ULONG ulStart, CRangeArray *pdrgprngDest);
 
 	// append the given range to the array or extend the last element
-	void AppendOrExtend(CMemoryPool *mp, CRangeArray *pdrgprng, CRange *prange);
+	static void AppendOrExtend(CMemoryPool *mp, CRangeArray *pdrgprng,
+							   CRange *prange);
 
 	// difference between two ranges on the left side only -
 	// any difference on the right side is reported as residual range
-	CRange *PrangeDiffWithRightResidual(CMemoryPool *mp, CRange *prangeFirst,
-										CRange *prangeSecond,
-										CRange **pprangeResidual,
-										CRangeArray *pdrgprngResidual);
+	static CRange *PrangeDiffWithRightResidual(CMemoryPool *mp,
+											   CRange *prangeFirst,
+											   CRange *prangeSecond,
+											   CRange **pprangeResidual,
+											   CRangeArray *pdrgprngResidual);
 
 	// type of this interval
 	IMDId *MdidType();

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
@@ -256,10 +256,10 @@ public:
 	BOOL FBetterThan(const CCostContext *pcc) const;
 
 	// is this cost context of a two stage scalar DQA created by CXformSplitDQA
-	BOOL IsTwoStageScalarDQACostCtxt(const CCostContext *pcc) const;
+	static BOOL IsTwoStageScalarDQACostCtxt(const CCostContext *pcc);
 
 	// is this cost context of a three stage scalar DQA created by CXformSplitDQA
-	BOOL IsThreeStageScalarDQACostCtxt(const CCostContext *pcc) const;
+	static BOOL IsThreeStageScalarDQACostCtxt(const CCostContext *pcc);
 
 	// equality function
 	static BOOL

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
@@ -231,7 +231,7 @@ public:
 									 CDistributionSpecHashed *other_spec);
 
 	// check if the equivalent spec (if any) has no matching columns with the main spec
-	BOOL HasCompleteEquivSpec(CMemoryPool *mp);
+	BOOL HasCompleteEquivSpec(CMemoryPool *mp) const;
 
 	// use given predicates to complete an incomplete spec, if possible
 	static CDistributionSpecHashed *TryToCompleteEquivSpec(

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
@@ -91,7 +91,7 @@ public:
 		CExpressionArray *pdrgpexpr,  // array of enforcer expressions
 		CExpression *pexprChild,	  // leaf in the target group where
 									  // enforcers will be added
-		CEnfdProp::EPropEnforcingType epet, CExpressionHandle &exprhdl)
+		CEnfdProp::EPropEnforcingType epet, CExpressionHandle &exprhdl) const
 	{
 		if (FEnforce(epet))
 		{

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
@@ -102,7 +102,7 @@ private:
 		IOstream &OsPrint(IOstream &os) const;
 
 		// copy part info entry into given memory pool
-		CPartInfoEntry *PpartinfoentryCopy(CMemoryPool *mp);
+		CPartInfoEntry *PpartinfoentryCopy(CMemoryPool *mp) const;
 
 	};	// CPartInfoEntry
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
@@ -77,14 +77,14 @@ private:
 	CExpression *PexprEquality(CMemoryPool *mp, const CColRef *colref);
 
 	// construct a scalar comparison expression from one of the ends
-	CExpression *PexprScalarCompEnd(CMemoryPool *mp, IDatum *datum,
-									ERangeInclusion eri,
-									IMDType::ECmpType ecmptIncl,
-									IMDType::ECmpType ecmptExcl,
-									const CColRef *colref);
+	static CExpression *PexprScalarCompEnd(CMemoryPool *mp, IDatum *datum,
+										   ERangeInclusion eri,
+										   IMDType::ECmpType ecmptIncl,
+										   IMDType::ECmpType ecmptExcl,
+										   const CColRef *colref);
 
 	// inverse of the inclusion option
-	ERangeInclusion
+	static ERangeInclusion
 	EriInverseInclusion(ERangeInclusion eri)
 	{
 		if (EriIncluded == eri)
@@ -95,8 +95,8 @@ private:
 	}
 
 	// print a bound
-	IOstream &OsPrintBound(IOstream &os, IDatum *datum,
-						   const CHAR *szInfinity) const;
+	static IOstream &OsPrintBound(IOstream &os, IDatum *datum,
+								  const CHAR *szInfinity);
 
 public:
 	CRange(const CRange &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
@@ -352,7 +352,7 @@ public:
 	virtual ECostModelType Ecmt() const = 0;
 
 	// set cost model params
-	void SetParams(ICostModelParamsArray *pdrgpcp);
+	void SetParams(ICostModelParamsArray *pdrgpcp) const;
 
 	// create a default cost model instance
 	static ICostModel *PcmDefault(CMemoryPool *mp);

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CEngine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CEngine.h
@@ -147,7 +147,8 @@ private:
 								  CGroupExpression *pgexprOrigin);
 
 	// create and schedule the main optimization job
-	void ScheduleMainJob(CSchedulerContext *psc, COptimizationContext *poc);
+	void ScheduleMainJob(CSchedulerContext *psc,
+						 COptimizationContext *poc) const;
 
 	// print activated xform
 	void PrintActivatedXforms(IOstream &os) const;
@@ -174,7 +175,7 @@ private:
 	void SamplePlans();
 
 	// check if all children were successfully optimized
-	BOOL FChildrenOptimized(COptimizationContextArray *pdrgpoc);
+	static BOOL FChildrenOptimized(COptimizationContextArray *pdrgpoc);
 
 	// check if ayn of the given property enforcing types prohibits enforcement
 	static BOOL FProhibited(CEnfdProp::EPropEnforcingType epetOrder,

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CEnumeratorConfig.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CEnumeratorConfig.h
@@ -250,15 +250,15 @@ public:
 	}
 
 	// is enumeration enabled?
-	BOOL
-	FEnumerate() const
+	static BOOL
+	FEnumerate()
 	{
 		return GPOS_FTRACE(EopttraceEnumeratePlans);
 	}
 
 	// is sampling enabled?
-	BOOL
-	FSample() const
+	static BOOL
+	FSample()
 	{
 		return GPOS_FTRACE(EopttraceSamplePlans);
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CPartialPlan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CPartialPlan.h
@@ -60,7 +60,7 @@ private:
 									ICostModel::SCostingInfo *pci);
 
 	// raise exception if the stats object is NULL
-	void RaiseExceptionIfStatsNull(IStatistics *stats);
+	static void RaiseExceptionIfStatsNull(IStatistics *stats);
 
 public:
 	CPartialPlan(const CPartialPlan &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/mdcache/CMDAccessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/mdcache/CMDAccessor.h
@@ -153,7 +153,7 @@ private:
 		}
 
 		// return the key for this hashtable element
-		IMDId *MDId();
+		IMDId *MDId() const;
 
 		// equality function for hash tables
 		static BOOL Equals(const MdidPtr &left_mdid, const MdidPtr &right_mdid);

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
@@ -72,7 +72,7 @@ private:
 
 #ifdef GPOS_DEBUG
 	// are all default partitions on all levels included
-	BOOL FAllDefaultPartsIncluded();
+	BOOL FAllDefaultPartsIncluded() const;
 #endif	//GPOS_DEBUG
 
 	// does the current constraint overlap with given one at the given level
@@ -89,8 +89,8 @@ private:
 
 	// return the remaining part of the first constraint that is not covered by
 	// the second constraint
-	CConstraint *PcnstrRemaining(CMemoryPool *mp, CConstraint *pcnstrFst,
-								 CConstraint *pcnstrSnd);
+	static CConstraint *PcnstrRemaining(CMemoryPool *mp, CConstraint *pcnstrFst,
+										CConstraint *pcnstrSnd);
 
 	// check if two constaint maps have the same constraints
 	static BOOL FEqualConstrMaps(UlongToConstraintMap *phmulcnstrFst,

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -215,8 +215,8 @@ public:
 
 	// helper function for finding the index of a column descriptor in
 	// an array of column descriptors
-	ULONG UlPos(const CColumnDescriptor *,
-				const CColumnDescriptorArray *) const;
+	static ULONG UlPos(const CColumnDescriptor *,
+					   const CColumnDescriptorArray *);
 
 	IOstream &OsPrint(IOstream &os) const;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/minidump/CSerializableMDAccessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/minidump/CSerializableMDAccessor.h
@@ -42,7 +42,7 @@ private:
 	void SerializeHeader(COstream &oos);
 
 	// serialize footer
-	void SerializeFooter(COstream &oos);
+	static void SerializeFooter(COstream &oos);
 
 public:
 	CSerializableMDAccessor(const CSerializableMDAccessor &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -129,7 +129,8 @@ public:
 
 	// stats derivation using given properties and context
 	void DeriveStats(CMemoryPool *pmpLocal, CMemoryPool *pmpGlobal,
-					 CReqdPropRelational *prprel, IStatisticsArray *stats_ctxt);
+					 CReqdPropRelational *prprel,
+					 IStatisticsArray *stats_ctxt) const;
 
 	// derive the properties of the plan carried by attached cost context,
 	// using default CDrvdPropCtxtPlan
@@ -226,21 +227,21 @@ public:
 
 	// check for outer references
 	BOOL
-	HasOuterRefs()
+	HasOuterRefs() const
 	{
 		return (0 < DeriveOuterReferences()->Size());
 	}
 
 	// check if attached expression must execute on a single host
 	BOOL
-	NeedsSingletonExecution()
+	NeedsSingletonExecution() const
 	{
 		return DeriveFunctionProperties()->NeedsSingletonExecution();
 	}
 
 	// check for outer references in the given child
 	BOOL
-	HasOuterRefs(ULONG child_index)
+	HasOuterRefs(ULONG child_index) const
 	{
 		return (0 < DeriveOuterReferences(child_index)->Size());
 	}
@@ -262,10 +263,10 @@ public:
 	ULONG UlPreviousOptimizedChildIndex(ULONG child_index) const;
 
 	// get the function properties of a child
-	CFunctionProp *PfpChild(ULONG child_index);
+	CFunctionProp *PfpChild(ULONG child_index) const;
 
 	// check whether an expression's children have a volatile function
-	BOOL FChildrenHaveVolatileFuncScan();
+	BOOL FChildrenHaveVolatileFuncScan() const;
 
 	// return a representative (inexact) scalar child at given index
 	CExpression *PexprScalarRepChild(ULONG child_index) const;
@@ -279,59 +280,59 @@ public:
 	// return an exact scalar expression attached to handle or null if not possible
 	CExpression *PexprScalarExact() const;
 
-	void DeriveProducerStats(ULONG child_index, CColRefSet *pcrsStat);
+	void DeriveProducerStats(ULONG child_index, CColRefSet *pcrsStat) const;
 
 	// return the columns used by a logical operator internally as well
 	// as columns used by all its scalar children
-	CColRefSet *PcrsUsedColumns(CMemoryPool *mp);
+	CColRefSet *PcrsUsedColumns(CMemoryPool *mp) const;
 
-	CColRefSet *DeriveOuterReferences();
-	CColRefSet *DeriveOuterReferences(ULONG child_index);
+	CColRefSet *DeriveOuterReferences() const;
+	CColRefSet *DeriveOuterReferences(ULONG child_index) const;
 
-	CColRefSet *DeriveOutputColumns();
-	CColRefSet *DeriveOutputColumns(ULONG child_index);
+	CColRefSet *DeriveOutputColumns() const;
+	CColRefSet *DeriveOutputColumns(ULONG child_index) const;
 
-	CColRefSet *DeriveNotNullColumns();
-	CColRefSet *DeriveNotNullColumns(ULONG child_index);
+	CColRefSet *DeriveNotNullColumns() const;
+	CColRefSet *DeriveNotNullColumns(ULONG child_index) const;
 
-	CColRefSet *DeriveCorrelatedApplyColumns();
-	CColRefSet *DeriveCorrelatedApplyColumns(ULONG child_index);
+	CColRefSet *DeriveCorrelatedApplyColumns() const;
+	CColRefSet *DeriveCorrelatedApplyColumns(ULONG child_index) const;
 
-	CMaxCard DeriveMaxCard();
-	CMaxCard DeriveMaxCard(ULONG child_index);
+	CMaxCard DeriveMaxCard() const;
+	CMaxCard DeriveMaxCard(ULONG child_index) const;
 
-	CKeyCollection *DeriveKeyCollection();
-	CKeyCollection *DeriveKeyCollection(ULONG child_index);
+	CKeyCollection *DeriveKeyCollection() const;
+	CKeyCollection *DeriveKeyCollection(ULONG child_index) const;
 
-	CPropConstraint *DerivePropertyConstraint();
-	CPropConstraint *DerivePropertyConstraint(ULONG child_index);
+	CPropConstraint *DerivePropertyConstraint() const;
+	CPropConstraint *DerivePropertyConstraint(ULONG child_index) const;
 
-	ULONG DeriveJoinDepth();
-	ULONG DeriveJoinDepth(ULONG child_index);
+	ULONG DeriveJoinDepth() const;
+	ULONG DeriveJoinDepth(ULONG child_index) const;
 
-	CFunctionProp *DeriveFunctionProperties();
-	CFunctionProp *DeriveFunctionProperties(ULONG child_index);
+	CFunctionProp *DeriveFunctionProperties() const;
+	CFunctionProp *DeriveFunctionProperties(ULONG child_index) const;
 
-	CFunctionalDependencyArray *Pdrgpfd();
-	CFunctionalDependencyArray *Pdrgpfd(ULONG child_index);
+	CFunctionalDependencyArray *Pdrgpfd() const;
+	CFunctionalDependencyArray *Pdrgpfd(ULONG child_index) const;
 
-	CPartInfo *DerivePartitionInfo();
-	CPartInfo *DerivePartitionInfo(ULONG child_index);
+	CPartInfo *DerivePartitionInfo() const;
+	CPartInfo *DerivePartitionInfo(ULONG child_index) const;
 
-	CTableDescriptor *DeriveTableDescriptor();
-	CTableDescriptor *DeriveTableDescriptor(ULONG child_index);
+	CTableDescriptor *DeriveTableDescriptor() const;
+	CTableDescriptor *DeriveTableDescriptor(ULONG child_index) const;
 
 	// Scalar property accessors
-	CColRefSet *DeriveDefinedColumns(ULONG child_index);
-	CColRefSet *DeriveUsedColumns(ULONG child_index);
-	CColRefSet *DeriveSetReturningFunctionColumns(ULONG child_index);
-	BOOL DeriveHasSubquery(ULONG child_index);
-	CPartInfo *DeriveScalarPartitionInfo(ULONG child_index);
-	CFunctionProp *DeriveScalarFunctionProperties(ULONG child_index);
-	BOOL DeriveHasNonScalarFunction(ULONG child_index);
-	ULONG DeriveTotalDistinctAggs(ULONG child_index);
-	BOOL DeriveHasMultipleDistinctAggs(ULONG child_index);
-	BOOL DeriveHasScalarArrayCmp(ULONG child_index);
+	CColRefSet *DeriveDefinedColumns(ULONG child_index) const;
+	CColRefSet *DeriveUsedColumns(ULONG child_index) const;
+	CColRefSet *DeriveSetReturningFunctionColumns(ULONG child_index) const;
+	BOOL DeriveHasSubquery(ULONG child_index) const;
+	CPartInfo *DeriveScalarPartitionInfo(ULONG child_index) const;
+	CFunctionProp *DeriveScalarFunctionProperties(ULONG child_index) const;
+	BOOL DeriveHasNonScalarFunction(ULONG child_index) const;
+	ULONG DeriveTotalDistinctAggs(ULONG child_index) const;
+	BOOL DeriveHasMultipleDistinctAggs(ULONG child_index) const;
+	BOOL DeriveHasScalarArrayCmp(ULONG child_index) const;
 
 };	// class CExpressionHandle
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -66,14 +66,14 @@ protected:
 	CColRefSet *m_pcrsLocalUsed;
 
 	// output column generation given a list of column descriptors
-	CColRefArray *PdrgpcrCreateMapping(
+	static CColRefArray *PdrgpcrCreateMapping(
 		CMemoryPool *mp, const CColumnDescriptorArray *pdrgpcoldesc,
-		ULONG ulOpSourceId, IMDId *mdid_table = nullptr) const;
+		ULONG ulOpSourceId, IMDId *mdid_table = nullptr);
 
 	// initialize the array of partition columns
-	CColRef2dArray *PdrgpdrgpcrCreatePartCols(CMemoryPool *mp,
-											  CColRefArray *colref_array,
-											  const ULongPtrArray *pdrgpulPart);
+	static CColRef2dArray *PdrgpdrgpcrCreatePartCols(
+		CMemoryPool *mp, CColRefArray *colref_array,
+		const ULongPtrArray *pdrgpulPart);
 
 	// derive dummy statistics
 	IStatistics *PstatsDeriveDummy(CMemoryPool *mp, CExpressionHandle &exprhdl,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalConstTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalConstTableGet.h
@@ -41,8 +41,8 @@ private:
 	CColRefArray *m_pdrgpcrOutput;
 
 	// construct column descriptors from column references
-	CColumnDescriptorArray *PdrgpcoldescMapping(
-		CMemoryPool *mp, CColRefArray *colref_array) const;
+	static CColumnDescriptorArray *PdrgpcoldescMapping(
+		CMemoryPool *mp, CColRefArray *colref_array);
 
 public:
 	CLogicalConstTableGet(const CLogicalConstTableGet &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalRowTrigger.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalRowTrigger.h
@@ -50,7 +50,7 @@ private:
 	void InitFunctionProperties();
 
 	// return the type of a given trigger as an integer
-	INT ITriggerType(const IMDTrigger *pmdtrigger) const;
+	static INT ITriggerType(const IMDTrigger *pmdtrigger);
 
 public:
 	CLogicalRowTrigger(const CLogicalRowTrigger &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPatternNode.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPatternNode.h
@@ -88,7 +88,7 @@ public:
 	}
 
 	BOOL
-	MatchesOperator(enum COperator::EOperatorId opid)
+	MatchesOperator(enum COperator::EOperatorId opid) const
 	{
 		switch (m_match)
 		{

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -75,10 +75,10 @@ private:
 
 	// create a child hashed distribution request based on input hashed distribution,
 	// return NULL if no such request can be created
-	CDistributionSpecHashed *PdshashedPassThru(
+	static CDistributionSpecHashed *PdshashedPassThru(
 		CMemoryPool *mp, CExpressionHandle &exprhdl,
 		CDistributionSpecHashed *pdshashedInput, ULONG child_index,
-		CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) const;
+		CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq);
 
 	// check whether a hash key is nullable
 	BOOL FNullableHashKey(ULONG ulKey, CColRefSet *pcrsNotNullInner,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalJoin.h
@@ -57,10 +57,10 @@ protected:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq);
 
 	// helper to compute required rewindability of correlated join's children
-	CRewindabilitySpec *PrsRequiredCorrelatedJoin(
+	static CRewindabilitySpec *PrsRequiredCorrelatedJoin(
 		CMemoryPool *mp, CExpressionHandle &exprhdl,
 		CRewindabilitySpec *prsRequired, ULONG child_index,
-		CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) const;
+		CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq);
 
 	// helper for propagating required sort order to outer child
 	static COrderSpec *PosPropagateToOuter(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalStreamAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalStreamAgg.h
@@ -38,8 +38,8 @@ private:
 	CColRefSet *m_pcrsMinimalGrpCols;
 
 	// construct order spec on grouping column so that it covers required order spec
-	COrderSpec *PosCovering(CMemoryPool *mp, COrderSpec *posRequired,
-							CColRefArray *pdrgpcrGrp) const;
+	static COrderSpec *PosCovering(CMemoryPool *mp, COrderSpec *posRequired,
+								   CColRefArray *pdrgpcrGrp);
 
 protected:
 	// compute required sort columns of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalUnionAll.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalUnionAll.h
@@ -47,16 +47,16 @@ private:
 
 	// derive strict random distribution spec if all the children of the parallel union all
 	// node derive strict random; derive null spec otherwise
-	CDistributionSpecRandom *PdsStrictRandomParallelUnionAllChildren(
-		CMemoryPool *mp, CExpressionHandle &expr_handle) const;
+	static CDistributionSpecRandom *PdsStrictRandomParallelUnionAllChildren(
+		CMemoryPool *mp, CExpressionHandle &expr_handle);
 
 	// compute output hashed distribution matching the outer child's hashed distribution
 	CDistributionSpecHashed *PdsMatching(
 		CMemoryPool *mp, const ULongPtrArray *pdrgpulOuter) const;
 
 	// derive output distribution based on child distribution
-	CDistributionSpec *PdsDeriveFromChildren(CMemoryPool *mp,
-											 CExpressionHandle &exprhdl) const;
+	static CDistributionSpec *PdsDeriveFromChildren(CMemoryPool *mp,
+													CExpressionHandle &exprhdl);
 
 protected:
 	// compute required hashed distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CBinding.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CBinding.h
@@ -52,12 +52,12 @@ private:
 						  CExpressionArray *pdrgpexpr);
 
 	// move cursor
-	CGroupExpression *PgexprNext(CGroup *pgroup,
-								 CGroupExpression *pgexpr) const;
+	static CGroupExpression *PgexprNext(CGroup *pgroup,
+										CGroupExpression *pgexpr);
 
 	// expand n-th child of pattern
-	CExpression *PexprExpandPattern(CExpression *pexpr, ULONG ulPos,
-									ULONG arity);
+	static CExpression *PexprExpandPattern(CExpression *pexpr, ULONG ulPos,
+										   ULONG arity);
 
 	// get binding for children
 	BOOL FExtractChildren(CMemoryPool *mp, CGroupExpression *pgexpr,
@@ -70,8 +70,8 @@ private:
 							  CExpression *pexprLast);
 
 	// build expression
-	CExpression *PexprFinalize(CMemoryPool *mp, CGroupExpression *pgexpr,
-							   CExpressionArray *pdrgpexprChildren);
+	static CExpression *PexprFinalize(CMemoryPool *mp, CGroupExpression *pgexpr,
+									  CExpressionArray *pdrgpexprChildren);
 
 	// private copy ctor
 	CBinding(const CBinding &);

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -289,24 +289,24 @@ private:
 	CGroupExpression *PgexprNext(CGroupExpression *pgexpr);
 
 	// return true if first promise is better than second promise
-	BOOL FBetterPromise(CMemoryPool *mp, CLogical::EStatPromise espFst,
-						CGroupExpression *pgexprFst,
-						CLogical::EStatPromise espSnd,
-						CGroupExpression *pgexprSnd) const;
+	static BOOL FBetterPromise(CMemoryPool *mp, CLogical::EStatPromise espFst,
+							   CGroupExpression *pgexprFst,
+							   CLogical::EStatPromise espSnd,
+							   CGroupExpression *pgexprSnd);
 
 	// derive stats recursively on child groups
-	CLogical::EStatPromise EspDerive(CMemoryPool *pmpLocal,
-									 CMemoryPool *pmpGlobal,
-									 CGroupExpression *pgexpr,
-									 CReqdPropRelational *prprel,
-									 IStatisticsArray *stats_ctxt,
-									 BOOL fDeriveChildStats);
+	static CLogical::EStatPromise EspDerive(CMemoryPool *pmpLocal,
+											CMemoryPool *pmpGlobal,
+											CGroupExpression *pgexpr,
+											CReqdPropRelational *prprel,
+											IStatisticsArray *stats_ctxt,
+											BOOL fDeriveChildStats);
 
 	// reset computed stats
 	void ResetStats();
 
 	// helper function to add links in child groups
-	void RecursiveBuildTreeMap(
+	static void RecursiveBuildTreeMap(
 		CMemoryPool *mp, COptimizationContext *poc, CCostContext *pccParent,
 		CGroupExpression *pgexprCurrent, ULONG child_index,
 		CTreeMap<CCostContext, CExpression, CDrvdPropCtxtPlan,

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -39,7 +39,7 @@ class CGroupExpression : public CRefCount
 public:
 #ifdef GPOS_DEBUG
 	// debug print; for interactive debugging sessions only
-	void DbgPrintWithProperties();
+	void DbgPrintWithProperties() const;
 #endif	// GPOS_DEBUG
 
 	// states of a group expression
@@ -144,8 +144,8 @@ private:
 	void SetId(ULONG id);
 
 	// print transformation
-	void PrintXform(CMemoryPool *mp, CXform *pxform, CExpression *pexpr,
-					CXformResult *pxfres, ULONG ulNumResults);
+	static void PrintXform(CMemoryPool *mp, CXform *pxform, CExpression *pexpr,
+						   CXformResult *pxfres, ULONG ulNumResults);
 
 	// preprocessing before applying transformation
 	void PreprocessTransform(CMemoryPool *pmpLocal, CMemoryPool *pmpGlobal,
@@ -153,10 +153,10 @@ private:
 
 	// postprocessing after applying transformation
 	void PostprocessTransform(CMemoryPool *pmpLocal, CMemoryPool *pmpGlobal,
-							  CXform *pxform);
+							  CXform *pxform) const;
 
 	// costing scheme
-	CCost CostCompute(CMemoryPool *mp, CCostContext *pcc) const;
+	static CCost CostCompute(CMemoryPool *mp, CCostContext *pcc);
 
 	// set optimization level of group expression
 	void SetOptimizationLevel();

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobTest.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobTest.h
@@ -71,7 +71,7 @@ private:
 	BOOL FQueue(CSchedulerContext *psc);
 
 	// burn some CPU to simulate actual work
-	void Loop();
+	void Loop() const;
 
 public:
 	// ctor

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
@@ -127,7 +127,7 @@ public:
 	ULONG UlDuplicateGroups();
 
 	// mark groups as duplicates
-	void MarkDuplicates(CGroup *pgroupFst, CGroup *pgroupSnd);
+	static void MarkDuplicates(CGroup *pgroupFst, CGroup *pgroupSnd);
 
 	// return tree map
 	MemoTreeMap *

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CScheduler.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CScheduler.h
@@ -137,7 +137,7 @@ private:
 	void PreExecute(CJob *pj);
 
 	// execute job
-	BOOL FExecute(CJob *pj, CSchedulerContext *psc);
+	static BOOL FExecute(CJob *pj, CSchedulerContext *psc);
 
 	// process job execution outcome
 	EJobResult EjrPostExecute(CJob *pj, BOOL fCompleted);

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -158,7 +158,7 @@ private:
 					   INT type_modifier, BOOL fStoreMapping, ULONG colid);
 
 	// check if we currently support the casting of such column types
-	BOOL FCastingUnknownType(IMDId *pmdidSource, IMDId *mdid_dest);
+	static BOOL FCastingUnknownType(IMDId *pmdidSource, IMDId *mdid_dest);
 
 	// translate a DXL logical get into an expr logical get
 	CExpression *PexprLogicalGet(const CDXLNode *pdxlnLgGet);
@@ -256,17 +256,17 @@ private:
 	CExpression *PexprWindowFunc(const CDXLNode *pdxlnWindowRef);
 
 	// translate the DXL representation of the window stage
-	CScalarWindowFunc::EWinStage Ews(EdxlWinStage edxlws) const;
+	static CScalarWindowFunc::EWinStage Ews(EdxlWinStage edxlws);
 
 	// translate the DXL representation of window frame into its respective representation in the optimizer
 	CWindowFrame *Pwf(const CDXLWindowFrame *window_frame);
 
 	// translate the DXL representation of window frame boundary into its respective representation in the optimizer
-	CWindowFrame::EFrameBoundary Efb(EdxlFrameBoundary frame_boundary) const;
+	static CWindowFrame::EFrameBoundary Efb(EdxlFrameBoundary frame_boundary);
 
 	// translate the DXL representation of window frame exclusion strategy into its respective representation in the optimizer
-	CWindowFrame::EFrameExclusionStrategy Efes(
-		EdxlFrameExclusionStrategy edxlfeb) const;
+	static CWindowFrame::EFrameExclusionStrategy Efes(
+		EdxlFrameExclusionStrategy edxlfeb);
 
 	// translate a DXL scalar array
 	CExpression *PexprArray(const CDXLNode *dxlnode);
@@ -278,7 +278,7 @@ private:
 	CExpression *PexprArrayRefIndexList(const CDXLNode *dxlnode);
 
 	// translate the arrayref index list type
-	CScalarArrayRefIndexList::EIndexListType Eilt(
+	static CScalarArrayRefIndexList::EIndexListType Eilt(
 		const CDXLScalarArrayRefIndexList::EIndexListBound eilb);
 
 	// translate a DXL scalar array compare
@@ -329,9 +329,9 @@ private:
 	CExpression *Pexpr(const CDXLNode *dxlnode);
 
 	// update table descriptor's distribution columns from the MD cache object
-	void AddDistributionColumns(CTableDescriptor *ptabdesc,
-								const IMDRelation *pmdrel,
-								IntToUlongMap *phmiulAttnoColMapping);
+	static void AddDistributionColumns(CTableDescriptor *ptabdesc,
+									   const IMDRelation *pmdrel,
+									   IntToUlongMap *phmiulAttnoColMapping);
 
 	// main translation routine for DXL tree -> Expr tree
 	CExpression *Pexpr(const CDXLNode *dxlnode,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -98,14 +98,14 @@ private:
 	// private copy ctor
 	CTranslatorExprToDXL(const CTranslatorExprToDXL &);
 
-	EdxlBoolExprType Edxlbooltype(
-		const CScalarBoolOp::EBoolOperator eboolop) const;
+	static EdxlBoolExprType Edxlbooltype(
+		const CScalarBoolOp::EBoolOperator eboolop);
 
 	// return the EdxlDmlType for a given DML op type
-	EdxlDmlType Edxldmloptype(const CLogicalDML::EDMLOperator edmlop) const;
+	static EdxlDmlType Edxldmloptype(const CLogicalDML::EDMLOperator edmlop);
 
 	// return outer refs in correlated join inner child
-	CColRefSet *PcrsOuterRefsForCorrelatedNLJoin(CExpression *pexpr) const;
+	static CColRefSet *PcrsOuterRefsForCorrelatedNLJoin(CExpression *pexpr);
 
 	// functions translating different optimizer expressions into their
 	// DXL counterparts
@@ -337,10 +337,9 @@ private:
 										   CTableDescriptor *root_table_desc);
 
 	// Construct a dxl index descriptor for a child partition
-	CDXLIndexDescr *PdxlnIndexDescForPart(CMemoryPool *m_mp,
-										  MdidHashSet *child_index_mdids_set,
-										  const IMDRelation *part,
-										  const CWStringConst *index_name);
+	static CDXLIndexDescr *PdxlnIndexDescForPart(
+		CMemoryPool *m_mp, MdidHashSet *child_index_mdids_set,
+		const IMDRelation *part, const CWStringConst *index_name);
 
 	// translate a dynamic bitmap table scan
 	CDXLNode *PdxlnDynamicBitmapTableScan(
@@ -541,7 +540,7 @@ private:
 	CDXLNode *PdxlnScWindowFuncExpr(CExpression *pexprScFunc);
 
 	// get the DXL representation of the window stage
-	EdxlWinStage Ews(CScalarWindowFunc::EWinStage ews) const;
+	static EdxlWinStage Ews(CScalarWindowFunc::EWinStage ews);
 
 	// translate a scalar aggref
 	CDXLNode *PdxlnScAggref(CExpression *pexprScAggFunc);
@@ -577,7 +576,7 @@ private:
 	CDXLNode *PdxlnArrayRefIndexList(CExpression *pexpr);
 
 	// translate the arrayref index list bound
-	CDXLScalarArrayRefIndexList::EIndexListBound Eilb(
+	static CDXLScalarArrayRefIndexList::EIndexListBound Eilb(
 		const CScalarArrayRefIndexList::EIndexListType eilt);
 
 	// translate an array compare
@@ -671,8 +670,8 @@ private:
 	IntPtrArray *GetOutputSegIdsArray(CExpression *pexprMotion);
 
 	// find the position of the given colref in the array
-	ULONG UlPosInArray(const CColRef *colref,
-					   const CColRefArray *colref_array) const;
+	static ULONG UlPosInArray(const CColRef *colref,
+							  const CColRefArray *colref_array);
 
 	// return hash join type
 	static EdxlJoinType EdxljtHashJoin(CPhysicalHashJoin *popHJ);
@@ -699,8 +698,9 @@ private:
 									  CColRefArray *pdrgpcrOrder);
 
 	// combines the ordered columns and required columns into a single list
-	CColRefArray *PdrgpcrMerge(CMemoryPool *mp, CColRefArray *pdrgpcrOrder,
-							   CColRefArray *pdrgpcrRequired);
+	static CColRefArray *PdrgpcrMerge(CMemoryPool *mp,
+									  CColRefArray *pdrgpcrOrder,
+									  CColRefArray *pdrgpcrRequired);
 
 	// helper to add a project of bool constant
 	CDXLNode *PdxlnProjectBoolConst(CDXLNode *dxlnode, BOOL value);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
@@ -167,7 +167,7 @@ public:
 
 		// get parent loj id
 		INT
-		ParentLojId()
+		ParentLojId() const
 		{
 			return m_parent_loj_id;
 		}
@@ -175,7 +175,7 @@ public:
 		// what is or must be the position of this component with
 		// respect to parent LOJ
 		EPosition
-		Position()
+		Position() const
 		{
 			return m_position;
 		}
@@ -241,10 +241,10 @@ public:
 	IOstream &OsPrint(IOstream &) const;
 
 	// is this a valid join combination
-	BOOL IsValidJoinCombination(SComponent *comp1, SComponent *comp2) const;
+	static BOOL IsValidJoinCombination(SComponent *comp1, SComponent *comp2);
 
 	// are these childs of the same LOJ
-	BOOL IsChildOfSameLOJ(SComponent *comp1, SComponent *comp2) const;
+	static BOOL IsChildOfSameLOJ(SComponent *comp1, SComponent *comp2);
 
 };	// class CJoinOrder
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -155,7 +155,7 @@ private:
 		}
 
 		BOOL
-		Satisfies(ULONG pt)
+		Satisfies(ULONG pt) const
 		{
 			return pt == (m_join_order & pt);
 		}
@@ -165,7 +165,7 @@ private:
 			m_join_order |= p.m_join_order;
 		}
 		BOOL
-		IsGreedy()
+		IsGreedy() const
 		{
 			return 0 != (m_join_order & (EJoinOrderQuery + EJoinOrderMincard +
 										 EJoinOrderGreedyAvoidXProd));
@@ -193,7 +193,7 @@ private:
 					   : (*m_group_info->m_best_expr_info_array)[m_expr_index];
 		}
 		BOOL
-		IsValid()
+		IsValid() const
 		{
 			return nullptr != m_group_info && gpos::ulong_max != m_expr_index;
 		}
@@ -279,19 +279,19 @@ private:
 
 		// cost (use -1 for greedy solutions to ensure we keep all of them)
 		CDouble
-		GetCostForHeap()
+		GetCostForHeap() const
 		{
 			return m_properties.IsGreedy() ? -1.0 : GetCost();
 		}
 
 		CDouble
-		GetCost()
+		GetCost() const
 		{
 			return m_cost + m_cost_adj_PS;
 		}
 
 		void
-		UnionPSProperties(SExpressionInfo *other)
+		UnionPSProperties(SExpressionInfo *other) const
 		{
 			m_contain_PS->Union(other->m_contain_PS);
 		}
@@ -337,12 +337,12 @@ private:
 		}
 
 		BOOL
-		IsAnAtom()
+		IsAnAtom() const
 		{
 			return 1 == m_atoms->Size();
 		}
 		CDouble
-		GetCostForHeap()
+		GetCostForHeap() const
 		{
 			return m_lowest_expr_cost;
 		}
@@ -487,20 +487,20 @@ private:
 								 SExpressionProperties &result_properties);
 
 	// does "prop" provide all the properties of "other_prop" plus maybe more?
-	BOOL IsASupersetOfProperties(SExpressionProperties &prop,
-								 SExpressionProperties &other_prop);
+	static BOOL IsASupersetOfProperties(SExpressionProperties &prop,
+										SExpressionProperties &other_prop);
 
 	// is one of the properties a subset of the other or are they disjoint?
-	BOOL ArePropertiesDisjoint(SExpressionProperties &prop,
-							   SExpressionProperties &other_prop);
+	static BOOL ArePropertiesDisjoint(SExpressionProperties &prop,
+									  SExpressionProperties &other_prop);
 
 	// get best expression in a group for a given set of properties
-	SGroupAndExpression GetBestExprForProperties(SGroupInfo *group_info,
-												 SExpressionProperties &props);
+	static SGroupAndExpression GetBestExprForProperties(
+		SGroupInfo *group_info, SExpressionProperties &props);
 
 	// add a new property to an existing predicate
-	void AddNewPropertyToExpr(SExpressionInfo *expr_info,
-							  SExpressionProperties props);
+	static void AddNewPropertyToExpr(SExpressionInfo *expr_info,
+									 SExpressionProperties props);
 
 	// enumerate bushy joins (joins where both children are also joins) of level "current_level"
 	void SearchBushyJoinOrders(ULONG current_level);
@@ -557,7 +557,7 @@ public:
 	// print function
 	IOstream &OsPrint(IOstream &) const;
 
-	IOstream &OsPrintProperty(IOstream &, SExpressionProperties &) const;
+	static IOstream &OsPrintProperty(IOstream &, SExpressionProperties &);
 
 };	// class CJoinOrderDPv2
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformEagerAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformEagerAgg.h
@@ -80,41 +80,41 @@ public:
 
 private:
 	// check if transform can be applied
-	BOOL CanApplyTransform(CExpression *agg_expr) const;
+	static BOOL CanApplyTransform(CExpression *agg_expr);
 
 	// is this aggregate supported for push down?
-	BOOL CanPushAggBelowJoin(CExpression *scalar_agg_func_expr) const;
+	static BOOL CanPushAggBelowJoin(CExpression *scalar_agg_func_expr);
 
 	// generate project lists for the lower and upper aggregates
 	// from all the original aggregates
-	void PopulateLowerUpperProjectList(
+	static void PopulateLowerUpperProjectList(
 		CMemoryPool *mp,			  // memory pool
 		CExpression *orig_proj_list,  // project list of the original aggregate
 		CExpression *
 			*lower_proj_list,  // output project list of the new lower aggregate
 		CExpression *
 			*upper_proj_list  // output project list of the new upper aggregate
-	) const;
+	);
 
 	// generate project element for lower aggregate for a single original aggregate
-	void PopulateLowerProjectElement(
+	static void PopulateLowerProjectElement(
 		CMemoryPool *mp,  // memory pool
 		IMDId *agg_mdid,  // original global aggregate function
 		CWStringConst *agg_name, CExpressionArray *agg_arg_array,
 		BOOL is_distinct,
 		CExpression **lower_proj_elem_expr	// output project element of the new
 											// lower aggregate
-	) const;
+	);
 
 	// generate project element for upper aggregate
-	void PopulateUpperProjectElement(
+	static void PopulateUpperProjectElement(
 		CMemoryPool *mp,  // memory pool
 		IMDId *agg_mdid,  // aggregate mdid to create
 		CWStringConst *agg_name, CColRef *lower_colref, CColRef *output_colref,
 		BOOL is_distinct,
 		CExpression **upper_proj_elem_expr	// output project element of the new
 											// upper aggregate
-	) const;
+	);
 };	// class CXformEagerAgg
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandFullOuterJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandFullOuterJoin.h
@@ -33,10 +33,10 @@ class CXformExpandFullOuterJoin : public CXformExploration
 private:
 	// construct a join expression of two CTEs using the given CTE ids
 	// and output columns
-	CExpression *PexprLogicalJoinOverCTEs(
+	static CExpression *PexprLogicalJoinOverCTEs(
 		CMemoryPool *mp, EdxlJoinType edxljointype, ULONG ulLeftCTEId,
 		CColRefArray *pdrgpcrLeft, ULONG ulRightCTEId,
-		CColRefArray *pdrgpcrRight, CExpression *pexprScalar) const;
+		CColRefArray *pdrgpcrRight, CExpression *pexprScalar);
 
 public:
 	CXformExpandFullOuterJoin(const CXformExpandFullOuterJoin &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
@@ -113,7 +113,7 @@ public:
 	static GPOS_RESULT Init();
 
 	// destroy global factory instance
-	void Shutdown();
+	static void Shutdown();
 
 };	// class CXformFactory
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformGbAgg2HashAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformGbAgg2HashAgg.h
@@ -32,7 +32,7 @@ class CXformGbAgg2HashAgg : public CXformImplementation
 private:
 protected:
 	// check if the transformation is applicable
-	BOOL FApplicable(CExpression *pexpr) const;
+	static BOOL FApplicable(CExpression *pexpr);
 
 public:
 	CXformGbAgg2HashAgg(const CXformGbAgg2HashAgg &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -24,43 +24,43 @@ class CXformJoin2IndexApply : public CXformExploration
 private:
 	// helper to add IndexApply expression to given xform results container
 	// for homogeneous b-tree indexes
-	void CreateHomogeneousBtreeIndexApplyAlternatives(
+	static void CreateHomogeneousBtreeIndexApplyAlternatives(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 		CExpression *pexprInner, CExpression *pexprScalar,
 		CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet,
 		CTableDescriptor *ptabdescInner, CColRefSet *pcrsScalarExpr,
 		CColRefSet *outer_refs, CColRefSet *pcrsReqd, ULONG ulIndices,
-		CXformResult *pxfres) const;
+		CXformResult *pxfres);
 
 	// helper to add IndexApply expression to given xform results container
 	// for homogeneous b-tree indexes
-	void CreateAlternativesForBtreeIndex(
+	static void CreateAlternativesForBtreeIndex(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 		CExpression *pexprInner, CExpression *origJoinPred,
 		CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet, CMDAccessor *md_accessor,
 		CExpressionArray *pdrgpexprConjuncts, CColRefSet *pcrsScalarExpr,
 		CColRefSet *outer_refs, CColRefSet *pcrsReqd, const IMDRelation *pmdrel,
-		const IMDIndex *pmdindex, CXformResult *pxfres) const;
+		const IMDIndex *pmdindex, CXformResult *pxfres);
 
 	// helper to add IndexApply expression to given xform results container
 	// for homogeneous bitmap indexes
-	void CreateHomogeneousBitmapIndexApplyAlternatives(
+	static void CreateHomogeneousBitmapIndexApplyAlternatives(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 		CExpression *pexprInner, CExpression *pexprScalar,
 		CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet,
 		CTableDescriptor *ptabdescInner, CColRefSet *outer_refs,
-		CColRefSet *pcrsReqd, CXformResult *pxfres) const;
+		CColRefSet *pcrsReqd, CXformResult *pxfres);
 
 	// based on the inner and the scalar expression, it computes scalar expression
 	// columns, outer references and required columns
-	void ComputeColumnSets(CMemoryPool *mp, CExpression *pexprInner,
-						   CExpression *pexprScalar,
-						   CColRefSet **ppcrsScalarExpr,
-						   CColRefSet **ppcrsOuterRefs,
-						   CColRefSet **ppcrsReqd) const;
+	static void ComputeColumnSets(CMemoryPool *mp, CExpression *pexprInner,
+								  CExpression *pexprScalar,
+								  CColRefSet **ppcrsScalarExpr,
+								  CColRefSet **ppcrsOuterRefs,
+								  CColRefSet **ppcrsReqd);
 
 protected:
 	// is the logical join that is being transformed an outer join?

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyGeneric.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyGeneric.h
@@ -27,10 +27,11 @@ private:
 	BOOL m_generateBitmapPlans;
 
 	// Can we transform left outer join to left outer index apply?
-	BOOL FCanLeftOuterIndexApply(CMemoryPool *mp, CExpression *pexprInner,
-								 CExpression *pexprScalar,
-								 CTableDescriptor *ptabDesc,
-								 const CColRefSet *pcrsDist) const;
+	static BOOL FCanLeftOuterIndexApply(CMemoryPool *mp,
+										CExpression *pexprInner,
+										CExpression *pexprScalar,
+										CTableDescriptor *ptabDesc,
+										const CColRefSet *pcrsDist);
 
 public:
 	CXformJoin2IndexApplyGeneric(const CXformJoin2IndexApplyGeneric &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoinAssociativity.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoinAssociativity.h
@@ -31,9 +31,9 @@ class CXformJoinAssociativity : public CXformExploration
 {
 private:
 	// helper function for creating the new join predicate
-	void CreatePredicates(CMemoryPool *mp, CExpression *pexpr,
-						  CExpressionArray *pdrgpexprLower,
-						  CExpressionArray *pdrgpexprUpper) const;
+	static void CreatePredicates(CMemoryPool *mp, CExpression *pexpr,
+								 CExpressionArray *pdrgpexprLower,
+								 CExpressionArray *pdrgpexprUpper);
 
 public:
 	CXformJoinAssociativity(const CXformJoinAssociativity &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin.h
@@ -52,8 +52,8 @@ private:
 	static const DOUBLE m_dOuterInnerRatioThreshold;
 
 	// check the stats ratio to decide whether to apply the xform or not
-	BOOL FApplyXformUsingStatsInfo(const IStatistics *outer_stats,
-								   const IStatistics *inner_side_stats) const;
+	static BOOL FApplyXformUsingStatsInfo(const IStatistics *outer_stats,
+										  const IStatistics *inner_side_stats);
 
 	// check if the inner expression is of a type which should be considered by this xform
 	static BOOL FValidInnerExpr(CExpression *pexprInner);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSplitLimit.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSplitLimit.h
@@ -31,7 +31,7 @@ class CXformSplitLimit : public CXformExploration
 {
 private:
 	// helper function for creating a limit expression
-	CExpression *PexprLimit(
+	static CExpression *PexprLimit(
 		CMemoryPool *mp,				// memory pool
 		CExpression *pexprRelational,	// relational child
 		CExpression *pexprScalarStart,	// limit offset
@@ -39,7 +39,7 @@ private:
 		COrderSpec *pos,				// ordering specification
 		BOOL fGlobal,					// is it a local or global limit
 		BOOL fHasCount,					// does limit specify a number of rows
-		BOOL fTopLimitUnderDML) const;
+		BOOL fTopLimitUnderDML);
 
 public:
 	CXformSplitLimit(const CXformSplitLimit &) = delete;

--- a/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
@@ -857,10 +857,8 @@ CConstraint::PdrgpcnstrDeduplicate(CMemoryPool *mp,
 //---------------------------------------------------------------------------
 ColRefToConstraintArrayMap *
 CConstraint::Phmcolconstr(CMemoryPool *mp, CColRefSet *pcrs,
-						  CConstraintArray *pdrgpcnstr) const
+						  CConstraintArray *pdrgpcnstr)
 {
-	GPOS_ASSERT(nullptr != m_pcrsUsed);
-
 	ColRefToConstraintArrayMap *phmcolconstr =
 		GPOS_NEW(mp) ColRefToConstraintArrayMap(mp);
 

--- a/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
@@ -508,7 +508,7 @@ CCostContext::FBetterThan(const CCostContext *pcc) const
 }
 
 BOOL
-CCostContext::IsTwoStageScalarDQACostCtxt(const CCostContext *pcc) const
+CCostContext::IsTwoStageScalarDQACostCtxt(const CCostContext *pcc)
 {
 	if (CUtils::FPhysicalAgg(pcc->Pgexpr()->Pop()))
 	{
@@ -523,7 +523,7 @@ CCostContext::IsTwoStageScalarDQACostCtxt(const CCostContext *pcc) const
 }
 
 BOOL
-CCostContext::IsThreeStageScalarDQACostCtxt(const CCostContext *pcc) const
+CCostContext::IsThreeStageScalarDQACostCtxt(const CCostContext *pcc)
 {
 	if (CUtils::FPhysicalAgg(pcc->Pgexpr()->Pop()))
 	{

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -965,7 +965,7 @@ CDistributionSpecHashed::Combine(CMemoryPool *mp,
 
 // check if the equivalent spec (if any) has no matching columns with the main spec
 BOOL
-CDistributionSpecHashed::HasCompleteEquivSpec(CMemoryPool *mp)
+CDistributionSpecHashed::HasCompleteEquivSpec(CMemoryPool *mp) const
 {
 	CDistributionSpecHashed *pdshashedEquiv = this->PdshashedEquiv();
 

--- a/src/backend/gporca/libgpopt/src/base/CPartInfo.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartInfo.cpp
@@ -114,7 +114,7 @@ CPartInfo::CPartInfoEntry::OsPrint(IOstream &os) const
 //
 //---------------------------------------------------------------------------
 CPartInfo::CPartInfoEntry *
-CPartInfo::CPartInfoEntry::PpartinfoentryCopy(CMemoryPool *mp)
+CPartInfo::CPartInfoEntry::PpartinfoentryCopy(CMemoryPool *mp) const
 {
 	IMDId *mdid = MDId();
 	mdid->AddRef();

--- a/src/backend/gporca/libgpopt/src/base/CRange.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CRange.cpp
@@ -707,7 +707,7 @@ CRange::OsPrint(IOstream &os) const
 //
 //---------------------------------------------------------------------------
 IOstream &
-CRange::OsPrintBound(IOstream &os, IDatum *datum, const CHAR *szInfinity) const
+CRange::OsPrintBound(IOstream &os, IDatum *datum, const CHAR *szInfinity)
 {
 	if (nullptr == datum)
 	{

--- a/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
@@ -381,7 +381,7 @@ CEngine::InsertXformResult(
 		if (pgroupContainer != pgroupOrigin &&
 			FPossibleDuplicateGroups(pgroupContainer, pgroupOrigin))
 		{
-			m_pmemo->MarkDuplicates(pgroupOrigin, pgroupContainer);
+			gpopt::CMemo::MarkDuplicates(pgroupOrigin, pgroupContainer);
 		}
 
 		pexpr = pxfres->PexprNext();
@@ -1281,9 +1281,6 @@ CEngine::Implement()
 void
 CEngine::RecursiveOptimize()
 {
-	COptimizerConfig *optimizer_config =
-		COptCtxt::PoctxtFromTLS()->GetOptimizerConfig();
-
 	CAutoTimer at("\n[OPT]: Total Optimization Time",
 				  GPOS_FTRACE(EopttracePrintOptimizationStatistics));
 
@@ -1332,7 +1329,7 @@ CEngine::RecursiveOptimize()
 					  << m_search_stage_array->Size();
 	}
 
-	if (optimizer_config->GetEnumeratorCfg()->FSample())
+	if (CEnumeratorConfig::FSample())
 	{
 		SamplePlans();
 	}
@@ -1421,7 +1418,8 @@ CEngine::PdrgpocChildren(CMemoryPool *mp, CExpressionHandle &exprhdl)
 //
 //---------------------------------------------------------------------------
 void
-CEngine::ScheduleMainJob(CSchedulerContext *psc, COptimizationContext *poc)
+CEngine::ScheduleMainJob(CSchedulerContext *psc,
+						 COptimizationContext *poc) const
 {
 	GPOS_ASSERT(nullptr != PgroupRoot());
 
@@ -1671,9 +1669,6 @@ CEngine::ProcessTraceFlags()
 void
 CEngine::Optimize()
 {
-	COptimizerConfig *optimizer_config =
-		COptCtxt::PoctxtFromTLS()->GetOptimizerConfig();
-
 	CAutoTimer at("\n[OPT]: Total Optimization Time",
 				  GPOS_FTRACE(EopttracePrintOptimizationStatistics));
 
@@ -1731,7 +1726,7 @@ CEngine::Optimize()
 	}
 
 
-	if (optimizer_config->GetEnumeratorCfg()->FSample())
+	if (CEnumeratorConfig::FSample())
 	{
 		SamplePlans();
 	}
@@ -1793,7 +1788,7 @@ CEngine::PexprExtractPlan()
 	COptimizerConfig *optimizer_config =
 		COptCtxt::PoctxtFromTLS()->GetOptimizerConfig();
 	CEnumeratorConfig *pec = optimizer_config->GetEnumeratorCfg();
-	if (pec->FEnumerate())
+	if (gpopt::CEnumeratorConfig::FEnumerate())
 	{
 		CAutoTrace at(m_mp);
 		ULLONG ullCount = Pmemotmap()->UllCount();

--- a/src/backend/gporca/libgpopt/src/init.cpp
+++ b/src/backend/gporca/libgpopt/src/init.cpp
@@ -74,7 +74,7 @@ gpopt_terminate()
 
 	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
 
-	CXformFactory::Pxff()->Shutdown();
+	CXformFactory::Shutdown();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -104,7 +104,7 @@ CMDAccessor::SMDAccessorElem::~SMDAccessorElem()
 //
 //---------------------------------------------------------------------------
 IMDId *
-CMDAccessor::SMDAccessorElem::MDId()
+CMDAccessor::SMDAccessorElem::MDId() const
 {
 	return m_mdid;
 }

--- a/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
@@ -162,7 +162,7 @@ CPartConstraint::PcnstrBuildCombined(CMemoryPool *mp)
 //
 //---------------------------------------------------------------------------
 BOOL
-CPartConstraint::FAllDefaultPartsIncluded()
+CPartConstraint::FAllDefaultPartsIncluded() const
 {
 	for (ULONG ul = 0; ul < m_num_of_part_levels; ul++)
 	{

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -113,7 +113,7 @@ CTableDescriptor::ColumnCount() const
 //---------------------------------------------------------------------------
 ULONG
 CTableDescriptor::UlPos(const CColumnDescriptor *pcoldesc,
-						const CColumnDescriptorArray *pdrgpcoldesc) const
+						const CColumnDescriptorArray *pdrgpcoldesc)
 {
 	GPOS_ASSERT(nullptr != pcoldesc);
 	GPOS_ASSERT(nullptr != pdrgpcoldesc);

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -616,7 +616,7 @@ CExpressionHandle::DeriveCostContextStats()
 void
 CExpressionHandle::DeriveStats(CMemoryPool *pmpLocal, CMemoryPool *pmpGlobal,
 							   CReqdPropRelational *prprel,
-							   IStatisticsArray *stats_ctxt)
+							   IStatisticsArray *stats_ctxt) const
 {
 	CReqdPropRelational *prprelNew = prprel;
 	if (nullptr == prprelNew)
@@ -1298,7 +1298,8 @@ CExpressionHandle::PopGrandchild(ULONG child_index, ULONG grandchild_index,
 //
 //---------------------------------------------------------------------------
 void
-CExpressionHandle::DeriveProducerStats(ULONG child_index, CColRefSet *pcrsStats)
+CExpressionHandle::DeriveProducerStats(ULONG child_index,
+									   CColRefSet *pcrsStats) const
 {
 	// check to see if there are any CTE consumers in the group whose properties have
 	// to be pushed to its corresponding CTE producer
@@ -1455,7 +1456,7 @@ CExpressionHandle::PexprScalarExact() const
 //
 //---------------------------------------------------------------------------
 CFunctionProp *
-CExpressionHandle::PfpChild(ULONG child_index)
+CExpressionHandle::PfpChild(ULONG child_index) const
 {
 	if (FScalarChild(child_index))
 	{
@@ -1474,7 +1475,7 @@ CExpressionHandle::PfpChild(ULONG child_index)
 //
 //---------------------------------------------------------------------------
 BOOL
-CExpressionHandle::FChildrenHaveVolatileFuncScan()
+CExpressionHandle::FChildrenHaveVolatileFuncScan() const
 {
 	const ULONG arity = Arity();
 	for (ULONG ul = 0; ul < arity; ul++)
@@ -1653,7 +1654,7 @@ CExpressionHandle::FNextChildIndex(ULONG *pulChildIndex) const
 //
 //---------------------------------------------------------------------------
 CColRefSet *
-CExpressionHandle::PcrsUsedColumns(CMemoryPool *mp)
+CExpressionHandle::PcrsUsedColumns(CMemoryPool *mp) const
 {
 	COperator *pop = Pop();
 	GPOS_ASSERT(pop->FLogical());
@@ -1705,7 +1706,7 @@ CExpressionHandle::Pstats()
 // If there is only a group expression or a cost context assoicated with the handle,
 // all properties must have already been derived as we can't derive anything.
 CColRefSet *
-CExpressionHandle::DeriveOuterReferences(ULONG child_index)
+CExpressionHandle::DeriveOuterReferences(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1716,7 +1717,7 @@ CExpressionHandle::DeriveOuterReferences(ULONG child_index)
 }
 
 CColRefSet *
-CExpressionHandle::DeriveOuterReferences()
+CExpressionHandle::DeriveOuterReferences() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1727,7 +1728,7 @@ CExpressionHandle::DeriveOuterReferences()
 }
 
 CColRefSet *
-CExpressionHandle::DeriveOutputColumns(ULONG child_index)
+CExpressionHandle::DeriveOutputColumns(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1738,7 +1739,7 @@ CExpressionHandle::DeriveOutputColumns(ULONG child_index)
 }
 
 CColRefSet *
-CExpressionHandle::DeriveOutputColumns()
+CExpressionHandle::DeriveOutputColumns() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1749,7 +1750,7 @@ CExpressionHandle::DeriveOutputColumns()
 }
 
 CColRefSet *
-CExpressionHandle::DeriveNotNullColumns(ULONG child_index)
+CExpressionHandle::DeriveNotNullColumns(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1760,7 +1761,7 @@ CExpressionHandle::DeriveNotNullColumns(ULONG child_index)
 }
 
 CColRefSet *
-CExpressionHandle::DeriveNotNullColumns()
+CExpressionHandle::DeriveNotNullColumns() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1771,7 +1772,7 @@ CExpressionHandle::DeriveNotNullColumns()
 }
 
 CMaxCard
-CExpressionHandle::DeriveMaxCard(ULONG child_index)
+CExpressionHandle::DeriveMaxCard(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1782,7 +1783,7 @@ CExpressionHandle::DeriveMaxCard(ULONG child_index)
 }
 
 CMaxCard
-CExpressionHandle::DeriveMaxCard()
+CExpressionHandle::DeriveMaxCard() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1793,7 +1794,7 @@ CExpressionHandle::DeriveMaxCard()
 }
 
 CColRefSet *
-CExpressionHandle::DeriveCorrelatedApplyColumns(ULONG child_index)
+CExpressionHandle::DeriveCorrelatedApplyColumns(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1804,7 +1805,7 @@ CExpressionHandle::DeriveCorrelatedApplyColumns(ULONG child_index)
 }
 
 CColRefSet *
-CExpressionHandle::DeriveCorrelatedApplyColumns()
+CExpressionHandle::DeriveCorrelatedApplyColumns() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1815,7 +1816,7 @@ CExpressionHandle::DeriveCorrelatedApplyColumns()
 }
 
 CKeyCollection *
-CExpressionHandle::DeriveKeyCollection(ULONG child_index)
+CExpressionHandle::DeriveKeyCollection(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1826,7 +1827,7 @@ CExpressionHandle::DeriveKeyCollection(ULONG child_index)
 }
 
 CKeyCollection *
-CExpressionHandle::DeriveKeyCollection()
+CExpressionHandle::DeriveKeyCollection() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1837,7 +1838,7 @@ CExpressionHandle::DeriveKeyCollection()
 }
 
 CPropConstraint *
-CExpressionHandle::DerivePropertyConstraint(ULONG child_index)
+CExpressionHandle::DerivePropertyConstraint(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1848,7 +1849,7 @@ CExpressionHandle::DerivePropertyConstraint(ULONG child_index)
 }
 
 CPropConstraint *
-CExpressionHandle::DerivePropertyConstraint()
+CExpressionHandle::DerivePropertyConstraint() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1859,7 +1860,7 @@ CExpressionHandle::DerivePropertyConstraint()
 }
 
 ULONG
-CExpressionHandle::DeriveJoinDepth(ULONG child_index)
+CExpressionHandle::DeriveJoinDepth(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1870,7 +1871,7 @@ CExpressionHandle::DeriveJoinDepth(ULONG child_index)
 }
 
 ULONG
-CExpressionHandle::DeriveJoinDepth()
+CExpressionHandle::DeriveJoinDepth() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1881,7 +1882,7 @@ CExpressionHandle::DeriveJoinDepth()
 }
 
 CFunctionProp *
-CExpressionHandle::DeriveFunctionProperties(ULONG child_index)
+CExpressionHandle::DeriveFunctionProperties(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1892,7 +1893,7 @@ CExpressionHandle::DeriveFunctionProperties(ULONG child_index)
 }
 
 CFunctionProp *
-CExpressionHandle::DeriveFunctionProperties()
+CExpressionHandle::DeriveFunctionProperties() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1903,7 +1904,7 @@ CExpressionHandle::DeriveFunctionProperties()
 }
 
 CFunctionalDependencyArray *
-CExpressionHandle::Pdrgpfd(ULONG child_index)
+CExpressionHandle::Pdrgpfd(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1914,7 +1915,7 @@ CExpressionHandle::Pdrgpfd(ULONG child_index)
 }
 
 CFunctionalDependencyArray *
-CExpressionHandle::Pdrgpfd()
+CExpressionHandle::Pdrgpfd() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1925,7 +1926,7 @@ CExpressionHandle::Pdrgpfd()
 }
 
 CPartInfo *
-CExpressionHandle::DerivePartitionInfo(ULONG child_index)
+CExpressionHandle::DerivePartitionInfo(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1936,7 +1937,7 @@ CExpressionHandle::DerivePartitionInfo(ULONG child_index)
 }
 
 CPartInfo *
-CExpressionHandle::DerivePartitionInfo()
+CExpressionHandle::DerivePartitionInfo() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1947,7 +1948,7 @@ CExpressionHandle::DerivePartitionInfo()
 }
 
 CTableDescriptor *
-CExpressionHandle::DeriveTableDescriptor()
+CExpressionHandle::DeriveTableDescriptor() const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1958,7 +1959,7 @@ CExpressionHandle::DeriveTableDescriptor()
 }
 
 CTableDescriptor *
-CExpressionHandle::DeriveTableDescriptor(ULONG child_index)
+CExpressionHandle::DeriveTableDescriptor(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1970,7 +1971,7 @@ CExpressionHandle::DeriveTableDescriptor(ULONG child_index)
 // Scalar property accessors
 
 CColRefSet *
-CExpressionHandle::DeriveDefinedColumns(ULONG child_index)
+CExpressionHandle::DeriveDefinedColumns(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1981,7 +1982,7 @@ CExpressionHandle::DeriveDefinedColumns(ULONG child_index)
 }
 
 CColRefSet *
-CExpressionHandle::DeriveUsedColumns(ULONG child_index)
+CExpressionHandle::DeriveUsedColumns(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -1992,7 +1993,7 @@ CExpressionHandle::DeriveUsedColumns(ULONG child_index)
 }
 
 CColRefSet *
-CExpressionHandle::DeriveSetReturningFunctionColumns(ULONG child_index)
+CExpressionHandle::DeriveSetReturningFunctionColumns(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2003,7 +2004,7 @@ CExpressionHandle::DeriveSetReturningFunctionColumns(ULONG child_index)
 }
 
 BOOL
-CExpressionHandle::DeriveHasSubquery(ULONG child_index)
+CExpressionHandle::DeriveHasSubquery(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2014,7 +2015,7 @@ CExpressionHandle::DeriveHasSubquery(ULONG child_index)
 }
 
 CPartInfo *
-CExpressionHandle::DeriveScalarPartitionInfo(ULONG child_index)
+CExpressionHandle::DeriveScalarPartitionInfo(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2025,7 +2026,7 @@ CExpressionHandle::DeriveScalarPartitionInfo(ULONG child_index)
 }
 
 CFunctionProp *
-CExpressionHandle::DeriveScalarFunctionProperties(ULONG child_index)
+CExpressionHandle::DeriveScalarFunctionProperties(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2036,7 +2037,7 @@ CExpressionHandle::DeriveScalarFunctionProperties(ULONG child_index)
 }
 
 BOOL
-CExpressionHandle::DeriveHasNonScalarFunction(ULONG child_index)
+CExpressionHandle::DeriveHasNonScalarFunction(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2047,7 +2048,7 @@ CExpressionHandle::DeriveHasNonScalarFunction(ULONG child_index)
 }
 
 ULONG
-CExpressionHandle::DeriveTotalDistinctAggs(ULONG child_index)
+CExpressionHandle::DeriveTotalDistinctAggs(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2058,7 +2059,7 @@ CExpressionHandle::DeriveTotalDistinctAggs(ULONG child_index)
 }
 
 BOOL
-CExpressionHandle::DeriveHasMultipleDistinctAggs(ULONG child_index)
+CExpressionHandle::DeriveHasMultipleDistinctAggs(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{
@@ -2069,7 +2070,7 @@ CExpressionHandle::DeriveHasMultipleDistinctAggs(ULONG child_index)
 }
 
 BOOL
-CExpressionHandle::DeriveHasScalarArrayCmp(ULONG child_index)
+CExpressionHandle::DeriveHasScalarArrayCmp(ULONG child_index) const
 {
 	if (nullptr != Pexpr())
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -83,7 +83,7 @@ CLogical::~CLogical()
 CColRefArray *
 CLogical::PdrgpcrCreateMapping(CMemoryPool *mp,
 							   const CColumnDescriptorArray *pdrgpcoldesc,
-							   ULONG ulOpSourceId, IMDId *mdid_table) const
+							   ULONG ulOpSourceId, IMDId *mdid_table)
 {
 	// get column factory from optimizer context object
 	CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalConstTableGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalConstTableGet.cpp
@@ -272,7 +272,7 @@ CLogicalConstTableGet::PxfsCandidates(CMemoryPool *mp) const
 //---------------------------------------------------------------------------
 CColumnDescriptorArray *
 CLogicalConstTableGet::PdrgpcoldescMapping(CMemoryPool *mp,
-										   CColRefArray *colref_array) const
+										   CColRefArray *colref_array)
 {
 	GPOS_ASSERT(nullptr != colref_array);
 	CColumnDescriptorArray *pdrgpcoldesc =

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalRowTrigger.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalRowTrigger.cpp
@@ -133,7 +133,7 @@ CLogicalRowTrigger::InitFunctionProperties()
 //
 //---------------------------------------------------------------------------
 INT
-CLogicalRowTrigger::ITriggerType(const IMDTrigger *pmdtrigger) const
+CLogicalRowTrigger::ITriggerType(const IMDTrigger *pmdtrigger)
 {
 	INT type = GPMD_TRIGGER_ROW;
 	if (pmdtrigger->IsBefore())

--- a/src/backend/gporca/libgpopt/src/operators/CPhysical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysical.cpp
@@ -274,8 +274,8 @@ CPhysical::PdsCompute(CMemoryPool *mp, const CTableDescriptor *ptabdesc,
 			for (ULONG ul = 0; ul < size; ul++)
 			{
 				CColumnDescriptor *pcoldesc = (*pdrgpcoldesc)[ul];
-				ULONG ulPos =
-					ptabdesc->UlPos(pcoldesc, ptabdesc->Pdrgpcoldesc());
+				ULONG ulPos = gpopt::CTableDescriptor::UlPos(
+					pcoldesc, ptabdesc->Pdrgpcoldesc());
 
 				GPOS_ASSERT(ulPos < ptabdesc->Pdrgpcoldesc()->Size() &&
 							"Column not found");

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -536,13 +536,8 @@ CPhysicalHashJoin::PdshashedPassThru(CMemoryPool *mp,
 									 CDistributionSpecHashed *pdshashedInput,
 									 ULONG,				// child_index
 									 CDrvdPropArray *,	// pdrgpdpCtxt
-									 ULONG
-#ifdef GPOS_DEBUG
-										 ulOptReq
-#endif	// GPOS_DEBUG
-) const
+									 ULONG ulOptReq GPOS_UNUSED)
 {
-	GPOS_ASSERT(ulOptReq == m_pdrgpdsRedistributeRequests->Size());
 	GPOS_ASSERT(nullptr != pdshashedInput);
 
 	if (!GPOS_FTRACE(EopttraceEnableRedistributeBroadcastHashJoin))

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -763,7 +763,7 @@ CPhysicalJoin::PrsRequiredCorrelatedJoin(CMemoryPool *mp,
 										 ULONG child_index,
 										 CDrvdPropArray *pdrgpdpCtxt,
 										 ULONG	// ulOptReq
-) const
+)
 {
 	GPOS_ASSERT(3 == exprhdl.Arity());
 	GPOS_ASSERT(2 > child_index);

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalStreamAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalStreamAgg.cpp
@@ -105,7 +105,7 @@ CPhysicalStreamAgg::~CPhysicalStreamAgg()
 //---------------------------------------------------------------------------
 COrderSpec *
 CPhysicalStreamAgg::PosCovering(CMemoryPool *mp, COrderSpec *posRequired,
-								CColRefArray *pdrgpcrGrp) const
+								CColRefArray *pdrgpcrGrp)
 {
 	GPOS_ASSERT(nullptr != posRequired);
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalUnionAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalUnionAll.cpp
@@ -448,7 +448,7 @@ CPhysicalUnionAll::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 // inserting into t1_x. So, derive CDistributionSpecStrictRandom
 CDistributionSpecRandom *
 CPhysicalUnionAll::PdsStrictRandomParallelUnionAllChildren(
-	CMemoryPool *mp, CExpressionHandle &expr_handle) const
+	CMemoryPool *mp, CExpressionHandle &expr_handle)
 {
 	if (COperator::EopPhysicalParallelUnionAll == expr_handle.Pop()->Eopid())
 	{
@@ -686,7 +686,7 @@ CPhysicalUnionAll::PdsDeriveFromChildren(CMemoryPool *
 											 mp
 #endif	// GPOS_DEBUG
 										 ,
-										 CExpressionHandle &exprhdl) const
+										 CExpressionHandle &exprhdl)
 {
 	const ULONG arity = exprhdl.Arity();
 

--- a/src/backend/gporca/libgpopt/src/search/CBinding.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CBinding.cpp
@@ -28,7 +28,7 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CGroupExpression *
-CBinding::PgexprNext(CGroup *pgroup, CGroupExpression *pgexpr) const
+CBinding::PgexprNext(CGroup *pgroup, CGroupExpression *pgexpr)
 {
 	CGroupProxy gp(pgroup);
 

--- a/src/backend/gporca/libgpopt/src/search/CGroup.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroup.cpp
@@ -1364,7 +1364,7 @@ BOOL
 CGroup::FBetterPromise(CMemoryPool *mp, CLogical::EStatPromise espFst,
 					   CGroupExpression *pgexprFst,
 					   CLogical::EStatPromise espSnd,
-					   CGroupExpression *pgexprSnd) const
+					   CGroupExpression *pgexprSnd)
 {
 	// if there is a tie and both group expressions are inner join, we prioritize
 	// the inner join having less predicates

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -557,7 +557,7 @@ CGroupExpression::ResetState()
 //
 //---------------------------------------------------------------------------
 CCost
-CGroupExpression::CostCompute(CMemoryPool *mp, CCostContext *pcc) const
+CGroupExpression::CostCompute(CMemoryPool *mp, CCostContext *pcc)
 {
 	GPOS_ASSERT(nullptr != pcc);
 
@@ -740,7 +740,7 @@ CGroupExpression::PreprocessTransform(CMemoryPool *pmpLocal,
 void
 CGroupExpression::PostprocessTransform(CMemoryPool *,  // pmpLocal
 									   CMemoryPool *,  // pmpGlobal
-									   CXform *pxform)
+									   CXform *pxform) const
 {
 	if (CXformUtils::FDeriveStatsBeforeXform(pxform))
 	{
@@ -1195,7 +1195,7 @@ CGroupExpression::OsPrintWithPrefix(IOstream &os, const CHAR *szPrefix) const
 //
 //---------------------------------------------------------------------------
 void
-CGroupExpression::DbgPrintWithProperties()
+CGroupExpression::DbgPrintWithProperties() const
 {
 	CAutoTraceFlag atf(EopttracePrintGroupProperties, true);
 	CAutoTrace at(CTask::Self()->Pmp());

--- a/src/backend/gporca/libgpopt/src/search/CJobTest.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobTest.cpp
@@ -235,7 +235,7 @@ CJobTest::FQueue(CSchedulerContext *psc)
 //
 //---------------------------------------------------------------------------
 void
-CJobTest::Loop()
+CJobTest::Loop() const
 {
 	ULONG ulOuter = 0;
 	while (ulOuter < m_ulIters)

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -1834,7 +1834,7 @@ CTranslatorDXLToExpr::Pwf(const CDXLWindowFrame *window_frame)
 //
 //---------------------------------------------------------------------------
 CWindowFrame::EFrameBoundary
-CTranslatorDXLToExpr::Efb(EdxlFrameBoundary frame_boundary) const
+CTranslatorDXLToExpr::Efb(EdxlFrameBoundary frame_boundary)
 {
 	ULONG window_frame_boundary_to_frame_boundary_mapping[][2] = {
 		{EdxlfbUnboundedPreceding, CWindowFrame::EfbUnboundedPreceding},
@@ -1869,7 +1869,7 @@ CTranslatorDXLToExpr::Efb(EdxlFrameBoundary frame_boundary) const
 //
 //---------------------------------------------------------------------------
 CWindowFrame::EFrameExclusionStrategy
-CTranslatorDXLToExpr::Efes(EdxlFrameExclusionStrategy edxlfeb) const
+CTranslatorDXLToExpr::Efes(EdxlFrameExclusionStrategy edxlfeb)
 {
 	ULONG window_frame_boundary_to_frame_boundary_mapping[][2] = {
 		{EdxlfesNone, CWindowFrame::EfesNone},
@@ -2952,7 +2952,7 @@ CTranslatorDXLToExpr::PexprWindowFunc(const CDXLNode *pdxlnWindowRef)
 //
 //---------------------------------------------------------------------------
 CScalarWindowFunc::EWinStage
-CTranslatorDXLToExpr::Ews(EdxlWinStage edxlws) const
+CTranslatorDXLToExpr::Ews(EdxlWinStage edxlws)
 {
 	ULONG window_frame_boundary_to_frame_boundary_mapping[][2] = {
 		{EdxlwinstageImmediate, CScalarWindowFunc::EwsImmediate},

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3661,7 +3661,7 @@ CTranslatorExprToDXL::BuildScalarSubplans(
 //
 //---------------------------------------------------------------------------
 CColRefSet *
-CTranslatorExprToDXL::PcrsOuterRefsForCorrelatedNLJoin(CExpression *pexpr) const
+CTranslatorExprToDXL::PcrsOuterRefsForCorrelatedNLJoin(CExpression *pexpr)
 {
 	GPOS_ASSERT(CUtils::FCorrelatedNLJoin(pexpr->Pop()));
 
@@ -5903,7 +5903,8 @@ CTranslatorExprToDXL::GetDXLDirectDispatchInfo(CExpression *pexprDML)
 
 	GPOS_ASSERT(1 == pdrgpcoldescDist->Size());
 	CColumnDescriptor *pcoldesc = (*pdrgpcoldescDist)[0];
-	ULONG ulPos = ptabdesc->UlPos(pcoldesc, ptabdesc->Pdrgpcoldesc());
+	ULONG ulPos =
+		gpopt::CTableDescriptor::UlPos(pcoldesc, ptabdesc->Pdrgpcoldesc());
 	GPOS_ASSERT(ulPos < ptabdesc->Pdrgpcoldesc()->Size() && "Column not found");
 
 	CColRef *pcrDistrCol = (*popDML->PdrgpcrSource())[ulPos];
@@ -6130,8 +6131,7 @@ CTranslatorExprToDXL::PdxlnRowTrigger(CExpression *pexpr,
 //
 //---------------------------------------------------------------------------
 EdxlDmlType
-CTranslatorExprToDXL::Edxldmloptype(
-	const CLogicalDML::EDMLOperator edmlop) const
+CTranslatorExprToDXL::Edxldmloptype(const CLogicalDML::EDMLOperator edmlop)
 {
 	switch (edmlop)
 	{
@@ -6336,8 +6336,7 @@ CTranslatorExprToDXL::PdxlnScBoolExpr(CExpression *pexprScBoolOp)
 //
 //---------------------------------------------------------------------------
 EdxlBoolExprType
-CTranslatorExprToDXL::Edxlbooltype(
-	const CScalarBoolOp::EBoolOperator eboolop) const
+CTranslatorExprToDXL::Edxlbooltype(const CScalarBoolOp::EBoolOperator eboolop)
 {
 	switch (eboolop)
 	{
@@ -6457,7 +6456,7 @@ CTranslatorExprToDXL::PdxlnScWindowFuncExpr(CExpression *pexprWindowFunc)
 //
 //---------------------------------------------------------------------------
 EdxlWinStage
-CTranslatorExprToDXL::Ews(CScalarWindowFunc::EWinStage ews) const
+CTranslatorExprToDXL::Ews(CScalarWindowFunc::EWinStage ews)
 {
 	ULONG window_frame_boundary_to_frame_boundary_mapping[][2] = {
 		{EdxlwinstageImmediate, CScalarWindowFunc::EwsImmediate},
@@ -8338,7 +8337,7 @@ CTranslatorExprToDXL::GetInputSegIdsArray(CExpression *pexprMotion)
 //---------------------------------------------------------------------------
 ULONG
 CTranslatorExprToDXL::UlPosInArray(const CColRef *colref,
-								   const CColRefArray *colref_array) const
+								   const CColRefArray *colref_array)
 {
 	GPOS_ASSERT(nullptr != colref_array);
 	GPOS_ASSERT(nullptr != colref);

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
@@ -628,7 +628,7 @@ CJoinOrder::OsPrint(IOstream &os) const
 }
 
 BOOL
-CJoinOrder::IsValidJoinCombination(SComponent *comp1, SComponent *comp2) const
+CJoinOrder::IsValidJoinCombination(SComponent *comp1, SComponent *comp2)
 {
 	INT comp1_parent_loj_id = comp1->ParentLojId();
 	INT comp2_parent_loj_id = comp2->ParentLojId();
@@ -689,7 +689,7 @@ CJoinOrder::IsValidJoinCombination(SComponent *comp1, SComponent *comp2) const
 }
 
 BOOL
-CJoinOrder::IsChildOfSameLOJ(SComponent *comp1, SComponent *comp2) const
+CJoinOrder::IsChildOfSameLOJ(SComponent *comp1, SComponent *comp2)
 {
 	// check if these components are inner and outer children of a same join
 	BOOL child_of_same_loj = comp1->ParentLojId() == comp2->ParentLojId() &&

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1922,8 +1922,7 @@ CJoinOrderDPv2::OsPrint(IOstream &os) const
 
 
 IOstream &
-CJoinOrderDPv2::OsPrintProperty(IOstream &os,
-								SExpressionProperties &props) const
+CJoinOrderDPv2::OsPrintProperty(IOstream &os, SExpressionProperties &props)
 {
 	os << "{ ";
 	if (0 == props.m_join_order)

--- a/src/backend/gporca/libgpopt/src/xforms/CXformEagerAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformEagerAgg.cpp
@@ -158,7 +158,7 @@ CXformEagerAgg::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 // Only following aggregates are supported:
 // 	min, max, sum, count, avg
 BOOL
-CXformEagerAgg::CanPushAggBelowJoin(CExpression *scalar_agg_func_expr) const
+CXformEagerAgg::CanPushAggBelowJoin(CExpression *scalar_agg_func_expr)
 {
 	CScalarAggFunc *scalar_agg_func =
 		CScalarAggFunc::PopConvert(scalar_agg_func_expr->Pop());
@@ -208,7 +208,7 @@ CXformEagerAgg::CanPushAggBelowJoin(CExpression *scalar_agg_func_expr) const
 //		- Single expression input in the agg
 //		- Input expression only part of outer child
 BOOL
-CXformEagerAgg::CanApplyTransform(CExpression *gb_agg_expr) const
+CXformEagerAgg::CanApplyTransform(CExpression *gb_agg_expr)
 {
 	CExpression *join_expr = (*gb_agg_expr)[0];
 	CExpression *agg_proj_list_expr = (*gb_agg_expr)[1];
@@ -253,7 +253,7 @@ CXformEagerAgg::PopulateLowerUpperProjectList(
 		*orig_proj_list,  // project list of the original global aggregate
 	CExpression **lower_proj_list,	// project list of the new lower aggregate
 	CExpression **upper_proj_list	// project list of the new upper aggregate
-) const
+)
 {
 	// build an array of project elements for the new lower and upper aggregates
 	CExpressionArray *lower_proj_elem_array = GPOS_NEW(mp) CExpressionArray(mp);
@@ -310,7 +310,7 @@ CXformEagerAgg::PopulateLowerProjectElement(
 	CWStringConst *agg_name, CExpressionArray *agg_arg_array, BOOL is_distinct,
 	CExpression **
 		lower_proj_elem_expr  // output project element of the new lower aggregate
-) const
+)
 {
 	CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
@@ -348,7 +348,7 @@ CXformEagerAgg::PopulateUpperProjectElement(
 	BOOL is_distinct,
 	CExpression **
 		upper_proj_elem_expr  // output project element of the new lower aggregate
-) const
+)
 {
 	// create a new operator
 	agg_mdid->AddRef();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandFullOuterJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandFullOuterJoin.cpp
@@ -182,7 +182,7 @@ CExpression *
 CXformExpandFullOuterJoin::PexprLogicalJoinOverCTEs(
 	CMemoryPool *mp, EdxlJoinType edxljointype, ULONG ulLeftCTEId,
 	CColRefArray *pdrgpcrLeft, ULONG ulRightCTEId, CColRefArray *pdrgpcrRight,
-	CExpression *pexprScalar) const
+	CExpression *pexprScalar)
 {
 	GPOS_ASSERT(nullptr != pexprScalar);
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformGbAgg2HashAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformGbAgg2HashAgg.cpp
@@ -150,7 +150,7 @@ CXformGbAgg2HashAgg::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 //
 //---------------------------------------------------------------------------
 BOOL
-CXformGbAgg2HashAgg::FApplicable(CExpression *pexpr) const
+CXformGbAgg2HashAgg::FApplicable(CExpression *pexpr)
 {
 	CExpression *pexprPrjList = (*pexpr)[1];
 	ULONG arity = pexprPrjList->Arity();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -67,7 +67,7 @@ CXformJoin2IndexApply::ComputeColumnSets(CMemoryPool *mp,
 										 CExpression *pexprScalar,
 										 CColRefSet **ppcrsScalarExpr,
 										 CColRefSet **ppcrsOuterRefs,
-										 CColRefSet **ppcrsReqd) const
+										 CColRefSet **ppcrsReqd)
 {
 	CColRefSet *pcrsInnerOutput = pexprInner->DeriveOutputColumns();
 	*ppcrsScalarExpr = pexprScalar->DeriveUsedColumns();
@@ -156,7 +156,7 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 	CExpression *endOfNodesToInsertAboveIndexGet,
 	CTableDescriptor *ptabdescInner, CColRefSet *pcrsScalarExpr,
 	CColRefSet *outer_refs, CColRefSet *pcrsReqd, ULONG ulIndices,
-	CXformResult *pxfres) const
+	CXformResult *pxfres)
 {
 	// array of expressions in the scalar expression
 	CExpressionArray *pdrgpexpr =
@@ -200,7 +200,7 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 	CExpression *endOfNodesToInsertAboveIndexGet, CMDAccessor *md_accessor,
 	CExpressionArray *pdrgpexprConjuncts, CColRefSet *pcrsScalarExpr,
 	CColRefSet *outer_refs, CColRefSet *pcrsReqd, const IMDRelation *pmdrel,
-	const IMDIndex *pmdindex, CXformResult *pxfres) const
+	const IMDIndex *pmdindex, CXformResult *pxfres)
 {
 	CExpression *pexprLogicalIndexGet = CXformUtils::PexprLogicalIndexGet(
 		mp, md_accessor, pexprInner, joinOp->UlOpId(), pdrgpexprConjuncts,
@@ -268,7 +268,7 @@ CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives(
 	CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet,
 	CTableDescriptor *ptabdescInner, CColRefSet *outer_refs,
-	CColRefSet *pcrsReqd, CXformResult *pxfres) const
+	CColRefSet *pcrsReqd, CXformResult *pxfres)
 {
 	CLogical *popGet = CLogical::PopConvert(pexprInner->Pop());
 	CExpression *pexprLogicalIndexGet = CXformUtils::PexprBitmapTableGet(

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
@@ -28,9 +28,8 @@ using namespace gpopt;
 BOOL
 CXformJoin2IndexApplyGeneric::FCanLeftOuterIndexApply(
 	CMemoryPool *mp, CExpression *pexprInner, CExpression *pexprScalar,
-	CTableDescriptor *ptabDesc, const CColRefSet *pcrsDist) const
+	CTableDescriptor *ptabDesc, const CColRefSet *pcrsDist)
 {
-	GPOS_ASSERT(m_fOuterJoin);
 	IMDRelation::Ereldistrpolicy ereldist = ptabDesc->GetRelDistribution();
 
 	if (ereldist == IMDRelation::EreldistrRandom)

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoinAssociativity.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoinAssociativity.cpp
@@ -66,9 +66,9 @@ CXformJoinAssociativity::CXformJoinAssociativity(CMemoryPool *mp)
 //
 //---------------------------------------------------------------------------
 void
-CXformJoinAssociativity::CreatePredicates(
-	CMemoryPool *mp, CExpression *pexpr, CExpressionArray *pdrgpexprLower,
-	CExpressionArray *pdrgpexprUpper) const
+CXformJoinAssociativity::CreatePredicates(CMemoryPool *mp, CExpression *pexpr,
+										  CExpressionArray *pdrgpexprLower,
+										  CExpressionArray *pdrgpexprUpper)
 {
 	GPOS_CHECK_ABORT;
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin.cpp
@@ -134,7 +134,7 @@ CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin::Exfp(
 //---------------------------------------------------------------------------
 BOOL
 CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin::FApplyXformUsingStatsInfo(
-	const IStatistics *outer_stats, const IStatistics *inner_side_stats) const
+	const IStatistics *outer_stats, const IStatistics *inner_side_stats)
 {
 	if (GPOS_FTRACE(
 			gpos::

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSplitLimit.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSplitLimit.cpp
@@ -136,7 +136,7 @@ CXformSplitLimit::PexprLimit(CMemoryPool *mp, CExpression *pexprRelational,
 							 CExpression *pexprScalarStart,
 							 CExpression *pexprScalarRows, COrderSpec *pos,
 							 BOOL fGlobal, BOOL fHasCount,
-							 BOOL fTopLimitUnderDML) const
+							 BOOL fTopLimitUnderDML)
 {
 	pexprScalarStart->AddRef();
 	pexprScalarRows->AddRef();

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -44,7 +44,7 @@ private:
 #ifdef GPOS_DEBUG
 	// sanity check to detect deleted memory
 	void
-	Check()
+	Check() const
 	{
 		// assert that first member of class has not been wiped
 		GPOS_ASSERT(m_refs != GPOS_WIPED_MEM_PATTERN);

--- a/src/backend/gporca/libgpos/include/gpos/io/CFileDescriptor.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/CFileDescriptor.h
@@ -31,7 +31,7 @@ class CFileDescriptor
 {
 private:
 	// file descriptor
-	INT m_file_descriptor;
+	INT m_file_descriptor{GPOS_FILE_DESCR_INVALID};
 
 protected:
 	// ctor -- accessible through inheritance only

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -67,7 +67,7 @@ public:
 	static GPOS_RESULT Init();
 
 	// destroy global instance
-	void Shutdown();
+	static void Shutdown();
 
 	// global accessor
 	inline static CCacheFactory *

--- a/src/backend/gporca/libgpos/include/gpos/task/CAutoTaskProxy.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CAutoTaskProxy.h
@@ -50,10 +50,10 @@ private:
 	FindFinished(CTask **task);
 
 	// propagate the error from sub-task to current task
-	void PropagateError(CTask *sub_task);
+	static void PropagateError(CTask *sub_task);
 
 	// check error from sub-task
-	void CheckError(CTask *sub_task);
+	void CheckError(CTask *sub_task) const;
 
 public:
 	CAutoTaskProxy(const CAutoTaskProxy &) = delete;
@@ -86,7 +86,7 @@ public:
 	void Schedule(CTask *task);
 
 	// execute task in thread owning ATP (synchronous execution)
-	void Execute(CTask *task);
+	void Execute(CTask *task) const;
 
 	// cancel task
 	void Cancel(CTask *task);

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -142,7 +142,7 @@ gpos_init(struct gpos_init_params *params)
 
 	if (GPOS_OK != gpos::CMessageRepository::Init())
 	{
-		CWorkerPoolManager::WorkerPoolManager()->Shutdown();
+		CWorkerPoolManager::Shutdown();
 		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
 		return;
 	}
@@ -276,8 +276,8 @@ gpos_terminate()
 #endif
 #ifdef GPOS_DEBUG
 	CMessageRepository::GetMessageRepository()->Shutdown();
-	CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-	CCacheFactory::GetFactory()->Shutdown();
+	CWorkerPoolManager::Shutdown();
+	CCacheFactory::Shutdown();
 	CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
 #endif	// GPOS_DEBUG
 }

--- a/src/backend/gporca/libgpos/src/io/CFileDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/io/CFileDescriptor.cpp
@@ -28,9 +28,7 @@ using namespace gpos;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CFileDescriptor::CFileDescriptor() : m_file_descriptor(GPOS_FILE_DESCR_INVALID)
-{
-}
+CFileDescriptor::CFileDescriptor() = default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
+++ b/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
@@ -269,7 +269,7 @@ CAutoTaskProxy::FindFinished(CTask **task)
 //
 //---------------------------------------------------------------------------
 void
-CAutoTaskProxy::Execute(CTask *task)
+CAutoTaskProxy::Execute(CTask *task) const
 {
 	GPOS_ASSERT(CTask::EtsInit == task->m_status && "Task already scheduled");
 
@@ -342,7 +342,7 @@ CAutoTaskProxy::Cancel(CTask *task)
 //
 //---------------------------------------------------------------------------
 void
-CAutoTaskProxy::CheckError(CTask *sub_task)
+CAutoTaskProxy::CheckError(CTask *sub_task) const
 {
 	// sub-task has a pending error
 	if (sub_task->HasPendingExceptions())
@@ -384,8 +384,6 @@ CAutoTaskProxy::CheckError(CTask *sub_task)
 void
 CAutoTaskProxy::PropagateError(CTask *sub_task)
 {
-	GPOS_ASSERT(m_propagate_error);
-
 	// sub-task must be in error status and have a pending exception
 	GPOS_ASSERT(ITask::EtsError == sub_task->GetStatus() &&
 				sub_task->HasPendingExceptions());

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/CIdGenerator.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/CIdGenerator.h
@@ -34,7 +34,7 @@ private:
 public:
 	explicit CIdGenerator(ULONG);
 	ULONG next_id();
-	ULONG current_id();
+	ULONG current_id() const;
 };
 }  // namespace gpdxl
 #endif	// GPDXL_CIdGenerator_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarWindowFrameEdge.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarWindowFrameEdge.h
@@ -83,8 +83,8 @@ public:
 	}
 
 	// return the string representation of frame boundary
-	const CWStringConst *GetFrameBoundaryStr(
-		EdxlFrameBoundary frame_boundary) const;
+	static const CWStringConst *GetFrameBoundaryStr(
+		EdxlFrameBoundary frame_boundary);
 
 	// serialize operator in DXL format
 	void SerializeToDXL(CXMLSerializer *xml_serializer,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowFrame.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowFrame.h
@@ -101,10 +101,10 @@ public:
 	}
 
 	// return the string representation of the exclusion strategy
-	const CWStringConst *PstrES(EdxlFrameExclusionStrategy edxles) const;
+	static const CWStringConst *PstrES(EdxlFrameExclusionStrategy edxles);
 
 	// return the string representation of the frame specification (row or range)
-	const CWStringConst *PstrFS(EdxlFrameSpec edxlfs) const;
+	static const CWStringConst *PstrFS(EdxlFrameSpec edxlfs);
 
 	// serialize operator in DXL format
 	virtual void SerializeToDXL(CXMLSerializer *xml_serializer) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalSetOp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalSetOp.h
@@ -49,7 +49,7 @@ private:
 	BOOL m_cast_across_input_req;
 
 	// return the set operation type
-	EdxlSetOpType GetSetOpType(const XMLCh *const element_local_name);
+	static EdxlSetOpType GetSetOpType(const XMLCh *const element_local_name);
 
 	// process the start of an element
 	void StartElement(

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBFunc.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBFunc.h
@@ -80,10 +80,11 @@ private:
 		) override;
 
 	// parse function stability property from XML string
-	CMDFunctionGPDB::EFuncStbl ParseFuncStability(const XMLCh *xml_val);
+	static CMDFunctionGPDB::EFuncStbl ParseFuncStability(const XMLCh *xml_val);
 
 	// parse function data access property from XML string
-	CMDFunctionGPDB::EFuncDataAcc ParseFuncDataAccess(const XMLCh *xml_val);
+	static CMDFunctionGPDB::EFuncDataAcc ParseFuncDataAccess(
+		const XMLCh *xml_val);
 
 public:
 	CParseHandlerMDGPDBFunc(const CParseHandlerMDGPDBFunc &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBScalarOp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBScalarOp.h
@@ -85,7 +85,7 @@ private:
 		) override;
 
 	// is this a supported child elem of the scalar op
-	BOOL IsSupportedChildElem(const XMLCh *const xml_str);
+	static BOOL IsSupportedChildElem(const XMLCh *const xml_str);
 
 public:
 	CParseHandlerMDGPDBScalarOp(const CParseHandlerMDGPDBScalarOp &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
@@ -144,7 +144,7 @@ private:
 	// parse the value for the given mdid variable name from the attributes
 	void ParseMdid(const XMLCh *element_local_name, const Attributes &attrs);
 
-	BOOL IsBuiltInType(const IMDId *mdid) const;
+	static BOOL IsBuiltInType(const IMDId *mdid);
 
 public:
 	CParseHandlerMDType(const CParseHandlerMDType &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMetadataIdList.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMetadataIdList.h
@@ -55,10 +55,10 @@ private:
 		) override;
 
 	// is this a supported element of a metadata list
-	BOOL FSupportedElem(const XMLCh *const xml_str);
+	static BOOL FSupportedElem(const XMLCh *const xml_str);
 
 	// is this a supported metadata list type
-	BOOL FSupportedListType(const XMLCh *const xml_str);
+	static BOOL FSupportedListType(const XMLCh *const xml_str);
 
 public:
 	CParseHandlerMetadataIdList(const CParseHandlerMetadataIdList &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarOpList.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarOpList.h
@@ -38,7 +38,7 @@ private:
 	CDXLScalarOpList::EdxlOpListType m_dxl_op_list_type;
 
 	// return the op list type corresponding to the given operator name
-	CDXLScalarOpList::EdxlOpListType GetDXLOpListType(
+	static CDXLScalarOpList::EdxlOpListType GetDXLOpListType(
 		const XMLCh *const element_local_name);
 
 	// process the start of an element

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarSubPlan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarSubPlan.h
@@ -42,7 +42,7 @@ private:
 	EdxlSubPlanType m_dxl_subplan_type;
 
 	// map character sequence to subplan type
-	EdxlSubPlanType GetDXLSubplanType(const XMLCh *xml_subplan_type);
+	static EdxlSubPlanType GetDXLSubplanType(const XMLCh *xml_subplan_type);
 
 	// process the start of an element
 	void StartElement(

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLBucket.h
@@ -60,10 +60,10 @@ private:
 	CDouble m_distinct;
 
 	// serialize the bucket boundary
-	void SerializeBoundaryValue(CXMLSerializer *xml_serializer,
-								const CWStringConst *elem_str,
-								CDXLDatum *dxl_datum,
-								BOOL is_bound_closed) const;
+	static void SerializeBoundaryValue(CXMLSerializer *xml_serializer,
+									   const CWStringConst *elem_str,
+									   CDXLDatum *dxl_datum,
+									   BOOL is_bound_closed);
 
 public:
 	CDXLBucket(const CDXLBucket &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDProviderGeneric.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDProviderGeneric.h
@@ -64,7 +64,7 @@ public:
 	IMDId *MDId(IMDType::ETypeInfo type_info) const;
 
 	// default system id
-	CSystemId SysidDefault() const;
+	static CSystemId SysidDefault();
 };
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
@@ -214,7 +214,7 @@ public:
 		return m_bucket_lower_bound->GetDatum()->StatsMappable();
 	}
 
-	BOOL Equals(const CBucket *bucket);
+	BOOL Equals(const CBucket *bucket) const;
 
 	// generate a random data point within bucket boundaries
 	CDouble GetSample(ULONG *seed) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -203,12 +203,12 @@ private:
 
 		// used for sorting in the binary heap
 		CDouble
-		DCost()
+		DCost() const
 		{
 			return m_similarity_factor;
 		}
 		CDouble
-		GetCostForHeap()
+		GetCostForHeap() const
 		{
 			return DCost();
 		}
@@ -304,12 +304,13 @@ public:
 											CDouble *num_output_rows) const;
 
 	// cleanup residual buckets
-	void CleanupResidualBucket(CBucket *bucket, BOOL bucket_is_residual) const;
+	static void CleanupResidualBucket(CBucket *bucket, BOOL bucket_is_residual);
 
 	// get the next bucket for union / union all
-	CBucket *GetNextBucket(const CHistogram *histogram, CBucket *new_bucket,
-						   BOOL *target_bucket_is_residual,
-						   ULONG *current_bucket_index) const;
+	static CBucket *GetNextBucket(const CHistogram *histogram,
+								  CBucket *new_bucket,
+								  BOOL *target_bucket_is_residual,
+								  ULONG *current_bucket_index);
 
 	// number of buckets
 	ULONG

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredUnsupported.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredUnsupported.h
@@ -37,7 +37,7 @@ private:
 	CDouble m_default_scale_factor;
 
 	// initialize the scale factor of the predicate
-	CDouble InitScaleFactor();
+	static CDouble InitScaleFactor();
 
 public:
 	CStatsPredUnsupported(const CStatsPredUnsupported &) = delete;

--- a/src/backend/gporca/libnaucrates/src/CIdGenerator.cpp
+++ b/src/backend/gporca/libnaucrates/src/CIdGenerator.cpp
@@ -43,7 +43,7 @@ CIdGenerator::next_id()
 //
 //---------------------------------------------------------------------------
 ULONG
-CIdGenerator::current_id()
+CIdGenerator::current_id() const
 {
 	return id;
 }

--- a/src/backend/gporca/libnaucrates/src/md/CDXLBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLBucket.cpp
@@ -164,8 +164,7 @@ CDXLBucket::Serialize(CXMLSerializer *xml_serializer) const
 void
 CDXLBucket::SerializeBoundaryValue(CXMLSerializer *xml_serializer,
 								   const CWStringConst *elem_str,
-								   CDXLDatum *dxl_datum,
-								   BOOL is_bound_closed) const
+								   CDXLDatum *dxl_datum, BOOL is_bound_closed)
 {
 	xml_serializer->OpenElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), elem_str);

--- a/src/backend/gporca/libnaucrates/src/md/CMDProviderGeneric.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDProviderGeneric.cpp
@@ -106,7 +106,7 @@ CMDProviderGeneric::MDId(IMDType::ETypeInfo type_info) const
 //
 //---------------------------------------------------------------------------
 CSystemId
-CMDProviderGeneric::SysidDefault() const
+CMDProviderGeneric::SysidDefault()
 {
 	return CSystemId(IMDId::EmdidGPDB, GPMD_GPDB_SYSID);
 }

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarWindowFrameEdge.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarWindowFrameEdge.cpp
@@ -77,8 +77,7 @@ CDXLScalarWindowFrameEdge::GetOpNameStr() const
 //
 //---------------------------------------------------------------------------
 const CWStringConst *
-CDXLScalarWindowFrameEdge::GetFrameBoundaryStr(
-	EdxlFrameBoundary frame_boundary) const
+CDXLScalarWindowFrameEdge::GetFrameBoundaryStr(EdxlFrameBoundary frame_boundary)
 {
 	GPOS_ASSERT(EdxlfbSentinel > frame_boundary);
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLWindowFrame.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLWindowFrame.cpp
@@ -67,7 +67,7 @@ CDXLWindowFrame::~CDXLWindowFrame()
 //
 //---------------------------------------------------------------------------
 const CWStringConst *
-CDXLWindowFrame::PstrES(EdxlFrameExclusionStrategy edxles) const
+CDXLWindowFrame::PstrES(EdxlFrameExclusionStrategy edxles)
 {
 	GPOS_ASSERT(EdxlfesSentinel > edxles);
 	ULONG window_frame_boundary_to_frame_boundary_mapping[][2] = {
@@ -103,7 +103,7 @@ CDXLWindowFrame::PstrES(EdxlFrameExclusionStrategy edxles) const
 //
 //---------------------------------------------------------------------------
 const CWStringConst *
-CDXLWindowFrame::PstrFS(EdxlFrameSpec edxlfs) const
+CDXLWindowFrame::PstrFS(EdxlFrameSpec edxlfs)
 {
 	GPOS_ASSERT(EdxlfsSentinel > edxlfs &&
 				"Unrecognized window frame specification");

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDType.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDType.cpp
@@ -283,7 +283,7 @@ CParseHandlerMDType::ParseMdid(const XMLCh *element_local_name,
 //
 //---------------------------------------------------------------------------
 BOOL
-CParseHandlerMDType::IsBuiltInType(const IMDId *mdid) const
+CParseHandlerMDType::IsBuiltInType(const IMDId *mdid)
 {
 	if (IMDId::EmdidGPDB != mdid->MdidType())
 	{

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -448,7 +448,7 @@ CBucket::MakeBucketCopy(CMemoryPool *mp)
 }
 
 BOOL
-CBucket::Equals(const CBucket *bucket)
+CBucket::Equals(const CBucket *bucket) const
 {
 	GPOS_ASSERT(bucket != nullptr);
 	if (this->GetLowerBound()->Equals(bucket->GetLowerBound()) &&

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -1757,8 +1757,7 @@ CHistogram::CombineBuckets(CMemoryPool *mp, CBucketArray *buckets,
 
 // cleanup residual buckets
 void
-CHistogram::CleanupResidualBucket(CBucket *bucket,
-								  BOOL bucket_is_residual) const
+CHistogram::CleanupResidualBucket(CBucket *bucket, BOOL bucket_is_residual)
 {
 	if (nullptr != bucket && bucket_is_residual)
 	{
@@ -1771,7 +1770,7 @@ CHistogram::CleanupResidualBucket(CBucket *bucket,
 CBucket *
 CHistogram::GetNextBucket(const CHistogram *histogram, CBucket *new_bucket,
 						  BOOL *result_bucket_is_residual,
-						  ULONG *current_bucket_index) const
+						  ULONG *current_bucket_index)
 {
 	GPOS_ASSERT(nullptr != histogram);
 	if (nullptr != new_bucket)

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -210,7 +210,7 @@ ConfigureTests()
 
 #ifdef GPOS_DEBUG
 	// reset xforms factory to exercise xforms ctors and dtors
-	CXformFactory::Pxff()->Shutdown();
+	CXformFactory::Shutdown();
 	GPOS_RESULT eres = CXformFactory::Init();
 
 	GPOS_ASSERT(GPOS_OK == eres);

--- a/src/backend/gporca/server/src/unittest/dxl/CParseHandlerOptimizerConfigSerializeTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/CParseHandlerOptimizerConfigSerializeTest.cpp
@@ -30,7 +30,7 @@ public:
 		return m_amp.Pmp();
 	}
 
-	const CHAR *
+	static const CHAR *
 	SzValidationPath(BOOL fValidate)
 	{
 		if (fValidate)
@@ -97,7 +97,7 @@ CParseHandlerOptimizerConfigSerializeTest::EresUnittest()
 	// This will cause the test to fail, as we do a byte-wise string comparison as opposed to a
 	// comparison of canonicalized XML
 	const CHAR *dxl_string = f.SzDxl(dxl_filename);
-	const CHAR *szValidationPath = f.SzValidationPath(fValidate);
+	const CHAR *szValidationPath = Fixture::SzValidationPath(fValidate);
 
 	CWStringDynamic str(mp);
 	COstreamString oss(&str);

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -165,7 +165,7 @@ public:
 
 private:
 	// Set the bitmapset of a plan to the list of param_ids defined by the plan
-	void SetParamIds(Plan *);
+	static void SetParamIds(Plan *);
 
 	// translate DXL table scan node into a SeqScan node
 	Plan *TranslateDXLTblScan(
@@ -427,7 +427,7 @@ private:
 
 	// create a target list containing column references for a hash node from the
 	// project list of its child node
-	List *TranslateDXLProjectListToHashTargetList(
+	static List *TranslateDXLProjectListToHashTargetList(
 		const CDXLNode *project_list_dxlnode,
 		CDXLTranslateContext *child_context,
 		CDXLTranslateContext *output_context);
@@ -484,10 +484,11 @@ private:
 		CDXLTranslationContextArray *ctxt_translation_prev_siblings,
 		BitmapHeapScan *bitmap_tbl_scan);
 
-	void TranslateSortCols(const CDXLNode *sort_col_list_dxl,
-						   const CDXLTranslateContext *child_context,
-						   AttrNumber *att_no_sort_colids, Oid *sort_op_oids,
-						   Oid *sort_collations_oids, bool *is_nulls_first);
+	static void TranslateSortCols(const CDXLNode *sort_col_list_dxl,
+								  const CDXLTranslateContext *child_context,
+								  AttrNumber *att_no_sort_colids,
+								  Oid *sort_op_oids, Oid *sort_collations_oids,
+								  bool *is_nulls_first);
 
 	List *TranslateDXLScCondToQual(
 		const CDXLNode *filter_dxlnode,
@@ -502,9 +503,9 @@ private:
 	BOOL IsTgtTblDistributed(CDXLOperator *dxlop);
 
 	// add a target entry for a junk column with given colid to the target list
-	void AddJunkTargetEntryForColId(List **target_list,
-									CDXLTranslateContext *dxl_translate_ctxt,
-									ULONG colid, const char *resname);
+	static void AddJunkTargetEntryForColId(
+		List **target_list, CDXLTranslateContext *dxl_translate_ctxt,
+		ULONG colid, const char *resname);
 
 	// translate the index condition list in an Index scan
 	void TranslateIndexConditions(
@@ -538,14 +539,15 @@ private:
 	static void SetVarTypMod(const CDXLPhysicalCTAS *dxlop, List *target_list);
 
 	// translate the into clause for a DXL physical CTAS operator
-	IntoClause *TranslateDXLPhyCtasToIntoClause(const CDXLPhysicalCTAS *dxlop);
+	static IntoClause *TranslateDXLPhyCtasToIntoClause(
+		const CDXLPhysicalCTAS *dxlop);
 
 	// translate the distribution policy for a DXL physical CTAS operator
-	GpPolicy *TranslateDXLPhyCtasToDistrPolicy(const CDXLPhysicalCTAS *dxlop,
-											   List *target_list);
+	static GpPolicy *TranslateDXLPhyCtasToDistrPolicy(
+		const CDXLPhysicalCTAS *dxlop, List *target_list);
 
 	// translate CTAS storage options
-	List *TranslateDXLCtasStorageOptions(
+	static List *TranslateDXLCtasStorageOptions(
 		CDXLCtasStorageOptions::CDXLCtasOptionArray *ctas_storage_options);
 
 	// compute directed dispatch segment ids
@@ -556,9 +558,9 @@ private:
 	ULONG GetDXLDatumGPDBHash(CDXLDatumArray *dxl_datum_array);
 
 	// translate nest loop colrefs to GPDB nestparams
-	List *TranslateNestLoopParamList(CDXLColRefArray *pdrgdxlcrOuterRefs,
-									 CDXLTranslateContext *dxltrctxLeft,
-									 CDXLTranslateContext *dxltrctxRight);
+	static List *TranslateNestLoopParamList(
+		CDXLColRefArray *pdrgdxlcrOuterRefs, CDXLTranslateContext *dxltrctxLeft,
+		CDXLTranslateContext *dxltrctxRight);
 };
 }  // namespace gpdxl
 

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -124,7 +124,7 @@ private:
 	Expr *TranslateDXLScalarSwitchToScalar(const CDXLNode *scalar_switch_node,
 										   CMappingColIdVar *colid_var);
 
-	Expr *TranslateDXLScalarCaseTestToScalar(
+	static Expr *TranslateDXLScalarCaseTestToScalar(
 		const CDXLNode *scalar_case_test_node, CMappingColIdVar *colid_var);
 
 	Expr *TranslateDXLScalarAggrefToScalar(const CDXLNode *aggref_node,
@@ -159,7 +159,7 @@ private:
 
 	CHAR *GetSubplanAlias(ULONG plan_id);
 
-	Param *TranslateParamFromMapping(
+	static Param *TranslateParamFromMapping(
 		const CMappingElementColIdParamId *colid_to_param_id_map);
 
 	// translate a scalar coalesce
@@ -189,8 +189,8 @@ private:
 		CMappingColIdVar *colid_var);
 
 	// translate a DML action expression
-	Expr *TranslateDXLScalarDMLActionToScalar(const CDXLNode *dml_action_node,
-											  CMappingColIdVar *colid_var);
+	static Expr *TranslateDXLScalarDMLActionToScalar(
+		const CDXLNode *dml_action_node, CMappingColIdVar *colid_var);
 
 
 	// translate children of DXL node, and add them to list
@@ -201,11 +201,11 @@ private:
 	OID GetFunctionReturnTypeOid(IMDId *mdid) const;
 
 	// translate dxldatum to GPDB Const
-	Const *ConvertDXLDatumToConstOid(CDXLDatum *datum_dxl);
-	Const *ConvertDXLDatumToConstInt2(CDXLDatum *datum_dxl);
-	Const *ConvertDXLDatumToConstInt4(CDXLDatum *datum_dxl);
-	Const *ConvertDXLDatumToConstInt8(CDXLDatum *datum_dxl);
-	Const *ConvertDXLDatumToConstBool(CDXLDatum *datum_dxl);
+	static Const *ConvertDXLDatumToConstOid(CDXLDatum *datum_dxl);
+	static Const *ConvertDXLDatumToConstInt2(CDXLDatum *datum_dxl);
+	static Const *ConvertDXLDatumToConstInt4(CDXLDatum *datum_dxl);
+	static Const *ConvertDXLDatumToConstInt8(CDXLDatum *datum_dxl);
+	static Const *ConvertDXLDatumToConstBool(CDXLDatum *datum_dxl);
 	Const *TranslateDXLDatumGenericToScalar(CDXLDatum *datum_dxl);
 	Expr *TranslateRelabelTypeOrFuncExprFromDXL(
 		const CDXLScalarCast *scalar_cast, Expr *pexprChild);
@@ -229,8 +229,8 @@ public:
 							   CMappingColIdVar *colid_var);
 
 	// translate a scalar ident into an Expr
-	Expr *TranslateDXLScalarIdentToScalar(const CDXLNode *scalar_id_node,
-										  CMappingColIdVar *colid_var);
+	static Expr *TranslateDXLScalarIdentToScalar(const CDXLNode *scalar_id_node,
+												 CMappingColIdVar *colid_var);
 
 	// translate a scalar comparison into an Expr
 	Expr *TranslateDXLScalarCmpToScalar(const CDXLNode *scalar_cmp_node,

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -139,7 +139,7 @@ private:
 
 	// check for unsupported node types, throws an exception if an unsupported
 	// node is found
-	void CheckUnsupportedNodeTypes(Query *query);
+	static void CheckUnsupportedNodeTypes(Query *query);
 
 	// check for SIRV functions in the targetlist without a FROM clause and
 	// throw an exception when found
@@ -165,7 +165,7 @@ private:
 										BOOL keep_res_junked) const;
 
 	// check if the set operation need to cast any of its input columns
-	BOOL SetOpNeedsCast(List *target_list, IMdIdArray *input_col_mdids) const;
+	static BOOL SetOpNeedsCast(List *target_list, IMdIdArray *input_col_mdids);
 	// translate a window operator
 	CDXLNode *TranslateWindowToDXL(
 		CDXLNode *child_dxlnode, List *target_list, List *window_clause,
@@ -269,7 +269,7 @@ private:
 	);
 
 	// throws an exception when RTE kind not yet supported
-	[[noreturn]] void UnsupportedRTEKind(RTEKind rtekind) const;
+	[[noreturn]] static void UnsupportedRTEKind(RTEKind rtekind);
 
 	// translate an entry of the from clause (this can either be FromExpr or JoinExpr)
 	CDXLNode *TranslateFromClauseToDXL(Node *node);
@@ -329,10 +329,10 @@ private:
 		List *target_list, IntToUlongMap *attno_to_colid_mapping) const;
 
 	// check for support command types, throws an exception when command type not yet supported
-	void CheckSupportedCmdType(Query *query);
+	static void CheckSupportedCmdType(Query *query);
 
 	// check for supported range table entries, throws an exception when something is not yet supported
-	void CheckRangeTable(Query *query);
+	static void CheckRangeTable(Query *query);
 
 	// translate a select-project-join expression into DXL
 	CDXLNode *TranslateSelectProjectJoinToDXL(
@@ -403,10 +403,10 @@ private:
 
 	// construct a new mapping based on the given one by replacing the colid in the "From" list
 	// with the colid at the same position in the "To" list
-	IntToUlongMap *RemapColIds(CMemoryPool *mp,
-							   IntToUlongMap *attno_to_colid_mapping,
-							   ULongPtrArray *from_list_colids,
-							   ULongPtrArray *to_list_colids) const;
+	static IntToUlongMap *RemapColIds(CMemoryPool *mp,
+									  IntToUlongMap *attno_to_colid_mapping,
+									  ULongPtrArray *from_list_colids,
+									  ULongPtrArray *to_list_colids);
 
 	// true iff this query or one of its ancestors is a DML query
 	BOOL IsDMLQuery();

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -85,7 +85,7 @@ private:
 	// list of CTE producers shared among the logical and scalar translators
 	CDXLNodeArray *m_cte_producers;
 
-	EdxlBoolExprType EdxlbooltypeFromGPDBBoolType(BoolExprType) const;
+	static EdxlBoolExprType EdxlbooltypeFromGPDBBoolType(BoolExprType);
 
 	CTranslatorQueryToDXL *CreateSubqueryTranslator(
 		Query *subquery, const CMappingVarColId *var_colid_mapping);

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -103,10 +103,10 @@ struct SOptContext
 	void HandleError(BOOL *had_unexpected_failure);
 
 	// free all members except input and output pointers
-	void Free(EPin input, EPin epinOutput);
+	void Free(EPin input, EPin epinOutput) const;
 
 	// Clone the error message in given context.
-	CHAR *CloneErrorMsg(struct MemoryContextData *context);
+	CHAR *CloneErrorMsg(struct MemoryContextData *context) const;
 
 	// casting function
 	static SOptContext *Cast(void *ptr);


### PR DESCRIPTION
As alluded to in commit d6471c23664cb964 ("Use switch cases, not loops over function pointers."), this patch makes two simple readability enhancements that are easily neglected by humans:

1. Make non-const member functions const because the function doesn't use "this" in a non-const way;

2. Make non-static member functions that don't use "this" static.

3. Make calls to static methods look like they're calling static methods (i.e. don't use the legal but confusing syntax of calling through an instance)

We also add 2 corresponding clang-tidy checks so that we'll continuously inspect the code for violations. Sadly we cannot add readability-convert-member-functions-to-static to clang-tidy because we have a bunch of functions that are flagged as "can be made static" in release build, but they each call a member function in an assertion (or assert on a field).

