### PR TITLE
Error out if ADD PARTITION specify subpartition to an invalid table

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -1556,6 +1556,11 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 								parser_errposition(pstate, subPartSpec->location)));
 				}
 			}
+			else if (elem->subSpec)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+							errmsg("subpartition specification provided but table doesn't have SUBPARTITION BY clause"),
+							parser_errposition(pstate, ((GpPartitionDefinition*)elem->subSpec)->location)));
 
 			/*
 			 * This was not allowed pre-GPDB7, so keeping the same

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -5536,6 +5536,11 @@ distributed by (pkid) partition by range (option3)
 	partition bb start(101) end(200),
 	partition cc start(201) end (300)
 );
+-- should error out since no subpartition in sales.
+alter table sales add partition dd start(301) end(300)
+	( subpartition opt1_1 VALUES (1),
+	  subpartition opt1_2 VALUES (2) );
+ERROR:  subpartition specification provided but table doesn't have SUBPARTITION BY clause
 -- root partition (and only root) should have relfrozenxid as 0
 select relname, relkind from pg_class where relkind in ('r', 'p') and relname like 'sales%' and relfrozenxid=0;
  relname | relkind 

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5537,6 +5537,11 @@ distributed by (pkid) partition by range (option3)
 	partition bb start(101) end(200),
 	partition cc start(201) end (300)
 );
+-- should error out since no subpartition in sales.
+alter table sales add partition dd start(301) end(300)
+	( subpartition opt1_1 VALUES (1),
+	  subpartition opt1_2 VALUES (2) );
+ERROR:  subpartition specification provided but table doesn't have SUBPARTITION BY clause
 -- root partition (and only root) should have relfrozenxid as 0
 select relname, relkind from pg_class where relkind in ('r', 'p') and relname like 'sales%' and relfrozenxid=0;
  relname | relkind 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3575,6 +3575,11 @@ distributed by (pkid) partition by range (option3)
 	partition cc start(201) end (300)
 );
 
+-- should error out since no subpartition in sales.
+alter table sales add partition dd start(301) end(300)
+	( subpartition opt1_1 VALUES (1),
+	  subpartition opt1_2 VALUES (2) );
+
 -- root partition (and only root) should have relfrozenxid as 0
 select relname, relkind from pg_class where relkind in ('r', 'p') and relname like 'sales%' and relfrozenxid=0;
 select gp_segment_id, relname, relkind from gp_dist_random('pg_class') where relkind in ('r', 'p') and relname like 'sales%' and relfrozenxid=0;


### PR DESCRIPTION
If the partitioned table doesn't contain subpartition, we should error
out when specifying subpartition in ALTER ADD PARTITION statement.
Create the partition and ignore the subpartitions is not correct.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
