### PR TITLE
5X backport: Limit anyarray coercion to INSERT statements

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -164,12 +164,15 @@ coerce_type(ParseState *pstate, Node *node,
 		 */
 
 		/*
-		 * BUG BUG 
-		 * JIRA MPP-3786
+		 * GPDB: Special handling for ANYARRAY type. This enables INSERTs into
+		 * catalog tables having anyarray columns.
 		 *
-		 * Special handling for ANYARRAY type.  
+		 * Restrict the type coercion to INSERT statements as this hack was only
+		 * meant to fix INSERTs for dumping/restoring pg_statistic tuples by
+		 * external utilities such as gpsd, minirepro, gpbackup/gprestore.
 		 */
-		if(targetTypeId == ANYARRAYOID && IsA(node, Const))
+		if(targetTypeId == ANYARRAYOID && IsA(node, Const)
+			&& (pstate != NULL && pstate->p_is_insert))
 		{
 			Const	   *con = (Const *) node;
 			Const	   *newcon = makeNode(Const);

--- a/src/include/rewrite/rewriteHandler.h
+++ b/src/include/rewrite/rewriteHandler.h
@@ -19,6 +19,7 @@
 
 extern List *QueryRewrite(Query *parsetree);
 extern void AcquireRewriteLocks(Query *parsetree);
+extern Query *get_view_query(Relation view);
 extern Node *build_column_default(Relation rel, int attrno);
 
 #endif   /* REWRITEHANDLER_H */

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -54,7 +54,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
 
 -- change stats manually so that MCV and MCF numbers do not match
 set allow_system_table_mods=DML;
-update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='bfv_statistics_foo2'::regclass;
+update pg_statistic set stavalues1=array_in('{6,3,1,5,4,2}', 'int'::regtype::oid, -1) where starelid='bfv_statistics_foo2'::regclass;
 -- excercise the translator
 explain select a from bfv_statistics_foo2 where a > 1 order by a;
                                  QUERY PLAN                                  
@@ -441,10 +441,10 @@ ANALYZE test_broken_stats;
 SET allow_system_table_mods='DML';
 -- Simulate broken stats by changing the data type of MCV slot to a different type than in pg_attribute 
 -- Broken MCVs
-UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
+UPDATE pg_statistic SET stavalues1=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
 -- Broken histogram
 UPDATE pg_statistic SET stakind2=2 WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
-UPDATE pg_statistic SET stavalues2='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
+UPDATE pg_statistic SET stavalues2=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
  a | b | a | b 
 ---+---+---+---

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -54,7 +54,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
 
 -- change stats manually so that MCV and MCF numbers do not match
 set allow_system_table_mods=DML;
-update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='bfv_statistics_foo2'::regclass;
+update pg_statistic set stavalues1=array_in('{6,3,1,5,4,2}', 'int'::regtype::oid, -1) where starelid='bfv_statistics_foo2'::regclass;
 -- excercise the translator
 explain select a from bfv_statistics_foo2 where a > 1 order by a;
 NOTICE:  The number of most common values and frequencies do not match on column a of table bfv_statistics_foo2.
@@ -444,10 +444,10 @@ ANALYZE test_broken_stats;
 SET allow_system_table_mods='DML';
 -- Simulate broken stats by changing the data type of MCV slot to a different type than in pg_attribute 
 -- Broken MCVs
-UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
+UPDATE pg_statistic SET stavalues1=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
 -- Broken histogram
 UPDATE pg_statistic SET stakind2=2 WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
-UPDATE pg_statistic SET stavalues2='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
+UPDATE pg_statistic SET stavalues2=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 NOTICE:  Type mismatch between attribute b of table test_broken_stats having type 25 and statistic having type 23, please ANALYZE the table again
 NOTICE:  Type mismatch between attribute b of table test_broken_stats having type 25 and statistic having type 23, please ANALYZE the table again

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -115,3 +115,12 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 NOTICE:  drop cascades to table "schema_view\'.gp_dist_random"."foo\'.bar"
 NOTICE:  drop cascades to rule _RETURN on view view_with_gp_dist_random_special_chars
 NOTICE:  drop cascades to view view_with_gp_dist_random_special_chars
+-- Check that views containing operator expressions involving arrays have the
+-- correct internal representation
+CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
+SELECT pg_get_viewdef('view_with_array_op_expr');
+                pg_get_viewdef                 
+-----------------------------------------------
+ SELECT ('{1}'::integer[] = '{2}'::integer[]);
+(1 row)
+ 

--- a/src/test/regress/sql/bfv_statistic.sql
+++ b/src/test/regress/sql/bfv_statistic.sql
@@ -28,7 +28,7 @@ explain select a from bfv_statistics_foo2 where a > 1 order by a;
 
 -- change stats manually so that MCV and MCF numbers do not match
 set allow_system_table_mods=DML;
-update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='bfv_statistics_foo2'::regclass;
+update pg_statistic set stavalues1=array_in('{6,3,1,5,4,2}', 'int'::regtype::oid, -1) where starelid='bfv_statistics_foo2'::regclass;
 
 -- excercise the translator
 explain select a from bfv_statistics_foo2 where a > 1 order by a;
@@ -273,11 +273,10 @@ ANALYZE test_broken_stats;
 SET allow_system_table_mods='DML';
 -- Simulate broken stats by changing the data type of MCV slot to a different type than in pg_attribute 
 -- Broken MCVs
-UPDATE pg_statistic SET stavalues1='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
+UPDATE pg_statistic SET stavalues1=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
 -- Broken histogram
 UPDATE pg_statistic SET stakind2=2 WHERE starelid ='test_broken_stats'::regclass AND staattnum=2;
-UPDATE pg_statistic SET stavalues2='{1,2,3}'::int[] WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
-
+UPDATE pg_statistic SET stavalues2=array_in('{1,2,3}', 'int'::regtype::oid, -1) WHERE starelid ='test_broken_stats'::regclass AND staattnum=2 and stakind2=2;
 SELECT * FROM test_broken_stats t1, good_tab t2 WHERE t1.b = t2.b;
 
 RESET allow_system_table_mods;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -63,3 +63,8 @@ CREATE TABLE "schema_view\'.gp_dist_random"."foo\'.bar" (a int);
 CREATE TEMP VIEW view_with_gp_dist_random_special_chars AS SELECT * FROM gp_dist_random(E'"schema_view\\''.gp_dist_random"."foo\\''.bar"');
 SELECT pg_get_viewdef('view_with_gp_dist_random_special_chars');
 DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
+
+-- Check that views containing operator expressions involving arrays have the
+-- correct internal representation
+CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
+SELECT pg_get_viewdef('view_with_array_op_expr');


### PR DESCRIPTION
This is a consolidated backport of #11506 and #11542.

Notes:

1. The first commit has the fix and is slightly different in implementation
from the 6X version, due to the `ParseState` struct's field differences.

2. The second commit is a partial backport of #11542: it includes only
the support UDF and helper walker. To get access to the view's query
tree, backporting the function `get_view_query` from upstream commit
a99c42f291 was necessary. Manually tested the UDF by loading in
the pg_upgrade_support library and ran it on the busted views referenced
in the commit message.