### PR TITLE
Introduce contentId parameter for WAL archiving

### DIFF
--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -50,6 +50,11 @@
 #include "utils/guc.h"
 #include "utils/ps_status.h"
 
+/*
+ * GPDB specific imports:
+ */
+#include "cdb/cdbvars.h"
+#include "utils/builtins.h"
 
 /* ----------
  * Timer definitions.
@@ -563,6 +568,8 @@ pgarch_archiveXlog(char *xlog)
 	const char *sp;
 	int			rc;
 
+	char		contentid[12];	/* sign, 10 digits and '\0' */
+
 	snprintf(pathname, MAXPGPATH, XLOGDIR "/%s", xlog);
 
 	/*
@@ -589,6 +596,14 @@ pgarch_archiveXlog(char *xlog)
 					/* %f: filename of source file */
 					sp++;
 					strlcpy(dp, xlog, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'c':
+					/* GPDB: %c: contentId of segment */
+					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.segindex, contentid);
+					strlcpy(dp, contentid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':


### PR DESCRIPTION
This commit introduces the contentId (%c) parameter to archive_command
and restore_command. It will be substituted with the contentId of the
segment involved in the archival/recovery process.
Thus, an archive_command = 'cp %p /tmp/archive/seg%c/%f' might be
substituted by (for a 3 segment cluster):

cp pg_wal/00000001000000A900000065 /tmp/archive/seg-1/00000001000000A900000065
cp pg_wal/00000001000000A900000065 /tmp/archive/seg0/00000001000000A900000065
cp pg_wal/00000001000000A900000065 /tmp/archive/seg1/00000001000000A900000065
cp pg_wal/00000001000000A900000065 /tmp/archive/seg2/00000001000000A900000065

The param will serve as a piece of identifying information for a WAL
stream from a given segment.

test_gpdb_pitr.sh updated to exercise the (%c) substitution.

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
