### PR TITLE
Print description of LOCKTAG_RESOURCE_QUEUE in DescribeLockTag().

### DIFF
--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -1262,6 +1262,11 @@ DescribeLockTag(StringInfo buf, const LOCKTAG *tag)
 							 tag->locktag_field3,
 							 tag->locktag_field4);
 			break;
+		case LOCKTAG_RESOURCE_QUEUE:
+			appendStringInfo(buf,
+							 _("resource queue %u"),
+							 tag->locktag_field1);
+			break;
 		default:
 			appendStringInfo(buf,
 							 _("unrecognized locktag type %d"),


### PR DESCRIPTION
Currently, DescribeLockTag() handles `LOCKTAG_RESOURCE_QUEUE` as default case, so it is printed as `unrecognized locktag 9`, like the example below.

````
DETAIL:  Process 51807 waits for ExclusiveLock on unrecognized locktag type 9; blocked by process 25040.
````

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
