### PR TITLE
GpFindTargetPartition() based on name should consider name mismatch

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -999,7 +999,22 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 alter table i add partition foo2 start(40) end (50);
 alter table i drop partition foo2;
+-- when using the partition name to find target partition table,
+-- we shoud check whether the matched table belong to the partitioned table.
+-- raise error instead of executing on the irrelevant table.
+create table i_1_prt_3 (like i);
+-- create another partitioned table which contains a partition table that
+-- could be matched by partition name when targeted on an irrelevant table.
+create table i2 (i int) partition by range(i) (start (1) end(3) every(1));
+create table i_1_prt_4 partition of i2 for values from (4) to (5);
+-- the matechd table name is i_1_prt_3, but it's a normal table, raise error.
+alter table i drop partition "3";
+ERROR:  partition "3" of "i" does not exist
+-- the matched table name is i_1_prt_4, but it belongs to i2, raise error
+alter table i drop partition "4";
+ERROR:  partition "4" of "i" does not exist
 drop table i;
+drop table i2;
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,
 PS_SUPPKEY INTEGER,

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -999,7 +999,22 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 alter table i add partition foo2 start(40) end (50);
 alter table i drop partition foo2;
+-- when using the partition name to find target partition table,
+-- we shoud check whether the matched table belong to the partitioned table.
+-- raise error instead of executing on the irrelevant table.
+create table i_1_prt_3 (like i);
+-- create another partitioned table which contains a partition table that
+-- could be matched by partition name when targeted on an irrelevant table.
+create table i2 (i int) partition by range(i) (start (1) end(3) every(1));
+create table i_1_prt_4 partition of i2 for values from (4) to (5);
+-- the matechd table name is i_1_prt_3, but it's a normal table, raise error.
+alter table i drop partition "3";
+ERROR:  partition "3" of "i" does not exist
+-- the matched table name is i_1_prt_4, but it belongs to i2, raise error
+alter table i drop partition "4";
+ERROR:  partition "4" of "i" does not exist
 drop table i;
+drop table i2;
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,
 PS_SUPPKEY INTEGER,

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -635,7 +635,25 @@ drop table i;
 create table i (i int) partition by range(i) (start (1) end(3) every(1));
 alter table i add partition foo2 start(40) end (50);
 alter table i drop partition foo2;
+
+
+-- when using the partition name to find target partition table,
+-- we shoud check whether the matched table belong to the partitioned table.
+-- raise error instead of executing on the irrelevant table.
+create table i_1_prt_3 (like i);
+
+-- create another partitioned table which contains a partition table that
+-- could be matched by partition name when targeted on an irrelevant table.
+create table i2 (i int) partition by range(i) (start (1) end(3) every(1));
+create table i_1_prt_4 partition of i2 for values from (4) to (5);
+
+-- the matechd table name is i_1_prt_3, but it's a normal table, raise error.
+alter table i drop partition "3";
+-- the matched table name is i_1_prt_4, but it belongs to i2, raise error
+alter table i drop partition "4";
+
 drop table i;
+drop table i2;
 
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,


### PR DESCRIPTION
When finding partition by name, After PG12 merge, users may use pg
syntax to do the partition maintenance, like `ALTER TABLE ...
DETACH/ATTACH PARTITION`.
This may cause the partition table's name different from GPDB's
partition table name pattern <parentname>_<level>_prt_<partition_name>.
When this happens, it's not possible to find the target partition table
based on the name specified by the user.
Users could always use PARTITION FOR or pg syntax instead.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
