### PR TITLE
gpMgmt testing: use unittest.mock instead of PyPi's mock

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -12,7 +12,7 @@ import errno
 from pg import DatabaseError
 
 from .gp_unittest import *
-from mock import *
+from unittest.mock import *
 from io import StringIO
 
 db_singleton_side_effect_list = []
@@ -185,7 +185,7 @@ class GpConfig(GpTestCase):
 
         self.subject.do_main()
 
-        self.pool.addCommand.assert_called_once()
+        self.assertEqual(self.pool.addCommand.call_count, 5)
         self.pool.join.assert_called_once_with()
         self.pool.check_results.assert_called_once_with()
         self.pool.haltWork.assert_called_once_with()


### PR DESCRIPTION
As of Python 3.3, mock is part of python's standard distribution.
Using it instead of getting it from PyPi.

This also works around a bug.  With Python 3.6.8 and mock==1.0.1, the `addCommand` was being called 5 times but mock thought it was only being called once.  The python standard distribution mock works.

The PyPi mock is still used in other unit tests; those will be removed in a separate effort.

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>

