### PR TITLE
Show log entries from CTestUtils::EresCompare routine

### DIFF
--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -2834,6 +2834,7 @@ CTestUtils::EresTranslate(CMemoryPool *mp, const CHAR *szQueryFileName,
 		true /*serialize_header_footer*/, true /*indentation*/);
 
 	GPOS_TRACE(str.GetBuffer());
+	str.Reset();
 	GPOS_RESULT eres = GPOS_OK;
 	if (nullptr != szPlanFileName)
 	{
@@ -2845,6 +2846,8 @@ CTestUtils::EresTranslate(CMemoryPool *mp, const CHAR *szQueryFileName,
 
 		eres = EresCompare(oss, &strTranslatedPlan, &strExpectedPlan,
 						   fIgnoreMismatch);
+		GPOS_TRACE(str.GetBuffer());
+		str.Reset();
 		GPOS_DELETE_ARRAY(szExpectedPlan);
 	}
 
@@ -2877,7 +2880,7 @@ CTestUtils::EresCompare(IOstream &os, CWStringDynamic *pstrActual,
 		os << pstrActual->GetBuffer() << std::endl;
 
 		os << "Expected: " << std::endl;
-		os << pstrExpected->GetBuffer() << std::endl;
+		os << pstrExpected->GetBuffer();
 
 		if (fIgnoreMismatch)
 		{
@@ -2887,7 +2890,7 @@ CTestUtils::EresCompare(IOstream &os, CWStringDynamic *pstrActual,
 	}
 	else
 	{
-		os << "Output matches expected DXL document" << std::endl;
+		os << "Output matches expected DXL document";
 		return GPOS_OK;
 	}
 }

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CFilterCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CFilterCardinalityTest.cpp
@@ -1096,7 +1096,9 @@ CFilterCardinalityTest::EresUnittest_CStatisticsCompare(
 		mp, md_accessor, pdrgpstatBefore, true /*serialize_header_footer*/,
 		true /*indentation*/
 	);
-	GPOS_TRACE(pstrInput->GetBuffer());
+	oss << pstrInput->GetBuffer();
+	GPOS_TRACE(str.GetBuffer());
+	str.Reset();
 	GPOS_DELETE(pstrInput);
 
 	oss << "Serializing Output Statistics Objects (After Filter)" << std::endl;
@@ -1104,7 +1106,9 @@ CFilterCardinalityTest::EresUnittest_CStatisticsCompare(
 		mp, md_accessor, pdrgpstatOutput, true /*serialize_header_footer*/,
 		true /*indentation*/
 	);
-	GPOS_TRACE(pstrOutput->GetBuffer());
+	oss << pstrOutput->GetBuffer();
+	GPOS_TRACE(str.GetBuffer());
+	str.Reset();
 
 	CWStringDynamic dstrExpected(mp);
 	dstrExpected.AppendFormat(GPOS_WSZ_LIT("%s"), szDXLOutput);
@@ -1112,6 +1116,8 @@ CFilterCardinalityTest::EresUnittest_CStatisticsCompare(
 	GPOS_RESULT eres = CTestUtils::EresCompare(
 		oss, pstrOutput, &dstrExpected, false /* ignore mismatch */
 	);
+	GPOS_TRACE(str.GetBuffer());
+	str.Reset();
 
 	if (fApplyTwice && GPOS_OK == eres)
 	{
@@ -1132,6 +1138,8 @@ CFilterCardinalityTest::EresUnittest_CStatisticsCompare(
 		eres = CTestUtils::EresCompare(
 			oss, pstrOutput2, &dstrExpected, false /* ignore mismatch */
 		);
+		GPOS_TRACE(str.GetBuffer());
+		str.Reset();
 
 		pdrgpstatOutput2->Release();
 		GPOS_DELETE(pstrOutput2);

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CMCVTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CMCVTest.cpp
@@ -138,6 +138,7 @@ CMCVTest::EresUnittest_SortInt4MCVs()
 		CTestUtils::EresCompare(oss, pstrOutput, &dstrExpected,
 								false  // mismatch will not be ignored
 		);
+	GPOS_TRACE(str.GetBuffer());
 
 	// cleanup
 	GPOS_DELETE(pstrOutput);
@@ -260,6 +261,7 @@ CMCVTest::EresUnittest_MergeHistMCV()
 			CTestUtils::EresCompare(oss, pstrOutput, &dstrExpected,
 									false  // mismatch will not be ignored
 			);
+		GPOS_TRACE(str.GetBuffer());
 
 		// cleanup
 		GPOS_DELETE_ARRAY(szDXLInputMCV);


### PR DESCRIPTION
## Motivation

Current PR resolves the issue https://github.com/greenplum-db/gpdb/issues/11281.

The [CTestUtils::EresCompare()](https://github.com/greenplum-db/gpdb/blob/7d7615cebe8bc763d95b8b75971f8e3ccb7054ce/src/backend/gporca/server/src/unittest/CTestUtils.cpp#L2861-L2893) function compares incoming strings that represents actual and expected objects participating in tests. As a side effect, this function logs to output stream (that is defined as incoming function argument) the result of such comparison including dumps of xmls in case of inequality.

Before the current patch any callers of `CTestUtils::EresCompare()` just ignored the output stream with comparison logs. As result, in the presence of failed object comparison inside `CTestUtils::EresCompare()` it's impossible to define the fact that failure regards to with this function. And comparable objects also was missed. This greatly complicates the debugging of such case forcing to use gdb.

Current patch adds all necessary printing of trace logs after all executions of `CTestUtils::EresCompare()` function.

## Tests that allows to check the result of patch

There are four function callers of `CTestUtils::EresCompare()` [[1](https://github.com/greenplum-db/gpdb/blob/6.12.1/src/backend/gporca/server/src/unittest/CTestUtils.cpp#L2776-L2852), [2](https://github.com/greenplum-db/gpdb/blob/6.12.1/src/backend/gporca/server/src/unittest/dxl/statistics/CFilterCardinalityTest.cpp#L1076-L1134), [3](https://github.com/greenplum-db/gpdb/blob/6.12.1/src/backend/gporca/server/src/unittest/dxl/statistics/CMCVTest.cpp#L130-L140), [4](https://github.com/https://github.com/greenplum-db/gpdb/blob/6.12.1/src/backend/gporca/server/src/unittest/dxl/statistics/CMCVTest.cpp#L130-L140)] and for testing purpose of current patch the following three test suites could be used (last test corresponds to last two callers):

1. CTranslatorExprToDXLTest
2. CTranslatorExprToDXLTest
3. CMCVTest