### PR TITLE
Restore list_qsort interface to how it is in PostgreSQL

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -65,7 +65,7 @@ static List *ic_proxy_unknown_addrs = NIL;
 static ICProxyAddr *ic_proxy_my_addr = NULL;
 
 static int
-ic_proxy_addr_compare_dbid(const void *a, const void *b, void *arg)
+ic_proxy_addr_compare_dbid(const void *a, const void *b)
 {
 	const ICProxyAddr *addr1 = a;
 	const ICProxyAddr *addr2 = b;
@@ -304,7 +304,7 @@ ic_proxy_reload_addresses(uv_loop_t *loop)
 
 	/* sort the new addrs so it's easy to diff */
 	ic_proxy_unknown_addrs = list_qsort(ic_proxy_unknown_addrs,
-										ic_proxy_addr_compare_dbid, NULL);
+										ic_proxy_addr_compare_dbid);
 
 	/* the last thing is to classify the addrs */
 	ic_proxy_classify_addresses(ic_proxy_prev_addrs /* oldaddrs */,

--- a/src/backend/nodes/list.c
+++ b/src/backend/nodes/list.c
@@ -1276,7 +1276,7 @@ list_copy_tail(const List *oldlist, int nskip)
  * The comparator function receives arguments of type ListCell **.
  */
 List *
-list_qsort(const List *list, list_qsort_comparator cmp, void *arg)
+list_qsort(const List *list, list_qsort_comparator cmp)
 {
 	int			len = list_length(list);
 	ListCell  **list_arr;
@@ -1295,7 +1295,7 @@ list_qsort(const List *list, list_qsort_comparator cmp, void *arg)
 	foreach(cell, list)
 		list_arr[i++] = cell;
 
-	qsort_arg(list_arr, len, sizeof(ListCell *), cmp, arg);
+	qsort(list_arr, len, sizeof(ListCell *), cmp);
 
 	/* Construct new list (this code is much like list_copy) */
 	newlist = new_list(list->type);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -65,8 +65,8 @@ typedef enum
 #define STD_FUZZ_FACTOR 1.01
 
 static List *translate_sub_tlist(List *tlist, int relid);
-static int	append_total_cost_compare(const void *a, const void *b, void *arg);
-static int	append_startup_cost_compare(const void *a, const void *b, void *arg);
+static int	append_total_cost_compare(const void *a, const void *b);
+static int	append_startup_cost_compare(const void *a, const void *b);
 static List *reparameterize_pathlist_by_child(PlannerInfo *root,
 											  List *pathlist,
 											  RelOptInfo *child_rel);
@@ -1366,9 +1366,9 @@ create_append_path(PlannerInfo *root,
 		 */
 		Assert(pathkeys == NIL);
 
-		subpaths = list_qsort(subpaths, append_total_cost_compare, NULL);
+		subpaths = list_qsort(subpaths, append_total_cost_compare);
 		partial_subpaths = list_qsort(partial_subpaths,
-									  append_startup_cost_compare, NULL);
+									  append_startup_cost_compare);
 	}
 	pathnode->first_partial_path = list_length(subpaths);
 	pathnode->subpaths = list_concat(subpaths, partial_subpaths);
@@ -1432,7 +1432,7 @@ create_append_path(PlannerInfo *root,
  * (This is to avoid getting unpredictable results from qsort.)
  */
 static int
-append_total_cost_compare(const void *a, const void *b, void *arg)
+append_total_cost_compare(const void *a, const void *b)
 {
 	Path	   *path1 = (Path *) lfirst(*(ListCell **) a);
 	Path	   *path2 = (Path *) lfirst(*(ListCell **) b);
@@ -1453,7 +1453,7 @@ append_total_cost_compare(const void *a, const void *b, void *arg)
  * (This is to avoid getting unpredictable results from qsort.)
  */
 static int
-append_startup_cost_compare(const void *a, const void *b, void *arg)
+append_startup_cost_compare(const void *a, const void *b)
 {
 	Path	   *path1 = (Path *) lfirst(*(ListCell **) a);
 	Path	   *path2 = (Path *) lfirst(*(ListCell **) b);

--- a/src/include/nodes/pg_list.h
+++ b/src/include/nodes/pg_list.h
@@ -303,8 +303,8 @@ extern List *list_copy_tail(const List *list, int nskip);
 
 extern void *list_nth_replace(List *list, int n, void *new_data);
 
-typedef int (*list_qsort_comparator) (const void *a, const void *b, void *arg);
-extern List *list_qsort(const List *list, list_qsort_comparator cmp, void *arg);
+typedef int (*list_qsort_comparator) (const void *a, const void *b);
+extern List *list_qsort(const List *list, list_qsort_comparator cmp);
 
 /*
  * To ease migration to the new list API, a set of compatibility


### PR DESCRIPTION
This interface is exposed to extensions.  And the Greenplum specific modifications were used only by Greenplum specific partitioning code.

The `pg_auto_failover` extension uses `list_qsort` and fails to build with Greenplum without this patch.

@gfphoenix78 it is inspired from your commit https://github.com/gfphoenix78/gpdb/commit/a589329dfe3b1e1ebaea955fd612d9019a710f6c