### PR TITLE
disable gpload test in ubuntu

### DIFF
--- a/gpMgmt/bin/gpload_test/Makefile
+++ b/gpMgmt/bin/gpload_test/Makefile
@@ -17,9 +17,15 @@ GPTest.pm:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/GPTest.pm
 
 .PHONY: installcheck
+ifeq "$(findstring ubuntu, $(TEST_OS))" "ubuntu"
 installcheck: gpdiff.pl gpstringsubs.pl
+	@echo "skip gpload test for ubuntu"
+else
+installcheck: gpdiff.pl gpstringsubs.pl
+	@echo "doing test in OS: "; echo $(TEST_OS)
 	@cd gpload && ./TEST.py
 	@cd gpload2 && pytest TEST_local_*
+endif
 
 clean distclean:
 	rm -f gpdiff.pl atmsort.pm explain.pm GPTest.pm gpstringsubs.pl


### PR DESCRIPTION
Gpload doesn't need to support ubuntu, and some test cases in ubuntu will fail. We disable gpload test in ubuntu for further convenience.
Modify Makefile in gpload_test folder, skip gpload test if TEST_OS contains ubuntu.
This change only skips gpload test if the OS is ubuntu and would not impact other tests.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
