### PR TITLE
6X-only Prohibit set returning functions in WHERE clause

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -30,6 +30,7 @@
 #include "parser/parse_agg.h"
 #include "parser/parse_clause.h"
 #include "parser/parse_coerce.h"
+#include "parser/parse_expr.h"
 #include "parser/parse_func.h"
 #include "parser/parse_relation.h"
 #include "parser/parse_target.h"
@@ -56,6 +57,7 @@ typedef struct
 static bool 
 checkTableFunctions_walker(Node *node, check_table_func_context *context);
 
+static void check_srf_call_placement(ParseState *pstate, int location);
 /*
  *	Parse a function call
  *
@@ -637,6 +639,9 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					 parser_errposition(pstate,
 									  exprLocation((Node *) llast(fargs)))));
 	}
+
+	if (retset)
+		check_srf_call_placement(pstate, location);
 
 	/* build the appropriate output structure */
 	if (fdresult == FUNCDETAIL_NORMAL)
@@ -2094,6 +2099,144 @@ LookupAggNameTypeNames(List *aggname, List *argtypes, bool noError)
 	ReleaseSysCache(ftup);
 
 	return oid;
+}
+
+/*
+ * check_srf_call_placement
+ *		Verify that a set-returning function is called in a valid place,
+ *		and throw a nice error if not.
+ *
+ * This is a partial cherry-pick of upstream commit a4c35ea1c from
+ * REL_12_STABLE.  It was found that queries with set returning functions on
+ * the left of ANY/ALL operator lead to wrong results.  Such queries and more
+ * are prohibited by the upstream commit.
+ */
+static void
+check_srf_call_placement(ParseState *pstate, int location)
+{
+	const char *err;
+	bool		errkind;
+
+	/*
+	 * Check to see if the set-returning function is in an invalid place
+	 * within the query.  Basically, we don't allow SRFs anywhere except in
+	 * the targetlist (which includes GROUP BY/ORDER BY expressions), VALUES,
+	 * and functions in FROM.
+	 *
+	 * For brevity we support two schemes for reporting an error here: set
+	 * "err" to a custom message, or set "errkind" true if the error context
+	 * is sufficiently identified by what ParseExprKindName will return, *and*
+	 * what it will return is just a SQL keyword.  (Otherwise, use a custom
+	 * message to avoid creating translation problems.)
+	 */
+	err = NULL;
+	errkind = false;
+	switch (pstate->p_expr_kind)
+	{
+		case EXPR_KIND_NONE:
+			Assert(false);		/* can't happen */
+			break;
+		case EXPR_KIND_OTHER:
+			/* Accept SRF here; caller must throw error if wanted */
+			break;
+		case EXPR_KIND_JOIN_ON:
+		case EXPR_KIND_JOIN_USING:
+			err = _("set-returning functions are not allowed in JOIN conditions");
+			break;
+		case EXPR_KIND_FROM_SUBSELECT:
+			/* can't get here, but just in case, throw an error */
+			errkind = true;
+			break;
+		case EXPR_KIND_FROM_FUNCTION:
+			break;
+		case EXPR_KIND_WHERE:
+			errkind = true;
+			break;
+		case EXPR_KIND_HAVING:
+			errkind = true;
+			break;
+		case EXPR_KIND_FILTER:
+			errkind = true;
+			break;
+		case EXPR_KIND_WINDOW_PARTITION:
+		case EXPR_KIND_WINDOW_ORDER:
+			break;
+		case EXPR_KIND_WINDOW_FRAME_RANGE:
+		case EXPR_KIND_WINDOW_FRAME_ROWS:
+			err = _("set-returning functions are not allowed in window definitions");
+			break;
+		case EXPR_KIND_SELECT_TARGET:
+		case EXPR_KIND_INSERT_TARGET:
+			break;
+		case EXPR_KIND_UPDATE_SOURCE:
+		case EXPR_KIND_UPDATE_TARGET:
+			/* disallowed because it would be ambiguous what to do */
+			errkind = true;
+			break;
+		case EXPR_KIND_GROUP_BY:
+		case EXPR_KIND_ORDER_BY:
+		case EXPR_KIND_DISTINCT_ON:
+			break;
+		case EXPR_KIND_LIMIT:
+		case EXPR_KIND_OFFSET:
+			errkind = true;
+			break;
+		case EXPR_KIND_RETURNING:
+			errkind = true;
+			break;
+		case EXPR_KIND_VALUES:
+			break;
+		case EXPR_KIND_CHECK_CONSTRAINT:
+		case EXPR_KIND_DOMAIN_CHECK:
+			err = _("set-returning functions are not allowed in check constraints");
+			break;
+		case EXPR_KIND_COLUMN_DEFAULT:
+		case EXPR_KIND_FUNCTION_DEFAULT:
+			err = _("set-returning functions are not allowed in DEFAULT expressions");
+			break;
+		case EXPR_KIND_INDEX_EXPRESSION:
+			err = _("set-returning functions are not allowed in index expressions");
+			break;
+		case EXPR_KIND_INDEX_PREDICATE:
+			err = _("set-returning functions are not allowed in index predicates");
+			break;
+		case EXPR_KIND_ALTER_COL_TRANSFORM:
+			err = _("set-returning functions are not allowed in transform expressions");
+			break;
+		case EXPR_KIND_EXECUTE_PARAMETER:
+			err = _("set-returning functions are not allowed in EXECUTE parameters");
+			break;
+		case EXPR_KIND_TRIGGER_WHEN:
+			err = _("set-returning functions are not allowed in trigger WHEN conditions");
+			break;
+		case EXPR_KIND_PARTITION_EXPRESSION:
+			err = _("set-returning functions are not allowed in partition key expressions");
+			break;
+
+		case EXPR_KIND_SCATTER_BY:
+			err = _("set-returning functions are not allowed in scatter by expressions");
+			break;
+
+			/*
+			 * There is intentionally no default: case here, so that the
+			 * compiler will warn if we add a new ParseExprKind without
+			 * extending this switch.  If we do see an unrecognized value at
+			 * runtime, the behavior will be the same as for EXPR_KIND_OTHER,
+			 * which is sane anyway.
+			 */
+	}
+	if (err)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg_internal("%s", err),
+				 parser_errposition(pstate, location)));
+	if (errkind)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		/* translator: %s is name of a SQL construct, eg GROUP BY */
+				 errmsg("set-returning functions are not allowed in %s",
+						ParseExprKindName(pstate->p_expr_kind)),
+				 parser_errposition(pstate, location)));
 }
 
 

--- a/src/interfaces/gppc/test/expected/tabfunc_gppc_demo.out
+++ b/src/interfaces/gppc/test/expected/tabfunc_gppc_demo.out
@@ -419,10 +419,9 @@ LINE 1: SELECT * FROM TABLE(select a from t1);
     SELECT * FROM t1 WHERE a IN ( 
         transform( TABLE(select a,e from t1 where a < 5) )
     );
-ERROR:  operator does not exist: integer = record
-LINE 1: SELECT * FROM t1 WHERE a IN ( 
-                                 ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 2:         transform( TABLE(select a,e from t1 where a < 5) )
+                ^
     -- ERROR:  operator does not exist: integer = outtable
     -- TVE in IN clause
     SELECT * FROM t1 WHERE a IN ( 
@@ -2425,7 +2424,7 @@ select * from t1 order by transform( TABLE(select * from intable));
 ERROR:  table functions must be invoked in FROM clause
 -- ETF in LIMIT
 select * from t1 LIMIT transform (TABLE(select * from intable));
-ERROR:  argument of LIMIT must be type bigint, not type record
+ERROR:  set-returning functions are not allowed in LIMIT
 LINE 1: select * from t1 LIMIT transform (TABLE(select * from intabl...
                                ^
 -- ETF in GROUP BY
@@ -2435,10 +2434,9 @@ ERROR:  table functions must be invoked in FROM clause
 -- ETF in IN clause
 select * from t1 where a in 
               (transform(TABLE(select a,e from t1 where a<10)));
-ERROR:  operator does not exist: integer = record
-LINE 1: select * from t1 where a in 
-                                 ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 2:               (transform(TABLE(select a,e from t1 where a<10...
+                       ^
 -- Positive: ETF can be used for table JOIN operation
 -- The followings should succeed
     -- join table t1 with ETF

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -3171,7 +3171,9 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = generate_series(1,10), c ='n';
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 10.152.10.75:25432 pid=28938)
+ERROR:  set-returning functions are not allowed in UPDATE
+LINE 1: UPDATE dml_heap_pt_r SET a = generate_series(1,10), c ='n';
+                                     ^
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
@@ -3834,7 +3836,9 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_r SET a = generate_series(1,10), c ='n';
-ERROR:  multiple updates to a row by the same query is not allowed  (seg1 10.152.10.75:25433 pid=4138)
+ERROR:  set-returning functions are not allowed in UPDATE
+LINE 1: UPDATE dml_heap_r SET a = generate_series(1,10), c ='n';
+                                  ^
 SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -3182,7 +3182,9 @@ SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_pt_r SET a = generate_series(1,10), c ='n';
-ERROR:  cross-partition or multi-update to a row
+ERROR:  set-returning functions are not allowed in UPDATE
+LINE 1: UPDATE dml_heap_pt_r SET a = generate_series(1,10), c ='n';
+                                     ^
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT COUNT(*) FROM dml_heap_pt_r WHERE a = 1;
@@ -3850,7 +3852,9 @@ SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 (1 row)
 
 UPDATE dml_heap_r SET a = generate_series(1,10), c ='n';
-ERROR:  cross-partition or multi-update to a row
+ERROR:  set-returning functions are not allowed in UPDATE
+LINE 1: UPDATE dml_heap_r SET a = generate_series(1,10), c ='n';
+                                  ^
 SELECT COUNT(*) FROM dml_heap_r WHERE c ='n';
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 SELECT SUM(a) FROM dml_heap_r WHERE a = 1;

--- a/src/test/regress/expected/qp_functions.out
+++ b/src/test/regress/expected/qp_functions.out
@@ -1138,3 +1138,29 @@ $$;
 NOTICE:  n: 9.12
 NOTICE:  t: 9.1
 NOTICE:  n: 9.12
+-- Set returning functions should be prohibited in predicates.
+create table srf_placement_tab ( a int, b int[], c text[]) distributed by (a);
+insert into srf_placement_tab values
+       (1, ARRAY[1,2,3,4,5], ARRAY['this','is','test']),
+       (1, ARRAY[10,20,30,40,50], ARRAY['this', 'is', 'another', 'test']),
+       (1, ARRAY[-1,-2,-3,-4,-5], ARRAY['and', 'yet', 'another', 'test']);
+-- both the following select statements should report error due to the
+-- set-returning-function unnest being called from the wrong place
+select * from srf_placement_tab where unnest(b) = ANY(ARRAY[3,4]);
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 1: select * from srf_placement_tab where unnest(b) = ANY(ARRAY[...
+                                              ^
+select * from srf_placement_tab where length(unnest(c)) = ALL(ARRAY[5, 4]);
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 1: select * from srf_placement_tab where length(unnest(c)) = AL...
+                                                     ^
+-- SRFs are not allowed in update statements
+update srf_placement_tab set a = generate_series(1,10);
+ERROR:  set-returning functions are not allowed in UPDATE
+LINE 1: update srf_placement_tab set a = generate_series(1,10);
+                                         ^
+-- And in limit clause
+select 1 limit generate_series(1,10);
+ERROR:  set-returning functions are not allowed in LIMIT
+LINE 1: select 1 limit generate_series(1,10);
+                       ^


### PR DESCRIPTION
A set returning function when used on the left of ANY/ALL clause in a WHERE clause leads to wrong results.  Such queries are prohibited in PostgreSQL version 12 / Greenplum 7.  This patch prohibits the queries in 6X by partially cherry-picking commit a4c35ea1 from REL_12_STABLE.

The executor is not equipped to handle more than one row when evaluating a scalar operator expresssion (ANY/ALL), see
`ExecEvalFPScalarArrayStr` as an example.

I have refrained from pulling in follow up commits such as d43a619c60405ecda275ca9e3ac9ead242e20ecb because that would be too much behavior churn on a stable branch.