### PR TITLE
gpMgmt unittests: allow unittests to run on new Python3 distributions

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -3,7 +3,6 @@
 
 from contextlib import closing
 import os
-import platform
 import shutil
 import sys
 import tarfile
@@ -122,16 +121,6 @@ class OSCompatibilityError(Exception):
 
     def __init__(self, requiredos, foundos):
         Exception.__init__(self, '%s OS required. %s OS found' % (requiredos, foundos))
-
-
-class ArchCompatibilityError(Exception):
-    """
-        Exception to notify that architecture does not meet
-        the requirement
-    """
-
-    def __init__(self, requiredarch, foundarch):
-        Exception.__init__(self, '%s Arch required. %s Arch found' % (requiredarch, foundarch))
 
 
 class RequiredDependencyError(Exception):
@@ -569,15 +558,6 @@ class ValidateInstallPackage(Operation):
         # Check the GPDB requirements
         if not IsVersionCompatible(self.gppkg).run():
             raise GpdbVersionError
-
-        # TODO: AK: I've changed our use of the OS tag from 'Linux' to 'rhel5' or 'suse10'.
-        # So, the two lines below will not work properly.
-        # if self.gppkg.os.lower() != platform.system().lower():
-        #    raise OSCompatibilityError(self.gppkg.os, platform.system().lower())
-
-        # architecture compatibility
-        if self.gppkg.architecture.lower() != platform.machine().lower():
-            raise ArchCompatibilityError(self.gppkg.architecture, platform.machine().lower())
 
         rpm_set = set([self.gppkg.main_rpm] + self.gppkg.dependencies)
         rpm_install_string = ' '.join([os.path.join(TEMP_EXTRACTION_PATH, rpm) for rpm in rpm_set])

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import unittest
 import tempfile
-import platform
 import getpass
 import tarfile
 
@@ -33,7 +32,6 @@ def get_os():
     return os_string
 
 OS = get_os()
-ARCH = platform.machine()
 
 # AK: use dereference_symlink when mucking with RPM database for the same reason
 # it's used in the gppylib.operations.package. For more info, see the function definition.
@@ -134,7 +132,7 @@ def run_remote_command(cmd_str, host):
 
 class GppkgSpec:
     """Represents the gppkg spec file"""
-    def __init__(self, name, version, gpdbversion = GPDB_VERSION, os = OS, arch = ARCH):
+    def __init__(self, name, version, gpdbversion = GPDB_VERSION, os = OS):
         """
         All the parameters require arguments of type string.
         """
@@ -142,7 +140,6 @@ class GppkgSpec:
         self.version = version
         self.gpdbversion = gpdbversion
         self.os = os
-        self.arch = arch
 
     def get_package_name(self):
         """Returns the package name of the form <name>-<version>"""
@@ -150,7 +147,7 @@ class GppkgSpec:
 
     def get_filename(self):
         """Returns the complete filename of the gppkg"""
-        return self.get_package_name() + '-' + self.os + '-' + self.arch + GPPKG_EXTENSION
+        return self.get_package_name() + '-' + self.os + '-x86_64' + GPPKG_EXTENSION
 
     def __str__(self):
         """Returns the GppkgSpec in the form of a string"""
@@ -160,7 +157,7 @@ Version: ''' + self.version + '''
 GPDBVersion: ''' + self.gpdbversion + '''
 Description: Temporary Test Package
 OS: ''' + self.os + '''
-Architecture: ''' + self.arch
+Architecture: x86_64'''
 
         return gppkg_spec_file
 
@@ -231,7 +228,7 @@ class RPMSpec:
 
     def get_filename(self):
         """Returns the complete filename of the rpm"""
-        return self.get_package_name() + '.' + ARCH + ".rpm"
+        return self.get_package_name() + '.x86_64.rpm'
 
     def __str__(self):
         """Returns the rpm spec file as a string"""
@@ -249,7 +246,7 @@ Group:          Development/Tools
 Prefix:         /temp
 AutoReq:        no
 AutoProv:       no
-BuildArch:      ''' + ARCH + '''
+BuildArch:      x86_64
 Provides:       ''' + self.name + ''' = '''+ self.version +''', /bin/sh
 BuildRoot:      %{_topdir}/BUILD '''
 
@@ -296,7 +293,7 @@ class BuildRPM(Operation):
 
                 os.system("cd " + SCRATCH_SPACE + "; rpmbuild --quiet -bb " + f.name)
 
-            shutil.copy(os.path.join(SCRATCH_SPACE, "RPMS", ARCH, self.spec.get_filename()), os.getcwd())
+            shutil.copy(os.path.join(SCRATCH_SPACE, "RPMS", "x86_64", self.spec.get_filename()), os.getcwd())
         finally:
             shutil.rmtree(build_dir)
             shutil.rmtree(rpms_dir)

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_package/__init__.py
@@ -15,17 +15,17 @@ from gppylib.commands.unix import Scp
 from gppylib.commands.base import Command, ExecutionError, REMOTE
 from gppylib.operations import Operation
 from gppylib.operations.unix import CheckFile, CheckRemoteFile, RemoveRemoteFile
-from gppylib.operations.package import dereference_symlink, GpScp
+from gppylib.operations.package import dereference_symlink, GpScp, linux_distribution_id, linux_distribution_version
 from gppylib.commands.base import Command, REMOTE
 
 def get_os():
-    dist, release, _ = platform.dist()
+    dist, release = linux_distribution_id(), linux_distribution_version()
     major_release = release.partition('.')[0]
 
     os_string = ''
-    if dist.lower() == 'redhat':
+    if dist.lower().startswith('redhat'):
         os_string += 'rhel'
-    elif dist.lower() == 'suse':
+    elif dist.lower().startswith('suse'):
         os_string += 'suse'
 
     os_string += major_release

--- a/gpMgmt/bin/gppylib/operations/test/regress/test_package/test_regress_simple_negative.py
+++ b/gpMgmt/bin/gppylib/operations/test/regress/test_package/test_regress_simple_negative.py
@@ -16,15 +16,6 @@ class SimpleNegativeTestCase(GppkgTestCase):
 
         with self.assertRaisesRegex(ExecutionError , "%s OS required. %s OS found" % (os, OS)):
             self.install(gppkg_file)
-       
-    def test01_wrong_arch(self):
-        arch = "abcde"
-        A_spec = self.A_spec 
-        alpha_spec = GppkgSpec("alpha", "1.0", GPDB_VERSION, OS, arch)
-        gppkg_file = self.build(alpha_spec, A_spec) 
-
-        with self.assertRaisesRegex(ExecutionError, "%s Arch required. %s Arch found" % (arch, ARCH)):
-            self.install(gppkg_file)
 
     def test02_wrong_gpdbversion(self):
         gpdb_version = "4.6"
@@ -107,16 +98,6 @@ class SimpleNegativeTestCase(GppkgTestCase):
         
         with self.assertRaisesRegex(ExecutionError, "%s os required. %s os found" % (os, OS)):
             self.update(gppkg_file)
-
-    def test09_wrong_arch_update(self):
-        arch = "abcde"
-        self.install(self.alpha_spec.get_filename())
-
-        invalid_os_gppkg = GppkgSpec("alpha", "1.1", GPDB_VERSION, OS, arch)
-        gppkg_file = self.build(invalid_os_gppkg, self.A_spec)
-
-        with self.assertRaisesRegex(ExecutionError, "%s Arch required. %s Arch found" % (arch, ARCH)):
-            self.update(gppkg_file) 
 
 if __name__ == "__main__":
     unittest.main()

--- a/gpMgmt/bin/gppylib/operations/test/test_package.py
+++ b/gpMgmt/bin/gppylib/operations/test/test_package.py
@@ -437,15 +437,6 @@ class SimpleNegativeTestCases(GppkgTestCase):
         with self.assertRaisesRegex(ExecutionError, "%s os required. %s os found" % (os, OS)):
             self.install(gppkg_file)
 
-    def test01_wrong_arch(self):
-        arch = "abcde"
-        rpm_spec = self.rpm_spec
-        gppkg_spec = GppkgSpec("test", "1.0", GPDB_VERSION, OS, arch)
-        gppkg_file = self.build(gppkg_spec, rpm_spec)
-
-        with self.assertRaisesRegex(ExecutionError, "%s Arch required. %s Arch found" % (arch, ARCH)):
-            self.install(gppkg_file)
-
     def test02_wrong_gpdbversion(self):
         gpdb_version = "4.6"
         rpm_spec = self.rpm_spec

--- a/gpMgmt/bin/gppylib/programs/gppkg.py
+++ b/gpMgmt/bin/gppylib/programs/gppkg.py
@@ -15,11 +15,10 @@ try:
     from gppylib.gpversion import GpVersion
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.mainUtils import addCoordinatorDirectoryOptionForSingleClusterProgram, addStandardLoggingAndHelpOptions, ExceptionNoStackTraceNeeded
-    from gppylib.operations.package import MigratePackages, InstallPackage, UninstallPackage, QueryPackage, BuildGppkg, UpdatePackage, CleanGppkg, Gppkg, GPPKG_EXTENSION, GPPKG_ARCHIVE_PATH
+    from gppylib.operations.package import MigratePackages, InstallPackage, UninstallPackage, QueryPackage, BuildGppkg, UpdatePackage, CleanGppkg, Gppkg, GPPKG_EXTENSION, GPPKG_ARCHIVE_PATH, linux_distribution_id
     from gppylib.userinput import ask_yesno
     from gppylib.operations.unix import ListFilesByPattern
 
-    import platform
 except ImportError as ex:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(ex))
 
@@ -188,7 +187,7 @@ class GpPkgProgram:
                 BuildGppkg(self.build, None).run()
             return
 
-        if platform.linux_distribution()[0] == 'Ubuntu':
+        if linux_distribution_id() == 'ubuntu':
             try:
                 cmd = Command(name='Check for dpkg', cmdStr='dpkg --version')
                 cmd.run(validateAfter=True)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_mainUtils.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_mainUtils.py
@@ -30,7 +30,7 @@ class MainUtilsTestCase(GpTestCase):
 
     def test_exceptionPIDLockHeld_if_same_pid(self):
         with self.lock:
-            with self.assertRaises(PIDLockHeld, message="PIDLock already held at %s" % (self.lockfile)):
+            with self.assertRaisesRegex(PIDLockHeld, "PIDLock already held at %s" % (self.lockfile)):
                 self.lock.acquire()
 
     def test_child_can_read_lock_owner(self):
@@ -47,7 +47,7 @@ class MainUtilsTestCase(GpTestCase):
         pid = os.fork()
         # if child, os.fork() == 0
         if pid == 0:
-            with self.assertRaises(PIDLockHeld, message="PIDLock already held at %s" % (self.lockfile)):
+            with self.assertRaisesRegex(PIDLockHeld, "PIDLock already held at %s" % (self.lockfile)):
                 self.lock.acquire()
             os._exit(0)
         else:

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import shutil
 
 import behave
@@ -11,6 +10,7 @@ from steps.mirrors_mgmt_utils import MirrorMgmtContext
 from steps.gpconfig_mgmt_utils import GpConfigContext
 from steps.gpssh_exkeys_mgmt_utils import GpsshExkeysMgmtContext
 from gppylib.db import dbconn
+from gppylib.operations.package import linux_distribution_id, linux_distribution_version
 
 def before_all(context):
     if list(map(int, behave.__version__.split('.'))) < [1,2,6]:
@@ -90,7 +90,7 @@ def after_feature(context, feature):
 
 def before_scenario(context, scenario):
     if "skip_fixme_ubuntu18.04" in scenario.effective_tags:
-        if platform.linux_distribution()[0].lower() == "ubuntu" and platform.linux_distribution()[1] == "18.04":
+        if linux_distribution_id() == "ubuntu" and linux_distribution_version() == "18.04":
             scenario.skip("skipping scenario tagged with @skip_fixme_ubuntu18.04")
             return
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -10,7 +10,6 @@ from steps.mirrors_mgmt_utils import MirrorMgmtContext
 from steps.gpconfig_mgmt_utils import GpConfigContext
 from steps.gpssh_exkeys_mgmt_utils import GpsshExkeysMgmtContext
 from gppylib.db import dbconn
-from gppylib.operations.package import linux_distribution_id, linux_distribution_version
 
 def before_all(context):
     if list(map(int, behave.__version__.split('.'))) < [1,2,6]:
@@ -88,12 +87,8 @@ def after_feature(context, feature):
             And gpstop should return a return code of 0
             ''')
 
-def before_scenario(context, scenario):
-    if "skip_fixme_ubuntu18.04" in scenario.effective_tags:
-        if linux_distribution_id() == "ubuntu" and linux_distribution_version() == "18.04":
-            scenario.skip("skipping scenario tagged with @skip_fixme_ubuntu18.04")
-            return
 
+def before_scenario(context, scenario):
     if "skip" in scenario.effective_tags:
         scenario.skip("skipping scenario tagged with @skip")
         return

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -61,7 +61,6 @@ Feature: gpactivatestandby
         And verify gpstate with options "-m" output is correct
         And clean up and revert back to original coordinator
 
-    @skip_fixme_ubuntu18.04
     Scenario: tablespaces work
         Given the database is running
           And the standby is not initialized

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -85,11 +85,6 @@ Feature: gpconfig integration tests
         | utf-8 works                                 | search_path                  | string     | boo        | Ομήρου    | 'Ομήρου'   | Ομήρου     | Ομήρου                 | 'Ομήρου'                    | Ομήρου            | 'Ομήρου'               | Ομήρου                 |
         | client min messages works                   | client_min_messages          | string     | log        | notice    | notice     | notice     | notice                 | notice                      | notice            | notice                 | notice                 |
 
-    @skip_fixme_ubuntu18.04
-    Examples:
-        | test_case                              | guc                          | type       | seed_value | value     | file_value | live_value | value_coordinator_only | file_value_coordinator_only | value_coordinator | file_value_coordinator | live_value_coordinator |
-        | utf-8 works                            | search_path                  | string     | boo        | Ομήρου    | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |
-
     @concourse_cluster
     @demo_cluster
     Scenario Outline: write directly to postgresql.conf file: <type>

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -125,7 +125,6 @@ Feature: gpinitsystem tests
         And gpinitsystem should print "Log file scan check passed" to stdout
         And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
-    @skip_fixme_ubuntu18.04
     Scenario: gpinitsystem creates a cluster in default timezone
         Given the database is not running
         And "TZ" environment variable is not set

--- a/gpMgmt/test/behave/mgmt_utils/gppkg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppkg.feature
@@ -59,7 +59,6 @@ Feature: gppkg tests
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --install should report success because the package is not yet installed
         Given the database is running
@@ -69,7 +68,6 @@ Feature: gppkg tests
         And gppkg should print "Completed local installation of sample" to stdout
         And "sample" gppkg files exist on all hosts
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --install should report failure because the package is already installed
         Given the database is running
@@ -77,7 +75,6 @@ Feature: gppkg tests
         Then gppkg should return a return code of 2
         And gppkg should print "sample.gppkg is already installed." to stdout
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --remove should report success when the package is already installed
         Given the database is running
@@ -88,7 +85,6 @@ Feature: gppkg tests
         And gppkg should print "sample.gppkg successfully uninstalled" to stdout
         And "sample" gppkg files do not exist on any hosts
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --query should report installed packages
         Given the database is running
@@ -100,7 +96,6 @@ Feature: gppkg tests
         And gppkg should print "Starting gppkg with args: --query --all" to stdout
         And gppkg should print "sample" to stdout
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --clean (which should be named "sync") should install to the segment host that lacks a gppkg found elsewhere
         Given the database is running
@@ -111,7 +106,6 @@ Feature: gppkg tests
         And gppkg should print "The following packages will be installed on .*: sample.gppkg" to stdout
         And "sample" gppkg files exist on all hosts
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --clean (which should be named "sync") should remove on all segment hosts when gppkg does not exist in coordinator
         Given the database is running
@@ -122,7 +116,6 @@ Feature: gppkg tests
         And gppkg should print "The following packages will be uninstalled on .*: sample.gppkg" to stdout
         And "sample" gppkg files do not exist on any hosts
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gppkg --migrate copies all packages from coordinator to all segment hosts
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -222,7 +222,6 @@ Feature: gprecoverseg tests
         And the backup pid file is deleted on "primary" segment
         And the background pid is killed on "primary" segment
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg full recovery testing
         Given the database is running
@@ -238,7 +237,6 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg with -i and -o option
         Given the database is running
@@ -257,7 +255,6 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg should not throw exception for empty input file
         Given the database is running
@@ -275,7 +272,6 @@ Feature: gprecoverseg tests
         Then all the segments are running
         And the segments are synchronized
 
-    @skip_fixme_ubuntu18.04
     @concourse_cluster
     Scenario: gprecoverseg should use the same setting for data_checksums for a full recovery
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 import pipes
-import platform
 import shutil
 import socket
 import tempfile
@@ -33,6 +32,7 @@ from test.behave_utils.cluster_expand import Gpexpand
 from test.behave_utils.gpexpand_dml import TestDML
 from gppylib.commands.base import Command, REMOTE
 from gppylib import pgconf
+from gppylib.operations.package import linux_distribution_id, linux_distribution_version
 
 
 coordinator_data_dir = gp.get_coordinatordatadir()
@@ -40,7 +40,7 @@ if coordinator_data_dir is None:
     raise Exception('Please set COORDINATOR_DATA_DIRECTORY in environment')
 
 def show_all_installed(gphome):
-    x = platform.linux_distribution()
+    x = linux_distribution_id(), linux_distribution_version()
     name = x[0].lower()
     if 'ubuntu' in name:
         return "dpkg --get-selections --admindir=%s/share/packages/database/deb | awk '{print $1}'" % gphome
@@ -50,7 +50,7 @@ def show_all_installed(gphome):
         raise Exception('UNKNOWN platform: %s' % str(x))
 
 def remove_native_package_command(gphome, full_gppkg_name):
-    x = platform.linux_distribution()
+    x = linux_distribution_id(), linux_distribution_version()
     name = x[0].lower()
     if 'ubuntu' in name:
         return 'fakeroot dpkg --force-not-root --log=/dev/null --instdir=%s --admindir=%s/share/packages/database/deb -r %s' % (gphome, gphome, full_gppkg_name)


### PR DESCRIPTION
Python does not guarantee backwards source compatibility.  We need to make a few changes to allow our unittests to run in Python3 later minor versions:

- implement platform.linux_distribution() directly

    As of Python 3.8, the standard library module 'platform' does not have
    linux_distribution().  However, we only use this function on our supported
    production platforms.  These evidently all use systemd, which requires a file
    /etc/os-release containing all the information we need.

- gppkg: remove import of platform for general cleanup

    We only use x86_64 architectures for Greenplum, so remove packaging support
    for 32-bit.  The motivation is to remove the import of platform.  This is general cleanup and isn't
    strictly required but removes an import.

- gpMgmt unit tests: remove obsolete field in mockutils assertRaises()

    When using a late enough version of mock, the self.assertRaises() signature
    changed, so modify our code to handle this.

- gpMgmt tests: remove skip_fixme_ubuntu18.04 tags in Behave tests

    It turns out that we no longer need to skip these tests on Ubuntu18.04
    in 7X.  They all pass now.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-cm-divyesh_unittest_fixes)