### PR TITLE
Dispatch ALTER SYSTEM command

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1431,6 +1431,9 @@ _outNode(StringInfo str, void *obj)
 			case T_AlterRoleSetStmt:
 				_outAlterRoleSetStmt(str, obj);
 				break;
+			case T_AlterSystemStmt:
+				_outAlterSystemStmt(str, obj);
+				break;
 
 			case T_AlterObjectSchemaStmt:
 				_outAlterObjectSchemaStmt(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3521,6 +3521,13 @@ _outAlterRoleSetStmt(StringInfo str, const AlterRoleSetStmt *node)
 	WRITE_NODE_FIELD(setstmt);
 }
 
+static  void
+_outAlterSystemStmt(StringInfo str, const AlterSystemStmt *node)
+{
+	WRITE_NODE_TYPE("ALTERSYSTEMSTMT");
+
+	WRITE_NODE_FIELD(setstmt);
+}
 
 static  void
 _outAlterOwnerStmt(StringInfo str, const AlterOwnerStmt *node)
@@ -6095,6 +6102,10 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_AlterRoleSetStmt:
 				_outAlterRoleSetStmt(str, obj);
+				break;
+
+			case T_AlterSystemStmt:
+				_outAlterSystemStmt(str, obj);
 				break;
 
 			case T_AlterObjectSchemaStmt:

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2216,6 +2216,10 @@ readNodeBinary(void)
 				return_value = _readAlterObjectDependsStmt();
 				break;
 
+			case T_AlterSystemStmt:
+				return_value = _readAlterSystemStmt();
+				break;
+
 			case T_AlterObjectSchemaStmt:
 				return_value = _readAlterObjectSchemaStmt();
 				break;

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1069,6 +1069,16 @@ _readAlterRoleSetStmt(void)
 	READ_DONE();
 }
 
+static AlterSystemStmt *
+_readAlterSystemStmt(void)
+{
+	READ_LOCALS(AlterSystemStmt);
+
+	READ_NODE_FIELD(setstmt);
+
+	READ_DONE();
+}
+
 static AlterObjectSchemaStmt *
 _readAlterObjectSchemaStmt(void)
 {
@@ -4648,6 +4658,8 @@ parseNodeString(void)
 		return_value = _readAlterPolicyStmt();
 	else if (MATCHX("ALTERROLESETSTMT"))
 		return_value = _readAlterRoleSetStmt();
+	else if (MATCHX("ALTERSYSTEMSTMT"))
+		return_value = _readAlterSystemStmt();
 	else if (MATCHX("ALTERROLESTMT"))
 		return_value = _readAlterRoleStmt();
 	else if (MATCHX("ALTERSEQSTMT"))

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -782,6 +782,11 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 		case T_AlterSystemStmt:
 			PreventInTransactionBlock(isTopLevel, "ALTER SYSTEM");
 			AlterSystemSetConfigFile((AlterSystemStmt *) parsetree);
+			if (Gp_role == GP_ROLE_DISPATCH)
+				CdbDispatchUtilityStatement((Node *) parsetree,
+											DF_CANCEL_ON_ERROR,
+											NULL,
+											NULL);
 			break;
 
 		case T_VariableSetStmt:

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -77,18 +77,15 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
 (2 rows)
 
 -- set GUCs to speed-up the test
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
--- start_ignore
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
--- start_ignore
--- end_ignore
-(exited with code 0)
-!\retcode gpstop -u;
--- start_ignore
--- end_ignore
-(exited with code 0)
+alter system set gp_fts_probe_retries to 2;
+ALTER
+alter system set gp_fts_probe_timeout to 5;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
 
 -- start_ignore
 select dbid from gp_segment_configuration where content = 0 and role = 'p';
@@ -128,21 +125,16 @@ select content, preferred_role, role, status, mode from gp_segment_configuration
  0       | p              | p    | u      | n    
 (2 rows)
 
--- set GUCs to speed-up the test
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-!\retcode gpstop -u;
--- start_ignore
--- end_ignore
-(exited with code 0)
+-- reset GUCs
+alter system set gp_fts_probe_retries to default;
+ALTER
+alter system set gp_fts_probe_timeout to default;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
 
 -- -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;

--- a/src/test/isolation2/expected/terminate_in_gang_creation.out
+++ b/src/test/isolation2/expected/terminate_in_gang_creation.out
@@ -165,9 +165,9 @@ SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid) FROM gp_
 --------------------------
  Success:                 
 (1 row)
-ALTER SYSTEM RESET gp_dtx_recovery_interval;
+2: ALTER SYSTEM RESET gp_dtx_recovery_interval;
 ALTER
-SELECT pg_reload_conf();
+2: SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
  t              

--- a/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/mirror_promotion.sql
@@ -42,9 +42,9 @@ from gp_segment_configuration
 where content = 0;
 
 -- set GUCs to speed-up the test
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
-!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
-!\retcode gpstop -u;
+alter system set gp_fts_probe_retries to 2;
+alter system set gp_fts_probe_timeout to 5;
+select pg_reload_conf();
 
 -- start_ignore
 select dbid from gp_segment_configuration where content = 0 and role = 'p';
@@ -67,10 +67,10 @@ select content, preferred_role, role, status, mode
 from gp_segment_configuration
 where content = 0;
 
--- set GUCs to speed-up the test
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
-!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
-!\retcode gpstop -u;
+-- reset GUCs
+alter system set gp_fts_probe_retries to default;
+alter system set gp_fts_probe_timeout to default;
+select pg_reload_conf();
 
 -- -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;

--- a/src/test/isolation2/sql/terminate_in_gang_creation.sql
+++ b/src/test/isolation2/sql/terminate_in_gang_creation.sql
@@ -95,5 +95,5 @@ SELECT gp_inject_fault('fts_probe', 'reset', dbid)
 	FROM gp_segment_configuration WHERE role='p' AND content=-1;
 SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid)
     FROM gp_segment_configuration WHERE role='p' AND content=-1;
-ALTER SYSTEM RESET gp_dtx_recovery_interval;
-SELECT pg_reload_conf();
+2: ALTER SYSTEM RESET gp_dtx_recovery_interval;
+2: SELECT pg_reload_conf();

--- a/src/test/regress/expected/disable_autovacuum.out
+++ b/src/test/regress/expected/disable_autovacuum.out
@@ -1,7 +1,10 @@
 alter system set autovacuum = off;
-select * from pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+             2 | t
+             1 | t
+             0 | t
+            -1 | t
+(4 rows)
 

--- a/src/test/regress/expected/enable_autovacuum.out
+++ b/src/test/regress/expected/enable_autovacuum.out
@@ -1,7 +1,10 @@
 alter system set autovacuum = on;
-select * from pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+             2 | t
+             1 | t
+             0 | t
+            -1 | t
+(4 rows)
 

--- a/src/test/regress/sql/disable_autovacuum.sql
+++ b/src/test/regress/sql/disable_autovacuum.sql
@@ -1,2 +1,2 @@
 alter system set autovacuum = off;
-select * from pg_reload_conf();
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');

--- a/src/test/regress/sql/enable_autovacuum.sql
+++ b/src/test/regress/sql/enable_autovacuum.sql
@@ -1,2 +1,2 @@
 alter system set autovacuum = on;
-select * from pg_reload_conf();
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');


### PR DESCRIPTION
`ALTER SYSTEM` only modified the GUC on coordinator. Changing it to dispatch the command to segments as well. Would be ideal in long run for `ALTER SYSTEM` similar to `gpconfig` to have `coordinator_only` option. But for now it seems more natural to set GUC on all nodes instead of only coordinator. Given this command directly works directly on filesystem and not transactional, if fails on a segment, the modification will still remain on other segments. I believe this is no different from `gpconfig` failing half way.

Also, in this PR then changing disable/enable autovacuum test to take effect on segments along with coordinator. That hopefully should help to fix the flakiness we are seeing in CI post the autovacuum feature was enabled for catalog on segments.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
