### PR TITLE
check_gp.c: Use pg_catalog to empty out search path

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -1302,7 +1302,7 @@ check_views_with_fabricated_anyarray_casts()
 								"view_has_anyarray_casts(c.oid) = TRUE;");
 
 		PQclear(executeQueryOrDie(conn, "DROP FUNCTION view_has_anyarray_casts(OID);"));
-		PQclear(executeQueryOrDie(conn, "SET search_path to '';"));
+		PQclear(executeQueryOrDie(conn, "SET search_path to 'pg_catalog';"));
 
 		ntups = PQntuples(res);
 		i_viewname = PQfnumber(res, "badviewname");


### PR DESCRIPTION
Setting search_path to `''` in 5X, during a 5X->6X upgrade leads to:

```
SET search_path to '';
ERROR:  schema "" does not exist.
```

So, set search_path to `'pg_catalog'` instead, which has the same effect.

PG Documentation excerpt: The system catalog schema, pg_catalog, is
always searched, whether it is mentioned in the path or not. If it is
mentioned in the path then it will be searched in the specified order.
If pg_catalog is not in the path then it will be searched before
searching any of the path items.

Co-authored-by: David Krieger <dkrieger@vmware.com>
Co-authored-by: Kevin Yeap <kyeap@vmware.com>
