### PR TITLE
Enable tests for GSSAPI and SSL on CI

### DIFF
--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -12,12 +12,14 @@ class GpBuild:
     def __init__(self, mode="orca"):
         self.mode = 'on' if mode == 'orca' else 'off'
         self.configure_options =  [
+                                    "--enable-gpcloud",
                                     "--enable-mapreduce",
                                     "--enable-orafce",
+                                    "--enable-tap-tests",
                                     "--with-gssapi",
-                                    "--with-perl",
-                                    "--enable-gpcloud",
                                     "--with-libxml",
+                                    "--with-openssl",
+                                    "--with-perl",
                                     "--with-python",
                                     # TODO: Remove this line as soon as zstd is built into Ubuntu docker image
                                     "--without-zstd",

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -31,7 +31,7 @@ function configure() {
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends
       # on these options for deciding what to test. Since we don't ship
-      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python PYTHON=python3 --enable-gpcloud --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
+      ./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpcloud --enable-mapreduce --enable-orafce --enable-tap-tests --with-gssapi --with-libxml --with-openssl --with-perl --with-python PYTHON=python3 PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
 
   popd
 }

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -31,7 +31,7 @@ function gen_env(){
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		cd "\${1}/gpdb_src"
 		source gpAux/gpdemo/gpdemo-env.sh
-		make -s ${MAKE_TEST_COMMAND}
+		PG_TEST_EXTRA="kerberos ssl" make -s ${MAKE_TEST_COMMAND}
 	EOF
 
 	chmod a+x /opt/run_test.sh


### PR DESCRIPTION
And sort the flags in alphabetical order.

We do the `configure` in the test task just for `src/test`, and some
tests are decided to run or not based on that `configure` but not the
one which built the binary.

For instance, this snippet is in the `src/test/Makefile`:

```
ifeq ($(with_gssapi),yes)
ifneq (,$(filter kerberos,$(PG_TEST_EXTRA)))
SUBDIRS += kerberos

SUBDIRS += gpkerberos

endif
```
