### PR TITLE
Fix io checking in fts probe

### DIFF
--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -53,7 +53,7 @@ checkIODataDirectory(void)
 	errno = 0;
 	bool failure = false;
 
-	fd = BasicOpenFile(FTS_PROBE_FILE_NAME, O_RDWR | PG_O_DIRECT | O_EXCL);
+	fd = BasicOpenFile(FTS_PROBE_FILE_NAME, O_RDWR | PG_O_DIRECT);
 	do
 	{
 		if (fd < 0)
@@ -80,6 +80,15 @@ checkIODataDirectory(void)
 						failure = true;
 					}
 				}
+			}
+			else if (errno == EINVAL)
+			{
+				ereport(WARNING, (errcode_for_file_access(),
+						errmsg("FTS: could not open file \"%s\" (%m)", FTS_PROBE_FILE_NAME)),
+						errdetail("Possibly because the file system does not "
+								  "support O_DIRECT (e.g. tmpfs does not). "
+								  "Skipping IO check anyway."));
+				failure = false;
 			}
 			else
 			{


### PR DESCRIPTION
O_EXCL should be usually with O_CREAT.  No need of PG_O_DIRECT or fsync since
usually if there is io error, read/write/open have already detected, also
O_DIRECT is broken at this moment in some releases (e.g. Photon OS) - this
leads all primaries to be marked as down by fts.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
