### PR TITLE
[6X backport] backport 2 commits to fix resource group wait queue corruption

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1915,15 +1915,9 @@ groupAcquireSlot(ResGroupInfo *pGroupInfo, bool isMoveQuery)
 
 	/*
 	 * Add into group wait queue (if not waiting yet).
-	 *
-	 * Need to handle a special case, when MyProc was interrupted
-	 * by SIGTERM while waiting for resource group slot.
-	 * Some callbacks - RemoveTempRelationsCallback for example -
-	 * open new transactions on proc exit. It can cause a double
-	 * add of MyProc to the waiting queue (and its corruption).
 	 */
-	if (!procIsWaiting(MyProc))
-		groupWaitQueuePush(group, MyProc);
+	Assert(!proc_exit_inprogress);
+	groupWaitQueuePush(group, MyProc);
 
 	if (!group->lockedForDrop)
 		group->totalQueued++;
@@ -2566,10 +2560,21 @@ DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
 bool
 ShouldAssignResGroupOnMaster(void)
 {
+	/*
+	 * Bypass resource group when it's waiting for a resource group slot. e.g.
+	 * MyProc was interrupted by SIGTERM while waiting for resource group slot.
+	 * Some callbacks - RemoveTempRelationsCallback for example - open new
+	 * transactions on proc exit. It can cause a double add of MyProc to the
+	 * waiting queue (and its corruption).
+	 *
+	 * Also bypass resource group when it's exiting.
+	 */
 	return IsResGroupActivated() &&
 		IsNormalProcessingMode() &&
 		Gp_role == GP_ROLE_DISPATCH &&
-		!AmIInSIGUSR1Handler();
+		!AmIInSIGUSR1Handler() &&
+		!proc_exit_inprogress &&
+		!procIsWaiting(MyProc);
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1913,8 +1913,17 @@ groupAcquireSlot(ResGroupInfo *pGroupInfo, bool isMoveQuery)
 		}
 	}
 
-	/* add into group wait queue */
-	groupWaitQueuePush(group, MyProc);
+	/*
+	 * Add into group wait queue (if not waiting yet).
+	 *
+	 * Need to handle a special case, when MyProc was interrupted
+	 * by SIGTERM while waiting for resource group slot.
+	 * Some callbacks - RemoveTempRelationsCallback for example -
+	 * open new transactions on proc exit. It can cause a double
+	 * add of MyProc to the waiting queue (and its corruption).
+	 */
+	if (!procIsWaiting(MyProc))
+		groupWaitQueuePush(group, MyProc);
 
 	if (!group->lockedForDrop)
 		group->totalQueued++;

--- a/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
@@ -243,5 +243,62 @@ DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
+-- test5: terminate a query waiting for a slot, that opens a transaction on exit callback
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1:CREATE TEMP TABLE tmp(a INT);
+CREATE
+2:SET ROLE role_concurrency_test;
+SET
+2:BEGIN;
+BEGIN
+1&:SELECT 1;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+ waiting | wait_event_type | state               | query     | rsgname             
+---------+-----------------+---------------------+-----------+---------------------
+ t       | Client          | idle in transaction | BEGIN;    | rg_concurrency_test 
+ t       | ResourceGroup   | active              | SELECT 1; | rg_concurrency_test 
+(2 rows)
+-- Upon receiving the terminate request, session 1 should start a new transaction to cleanup temp table.
+-- Note, that session 1 has already been waiting for resource group slot, so its new transaction also
+-- waits for the slot (until session 2 commits). We check that session 1 should not add its proc to the
+-- wait queue again. Such double addition of the same proc to the wait queue leads to the queue corruption
+-- (was found to occur previously).
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE wait_event_type='ResourceGroup' AND rsgname='rg_concurrency_test';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+2:COMMIT;
+COMMIT
+2<:  <... completed>
+FAILED:  Execution failed
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+SELECT * FROM rg_concurrency_view;
+ waiting | wait_event_type | state | query | rsgname 
+---------+-----------------+-------+-------+---------
+(0 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
 DROP VIEW rg_concurrency_view;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
@@ -271,24 +271,20 @@ SELECT * FROM rg_concurrency_view;
  t       | ResourceGroup   | active              | SELECT 1; | rg_concurrency_test 
 (2 rows)
 -- Upon receiving the terminate request, session 1 should start a new transaction to cleanup temp table.
--- Note, that session 1 has already been waiting for resource group slot, so its new transaction also
--- waits for the slot (until session 2 commits). We check that session 1 should not add its proc to the
--- wait queue again. Such double addition of the same proc to the wait queue leads to the queue corruption
--- (was found to occur previously).
+-- Note, that session 1 has already been waiting for resource group slot, its new transaction will bypass
+-- resource group since it's exiting.
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE wait_event_type='ResourceGroup' AND rsgname='rg_concurrency_test';
  pg_terminate_backend 
 ----------------------
  t                    
 (1 row)
-2:COMMIT;
-COMMIT
-2<:  <... completed>
-FAILED:  Execution failed
 1<:  <... completed>
 FATAL:  terminating connection due to administrator command
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
+2:COMMIT;
+COMMIT
 SELECT * FROM rg_concurrency_view;
  waiting | wait_event_type | state | query | rsgname 
 ---------+-----------------+-------+-------+---------

--- a/src/test/isolation2/sql/resgroup/resgroup_cancel_terminate_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cancel_terminate_concurrency.sql
@@ -130,14 +130,11 @@ CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
 1&:SELECT 1;
 SELECT * FROM rg_concurrency_view;
 -- Upon receiving the terminate request, session 1 should start a new transaction to cleanup temp table.
--- Note, that session 1 has already been waiting for resource group slot, so its new transaction also
--- waits for the slot (until session 2 commits). We check that session 1 should not add its proc to the
--- wait queue again. Such double addition of the same proc to the wait queue leads to the queue corruption
--- (was found to occur previously).
+-- Note, that session 1 has already been waiting for resource group slot, its new transaction will bypass
+-- resource group since it's exiting.
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE wait_event_type='ResourceGroup' AND rsgname='rg_concurrency_test';
-2:COMMIT;
-2<:
 1<:
+2:COMMIT;
 SELECT * FROM rg_concurrency_view;
 1q:
 2q:


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
