### PR TITLE
ic-proxy: Fix the memory bump after query cancelled

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -1227,6 +1227,15 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 			return;
 		}
 
+		if (client->state & IC_PROXY_CLIENT_STATE_C2P_SHUTTING)
+		{
+			/*
+			 * drop any data packet when client is in C2P SHUTTING state
+			 */
+			ic_proxy_pkt_cache_free(pkt);
+			return;
+		}
+
 		client->unconsumed++;
 		client->sending++;
 


### PR DESCRIPTION
After query is cancelled, the ic proxy client cannot exit immediately,
it will be in C2P SHUTTING state, but wait for the ack from peer side.
Client should drop any incoming data packets in this case.

Also the MemoryContext cannot be reset in ic proxy bgworker, so the
memory will be cached and accumulated in freelist for small chunks.
We use malloc/free for ic proxy bgworker to avoid this problem.

The issue of memory bump after query cancelled happens in large
cluster only. Manually tested on a Azure cluster.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
