### PR TITLE
Added reference to RHEL 6 not supported on both sections

### DIFF
--- a/gpdb-doc/dita/analytics/madlib.xml
+++ b/gpdb-doc/dita/analytics/madlib.xml
@@ -52,7 +52,8 @@
           scope="external">supported libraries and configuration instructions</xref> on the Apache
         MADlib pages as well as user documentation for <xref
           href="http://madlib.apache.org/docs/latest/group__grp__dl.html" format="html"
-          scope="external">Keras API </xref>using the Tensorflow backend.</p>
+          scope="external">Keras API </xref>using the Tensorflow backend. Note that it is not
+        supported with RHEL 6</p>
       <p dir="ltr">MADlib supports Keras with a TensorFlow backend, with or without Graphics
         Processing Units (GPUs). GPUs can significantly accelerate the training of deep neural
         networks so they are typically used for enterprise level workloads. For further GPU

--- a/gpdb-doc/dita/analytics/madlib.xml
+++ b/gpdb-doc/dita/analytics/madlib.xml
@@ -53,7 +53,7 @@
         MADlib pages as well as user documentation for <xref
           href="http://madlib.apache.org/docs/latest/group__grp__dl.html" format="html"
           scope="external">Keras API </xref>using the Tensorflow backend. Note that it is not
-        supported with RHEL 6</p>
+        supported with RHEL 6.</p>
       <p dir="ltr">MADlib supports Keras with a TensorFlow backend, with or without Graphics
         Processing Units (GPUs). GPUs can significantly accelerate the training of deep neural
         networks so they are typically used for enterprise level workloads. For further GPU

--- a/gpdb-doc/dita/install_guide/install_python_dsmod.xml
+++ b/gpdb-doc/dita/install_guide/install_python_dsmod.xml
@@ -28,7 +28,9 @@
   <topic id="topic_pydatascimod">
     <title>Python Data Science Modules</title>
     <body>
-      <p>Modules provided in the Python Data Science package include: <table id="iq1395577">
+      <p>Modules provided in the Python Data Science package are listed below.</p>
+      <p> Packages required for Deep Learning features of MADlib are now included. Note that it is
+        not supported for RHEL 6.<table id="iq1395577">
           <title>Data Science Modules</title>
           <tgroup cols="2">
             <colspec colnum="1" colname="col1" colwidth="1*"/>


### PR DESCRIPTION
Here are the links of the staging app for review:
https://mireia-deeplearning.sc2-04-pcf1-apps.oc.vmware.com/7-0/analytics/madlib.html
https://mireia-deeplearning.sc2-04-pcf1-apps.oc.vmware.com/7-0/install_guide/install_python_dsmod.html

Note I have used the GPDB branded book since Python Data Science Module Package is only available on the branded GPDB docs.