### PR TITLE
Enable hot-standby in utility mode

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8056,7 +8056,6 @@ StartupXLOG(void)
 
 	SpinLockAcquire(&XLogCtl->info_lck);
 	XLogCtl->SharedRecoveryInProgress = false;
-	XLogCtl->SharedHotStandbyActive = false;
 	SpinLockRelease(&XLogCtl->info_lck);
 
 	UpdateControlFile();

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8056,6 +8056,7 @@ StartupXLOG(void)
 
 	SpinLockAcquire(&XLogCtl->info_lck);
 	XLogCtl->SharedRecoveryInProgress = false;
+	XLogCtl->SharedHotStandbyActive = false;
 	SpinLockRelease(&XLogCtl->info_lck);
 
 	UpdateControlFile();

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -345,9 +345,13 @@ InitProcess(void)
 	 * as GP_ROLE_UTILITY to prevent unwanted GP_ROLE_DISPATCH MyProc settings
 	 * such as mppSessionId being valid and mppIsWriter set to true.
 	 */
-	if (am_walsender || am_ftshandler ||
-		IsFaultHandler)
+	if (am_walsender || am_ftshandler || IsFaultHandler ||
+		(GpIdentity.segindex == -1 && HotStandbyActive()))
+	{
 		Gp_role = GP_ROLE_UTILITY;
+		if (GpIdentity.segindex == -1 && HotStandbyActive())
+			elog(WARNING, "force to utility mode in hot-standby");
+	}
 
 	/*
 	 * ProcGlobal should be set up already (if we are a backend, we inherit

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -344,12 +344,15 @@ InitProcess(void)
 	 * WAL sender, FTS handler and FTS daemon processes are marked
 	 * as GP_ROLE_UTILITY to prevent unwanted GP_ROLE_DISPATCH MyProc settings
 	 * such as mppSessionId being valid and mppIsWriter set to true.
+	 *
+	 * RecoveryInProgress() to see if we are in hot standby, because
+	 * HotStandbyActive() is still true after promotion.
 	 */
 	if (am_walsender || am_ftshandler || IsFaultHandler ||
-		(GpIdentity.segindex == -1 && HotStandbyActive()))
+		(GpIdentity.segindex == -1 && RecoveryInProgress()))
 	{
 		Gp_role = GP_ROLE_UTILITY;
-		if (GpIdentity.segindex == -1 && HotStandbyActive())
+		if (GpIdentity.segindex == -1 && RecoveryInProgress())
 			elog(WARNING, "Force to run in utility mode in hot standby");
 	}
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -350,7 +350,7 @@ InitProcess(void)
 	{
 		Gp_role = GP_ROLE_UTILITY;
 		if (GpIdentity.segindex == -1 && HotStandbyActive())
-			elog(WARNING, "force to utility mode in hot-standby");
+			elog(WARNING, "Force to run in utility mode in hot standby");
 	}
 
 	/*

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -562,13 +562,16 @@ start_postmaster(void)
 static bool
 is_secondary_instance(const char *pg_data)
 {
-	char		standby_file[MAXPGPATH];
-	int			fd;
-	snprintf(standby_file, sizeof(standby_file), "%s/standby.signal", pg_data);
-	fd = open(standby_file, O_RDONLY);
-	if (fd >= 0)
-		close(fd);
-	return fd >= 0;
+	char		standby_signal[MAXPGPATH];
+	int			rc;
+
+	snprintf(standby_signal, sizeof(standby_signal), "%s/standby.signal", pg_data);
+	rc = access(standby_signal, R_OK);
+
+	if (rc == -1 && errno != ENOENT)
+		write_stderr(_("could not test the existence of standby.signal: %m"));
+
+	return rc == 0;
 }
 
 /*

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -169,14 +169,9 @@ static void free_readfile(char **optlines);
 static pgpid_t start_postmaster(void);
 static void read_post_opts(void);
 
+static bool is_secondary_instance(const char *pg_data);
 static WaitPMResult wait_for_postmaster(pgpid_t pm_pid, bool do_checkpoint);
 static bool postmaster_is_alive(pid_t pid);
-
-static char postopts_file[MAXPGPATH];
-static char backup_file[MAXPGPATH];
-static char promote_file[MAXPGPATH];
-static char pid_file[MAXPGPATH];
-static char backup_file[MAXPGPATH];
 
 #if defined(HAVE_GETRLIMIT) && defined(RLIMIT_CORE)
 static void unlimit_core_size(void);
@@ -564,6 +559,17 @@ start_postmaster(void)
 }
 
 
+static bool
+is_secondary_instance(const char *pg_data)
+{
+	char		standby_file[MAXPGPATH];
+	int			fd;
+	snprintf(standby_file, sizeof(standby_file), "%s/standby.signal", pg_data);
+	fd = open(standby_file, O_RDONLY);
+	if (fd >= 0)
+		close(fd);
+	return fd >= 0;
+}
 
 /*
  * Wait for the postmaster to become ready.
@@ -583,13 +589,11 @@ static WaitPMResult
 wait_for_postmaster(pgpid_t pm_pid, bool do_checkpoint)
 {
 	int			i;
-	bool		gpdb_master_distributed_mode;
+	bool		is_coordinator;
 
-	/* check if starting GPDB master in distributed mode */
-	if (strstr(post_opts, "gp_role=dispatch"))
-		gpdb_master_distributed_mode = true;
-	else
-		gpdb_master_distributed_mode = false;
+	/* check if starting GPDB coordinator in distributed mode */
+	is_coordinator = strstr(post_opts, "gp_role=dispatch") != NULL
+                        && !is_secondary_instance(pg_data);
 
 	for (i = 0; i < wait_seconds * WAITS_PER_SEC; i++)
 	{
@@ -631,7 +635,11 @@ wait_for_postmaster(pgpid_t pm_pid, bool do_checkpoint)
 				 */
 				char	   *pmstatus = optlines[LOCK_FILE_LINE_PM_STATUS - 1];
 
-				if (strcmp(pmstatus, gpdb_master_distributed_mode?PM_STATUS_DTM_RECOVERED:PM_STATUS_READY) == 0 ||
+				/*
+				 * The READY status for coordinator is `dtmready`, while the READY
+				 * status is really ready for other nodes.
+				 */
+				if (strcmp(pmstatus, is_coordinator ? PM_STATUS_DTM_RECOVERED : PM_STATUS_READY) == 0 ||
 					strcmp(pmstatus, PM_STATUS_STANDBY) == 0)
 				{
 					/* postmaster is done starting up */


### PR DESCRIPTION
~~To run pg_auto_failover for GPDB, we need some adapter code
for some reasons:~~
~~1. Enable hot-standby feature but only in utility mode.
        Calling cdb_setup() in hot-standby should be OK.
2. Fix `cdbcomponent_getComponentInfo()` issue.
        Currently, cdbcomponent_getComponentInfo() can't work well
        in hot-standby, it gets the coordinator's entry on the standby.
3. Fix ready status for hot-standby.
4. Set proper `dbid` and `content` for monitor instance.
        Monitor has dummy dbid and content. -1 is OK~~


Enable hot-standby in utility mode

1. When the standby turns on hot_standby, the ready status changed.
     pg_ctl can't properly wait for the ready status for the standby.

2. To connect to the GPDB cluster with multi-host/port in connection info,
     connecting to the hot-standby in dispatch(the default) mode is required,
     unless we change the retry policy in libpq. However, we're not intented
     to support distributed query in this patch. So, we force to use utility
     role when connecting to hot-standby.

syncrep is an issue, but it doesn't prevent from running pg_auto_failover.
We'll fix the issue in a later patch.

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
