### PR TITLE
Remove FIXME for multi drop partition table in same alter statement.

### DIFF
--- a/src/backend/commands/tablecmds_gp.c
+++ b/src/backend/commands/tablecmds_gp.c
@@ -1205,9 +1205,15 @@ ATExecGPPartCmds(Relation origrel, AlterTableCmd *cmd)
 
 			partrel = table_open(partrelid, AccessShareLock);
 			partdesc = RelationGetPartitionDesc(rel);
+
 			/*
-			 * GPDB_12_MERGE_FIXME: how to protect if two drop partition cmds
-			 * are specified in same alter table stmt?
+			 * If two drop partition cmds are specified in same alter table stmt,
+			 * the blow check still works to make sure the partitioned table at least
+			 * have one partition table.
+			 * When the first drop get executed, the catalog will have an update which make
+			 * current Relation get invalid and call RelationClearRelation to refresh
+			 * the Relation. After that the next drop cmd will have partdesc->nparts = 1,
+			 * and raise error to abort.
 			 */
 			if (partdesc->nparts == 1)
 			{

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1013,8 +1013,27 @@ ERROR:  partition "3" of "i" does not exist
 -- the matched table name is i_1_prt_4, but it belongs to i2, raise error
 alter table i drop partition "4";
 ERROR:  partition "4" of "i" does not exist
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i drop partition "1", drop partition "2";
+ERROR:  cannot drop partition "i_1_prt_2" of "i" -- only one remains
+HINT:  Use DROP TABLE "i" to remove the table and the final partition
 drop table i;
 drop table i2;
+drop table i_1_prt_3;
+create table i (i int) partition by range(i) (start(1) end(3) every(1), default partition extra);
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i drop partition "2", drop partition "3", drop default partition;
+ERROR:  cannot drop partition "i_1_prt_extra" of "i" -- only one remains
+HINT:  Use DROP TABLE "i" to remove the table and the final partition
+drop table i;
+create table i (i int, c text) partition by range(i) subpartition by list(c)
+subpartition template (subpartition a values ('a'), subpartition b values ('b'))
+(start (1) end(3) every(1));
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i alter partition "1" drop partition a, alter partition "1" drop partition b;
+ERROR:  cannot drop partition "i_1_prt_1_2_prt_b" of "i_1_prt_1" -- only one remains
+HINT:  Use DROP TABLE "i_1_prt_1" to remove the table and the final partition
+drop table i;
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,
 PS_SUPPKEY INTEGER,

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1013,8 +1013,27 @@ ERROR:  partition "3" of "i" does not exist
 -- the matched table name is i_1_prt_4, but it belongs to i2, raise error
 alter table i drop partition "4";
 ERROR:  partition "4" of "i" does not exist
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i drop partition "1", drop partition "2";
+ERROR:  cannot drop partition "i_1_prt_2" of "i" -- only one remains
+HINT:  Use DROP TABLE "i" to remove the table and the final partition
 drop table i;
 drop table i2;
+drop table i_1_prt_3;
+create table i (i int) partition by range(i) (start(1) end(3) every(1), default partition extra);
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i drop partition "2", drop partition "3", drop default partition;
+ERROR:  cannot drop partition "i_1_prt_extra" of "i" -- only one remains
+HINT:  Use DROP TABLE "i" to remove the table and the final partition
+drop table i;
+create table i (i int, c text) partition by range(i) subpartition by list(c)
+subpartition template (subpartition a values ('a'), subpartition b values ('b'))
+(start (1) end(3) every(1));
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i alter partition "1" drop partition a, alter partition "1" drop partition b;
+ERROR:  cannot drop partition "i_1_prt_1_2_prt_b" of "i_1_prt_1" -- only one remains
+HINT:  Use DROP TABLE "i_1_prt_1" to remove the table and the final partition
+drop table i;
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,
 PS_SUPPKEY INTEGER,

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -636,7 +636,6 @@ create table i (i int) partition by range(i) (start (1) end(3) every(1));
 alter table i add partition foo2 start(40) end (50);
 alter table i drop partition foo2;
 
-
 -- when using the partition name to find target partition table,
 -- we shoud check whether the matched table belong to the partitioned table.
 -- raise error instead of executing on the irrelevant table.
@@ -652,8 +651,24 @@ alter table i drop partition "3";
 -- the matched table name is i_1_prt_4, but it belongs to i2, raise error
 alter table i drop partition "4";
 
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i drop partition "1", drop partition "2";
+
 drop table i;
 drop table i2;
+drop table i_1_prt_3;
+
+create table i (i int) partition by range(i) (start(1) end(3) every(1), default partition extra);
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i drop partition "2", drop partition "3", drop default partition;
+drop table i;
+
+create table i (i int, c text) partition by range(i) subpartition by list(c)
+subpartition template (subpartition a values ('a'), subpartition b values ('b'))
+(start (1) end(3) every(1));
+-- should raise error since we always make sure the partitioned table at least have one partition;
+alter table i alter partition "1" drop partition a, alter partition "1" drop partition b;
+drop table i;
 
 CREATE TABLE PARTSUPP (
 PS_PARTKEY INTEGER,


### PR DESCRIPTION
If two drop partition cmds are specified in same alter table stmt,
the blow check still works to make sure the partitioned table at least
have one partition table.
When the first drop gets executed, the catalog will have an update which make
current Relation get invalid and call RelationClearRelation to refresh
the Relation. After that the next drop cmd will have parties->nparts = 1,
and raise error to abort.
So remove the fixme and add more tests to cover it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
