### PR TITLE
Fix compilation with CDB_MOTION_DEBUG compiler flag

### DIFF
--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -77,7 +77,7 @@ formatTuple(StringInfo buf, TupleTableSlot *slot, Oid *outputFunArray)
 		if (d && !isnull)
 		{
 			char	   *s = OidOutputFunctionCall(outputFunArray[i], d);
-			char	   *name = NameStr(tupdesc->attrs[i]->attname);
+			char	   *name = NameStr(tupdesc->attrs[i].attname);
 
 			if (name && *name)
 				appendStringInfo(buf, "  %s=\"%.30s\"", name, s);
@@ -820,7 +820,7 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	{
 		bool		typisvarlena;
 
-		getTypeOutputInfo(tupDesc->attrs[i]->atttypid,
+		getTypeOutputInfo(tupDesc->attrs[i].atttypid,
 						  &motionstate->outputFunArray[i],
 						  &typisvarlena);
 	}


### PR DESCRIPTION
The flag can be set as `CPPFLAGS=-DCDB_MOTION_DEBUG`.