### PR TITLE
Moving open partition bounds check into individual comparisons

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -563,31 +563,7 @@ select * from x, y where x.i > y.j and y.k = 10;
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Not>
-                      <dxl:Or>
-                        <dxl:DefaultPart Level="0"/>
-                        <dxl:Or>
-                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                        </dxl:Or>
-                      </dxl:Or>
-                    </dxl:Not>
-                    <dxl:And>
-                      <dxl:IsNotNull>
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                      </dxl:IsNotNull>
-                      <dxl:IsNotNull>
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                      </dxl:IsNotNull>
-                    </dxl:And>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                  </dxl:Or>
-                </dxl:Or>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
@@ -1755,20 +1755,23 @@
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -1749,20 +1749,23 @@
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
@@ -564,20 +564,23 @@
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -375,40 +375,46 @@ SELECT * FROM pp WHERE b=2 AND c=2;
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -488,7 +494,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
                       </dxl:And>
                     </dxl:And>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
                   </dxl:If>
                 </dxl:If>
               </dxl:PropagationExpression>

--- a/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
@@ -932,68 +932,86 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
-                        <dxl:Or>
-                          <dxl:And>
+                    <dxl:And>
+                      <dxl:Or>
+                        <dxl:And>
+                          <dxl:Or>
                             <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                               <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                             </dxl:Comparison>
-                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                          </dxl:And>
+                            <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                          </dxl:Or>
+                          <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                        </dxl:And>
+                        <dxl:Or>
                           <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                         </dxl:Or>
-                        <dxl:Or>
-                          <dxl:And>
+                      </dxl:Or>
+                      <dxl:Or>
+                        <dxl:And>
+                          <dxl:Or>
                             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                               <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                             </dxl:Comparison>
-                            <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                          </dxl:And>
+                            <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                          </dxl:Or>
+                          <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                        </dxl:And>
+                        <dxl:Or>
                           <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                         </dxl:Or>
-                      </dxl:And>
-                      <dxl:And>
-                        <dxl:Or>
-                          <dxl:And>
+                      </dxl:Or>
+                    </dxl:And>
+                    <dxl:And>
+                      <dxl:Or>
+                        <dxl:And>
+                          <dxl:Or>
                             <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                               <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                               <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                             </dxl:Comparison>
-                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                          </dxl:And>
+                            <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                          </dxl:Or>
+                          <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                        </dxl:And>
+                        <dxl:Or>
                           <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                           </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                         </dxl:Or>
-                        <dxl:Or>
-                          <dxl:And>
+                      </dxl:Or>
+                      <dxl:Or>
+                        <dxl:And>
+                          <dxl:Or>
                             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                               <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                               <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                             </dxl:Comparison>
-                            <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                          </dxl:And>
+                            <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                          </dxl:Or>
+                          <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                        </dxl:And>
+                        <dxl:Or>
                           <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                           </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                         </dxl:Or>
-                      </dxl:And>
-                    </dxl:Or>
-                    <dxl:Or>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
+                      </dxl:Or>
+                    </dxl:And>
                   </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -922,24 +922,30 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:And>
+                        <dxl:Or>
                           <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                        </dxl:Or>
+                        <dxl:Or>
                           <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                           </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:Or>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                        </dxl:Or>
+                      </dxl:And>
+                    </dxl:Or>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
-                    </dxl:Or>
-                    <dxl:Or>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                       <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
                   </dxl:Or>

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2164,7 +2164,22 @@
                     <dxl:And>
                       <dxl:Or>
                         <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:Or>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                              <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
+                                <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                  <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                                </dxl:FuncExpr>
+                              </dxl:CoerceViaIO>
+                            </dxl:Comparison>
+                            <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                          </dxl:Or>
+                          <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                        </dxl:And>
+                        <dxl:Or>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                             <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                               <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -2173,21 +2188,27 @@
                               </dxl:FuncExpr>
                             </dxl:CoerceViaIO>
                           </dxl:Comparison>
-                          <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                        </dxl:And>
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
-                            <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                              <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
-                            </dxl:FuncExpr>
-                          </dxl:CoerceViaIO>
-                        </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                        </dxl:Or>
                       </dxl:Or>
                       <dxl:Or>
                         <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                          <dxl:Or>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                              <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
+                                <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                  <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                                </dxl:FuncExpr>
+                              </dxl:CoerceViaIO>
+                            </dxl:Comparison>
+                            <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                          </dxl:Or>
+                          <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                        </dxl:And>
+                        <dxl:Or>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                             <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                             <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                               <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -2196,26 +2217,11 @@
                               </dxl:FuncExpr>
                             </dxl:CoerceViaIO>
                           </dxl:Comparison>
-                          <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                        </dxl:And>
-                        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
-                            <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                              <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
-                            </dxl:FuncExpr>
-                          </dxl:CoerceViaIO>
-                        </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                        </dxl:Or>
                       </dxl:Or>
                     </dxl:And>
-                    <dxl:Or>
-                      <dxl:DefaultPart Level="0"/>
-                      <dxl:Or>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                    </dxl:Or>
+                    <dxl:DefaultPart Level="0"/>
                   </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
@@ -377,14 +377,14 @@ where a=1 and b>0;
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                </dxl:Comparison>
                 <dxl:Or>
-                  <dxl:DefaultPart Level="0"/>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  </dxl:Comparison>
                   <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
+                <dxl:DefaultPart Level="0"/>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1812,31 +1812,7 @@
                                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                               </dxl:PartEqFilters>
                                               <dxl:PartFilters>
-                                                <dxl:Or>
-                                                  <dxl:And>
-                                                    <dxl:Not>
-                                                      <dxl:Or>
-                                                        <dxl:DefaultPart Level="0"/>
-                                                        <dxl:Or>
-                                                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                                                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                                                        </dxl:Or>
-                                                      </dxl:Or>
-                                                    </dxl:Not>
-                                                    <dxl:And>
-                                                      <dxl:IsNotNull>
-                                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                                                      </dxl:IsNotNull>
-                                                      <dxl:IsNotNull>
-                                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                                                      </dxl:IsNotNull>
-                                                    </dxl:And>
-                                                  </dxl:And>
-                                                  <dxl:Or>
-                                                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                                                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                                                  </dxl:Or>
-                                                </dxl:Or>
+                                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                               </dxl:PartFilters>
                                               <dxl:ResidualFilter>
                                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -382,38 +382,44 @@
                   <dxl:And>
                     <dxl:Or>
                       <dxl:And>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                        <dxl:Or>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                        </dxl:Or>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                      </dxl:And>
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
                     </dxl:Or>
                     <dxl:Or>
                       <dxl:And>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                        <dxl:Or>
+                          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                        </dxl:Or>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
                     </dxl:Or>
                   </dxl:And>
-                  <dxl:Or>
-                    <dxl:DefaultPart Level="0"/>
-                    <dxl:Or>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
+                  <dxl:DefaultPart Level="0"/>
                 </dxl:Or>
               </dxl:PartFilters>
               <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -369,40 +369,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1096.1.0">
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                         <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -342,40 +342,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -342,40 +342,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -588,40 +588,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -589,20 +589,23 @@
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="500"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="500"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   </dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                 </dxl:Or>
               </dxl:PartFilters>
               <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -342,40 +342,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -396,40 +396,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp
@@ -435,40 +435,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp
@@ -436,40 +436,46 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
@@ -799,31 +799,7 @@ select * from x, y where (x.i > y.j);
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Not>
-                        <dxl:Or>
-                          <dxl:DefaultPart Level="0"/>
-                          <dxl:Or>
-                            <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                            <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                          </dxl:Or>
-                        </dxl:Or>
-                      </dxl:Not>
-                      <dxl:And>
-                        <dxl:IsNotNull>
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        </dxl:IsNotNull>
-                        <dxl:IsNotNull>
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        </dxl:IsNotNull>
-                      </dxl:And>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -711,31 +711,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Not>
-                      <dxl:Or>
-                        <dxl:DefaultPart Level="0"/>
-                        <dxl:Or>
-                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                        </dxl:Or>
-                      </dxl:Or>
-                    </dxl:Not>
-                    <dxl:And>
-                      <dxl:IsNotNull>
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                      </dxl:IsNotNull>
-                      <dxl:IsNotNull>
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                      </dxl:IsNotNull>
-                    </dxl:And>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                  </dxl:Or>
-                </dxl:Or>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-IN.mdp
@@ -492,68 +492,86 @@ Select * from P where P.a IN (1,2);
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-NOT-IN.mdp
@@ -469,24 +469,30 @@ Select * from P where P.a NOT IN (1,2);
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                     </dxl:Comparison>
-                    <dxl:And>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                  </dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
-                    </dxl:And>
-                  </dxl:Or>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
+                  </dxl:And>
+                </dxl:Or>
+                <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                     <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                   </dxl:Comparison>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
               </dxl:Or>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
@@ -2296,40 +2296,46 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
+              <dxl:And>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2002"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="2002"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
+                </dxl:Or>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2003"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="2003"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   </dxl:Or>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
@@ -303,68 +303,86 @@ WHERE b in (1,2);
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-PartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-PartKey.mdp
@@ -415,31 +415,7 @@
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
-                              <dxl:Or>
-                                <dxl:And>
-                                  <dxl:Not>
-                                    <dxl:Or>
-                                      <dxl:DefaultPart Level="0"/>
-                                      <dxl:Or>
-                                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                                      </dxl:Or>
-                                    </dxl:Or>
-                                  </dxl:Not>
-                                  <dxl:And>
-                                    <dxl:IsNotNull>
-                                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                                    </dxl:IsNotNull>
-                                    <dxl:IsNotNull>
-                                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                                    </dxl:IsNotNull>
-                                  </dxl:And>
-                                </dxl:And>
-                                <dxl:Or>
-                                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                                </dxl:Or>
-                              </dxl:Or>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                             </dxl:PartFilters>
                             <dxl:ResidualFilter>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
@@ -299,68 +299,86 @@ explain select * from foo where b = 25 or b = 35;
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate2.mdp
@@ -310,39 +310,48 @@ explain select * from foo where (b = 25 and a > 10) or b<15;
                     <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
                   </dxl:Comparison>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                </dxl:Or>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate3.mdp
@@ -316,39 +316,48 @@ explain select * from foo where (b = 25 and a > 10) or (b<15 and a>5);
                     <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
                   </dxl:Comparison>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                </dxl:Or>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate4.mdp
@@ -323,68 +323,89 @@ explain select * from foo where ((b = 25 or b=35) and a > 10) or (b<15 and a>5);
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
                     </dxl:Comparison>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
-                          </dxl:Comparison>
-                          <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                        </dxl:And>
-                        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
-                        </dxl:Comparison>
-                      </dxl:Or>
-                      <dxl:Or>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
-                          </dxl:Comparison>
-                          <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                        </dxl:And>
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
-                        </dxl:Comparison>
-                      </dxl:Or>
-                    </dxl:And>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   </dxl:Or>
                   <dxl:And>
                     <dxl:Or>
                       <dxl:And>
+                        <dxl:Or>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
+                          </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                        </dxl:Or>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                      </dxl:And>
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                    </dxl:Or>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
+                          </dxl:Comparison>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                        </dxl:Or>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                    </dxl:Or>
+                  </dxl:And>
+                </dxl:Or>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate5.mdp
@@ -295,21 +295,24 @@ explain select * from foo where (b > 25 and b<35 and a > 10) or (b<15 and a>5);
                     <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
                   </dxl:Comparison>
-                  <dxl:And>
+                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                </dxl:Or>
+                <dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                     </dxl:Comparison>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -526,22 +526,22 @@
             <dxl:PartFilters>
               <dxl:Or>
                 <dxl:And>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
-                  </dxl:Comparison>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:DefaultPart Level="0"/>
                   <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:Comparison>
                     <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                  <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+                    </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                  </dxl:Or>
+                </dxl:And>
+                <dxl:DefaultPart Level="0"/>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-NoDefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-NoDefaultPart.mdp
@@ -267,31 +267,34 @@
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
+              <dxl:And>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
+                </dxl:Or>
+                <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                     <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                   </dxl:Comparison>
-                </dxl:And>
-                <dxl:Or>
                   <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Disjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Disjunction.mdp
@@ -306,68 +306,86 @@ WHERE b = 1 or b = 2;
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:And>
+                      <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                           <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                         </dxl:Comparison>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                     </dxl:Or>
-                  </dxl:And>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                </dxl:Or>
+                  </dxl:Or>
+                </dxl:And>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-EqPredicateWithCastRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-EqPredicateWithCastRange.mdp
@@ -294,48 +294,54 @@ explain select * from R where b::int8=5::int8;
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
+              <dxl:And>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                         <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         </dxl:Cast>
                         <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.412.1.0">
                       <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       </dxl:Cast>
                       <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
+                </dxl:Or>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.415.1.0">
                         <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         </dxl:Cast>
                         <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
                       <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                       </dxl:Cast>
                       <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
@@ -262,25 +262,7 @@ explain select * from dd_part_singlecol where a is null and b is null;
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:And>
-                  <dxl:Not>
-                    <dxl:Or>
-                      <dxl:DefaultPart Level="0"/>
-                      <dxl:Or>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                    </dxl:Or>
-                  </dxl:Not>
-                  <dxl:And>
-                    <dxl:IsNull>
-                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                    </dxl:IsNull>
-                    <dxl:IsNull>
-                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                    </dxl:IsNull>
-                  </dxl:And>
-                </dxl:And>
+                <dxl:DefaultPart Level="0"/>
                 <dxl:DefaultPart Level="0"/>
               </dxl:Or>
             </dxl:PartFilters>
@@ -340,7 +322,7 @@ explain select * from dd_part_singlecol where a is null and b is null;
       </dxl:GatherMotion>
       <dxl:DirectDispatchInfo>
         <dxl:KeyValue>
-          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
         </dxl:KeyValue>
       </dxl:DirectDispatchInfo>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -524,22 +524,22 @@
             <dxl:PartFilters>
               <dxl:Or>
                 <dxl:Or>
-                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:Comparison>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:DefaultPart Level="0"/>
                   <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:Comparison>
                     <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                  </dxl:Or>
+                  <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:Comparison>
                     <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
                 </dxl:Or>
+                <dxl:DefaultPart Level="0"/>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCast.mdp
@@ -294,48 +294,54 @@ explain select * from R where b::int8=5::int8;
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
+              <dxl:And>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                         <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         </dxl:Cast>
                         <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.412.1.0">
                       <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       </dxl:Cast>
                       <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
+                </dxl:Or>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.415.1.0">
                         <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                           <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         </dxl:Cast>
                         <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
                       <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                       </dxl:Cast>
                       <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
@@ -5426,29 +5426,32 @@ where d.msisdn=f.subscriberaddress and f.sessioncreationtimestamp >= d.start_dtm
                 <dxl:And>
                   <dxl:Or>
                     <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1325.1.0">
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1325.1.0">
+                          <dxl:PartBound Level="0" Type="0.1184.1.0" LowerBound="false"/>
+                          <dxl:Ident ColId="70" ColName="start_dtm" TypeMdid="0.1184.1.0"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1324.1.0">
                         <dxl:PartBound Level="0" Type="0.1184.1.0" LowerBound="false"/>
                         <dxl:Ident ColId="70" ColName="start_dtm" TypeMdid="0.1184.1.0"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1324.1.0">
-                      <dxl:PartBound Level="0" Type="0.1184.1.0" LowerBound="false"/>
-                      <dxl:Ident ColId="70" ColName="start_dtm" TypeMdid="0.1184.1.0"/>
-                    </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
                   </dxl:Or>
-                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1322.1.0">
-                    <dxl:PartBound Level="0" Type="0.1184.1.0" LowerBound="true"/>
-                    <dxl:Ident ColId="71" ColName="end_dtm" TypeMdid="0.1184.1.0"/>
-                  </dxl:Comparison>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:DefaultPart Level="0"/>
                   <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1322.1.0">
+                      <dxl:PartBound Level="0" Type="0.1184.1.0" LowerBound="true"/>
+                      <dxl:Ident ColId="71" ColName="end_dtm" TypeMdid="0.1184.1.0"/>
+                    </dxl:Comparison>
                     <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:Or>
+                </dxl:And>
+                <dxl:DefaultPart Level="0"/>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
@@ -500,14 +500,14 @@
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                          <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
-                        </dxl:Comparison>
                         <dxl:Or>
-                          <dxl:DefaultPart Level="0"/>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
+                            <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
+                          </dxl:Comparison>
                           <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                         </dxl:Or>
+                        <dxl:DefaultPart Level="0"/>
                       </dxl:Or>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                     </dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -489,14 +489,14 @@
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                        <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
-                      </dxl:Comparison>
                       <dxl:Or>
-                        <dxl:DefaultPart Level="0"/>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
+                          <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
+                        </dxl:Comparison>
                         <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                       </dxl:Or>
+                      <dxl:DefaultPart Level="0"/>
                     </dxl:Or>
                     <dxl:Or>
                       <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqInPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqInPartitionRange.mdp
@@ -300,26 +300,26 @@
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
+              <dxl:And>
+                <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                     <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.317.1.0">
                       <dxl:PartBound Level="0" Type="0.701.1.0" LowerBound="true"/>
                     </dxl:Cast>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
                   </dxl:Comparison>
+                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                </dxl:Or>
+                <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                     <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.317.1.0">
                       <dxl:PartBound Level="0" Type="0.701.1.0" LowerBound="false"/>
                     </dxl:Cast>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
                   </dxl:Comparison>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqOnEndPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqOnEndPartitionRange.mdp
@@ -298,26 +298,26 @@
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
+              <dxl:And>
+                <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                     <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.317.1.0">
                       <dxl:PartBound Level="0" Type="0.701.1.0" LowerBound="true"/>
                     </dxl:Cast>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
                   </dxl:Comparison>
+                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                </dxl:Or>
+                <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                     <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.317.1.0">
                       <dxl:PartBound Level="0" Type="0.701.1.0" LowerBound="false"/>
                     </dxl:Cast>
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
                   </dxl:Comparison>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/SPE-IS-NULL.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SPE-IS-NULL.mdp
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Test IS NULL predicate used for partition elimination
+
+    drop table if not exists p;
+    create table P(a int, b int)   with (appendonly=true, orientation=row)
+      partition by range (a)
+      (
+        PARTITION pfirst  END(5) INCLUSIVE,
+        PARTITION pinter  START(5) EXCLUSIVE END (10) INCLUSIVE,
+        PARTITION plast   START (10) EXCLUSIVE,
+        DEFAULT PARTITION for_nulls
+      );
+    insert into p values (null,null), (1,1);
+
+    select * from p where a is null;
+
+    Physical plan:
+    -- Make sure the partition selector says "Partitions selected: 1 (out of 4)",
+    -- this should select the default partition. NOTE: Right now it actually
+    -- checks (default_partition OR default_partition). That's a "feature", sorry.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102155,102156,103001,103014,103022,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.714849.1.0" Name="p" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.714849.1.0" Name="p" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Hash" DistributionColumns="0" Keys="3,4,2" PartitionColumns="0" PartitionTypes="r" NumberLeafPartitions="4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.714849.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:IsNull>
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        </dxl:IsNull>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.714849.1.0" TableName="p">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000080" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Sequence>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:PartitionSelector RelationMdid="0.714849.1.0" PartitionLevels="1" ScanId="1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:PartEqFilters>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:PartEqFilters>
+            <dxl:PartFilters>
+              <dxl:Or>
+                <dxl:DefaultPart Level="0"/>
+                <dxl:DefaultPart Level="0"/>
+              </dxl:Or>
+            </dxl:PartFilters>
+            <dxl:ResidualFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ResidualFilter>
+            <dxl:PropagationExpression>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:PropagationExpression>
+            <dxl:PrintableFilter>
+              <dxl:IsNull>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+            </dxl:PrintableFilter>
+          </dxl:PartitionSelector>
+          <dxl:DynamicTableScan PartIndexId="1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:IsNull>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.714849.1.0" TableName="p">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:DynamicTableScan>
+        </dxl:Sequence>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -4452,38 +4452,44 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                             <dxl:And>
                               <dxl:Or>
                                 <dxl:And>
-                                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.2065.1.0">
+                                  <dxl:Or>
+                                    <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.2065.1.0">
+                                      <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="false"/>
+                                      <dxl:ConstValue TypeMdid="0.1114.1.0" Value="AKAEUCAmAQA=" DoubleValue="323395200000000.000000"/>
+                                    </dxl:Comparison>
+                                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                                  </dxl:Or>
+                                  <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                                </dxl:And>
+                                <dxl:Or>
+                                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.2064.1.0">
                                     <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="false"/>
                                     <dxl:ConstValue TypeMdid="0.1114.1.0" Value="AKAEUCAmAQA=" DoubleValue="323395200000000.000000"/>
                                   </dxl:Comparison>
-                                  <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                                </dxl:And>
-                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.2064.1.0">
-                                  <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="false"/>
-                                  <dxl:ConstValue TypeMdid="0.1114.1.0" Value="AKAEUCAmAQA=" DoubleValue="323395200000000.000000"/>
-                                </dxl:Comparison>
+                                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                                </dxl:Or>
                               </dxl:Or>
                               <dxl:Or>
                                 <dxl:And>
-                                  <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2372.1.0">
+                                  <dxl:Or>
+                                    <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2372.1.0">
+                                      <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="true"/>
+                                      <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
+                                    </dxl:Comparison>
+                                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                                  </dxl:Or>
+                                  <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                                </dxl:And>
+                                <dxl:Or>
+                                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2371.1.0">
                                     <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="true"/>
                                     <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
                                   </dxl:Comparison>
-                                  <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                                </dxl:And>
-                                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2371.1.0">
-                                  <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="true"/>
-                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
-                                </dxl:Comparison>
+                                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                                </dxl:Or>
                               </dxl:Or>
                             </dxl:And>
-                            <dxl:Or>
-                              <dxl:DefaultPart Level="0"/>
-                              <dxl:Or>
-                                <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                                <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                              </dxl:Or>
-                            </dxl:Or>
+                            <dxl:DefaultPart Level="0"/>
                           </dxl:Or>
                         </dxl:PartFilters>
                         <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
@@ -307,48 +307,54 @@ select * from PT where j < 5 and k = 4;
                 <dxl:And>
                   <dxl:Or>
                     <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                    </dxl:And>
+                    <dxl:Or>
+                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                    </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
                   </dxl:Or>
                   <dxl:Or>
                     <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                      <dxl:Or>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                      </dxl:Or>
+                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                    </dxl:And>
+                    <dxl:Or>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                    </dxl:Comparison>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
                   </dxl:Or>
                 </dxl:And>
-                <dxl:Or>
-                  <dxl:DefaultPart Level="0"/>
-                  <dxl:Or>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                  </dxl:Or>
-                </dxl:Or>
+                <dxl:DefaultPart Level="0"/>
               </dxl:Or>
               <dxl:Or>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:PartBound Level="1" Type="0.23.1.0" LowerBound="true"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                </dxl:Comparison>
                 <dxl:Or>
-                  <dxl:DefaultPart Level="1"/>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:PartBound Level="1" Type="0.23.1.0" LowerBound="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  </dxl:Comparison>
                   <dxl:PartBoundOpen Level="1" LowerBound="true"/>
                 </dxl:Or>
+                <dxl:DefaultPart Level="1"/>
               </dxl:Or>
             </dxl:PartFilters>
             <dxl:ResidualFilter>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-NoDefault.mdp
@@ -301,40 +301,46 @@ explain select * from PT where j < 5 and k = 4;
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
+              <dxl:And>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                   </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
+                </dxl:Or>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
                         <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                       </dxl:Comparison>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
+                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                    </dxl:Or>
+                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                  </dxl:And>
+                  <dxl:Or>
                     <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                       <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                     </dxl:Comparison>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                   </dxl:Or>
-                </dxl:And>
-                <dxl:Or>
-                  <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  <dxl:PartBoundOpen Level="0" LowerBound="false"/>
                 </dxl:Or>
-              </dxl:Or>
+              </dxl:And>
               <dxl:Or>
                 <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                   <dxl:PartBound Level="1" Type="0.23.1.0" LowerBound="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-Default.mdp
@@ -261,14 +261,14 @@ select * from PT where k < 4;
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:Or>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                </dxl:Comparison>
                 <dxl:Or>
-                  <dxl:DefaultPart Level="0"/>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  </dxl:Comparison>
                   <dxl:PartBoundOpen Level="0" LowerBound="true"/>
                 </dxl:Or>
+                <dxl:DefaultPart Level="0"/>
               </dxl:Or>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartFilters>

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -488,24 +488,20 @@ private:
 	// comparison type flags accordingly
 	CDXLNode *PdxlnPredOnPartKey(CExpression *pexprPred, CColRef *pcrPartKey,
 								 IMDId *pmdidTypePartKey, ULONG ulPartLevel,
-								 BOOL fRangePart, BOOL *pfLTComparison,
-								 BOOL *pfGTComparison, BOOL *pfEQComparison);
+								 BOOL fRangePart);
 
 	// translate a conjunctive or disjunctive predicate on a part key and update the various
 	// comparison type flags accordingly
 	CDXLNode *PdxlnConjDisjOnPartKey(CExpression *pexprPred,
 									 CColRef *pcrPartKey,
 									 IMDId *pmdidTypePartKey, ULONG ulPartLevel,
-									 BOOL fRangePart, BOOL *pfLTComparison,
-									 BOOL *pfGTComparison,
-									 BOOL *pfEQComparison);
+									 BOOL fRangePart);
 
 	// translate a scalar comparison on a part key and update the various
 	// comparison type flags accordingly
 	CDXLNode *PdxlnScCmpPartKey(CExpression *pexprScCmp, CColRef *pcrPartKey,
 								IMDId *pmdidTypePartKey, ULONG ulPartLevel,
-								BOOL fRangePart, BOOL *pfLTComparison,
-								BOOL *pfGTComparison, BOOL *pfEQComparison);
+								BOOL fRangePart);
 
 	// translate a scalar null test on a part key
 	CDXLNode *PdxlnScNullTestPartKey(IMDId *pmdidTypePartKey, ULONG ulPartLevel,
@@ -522,11 +518,7 @@ private:
 	CDXLNode *PdxlArrayExprOnPartKey(CExpression *pexprPred,
 									 CColRef *pcrPartKey,
 									 IMDId *pmdidTypePartKey, ULONG ulPartLevel,
-									 BOOL fRangePart,
-									 BOOL *pfLTComparison,	// input/output
-									 BOOL *pfGTComparison,	// input/output
-									 BOOL *pfEQComparison	// input/output
-	);
+									 BOOL fRangePart);
 
 	// translate a DML operator
 	CDXLNode *PdxlnDML(CExpression *pexpr, CColRefArray *colref_array,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
@@ -221,8 +221,8 @@ public:
 	// construct predicates to cover the cases of default partition and
 	// open-ended partitions if necessary
 	static CDXLNode *PdxlnRangeFilterDefaultAndOpenEnded(
-		CMemoryPool *mp, ULONG ulPartLevel, BOOL fLTComparison,
-		BOOL fGTComparison, BOOL fEQComparison, BOOL fDefaultPart);
+		CMemoryPool *mp, ULONG ulPartLevel, BOOL addCheckForOpenLowerBound,
+		BOOL addCheckForOpenUpperBound, BOOL fDefaultPart);
 
 	// construct a test for partial scan in the partial partition propagator
 	static CDXLNode *PdxlnPartialScanTest(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
@@ -220,9 +220,8 @@ public:
 
 	// construct predicates to cover the cases of default partition and
 	// open-ended partitions if necessary
-	static CDXLNode *PdxlnRangeFilterDefaultAndOpenEnded(
-		CMemoryPool *mp, ULONG ulPartLevel, BOOL addCheckForOpenLowerBound,
-		BOOL addCheckForOpenUpperBound, BOOL fDefaultPart);
+	static CDXLNode *PdxlnRangeFilterDefault(CMemoryPool *mp,
+											 ULONG ulPartLevel);
 
 	// construct a test for partial scan in the partial partition propagator
 	static CDXLNode *PdxlnPartialScanTest(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
@@ -218,11 +218,6 @@ public:
 		IMDId *pmdidTypeCastExpr, IMDId *mdid_cast_func, ULONG ulPartLevel,
 		ULONG fLowerBound, IMDType::ECmpType cmp_type);
 
-	// construct predicates to cover the cases of default partition and
-	// open-ended partitions if necessary
-	static CDXLNode *PdxlnRangeFilterDefault(CMemoryPool *mp,
-											 ULONG ulPartLevel);
-
 	// construct a test for partial scan in the partial partition propagator
 	static CDXLNode *PdxlnPartialScanTest(CMemoryPool *mp,
 										  CMDAccessor *md_accessor,

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5366,9 +5366,9 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 
 		if (NULL != filter_dxlnode && fRangePart && fDefaultPartition)
 		{
-			CDXLNode *pdxlnDefault =
-				CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault(m_mp,
-																   ulLevel);
+			// add a condition to select the default partition
+			CDXLNode *pdxlnDefault = GPOS_NEW(m_mp) CDXLNode(
+				m_mp, GPOS_NEW(m_mp) CDXLScalarPartDefault(m_mp, ulLevel));
 
 			filter_dxlnode = CTranslatorExprToDXLUtils::PdxlnCombineBoolean(
 				m_mp, filter_dxlnode, pdxlnDefault, Edxlor);
@@ -5661,8 +5661,8 @@ CTranslatorExprToDXL::PdxlnScNullTestPartKey(IMDId *, ULONG ulPartLevel,
 
 	// select the default partition since in a range-partitioned table only it can contain
 	// the NULL value
-	return CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault(m_mp,
-															  ulPartLevel);
+	return GPOS_NEW(m_mp)
+		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarPartDefault(m_mp, ulPartLevel));
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5368,8 +5368,8 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 		{
 			CDXLNode *pdxlnDefaultAndOpenEnded =
 				CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded(
-					m_mp, ulLevel, true /*check open lower bound*/,
-					true /*check open upper bound*/, fDefaultPartition);
+					m_mp, ulLevel, false /*check open lower bound*/,
+					false /*check open upper bound*/, fDefaultPartition);
 
 			filter_dxlnode = CTranslatorExprToDXLUtils::PdxlnCombineBoolean(
 				m_mp, filter_dxlnode, pdxlnDefaultAndOpenEnded, Edxlor);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5637,9 +5637,8 @@ CTranslatorExprToDXL::PdxlnScCmpPartKey(CExpression *pexprScCmp,
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorExprToDXL::PdxlnScNullTestPartKey(IMDId *,
-											 ULONG ulPartLevel, BOOL fRangePart,
-											 BOOL is_null)
+CTranslatorExprToDXL::PdxlnScNullTestPartKey(IMDId *, ULONG ulPartLevel,
+											 BOOL fRangePart, BOOL is_null)
 {
 	if (!fRangePart)  // list partition
 	{
@@ -5656,7 +5655,8 @@ CTranslatorExprToDXL::PdxlnScNullTestPartKey(IMDId *,
 	if (!is_null)
 	{
 		// IS NOT NULL can't easily eliminate any range partition
-		return CTranslatorExprToDXLUtils::PdxlnBoolConst(m_mp, m_pmda, true /*value*/);
+		return CTranslatorExprToDXLUtils::PdxlnBoolConst(m_mp, m_pmda,
+														 true /*value*/);
 	}
 
 	// select the default partition since in a range-partitioned table only it can contain

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5364,15 +5364,14 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 			pdrgpexprConjuncts->Release();
 		}
 
-		if (NULL != filter_dxlnode && fRangePart)
+		if (NULL != filter_dxlnode && fRangePart && fDefaultPartition)
 		{
-			CDXLNode *pdxlnDefaultAndOpenEnded =
-				CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded(
-					m_mp, ulLevel, false /*check open lower bound*/,
-					false /*check open upper bound*/, fDefaultPartition);
+			CDXLNode *pdxlnDefault =
+				CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault(m_mp,
+																   ulLevel);
 
 			filter_dxlnode = CTranslatorExprToDXLUtils::PdxlnCombineBoolean(
-				m_mp, filter_dxlnode, pdxlnDefaultAndOpenEnded, Edxlor);
+				m_mp, filter_dxlnode, pdxlnDefault, Edxlor);
 		}
 
 		if (NULL == filter_dxlnode)
@@ -5662,12 +5661,8 @@ CTranslatorExprToDXL::PdxlnScNullTestPartKey(IMDId *,
 
 	// select the default partition since in a range-partitioned table only it can contain
 	// the NULL value
-	return CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded(
-			m_mp, ulPartLevel,
-			false,  //add check for lower bound
-			false,  //add check for upper bound
-			true   //fDefaultPartition
-		);
+	return CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault(m_mp,
+															  ulPartLevel);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -902,7 +902,8 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterScCmp(
 		GPOS_NEW(mp) CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxland),
 							  pdxlnInclusiveCmp, pdxlnInclusiveBoolPredicate);
 
-	// return the final predicate in the form "(point <= col and colIncluded) or point < col" / "(point >= col and colIncluded) or point > col"
+	// return the final predicate in the form "(point <= col and colIncluded) or point < col" or
+	//                                        "(point >= col and colIncluded) or point > col"
 	return GPOS_NEW(mp)
 		CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxlor),
 				 pdxlnPredicateInclusive, pdxlnPredicateExclusive);
@@ -922,6 +923,9 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterEqCmp(
 	IMDId *pmdidTypePartKey, IMDId *pmdidTypeOther, IMDId *pmdidTypeCastExpr,
 	IMDId *mdid_cast_func, ULONG ulPartLevel)
 {
+	// create a predicate of the form
+	// (lower_bound < part_key or lower_bound_is_open) and
+	// (upper_bound > part_key or upper_bound_is_open)
 	CDXLNode *pdxlnPredicateMin = PdxlnRangeFilterPartBound(
 		mp, md_accessor, pdxlnScalar, pmdidTypePartKey, pmdidTypeOther,
 		pmdidTypeCastExpr, mdid_cast_func, ulPartLevel, true /*fLowerBound*/,
@@ -1154,6 +1158,39 @@ CTranslatorExprToDXLUtils::PdxlnCmp(
 	}
 	pdxlnScCmp->AddChild(pdxlnPartBound);
 	pdxlnScCmp->AddChild(pdxlnScalar);
+
+	// We added a check for boundary op expr, but in many cases we also need
+	// to handle the case where there is an open boundary (-inf or inf).
+	// So, instead of (boundary op expr) return
+	// (boundary op expr) or boundary_is_open
+	CDXLNode *pdxlnOpenBound = GPOS_NEW(mp) CDXLNode(
+		mp, GPOS_NEW(mp) CDXLScalarPartBoundOpen(mp, ulPartLevel, fLowerBound));
+
+	// For certain cases we would have to negate the open boundary
+	// boolean value to get the right result, but those cases currently
+	// don't happen.
+	//
+	// comparison             result for an open bound
+	// ------------------   ----------------------------
+	// lower_bound < expr             true
+	// lower_bound = expr             false
+	// lower_bound > expr             false
+	// upper_bound < expr             false
+	// upper_bound = expr             false
+	// upper_bound > expr             true
+	// lower_bound <> expr            true
+	// upper_bound <> expr            true
+	// NOTE: <= and >= give the same result as < and >
+	GPOS_ASSERT(((fLowerBound && IMDType::EcmptEq != cmp_type &&
+				  IMDType::EcmptG != cmp_type &&
+				  IMDType::EcmptGEq != cmp_type) ||
+				 (!fLowerBound && IMDType::EcmptL != cmp_type &&
+				  IMDType::EcmptLEq != cmp_type &&
+				  IMDType::EcmptEq != cmp_type)));
+
+	pdxlnScCmp =
+		GPOS_NEW(mp) CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxlor),
+							  pdxlnScCmp, pdxlnOpenBound);
 
 	return pdxlnScCmp;
 }

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1132,12 +1132,11 @@ CTranslatorExprToDXLUtils::PdxlnCmp(
 	// lower_bound <> expr            true
 	// upper_bound <> expr            true
 	// NOTE: <= and >= give the same result as < and >
-	GPOS_ASSERT(((fLowerBound && IMDType::EcmptEq != cmp_type &&
-				  IMDType::EcmptG != cmp_type &&
-				  IMDType::EcmptGEq != cmp_type) ||
-				 (!fLowerBound && IMDType::EcmptL != cmp_type &&
-				  IMDType::EcmptLEq != cmp_type &&
-				  IMDType::EcmptEq != cmp_type)));
+	GPOS_ASSERT(
+		((fLowerBound && IMDType::EcmptEq != cmp_type &&
+		  IMDType::EcmptG != cmp_type && IMDType::EcmptGEq != cmp_type) ||
+		 (!fLowerBound && IMDType::EcmptL != cmp_type &&
+		  IMDType::EcmptLEq != cmp_type && IMDType::EcmptEq != cmp_type)));
 
 	pdxlnScCmp =
 		GPOS_NEW(mp) CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxlor),

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1009,21 +1009,23 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterPartBound(
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded(
-	CMemoryPool *mp, ULONG ulPartLevel, BOOL fLTComparison, BOOL fGTComparison,
-	BOOL fEQComparison, BOOL fDefaultPart)
+	CMemoryPool *mp, ULONG ulPartLevel, BOOL addCheckForOpenLowerBound,
+	BOOL addCheckForOpenUpperBound, BOOL fDefaultPart)
 {
 	CDXLNode *pdxlnResult = NULL;
-	if (fLTComparison || fEQComparison)
+	if (addCheckForOpenLowerBound)
 	{
 		// add a condition to cover the cases of open-ended interval (-inf, x)
+		// for those cases where this hasn't been done yet on the individual predicates
 		pdxlnResult = GPOS_NEW(mp)
 			CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartBoundOpen(
 							 mp, ulPartLevel, true /*is_lower_bound*/));
 	}
 
-	if (fGTComparison || fEQComparison)
+	if (addCheckForOpenUpperBound)
 	{
 		// add a condition to cover the cases of open-ended interval (x, inf)
+		// for those cases where this hasn't been done yet on the individual predicates
 		CDXLNode *pdxlnOpenMax = GPOS_NEW(mp)
 			CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartBoundOpen(
 							 mp, ulPartLevel, false /*is_lower_bound*/));

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1004,68 +1004,19 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterPartBound(
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded
+//		CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault
 //
 //	@doc:
-//		Construct predicates to cover the cases of default partition and
-//		open-ended partitions if necessary
+//		Construct predicates to cover the cases of default partition
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded(
-	CMemoryPool *mp, ULONG ulPartLevel, BOOL addCheckForOpenLowerBound,
-	BOOL addCheckForOpenUpperBound, BOOL fDefaultPart)
+CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault(CMemoryPool *mp,
+												   ULONG ulPartLevel)
 {
-	CDXLNode *pdxlnResult = NULL;
-	if (addCheckForOpenLowerBound)
-	{
-		// add a condition to cover the cases of open-ended interval (-inf, x)
-		// for those cases where this hasn't been done yet on the individual predicates
-		pdxlnResult = GPOS_NEW(mp)
-			CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartBoundOpen(
-							 mp, ulPartLevel, true /*is_lower_bound*/));
-	}
-
-	if (addCheckForOpenUpperBound)
-	{
-		// add a condition to cover the cases of open-ended interval (x, inf)
-		// for those cases where this hasn't been done yet on the individual predicates
-		CDXLNode *pdxlnOpenMax = GPOS_NEW(mp)
-			CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartBoundOpen(
-							 mp, ulPartLevel, false /*is_lower_bound*/));
-
-		// construct a boolean OR expression over the two expressions
-		if (NULL != pdxlnResult)
-		{
-			pdxlnResult = GPOS_NEW(mp)
-				CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxlor),
-						 pdxlnResult, pdxlnOpenMax);
-		}
-		else
-		{
-			pdxlnResult = pdxlnOpenMax;
-		}
-	}
-
-	if (fDefaultPart)
-	{
-		// add a condition to cover the cases of default partition
-		CDXLNode *pdxlnDefault = GPOS_NEW(mp)
-			CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartDefault(mp, ulPartLevel));
-
-		if (NULL != pdxlnResult)
-		{
-			pdxlnResult = GPOS_NEW(mp)
-				CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxlor),
-						 pdxlnDefault, pdxlnResult);
-		}
-		else
-		{
-			pdxlnResult = pdxlnDefault;
-		}
-	}
-
-	return pdxlnResult;
+	// add a condition to cover the cases of default partition
+	return GPOS_NEW(mp)
+		CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartDefault(mp, ulPartLevel));
 }
 
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1004,24 +1004,6 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterPartBound(
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault
-//
-//	@doc:
-//		Construct predicates to cover the cases of default partition
-//
-//---------------------------------------------------------------------------
-CDXLNode *
-CTranslatorExprToDXLUtils::PdxlnRangeFilterDefault(CMemoryPool *mp,
-												   ULONG ulPartLevel)
-{
-	// add a condition to cover the cases of default partition
-	return GPOS_NEW(mp)
-		CDXLNode(mp, GPOS_NEW(mp) CDXLScalarPartDefault(mp, ulPartLevel));
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CTranslatorExprToDXLUtils::PdxlpropCopy
 //
 //	@doc:
@@ -1110,7 +1092,7 @@ CTranslatorExprToDXLUtils::PdxlnCmp(
 	pdxlnScCmp->AddChild(pdxlnPartBound);
 	pdxlnScCmp->AddChild(pdxlnScalar);
 
-	// We added a check for boundary op expr, but in many cases we also need
+	// We added a check for (boundary op expr), but in many cases we also need
 	// to handle the case where there is an open boundary (-inf or inf).
 	// So, instead of (boundary op expr) return
 	// (boundary op expr) or boundary_is_open
@@ -1132,7 +1114,11 @@ CTranslatorExprToDXLUtils::PdxlnCmp(
 	// lower_bound <> expr            true
 	// upper_bound <> expr            true
 	// NOTE: <= and >= give the same result as < and >
-	GPOS_ASSERT(
+
+	// Assert that we can use the positive condition <boundary_is_open>.
+	// If we ever hit this assert then we'll have to add a NOT on top
+	// of pdxlnOpenBound.
+	GPOS_RTL_ASSERT(
 		((fLowerBound && IMDType::EcmptEq != cmp_type &&
 		  IMDType::EcmptG != cmp_type && IMDType::EcmptGEq != cmp_type) ||
 		 (!fLowerBound && IMDType::EcmptL != cmp_type &&

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -220,7 +220,7 @@ DPE-with-unsupported-pred DPE-SemiJoin DPE-IN DPE-NOT-IN HJN-DPE-Bitmap-Outer-Ch
 NLJ-Broadcast-DPE-Outer-Child PartTbl-MultiWayJoinWithDPE PartTbl-MultiWayJoinWithDPE-2
 PartTbl-LeftOuterHashJoin-DPE-IsNull PartTbl-LeftOuterNLJoin-DPE-IsNull
 PartTbl-List-DPE-Varchar-Predicates PartTbl-List-DPE-Int-Predicates PartTbl-DPE-PartitionSelectorRewindability
-PartTbl-RightOuterHashJoin-DPE-IsNull;
+PartTbl-RightOuterHashJoin-DPE-IsNull SPE-IS-NULL;
 
 CSetop1Test:
 ValueScanWithDuplicateAndSelfComparison PushGbBelowNaryUnionAll


### PR DESCRIPTION
The current ORCA code adds a global check for open boundaries when
the partition elimination expression does any comparisons for a range
partition scheme. For example, we do this for the following
partition selection predicates:

```
part_key = const (check for both open lower and upper boundary)
part_key > const (check for open upper boundary)
part_key < const (check for open lower boundary)
```

However, this can sometimes scan unnecessary partitions, because
the check is done globally, after evaluating all the other conditions.

Example:

`select * from t where part_col > 5 and part_col < 10;`

Partition selection predicate generated:

`(upper_bound > 5 and lower_bound < 10) or (upper_bound_is_open or lower_bound_is_open)`

With this change, we put the open bounds checks locally to the individual comparison,
so that other predicates can still be used to eliminate partitions:

`(upper_bound > 5 or upper_bound_is_open) and (lower_bound < 10 or lower_bound_is_open)`

Take a partition `[1000, inf)`. Clearly, this partition does not contain any
qualifying rows. The first expression above scans it while the second
expression is more efficient and eliminates this partition.

How to we make sure we do this for all comparisons in range-partitioned levels?

These range-partition checks are added in two places: 

- CTranslatorExprToDXLUtils::PdxlnCmp, called from various places:
  - CTranslatorExprToDXLUtils::PdxlnRangeFilterScCmp
    ==> This handles <, <=, > and >= comparisons
  - CTranslatorExprToDXLUtils::PdxlnRangeFilterPartBound, which is
    called by CTranslatorExprToDXLUtils::PdxlnRangeFilterEqCmp
    ==> This handles = comparisons
- CTranslatorExprToDXLUtils::PdxlnRangeFilterDefaultAndOpenEnded
  called from CTranslatorExprToDXL::PdxlnScNullTestPartKey
  ==> This handles predicates of the form `part_key IS NOT NULL`
- IS NULL predicates don't require open bounds checks
- AND and OR predicates are processed recursively, handled by
  the methods above
- Array comparisons get transformed into AND and OR predicates

Note that the new predicates are more efficient at eliminating range
partitions with open boundaries, but the predicates may also get
somewhat more complicated. For example, a predicate
WHERE part_col IN (1,2,3,4,5,6,7,8,9)
would do the open boundary checks 9 times as often as before.
Hopefully this is still better than reading unnecessary partitions.

The logic for list partitions should remain unchanged.

Thanks to @hardikar for analyzing this root cause of this issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
