### PR TITLE
[6X] Fix mistake in resgroup bypass isolation test

### DIFF
--- a/src/test/isolation2/output/resgroup/resgroup_bypass.source
+++ b/src/test/isolation2/output/resgroup/resgroup_bypass.source
@@ -181,12 +181,11 @@ SELECT * FROM memory_result;
 ABORT
 61: BEGIN;
 BEGIN
-SELECT * FROM memory_result;
- rsgname        | ismaster | avg_mem 
-----------------+----------+---------
- rg_bypass_test | 0        | 0.0     
- rg_bypass_test | 1        | 30.0    
-(2 rows)
+SELECT 1 FROM memory_result where avg_mem > 10 and ismaster = 1;
+ ?column? 
+----------
+ 1        
+(1 row)
 61q: ... <quitting>
 
 --
@@ -235,11 +234,12 @@ SELECT * FROM memory_result;
 ABORT
 61: BEGIN;
 BEGIN
-SELECT 1 FROM memory_result where avg_mem > 10 and ismaster = 1;
- ?column? 
-----------
- 1        
-(1 row)
+SELECT * FROM memory_result;
+ rsgname        | ismaster | avg_mem 
+----------------+----------+---------
+ rg_bypass_test | 0        | 0.0     
+ rg_bypass_test | 1        | 0.0     
+(2 rows)
 61q: ... <quitting>
 
 --


### PR DESCRIPTION
There is small mistake in 178a555a33146aef20b25fb1ca801a7e7a67582b
This commit has changed input for `memory limit in bypass mode, on qd`,
but corrupt output for `memory limit in bypass mode, on one slice` test

To reproduce the problem run resgroup tests with command:
`make PGOPTIONS="-c optimizer=off" installcheck-resgroups`

Mentioned mistake was fixed in master by https://github.com/greenplum-db/gpdb/commit/19cd1cf4b68faff2e29bc2fa884c480e4644cdb4

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
