### PR TITLE
Miscellaneous improvements to WAL archiving/PITR

### DIFF
--- a/src/test/gpdb_pitr/test_gpdb_pitr_cleanup.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr_cleanup.sh
@@ -9,7 +9,7 @@
 
 # Store gpdemo master and primary segment data directories.
 # This assumes default settings for the data directories.
-DATADIR="${MASTER_DATA_DIRECTORY%*/*/*}"
+DATADIR="${COORDINATOR_DATA_DIRECTORY%*/*/*}"
 MASTER=${DATADIR}/qddir/demoDataDir-1
 PRIMARY1=${DATADIR}/dbfast1/demoDataDir0
 PRIMARY2=${DATADIR}/dbfast2/demoDataDir1
@@ -20,7 +20,7 @@ TEMP_DIR=$PWD/temp_test
 # Stop the PITR cluster.
 echo "Stopping the PITR cluster..."
 REPLICA_MASTER=$TEMP_DIR/replica_m
-MASTER_DATA_DIRECTORY=$REPLICA_MASTER gpstop -ai -q
+COORDINATOR_DATA_DIRECTORY=$REPLICA_MASTER gpstop -ai -q
 
 # Remove the temp_test directory.
 echo "Removing the temporary test directory..."
@@ -37,3 +37,4 @@ done
 # Start back up the gpdemo cluster.
 echo "Starting back up the gpdemo cluster..."
 gpstart -a
+dropdb gpdb_pitr_database


### PR DESCRIPTION
This PR comprises of two commits.

The first one removes some unnecessary diffs (some of which are
historical) in xlog.c by performing a re-merge against the 12 merge
iteration PG parent: 9e1c9f95942.

The second one updates the gpdb_pitr test suite to the post 12 merge
world. There is an [upstream bug](https://www.postgresql.org/message-id/flat/CAE-ML%2B_EjH_fzfq1F3RJ1%3DXaaNG%3D-Jz-i3JqkNhXiLAsM3z-Ew%40mail.gmail.com) that hinders it from fully passing. The
plan is to backport that fix, when it is accepted upstream and then add
this test suite to CI.

More details in the commit messages.

Co-authored-by: Kevin Yeap <kyeap@vmware.com>