### PR TITLE
Fix direct dispatch issue.

### DIFF
--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
+-- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- end_matchsubs
 create schema bfv_partition_plans;
 set search_path=bfv_partition_plans;
 --
@@ -1341,11 +1345,9 @@ explain select * from fact where dd < to_date('2009-01-02','YYYY-MM-DD'); -- par
 explain select * from fact where dd < current_date; --partitions eliminated
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.10 rows=4 width=40)
-   ->  Append  (cost=0.00..4.02 rows=2 width=40)
-         Subplans Removed: 3
-         ->  Seq Scan on fact_1_prt_1  (cost=0.00..1.00 rows=1 width=40)
-               Filter: (dd < CURRENT_DATE)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=40)
+   ->  Seq Scan on fact_1_prt_1  (cost=0.00..1.01 rows=1 width=40)
+         Filter: (dd < '03-12-2021'::date)
  Optimizer: Postgres query optimizer
 (6 rows)
 

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
+-- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- end_matchsubs
 create schema bfv_partition_plans;
 set search_path=bfv_partition_plans;
 --

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -761,6 +761,61 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
              2 |     2
 (3 rows)
 
+-- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
+create table t_sql_value_function1 (a int, b date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create table t_sql_value_function2 (a date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) insert into t_sql_value_function1 values(1, current_timestamp);
+             QUERY PLAN              
+-------------------------------------
+ Insert on t_sql_value_function1
+   ->  Result
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+insert into t_sql_value_function1 values(1, current_timestamp);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) insert into t_sql_value_function2 values(current_timestamp);
+             QUERY PLAN              
+-------------------------------------
+ Insert on t_sql_value_function2
+   ->  Result
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+insert into t_sql_value_function2 values(current_timestamp);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) insert into t_sql_value_function1 values(2, now());
+             QUERY PLAN              
+-------------------------------------
+ Insert on t_sql_value_function1
+   ->  Result
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+insert into t_sql_value_function1 values(2, now());
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) insert into t_sql_value_function2 values(now());
+             QUERY PLAN              
+-------------------------------------
+ Insert on t_sql_value_function2
+   ->  Result
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+insert into t_sql_value_function2 values(now());
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;
@@ -773,4 +828,6 @@ drop table if exists direct_dispatch_foo;
 drop table if exists direct_dispatch_bar;
 drop table if exists MPP_22019_a;
 drop table if exists MPP_22019_b;
+drop table if exists t_sql_value_function1;
+drop table if exists t_sql_value_function2;
 commit;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -776,6 +776,69 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
              2 |     2
 (3 rows)
 
+-- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
+create table t_sql_value_function1 (a int, b date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create table t_sql_value_function2 (a date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) insert into t_sql_value_function1 values(1, current_timestamp);
+              QUERY PLAN               
+---------------------------------------
+ Insert on t_sql_value_function1
+   ->  Result
+         ->  Result
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+insert into t_sql_value_function1 values(1, current_timestamp);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) insert into t_sql_value_function2 values(current_timestamp);
+              QUERY PLAN               
+---------------------------------------
+ Insert on t_sql_value_function2
+   ->  Result
+         ->  Result
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+insert into t_sql_value_function2 values(current_timestamp);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) insert into t_sql_value_function1 values(2, now());
+              QUERY PLAN               
+---------------------------------------
+ Insert on t_sql_value_function1
+   ->  Result
+         ->  Result
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+insert into t_sql_value_function1 values(2, now());
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) insert into t_sql_value_function2 values(now());
+              QUERY PLAN               
+---------------------------------------
+ Insert on t_sql_value_function2
+   ->  Result
+         ->  Result
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+insert into t_sql_value_function2 values(now());
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;
@@ -788,4 +851,6 @@ drop table if exists direct_dispatch_foo;
 drop table if exists direct_dispatch_bar;
 drop table if exists MPP_22019_a;
 drop table if exists MPP_22019_b;
+drop table if exists t_sql_value_function1;
+drop table if exists t_sql_value_function2;
 commit;

--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -13,6 +13,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/
+-- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
+-- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
+-- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
 -- end_matchsubs
 create table lp (a char) partition by list (a);
 create table lp_default partition of lp default;
@@ -3430,8 +3434,10 @@ select * from listp where a = (select null::int);
 drop table listp;
 --
 -- check that stable query clauses are only used in run-time pruning
+-- because a is the distributed key by default in stable_qual_pruning,
+-- to get consistent results, we make the table distributed randomly.
 --
-create table stable_qual_pruning (a timestamp) partition by range (a);
+create table stable_qual_pruning (a timestamp) distributed randomly partition by range (a);
 create table stable_qual_pruning1 partition of stable_qual_pruning
   for values from ('2000-01-01') to ('2000-02-01');
 create table stable_qual_pruning2 partition of stable_qual_pruning
@@ -3441,17 +3447,16 @@ create table stable_qual_pruning3 partition of stable_qual_pruning
 -- comparison against a stable value requires run-time pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning where a < localtimestamp;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
-         Subplans Removed: 1
          ->  Seq Scan on stable_qual_pruning1 (never executed)
-               Filter: (a < LOCALTIMESTAMP)
+               Filter: (a < 'Tue Mar 16 00:06:06.937984 2021'::timestamp without time zone)
          ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a < LOCALTIMESTAMP)
+               Filter: (a < 'Tue Mar 16 00:06:06.937984 2021'::timestamp without time zone)
  Optimizer: Postgres query optimizer
-(8 rows)
+(7 rows)
 
 -- timestamp < timestamptz comparison is only stable, not immutable
 explain (analyze, costs off, summary off, timing off)
@@ -3481,7 +3486,7 @@ select * from stable_qual_pruning
   where a = any(array['2000-02-01', '2010-01-01']::timestamp[]);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1) (actual rows=0 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on stable_qual_pruning2 (never executed)
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Fri Jan 01 00:00:00 2010"}'::timestamp without time zone[]))
  Optimizer: Postgres query optimizer
@@ -3490,15 +3495,13 @@ select * from stable_qual_pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(array['2000-02-01', localtimestamp]::timestamp[]);
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
-         Subplans Removed: 2
-         ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a = ANY (ARRAY['Tue Feb 01 00:00:00 2000'::timestamp without time zone, LOCALTIMESTAMP]))
+   ->  Seq Scan on stable_qual_pruning2 (never executed)
+         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Tue Mar 16 00:06:06.94494 2021"}'::timestamp without time zone[]))
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -13,6 +13,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/
+-- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
+-- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
+-- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
 -- end_matchsubs
 create table lp (a char) partition by list (a);
 create table lp_default partition of lp default;
@@ -3356,8 +3360,10 @@ select * from listp where a = (select null::int);
 drop table listp;
 --
 -- check that stable query clauses are only used in run-time pruning
+-- because a is the distributed key by default in stable_qual_pruning,
+-- to get consistent results, we make the table distributed randomly.
 --
-create table stable_qual_pruning (a timestamp) partition by range (a);
+create table stable_qual_pruning (a timestamp) distributed randomly partition by range (a);
 create table stable_qual_pruning1 partition of stable_qual_pruning
   for values from ('2000-01-01') to ('2000-02-01');
 create table stable_qual_pruning2 partition of stable_qual_pruning
@@ -3367,17 +3373,16 @@ create table stable_qual_pruning3 partition of stable_qual_pruning
 -- comparison against a stable value requires run-time pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning where a < localtimestamp;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
-         Subplans Removed: 1
          ->  Seq Scan on stable_qual_pruning1 (never executed)
-               Filter: (a < LOCALTIMESTAMP)
+               Filter: (a < 'Tue Mar 16 06:49:12.723026 2021'::timestamp without time zone)
          ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a < LOCALTIMESTAMP)
- Optimizer: Postgres query optimizer
-(8 rows)
+               Filter: (a < 'Tue Mar 16 06:49:12.723026 2021'::timestamp without time zone)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 -- timestamp < timestamptz comparison is only stable, not immutable
 explain (analyze, costs off, summary off, timing off)
@@ -3407,7 +3412,7 @@ select * from stable_qual_pruning
   where a = any(array['2000-02-01', '2010-01-01']::timestamp[]);
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1) (actual rows=0 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
          ->  Seq Scan on stable_qual_pruning2 (never executed)
                Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Fri Jan 01 00:00:00 2010"}'::timestamp without time zone[]))
@@ -3417,15 +3422,14 @@ select * from stable_qual_pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(array['2000-02-01', localtimestamp]::timestamp[]);
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
-         Subplans Removed: 2
          ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a = ANY (ARRAY['Tue Feb 01 00:00:00 2000'::timestamp without time zone, LOCALTIMESTAMP]))
- Optimizer: Postgres query optimizer
-(6 rows)
+               Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Tue Mar 16 06:49:12.74736 2021"}'::timestamp without time zone[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning

--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+-- m/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/
+-- s/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/xxxx-xx-xx xx:xx:xx.xxxxxx/
+-- m/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/
+-- s/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/xxx xx xx xx:xx:xx xxxx/
+-- end_matchsubs
 --
 -- Tests to exercise the plan caching/invalidation mechanism
 --
@@ -372,3 +378,61 @@ explain (costs off) execute test_mode_pp(2);
 (5 rows)
 
 drop table test_mode;
+--
+-- Test correctness of prepare/execute statement after fixing the direct dispatch issue 
+--
+create table test_prepare_sql_value_function (a int, b timestamp);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+prepare test_sql_value_function as select * from test_prepare_sql_value_function where b < current_timestamp and a < $1;
+execute test_sql_value_function(1); -- 1x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 2x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 3x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 4x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 5x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 6x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 7x
+ a | b 
+---+---
+(0 rows)
+
+insert into test_prepare_sql_value_function values (1, current_timestamp);
+-- should return one row
+execute test_sql_value_function(100);
+ a |                b                
+---+---------------------------------
+ 1 | Sun Mar 21 20:38:37.337624 2021
+(1 row)
+
+-- should return one row
+select * from test_prepare_sql_value_function where b < current_timestamp and a < 100;
+ a |                b                
+---+---------------------------------
+ 1 | Sun Mar 21 20:38:37.337624 2021
+(1 row)
+
+drop table test_prepare_sql_value_function;

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+-- m/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/
+-- s/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/xxxx-xx-xx xx:xx:xx.xxxxxx/
+-- m/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/
+-- s/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/xxx xx xx xx:xx:xx xxxx/
+-- end_matchsubs
 --
 -- Tests to exercise the plan caching/invalidation mechanism
 --
@@ -372,3 +378,61 @@ explain (costs off) execute test_mode_pp(2);
 (5 rows)
 
 drop table test_mode;
+--
+-- Test correctness of prepare/execute statement after fixing the direct dispatch issue 
+--
+create table test_prepare_sql_value_function (a int, b timestamp);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+prepare test_sql_value_function as select * from test_prepare_sql_value_function where b < current_timestamp and a < $1;
+execute test_sql_value_function(1); -- 1x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 2x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 3x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 4x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 5x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 6x
+ a | b 
+---+---
+(0 rows)
+
+execute test_sql_value_function(1); -- 7x
+ a | b 
+---+---
+(0 rows)
+
+insert into test_prepare_sql_value_function values (1, current_timestamp);
+-- should return one row
+execute test_sql_value_function(100);
+ a |                b                
+---+---------------------------------
+ 1 | Sun Mar 21 20:48:35.962858 2021
+(1 row)
+
+-- should return one row
+select * from test_prepare_sql_value_function where b < current_timestamp and a < 100;
+ a |                b                
+---+---------------------------------
+ 1 | Sun Mar 21 20:48:35.962858 2021
+(1 row)
+
+drop table test_prepare_sql_value_function;

--- a/src/test/regress/expected/rowsecurity.out
+++ b/src/test/regress/expected/rowsecurity.out
@@ -264,9 +264,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_carol'::name)
    ->  Seq Scan on document
          Filter: ((dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
@@ -277,9 +277,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM document NATURAL JOIN category WHERE f_leak(dt
 -----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice3)
-     ->  Gather Motion 3:1  (slice4; segments: 3)
+     ->  Gather Motion 1:1  (slice4; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_carol'::name)
    ->  Hash Join
          Hash Cond: (category.cid = document.cid)
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
@@ -335,9 +335,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_dave'::name)
    ->  Seq Scan on document
          Filter: ((cid <> 44) AND (cid <> 44) AND (cid < 50) AND (dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
@@ -348,9 +348,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM document NATURAL JOIN category WHERE f_leak(dt
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice3)
-     ->  Gather Motion 3:1  (slice4; segments: 3)
+     ->  Gather Motion 1:1  (slice4; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_dave'::name)
    ->  Hash Join
          Hash Cond: (category.cid = document.cid)
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
@@ -437,7 +437,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on document
-         Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+         Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -451,7 +451,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM document NATURAL JOIN category WHERE f_leak(dt
                ->  Seq Scan on category
          ->  Hash
                ->  Seq Scan on document
-                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+                     Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -1029,9 +1029,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_bob'::name)
    ->  Append
          ->  Seq Scan on part_document_fiction
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
@@ -1074,9 +1074,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_carol'::name)
    ->  Append
          ->  Seq Scan on part_document_fiction
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
@@ -1107,9 +1107,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
 --------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_dave'::name)
    ->  Seq Scan on part_document_fiction
          Filter: ((cid < 55) AND (dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
@@ -1188,9 +1188,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
 --------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_dave'::name)
    ->  Seq Scan on part_document_fiction
          Filter: ((cid < 55) AND (dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
@@ -1230,9 +1230,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
+     ->  Gather Motion 1:1  (slice3; segments: 1)
            ->  Seq Scan on uaccount
-                 Filter: (pguser = CURRENT_USER)
+                 Filter: (pguser = 'regress_rls_carol'::name)
    ->  Append
          ->  Seq Scan on part_document_fiction
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
@@ -1286,11 +1286,11 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Seq Scan on part_document_fiction
-               Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
          ->  Seq Scan on part_document_satire
-               Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
          ->  Seq Scan on part_document_nonfiction
-               Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (9 rows)
 

--- a/src/test/regress/expected/select_views.out
+++ b/src/test/regress/expected/select_views.out
@@ -1339,7 +1339,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal WHERE f_leak(passwd);
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
-         Filter: (f_leak(passwd) AND (name = CURRENT_USER))
+         Filter: (f_leak(passwd) AND (name = 'regress_alice'::name))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -1357,7 +1357,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_secure WHERE f_leak(passwd);
    ->  Subquery Scan on my_property_secure
          Filter: f_leak(my_property_secure.passwd)
          ->  Seq Scan on customer
-               Filter: (name = CURRENT_USER)
+               Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -1384,7 +1384,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal v
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
-         Filter: (f_leak('passwd'::text) AND f_leak(passwd) AND (name = CURRENT_USER))
+         Filter: (f_leak('passwd'::text) AND f_leak(passwd) AND (name = 'regress_alice'::name))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -1407,7 +1407,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_secure v
    ->  Subquery Scan on v
          Filter: f_leak(v.passwd)
          ->  Seq Scan on customer
-               Filter: (f_leak('passwd'::text) AND (name = CURRENT_USER))
+               Filter: (f_leak('passwd'::text) AND (name = 'regress_alice'::name))
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -1435,7 +1435,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_normal WHERE f_leak(cnum);
                Filter: f_leak(cnum)
          ->  Hash
                ->  Seq Scan on customer l
-                     Filter: (name = CURRENT_USER)
+                     Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -1457,7 +1457,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_secure WHERE f_leak(cnum);
                ->  Seq Scan on credit_card r
                ->  Hash
                      ->  Seq Scan on customer l
-                           Filter: (name = CURRENT_USER)
+                           Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -1494,7 +1494,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_normal
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l_1
-                                             Filter: (name = CURRENT_USER)
+                                             Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -1531,7 +1531,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_secure
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l
-                                             Filter: (name = CURRENT_USER)
+                                             Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (19 rows)
 

--- a/src/test/regress/expected/select_views_optimizer.out
+++ b/src/test/regress/expected/select_views_optimizer.out
@@ -1347,7 +1347,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal WHERE f_leak(passwd);
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
-         Filter: (f_leak(passwd) AND (name = CURRENT_USER))
+         Filter: (f_leak(passwd) AND (name = 'regress_alice'::name))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -1365,7 +1365,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_secure WHERE f_leak(passwd);
    ->  Subquery Scan on my_property_secure
          Filter: f_leak(my_property_secure.passwd)
          ->  Seq Scan on customer
-               Filter: (name = CURRENT_USER)
+               Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -1392,7 +1392,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_normal v
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on customer
-         Filter: (f_leak('passwd'::text) AND f_leak(passwd) AND (name = CURRENT_USER))
+         Filter: (f_leak('passwd'::text) AND f_leak(passwd) AND (name = 'regress_alice'::name))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -1415,7 +1415,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_property_secure v
    ->  Subquery Scan on v
          Filter: f_leak(v.passwd)
          ->  Seq Scan on customer
-               Filter: (f_leak('passwd'::text) AND (name = CURRENT_USER))
+               Filter: (f_leak('passwd'::text) AND (name = 'regress_alice'::name))
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -1443,7 +1443,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_normal WHERE f_leak(cnum);
                Filter: f_leak(cnum)
          ->  Hash
                ->  Seq Scan on customer l
-                     Filter: (name = CURRENT_USER)
+                     Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -1465,7 +1465,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_secure WHERE f_leak(cnum);
                ->  Seq Scan on credit_card r
                ->  Hash
                      ->  Seq Scan on customer l
-                           Filter: (name = CURRENT_USER)
+                           Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -1502,7 +1502,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_normal
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l_1
-                                             Filter: (name = CURRENT_USER)
+                                             Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -1539,7 +1539,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM my_credit_card_usage_secure
                                  ->  Seq Scan on credit_card r_1
                                  ->  Hash
                                        ->  Seq Scan on customer l
-                                             Filter: (name = CURRENT_USER)
+                                             Filter: (name = 'regress_alice'::name)
  Optimizer: Postgres query optimizer
 (19 rows)
 

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -179,11 +179,8 @@ UPDATE update_test t
          Output: ($1), ($2), t.c, ((SubPlan 1 (returns $1,$2))), t.ctid, t.gp_segment_id, (DMLAction)
          ->  Split
                Output: ($1), ($2), t.c, ((SubPlan 1 (returns $1,$2))), t.ctid, t.gp_segment_id, DMLAction
-               ->  Result
+               ->  Seq Scan on public.update_test t
                      Output: $1, $2, t.c, (SubPlan 1 (returns $1,$2)), t.ctid, t.gp_segment_id
-                     One-Time Filter: (CURRENT_USER = SESSION_USER)
-                     ->  Seq Scan on public.update_test t
-                           Output: t.c, t.a, t.ctid, t.gp_segment_id
                      SubPlan 1 (returns $1,$2)
                        ->  Result
                              Output: s.b, s.a

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -179,11 +179,8 @@ UPDATE update_test t
          Output: ($1), ($2), t.c, ((SubPlan 1 (returns $1,$2))), t.ctid, t.gp_segment_id, (DMLAction)
          ->  Split
                Output: ($1), ($2), t.c, ((SubPlan 1 (returns $1,$2))), t.ctid, t.gp_segment_id, DMLAction
-               ->  Result
+               ->  Seq Scan on public.update_test t
                      Output: $1, $2, t.c, (SubPlan 1 (returns $1,$2)), t.ctid, t.gp_segment_id
-                     One-Time Filter: (CURRENT_USER = SESSION_USER)
-                     ->  Seq Scan on public.update_test t
-                           Output: t.c, t.a, t.ctid, t.gp_segment_id
                      SubPlan 1 (returns $1,$2)
                        ->  Result
                              Output: s.b, s.a

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
+-- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- end_matchsubs
+
 create schema bfv_partition_plans;
 set search_path=bfv_partition_plans;
 

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -318,6 +318,22 @@ select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test
 explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 
+-- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
+create table t_sql_value_function1 (a int, b date);
+create table t_sql_value_function2 (a date);
+
+explain (costs off) insert into t_sql_value_function1 values(1, current_timestamp);
+insert into t_sql_value_function1 values(1, current_timestamp);
+
+explain (costs off) insert into t_sql_value_function2 values(current_timestamp);
+insert into t_sql_value_function2 values(current_timestamp);
+
+explain (costs off) insert into t_sql_value_function1 values(2, now());
+insert into t_sql_value_function1 values(2, now());
+
+explain (costs off) insert into t_sql_value_function2 values(now());
+insert into t_sql_value_function2 values(now());
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 
@@ -332,4 +348,8 @@ drop table if exists direct_dispatch_bar;
 
 drop table if exists MPP_22019_a;
 drop table if exists MPP_22019_b;
+
+drop table if exists t_sql_value_function1;
+drop table if exists t_sql_value_function2;
+
 commit;

--- a/src/test/regress/sql/partition_prune.sql
+++ b/src/test/regress/sql/partition_prune.sql
@@ -14,6 +14,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/
+-- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
+-- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
+-- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
 -- end_matchsubs
 
 create table lp (a char) partition by list (a);
@@ -782,8 +786,10 @@ drop table listp;
 
 --
 -- check that stable query clauses are only used in run-time pruning
+-- because a is the distributed key by default in stable_qual_pruning,
+-- to get consistent results, we make the table distributed randomly.
 --
-create table stable_qual_pruning (a timestamp) partition by range (a);
+create table stable_qual_pruning (a timestamp) distributed randomly partition by range (a);
 create table stable_qual_pruning1 partition of stable_qual_pruning
   for values from ('2000-01-01') to ('2000-02-01');
 create table stable_qual_pruning2 partition of stable_qual_pruning


### PR DESCRIPTION
The issue is that we do not pre-evaluate SQLValueFunction for a single
row insertion query and add a redistribution motion to it where performance
degrades significantly. However, for a stable build-in function like
now(), we can pre-evaluate it and directly dispatch it to a single segment.

An example:
+ insert into t values(now());
+ insert into t values(current_timestamp);

Actually, the two functions do the same thing and exhibit the same
behavior. But for the first query, we can use the direct dispatch
feature but for the second one we cannot. This commit aims to solve
this problem.
