### PR TITLE
[WIP]: Add utility code support for pg_auto_failover

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -12,7 +12,7 @@ SUBDIRS += ifaddrs
 
 $(recurse)
 
-PROGRAMS= analyzedb gpactivatestandby gpaddmirrors gpcheckcat gpcheckperf \
+PROGRAMS= analyzedb gpactivatestandby gpaddmirrors gpautoctl gpcheckcat gpcheckperf \
 	gpcheckresgroupimpl gpconfig gpdeletesystem gpexpand gpinitstandby \
 	gpinitsystem gpload gpload.py gplogfilter gpmovemirrors \
 	gppkg gprecoverseg gpreload gpscp gpsd gpssh gpssh-exkeys gpstart \
@@ -196,7 +196,7 @@ clean distclean:
 	rm -rf $(PYLIB_SRC_EXT)/$(PYGRESQL_DIR)/build
 	rm -rf $(PYLIB_SRC)/$(PYGRESQL_DIR)/build
 	rm -rf *.pyc
-	rm -f analyzedbc gpactivatestandbyc gpaddmirrorsc gpcheckcatc \
+	rm -f analyzedbc gpactivatestandbyc gpaddmirrorsc gpautoctlc gpcheckcatc \
 		  gpcheckperfc gpcheckresgroupimplc gpchecksubnetcfgc gpconfigc \
 		  gpdeletesystemc gpexpandc gpinitstandbyc gplogfilterc gpmovemirrorsc \
 		  gppkgc gprecoversegc gpreloadc gpscpc gpsdc gpssh-exkeysc gpsshc \

--- a/gpMgmt/bin/gpautoctl
+++ b/gpMgmt/bin/gpautoctl
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+import time
+from optparse import OptionGroup, SUPPRESS_HELP
+
+from gppylib.mainUtils import *
+try:
+    from gppylib import userinput
+    from gppylib.db import dbconn
+    from gppylib.gpparseopts import OptParser, OptChecker
+    from gppylib.gparray import *
+    from gppylib.commands import gp
+except ImportError as e:
+    sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
+
+logger = get_default_logger()
+
+def id_to_name(dbid):
+    assert type(dbid) is int
+    return "gpaf_%d" % dbid
+
+def _get_conf_by_dbid(gparray, dbid, missingOK=True):
+    if gparray.coordinator.dbid == dbid:
+        return gparray.coordinator
+    node = gparray.standbyCoordinator
+    if node is not None and node.dbid == dbid:
+        return node
+    if missingOK:
+        return None
+    raise Exception("not exist dbid=%d in gp_segment_configuration" % dbid)
+
+
+class GpCAF:
+    ######
+    '''
+    When configuring the GPDB cluster with coordinator auto failover,
+    the cluster must be running.
+    '''
+    def __init__(self, mode, coordinator_host, coordinator_port,
+                 monitor_host, monitor_port, monitor_datadir,
+                 single = None, interactive=False):
+        self.gphome = None
+        self.mode = mode
+        self.coordinator_host = coordinator_host
+        self.coordinator_port = coordinator_port
+        self.monitor = gp.MonitorNode()
+        self.monitor.host = monitor_host
+        self.monitor.port = monitor_port
+        self.monitor.datadir = monitor_datadir
+        self.monitor_uri = None
+        self.single = None
+        if single is not None:
+            self.single = single
+        self.interactive = interactive
+
+        self.pool = None
+        self.gparray = None
+
+    def _basic_prepare(self):
+        if self.gphome is None:
+            self.gphome = os.environ.get('GPHOME')
+            if self.gphome is None:
+                raise Exception('gphome is not set, set it by either environment GPHOME')
+        logger.debug("host = %s, port = %s" % (self.coordinator_host, self.coordinator_port))
+        dburl = dbconn.DbURL(hostname=self.coordinator_host, port=self.coordinator_port,
+                             dbname='template1')
+        self.gparray = GpArray.initFromCatalog(dburl, utility=True)
+        if self.mode == 'config' and not self.gparray.hasStandbyCoordinator():
+            logger.error("Must have standby")
+            raise Exception("Must have standby")
+
+    def _prepare(self):
+        self._basic_prepare()
+
+    def _config(self):
+        # prepare monitor and config nodes.
+        if self.single is None:
+            self._prepare_monitor()
+            self._config_nodes()
+        else:
+            self._get_monitor_uri()
+            node = _get_conf_by_dbid(self.gparray, self.single, missingOK=False)
+            assert node is not None
+            self._config_node(node, ('dtmready','ready'))
+
+    def _prepare_monitor(self):
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " %s/bin/pg_autoctl create monitor" % self.gphome
+        cmdStr += " --pgdata %s" % self.monitor.datadir
+        cmdStr += " --pgport %s" % self.monitor.port
+        cmdStr += " --hostname %s" % self.monitor.host
+        cmdStr += " --auth trust --no-ssl"
+        cmd = Command(name="create monitor", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=self.monitor.host)
+        cmd.run(validateAfter=True)
+
+        logger.info("Create monitor successfully")
+        logger.info("Starting the monitor...")
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " PGAUTOCTL_DAEMON=yes %s/bin/pg_autoctl run" % self.gphome
+        cmdStr += " --pgdata %s" % self.monitor.datadir
+        cmd = Command(name="Start monitor", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=self.monitor.host)
+        cmd.run(validateAfter=True)
+
+        gp.wait_for_server_ready(self.monitor.host, self.monitor.datadir, 'ready')
+        logger.info("Started the monitor successfully")
+        self._get_monitor_uri()
+
+    def _get_monitor_uri(self):
+        if self.monitor_uri is not None:
+            return self.monitor_uri
+        logger.info("Query monitor uri")
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " %s/bin/pg_autoctl show uri --monitor" % self.gphome
+        cmdStr += " --pgdata %s" % self.monitor.datadir
+        cmd = Command(name="Show monitor uri", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=self.monitor.host)
+        cmd.run(validateAfter=True)
+        result = cmd.get_results().stdout
+        self.monitor_uri = result.strip()
+        logger.info("Query monitor uri successfully: '%s'" % self.monitor_uri)
+        return result
+
+    def _do_checks(self):
+        #
+        if self.mode == 'config':
+            self._check_config()
+        elif self.mode == 'deconfig':
+            self._check_deconfig()
+        else:
+            logger.error("Invalidate mode value: %s, see HELP" % self.mode)
+
+    def _check_config(self):
+    # host, port, pgdata of the monitor is required currently.
+    # host, port of the coordinator is required or get it from the ENV
+    # the GPDB cluster is required to be running
+        assert self.coordinator_host is not None
+        if self.coordinator_port is None or self.coordinator_port == '':
+            self.coordinator_port = os.environ.get('PGPORT')
+        assert self.monitor.port is not None
+        assert self.monitor.datadir is not None and self.monitor.datadir != ''
+
+    def _check_deconfig(self):
+        pass
+    def _config_nodes(self):
+        assert self.gparray.coordinator is not None
+        assert self.gparray.standbyCoordinator is not None
+        self._config_node(self.gparray.coordinator, 'dtmready')
+        self._config_node(self.gparray.standbyCoordinator, ('ready', 'standby'))
+    def _config_node(self, node, final_status):
+        assert node is not None
+        cmdStr = ""
+        cmdStr += " . %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " pg_ctl stop -D %s" % node.datadir
+        cmd = Command(name="Stop coordinator", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=node.hostname)
+        logger.info(cmd)
+        cmd.run(validateAfter=True)
+
+        monitor_uri = self.monitor_uri
+        logger.info("monitor_uri :'%s'" % monitor_uri)
+
+        cmdStr = ""
+        cmdStr += " . %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " %s/bin/pg_autoctl create postgres" % self.gphome
+        cmdStr += " --name %s" % id_to_name(node.dbid)
+        cmdStr += " --hostname %s" % node.hostname
+        cmdStr += " --pghost %s" % node.address
+        cmdStr += " --pgport %s" % node.port
+        cmdStr += " --pgdata %s" % node.datadir
+        cmdStr += " --gp_dbid %s" % node.dbid
+        cmdStr += " --gp_role dispatch"
+        cmdStr += " --monitor %s" % monitor_uri
+        cmdStr += " --auth trust --no-ssl"
+        logger.info(cmdStr)
+        cmd = Command(name="Create coordinator", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=node.hostname)
+        logger.info(cmd)
+        cmd.run(validateAfter=True)
+
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " PGAUTOCTL_DAEMON=yes %s/bin/pg_autoctl run" % self.gphome
+        cmdStr += " --pgdata %s" % node.datadir
+        cmd = Command(name="Run coordinator", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=node.hostname)
+        logger.info(cmd)
+        cmd.run(validateAfter=True)
+        gp.wait_for_server_ready(node.hostname, node.datadir, final_status)
+
+    def _deconfig_node(self, host, datadir):
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " %s/bin/pg_autoctl drop node" % self.gphome
+        cmdStr += " --pgdata %s" % datadir
+        cmd = Command(name='Drop node - %s' % host, cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=host)
+        logger.info(cmd)
+        cmd.run(validateAfter=False)
+
+    def _start_node(self, host, port, datadir):
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " %s/bin/pg_ctl start -D %s" % (self.gphome, datadir)
+        cmdStr += " -o '-p %s -c gp_role=dispatch'" % port
+        cmd = Command(name="Start node - %s" % host, cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=host)
+        logger.info(cmd)
+        cmd.run(validateAfter=True)
+
+    def _deconfig_single_node(self):
+        assert self.single is not None
+        name = id_to_name(self.single)
+        logger.info("deconfig %s from monitor" % name)
+        monitor_uri = self._get_monitor_uri()
+
+        url = dbconn.DbURL(hostname=self.monitor.host, port=self.monitor.port, dbname='pg_auto_failover', username='autoctl_node')
+        with closing(dbconn.connect(url, True)) as conn:
+            line = dbconn.queryRow(conn, "select nodehost, pgdata from pgautofailover.node where nodename='%s'" % name)
+            logger.debug("host, pgdata = (%s, %s)" % (line.nodehost, line.pgdata))
+            try:
+                self._deconfig_node(line.nodehost, line.pgdata)
+            except e:
+                logger.info("Error")
+
+    # try to connect to the monitor first, so we can safely
+    # stop & deconfig the standby first, and then coordinator.
+    # If coordinator is stopped first, the standby may be unnecessarily
+    # promoted.
+    def _deconfig_nodes(self):
+        err_s, err_c, err_m = None, None, None
+        node = self.gparray.standbyCoordinator
+        if node is not None:
+            try:
+                self._deconfig_node(node.hostname, node.datadir)
+            except e:
+# if the monitor is down, we can't run pg_autoctl drop node
+                err_s = e
+                logger.info("Error in deconfiging standy node: %s" % str(e))
+
+        node = self.gparray.coordinator
+        try:
+            self._deconfig_node(node.hostname, node.datadir)
+        except e:
+            err_c = e
+            logger.info("Error in deconfiging coordinator node: %s" % str(e))
+
+        try:
+            self._destroy_monitor()
+        except e:
+            err_m = e
+            logger.info("Error in deconfiging monitor node: %s" % str(e))
+
+        if err_c is None:
+            node = self.gparray.coordinator
+            self._start_node(node.hostname, node.port, node.datadir)
+        if err_s is None:
+            node = self.gparray.standbyCoordinator
+            self._start_node(node.hostname, node.port, node.datadir)
+
+    def _destroy_monitor_(self):
+        cmdStr = ""
+        cmdStr += ". %s/greenplum_path.sh;" % self.gphome
+        cmdStr += " %s/bin/pg_autoctl drop monitor --destroy" % self.gphome
+        cmdStr += " --pgdata %s" % self.monitor.datadir
+        cmd = Command(name="Drop monitor", cmdStr=cmdStr,
+                        ctxt=REMOTE, remoteHost=self.monitor.host)
+        logger.info(cmd)
+        cmd.run(validateAfter=False)
+        
+
+    def _destroy_monitor(self):
+        try:
+            self._destroy_monitor_()
+        except e:
+            logger.info(e)
+        pass
+    def _summary(self):
+        if self.single is None:
+            title = "Summary: %s the GPDB cluster with pg_auto_failover" % self.mode
+            logger.info(title)
+            logger.info("============================================")
+            logger.info("   MONITOR HOST:PORT       = %s:%s" % (self.monitor.host, self.monitor.port))
+            logger.info("   MONITOR DATADIR         = %s" % self.monitor.datadir)
+            node = self.gparray.coordinator
+            logger.info("   COORDINATOR HOST:PORT   = %s:%s" % (node.hostname, node.port))
+            logger.info("   COORDINATOR DATADIR     = %s" % node.datadir)
+            node = self.gparray.standbyCoordinator
+            if node is not None:
+                logger.info("   STANDBY HOST:PORT       = %s:%s" % (node.hostname, node.port))
+                logger.info("   STANDBY DATADIR         = %s" % node.datadir)
+            logger.info("============================================")
+        else:
+            # config/deconfig a single node
+            logger.info("Summary: %s the GPDB cluster for instance dbid=%s" % (self.mode, self.single))
+
+    def cleanup(self):
+        logger.info("cleanup:")
+        if self.pool:
+            self.pool.haltWork()
+    def run(self):
+        logger.info("running:")
+        self._do_checks()
+        self._prepare()
+        self._summary()
+        if self.interactive:
+            if not userinput.ask_yesno(None, "\nContinue to run %s?" % self.mode, "N"):
+                raise UserAbortedException()
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        if self.mode == 'config':
+            self._config()
+        elif self.mode == 'deconfig':
+            if self.single is not None:
+                self._deconfig_single_node()
+            else:
+                self._deconfig_nodes()
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+
+    # ----------------------- Command line option parser ----------------------
+    @staticmethod
+    def createParser():
+        parser = OptParser(option_class=OptChecker,
+                            description='Config/Deconfig GPDB with coordinator auto failover',
+                            version='0')
+        parser.setHelp([])
+        parser.add_option("-m", "--mode", dest="mode", default="config",
+                          choices=["config", "deconfig"],
+                          help="running mode: config|deconfig")
+        parser.add_option("-q", "--quiet",
+                          action="store_false", dest="verbose", default=True,
+                          help="don't print status messages to stdout")
+        parser.add_option("-M", "--monitor", dest="monitor",
+                            help="host:port of the monitor")
+        parser.add_option("-D", dest="pgdata",
+                          help="data directory of the monitor")
+        parser.add_option('-a', dest="interactive", action='store_false',
+                          default=True,
+                          help="quiet mode, do not require user input for confirmations")
+        # config single: dbid
+        # deconfig single: dbid
+        parser.add_option('-s', "--single", dest="single",
+                          default=None, type=int,
+                          help="config/deconfig for a single node(dbid)")
+        parser.add_option("-c", "--coordinator", dest="coordinator",
+                          help="host:port of the coordinator")
+
+        return parser
+    
+    @staticmethod
+    def createProgram(options, args):
+        def get_host_port(line, def_host, def_port):
+            host, port = def_host, def_port
+            if line is not None:
+                host_port = line.strip().split(':')
+                if host_port[0] != '':
+                    host = host_port[0]
+                if host_port[1] != '':
+                    port = host_port[1]
+            return host, port
+
+        coordinator_host, coordinator_port = get_host_port(options.coordinator,
+                                                'localhost', None)
+        monitor_host, monitor_port = get_host_port(options.monitor,
+                                                    None, None)
+        if not options.mode in ('config', 'deconfig'):
+            logger.error("Invalidate mode value: %s, see HELP" % options.mode)
+            sys.exit(1)
+
+        return GpCAF(mode=options.mode,
+                     coordinator_host=coordinator_host,
+                     coordinator_port=coordinator_port,
+                     monitor_host=monitor_host,
+                     monitor_port=monitor_port,
+                     monitor_datadir=options.pgdata,
+                     single=options.single,
+                     interactive=options.interactive)
+
+
+if __name__ == '__main__':
+    simple_main(GpCAF.createParser, GpCAF.createProgram)
+

--- a/gpMgmt/bin/gpautoctl
+++ b/gpMgmt/bin/gpautoctl
@@ -32,10 +32,10 @@ def _get_conf_by_dbid(gparray, dbid, missingOK=True):
     raise Exception("not exist dbid=%d in gp_segment_configuration" % dbid)
 
 
-class GpCAF:
+class GpAutoctl:
     ######
     '''
-    When configuring the GPDB cluster with coordinator auto failover,
+    When registering the GPDB cluster with coordinator auto failover,
     the cluster must be running.
     '''
     def __init__(self, mode, coordinator_host, coordinator_port,
@@ -67,23 +67,23 @@ class GpCAF:
         dburl = dbconn.DbURL(hostname=self.coordinator_host, port=self.coordinator_port,
                              dbname='template1')
         self.gparray = GpArray.initFromCatalog(dburl, utility=True)
-        if self.mode == 'config' and not self.gparray.hasStandbyCoordinator():
+        if self.mode == 'register' and not self.gparray.hasStandbyCoordinator():
             logger.error("Must have standby")
             raise Exception("Must have standby")
 
     def _prepare(self):
         self._basic_prepare()
 
-    def _config(self):
-        # prepare monitor and config nodes.
+    def _register(self):
+        # prepare monitor and register nodes.
         if self.single is None:
             self._prepare_monitor()
-            self._config_nodes()
+            self._register_nodes()
         else:
             self._get_monitor_uri()
             node = _get_conf_by_dbid(self.gparray, self.single, missingOK=False)
             assert node is not None
-            self._config_node(node, ('dtmready','ready'))
+            self._register_node(node, ('dtmready','ready'))
 
     def _prepare_monitor(self):
         cmdStr = ""
@@ -129,14 +129,14 @@ class GpCAF:
 
     def _do_checks(self):
         #
-        if self.mode == 'config':
-            self._check_config()
-        elif self.mode == 'deconfig':
-            self._check_deconfig()
+        if self.mode == 'register':
+            self._check_register()
+        elif self.mode == 'unregister':
+            self._check_unregister()
         else:
             logger.error("Invalidate mode value: %s, see HELP" % self.mode)
 
-    def _check_config(self):
+    def _check_register(self):
     # host, port, pgdata of the monitor is required currently.
     # host, port of the coordinator is required or get it from the ENV
     # the GPDB cluster is required to be running
@@ -146,14 +146,14 @@ class GpCAF:
         assert self.monitor.port is not None
         assert self.monitor.datadir is not None and self.monitor.datadir != ''
 
-    def _check_deconfig(self):
+    def _check_unregister(self):
         pass
-    def _config_nodes(self):
+    def _register_nodes(self):
         assert self.gparray.coordinator is not None
         assert self.gparray.standbyCoordinator is not None
-        self._config_node(self.gparray.coordinator, 'dtmready')
-        self._config_node(self.gparray.standbyCoordinator, ('ready', 'standby'))
-    def _config_node(self, node, final_status):
+        self._register_node(self.gparray.coordinator, 'dtmready')
+        self._register_node(self.gparray.standbyCoordinator, ('ready', 'standby'))
+    def _register_node(self, node, final_status):
         assert node is not None
         cmdStr = ""
         cmdStr += " . %s/greenplum_path.sh;" % self.gphome
@@ -174,8 +174,6 @@ class GpCAF:
         cmdStr += " --pghost %s" % node.address
         cmdStr += " --pgport %s" % node.port
         cmdStr += " --pgdata %s" % node.datadir
-        cmdStr += " --gp_dbid %s" % node.dbid
-        cmdStr += " --gp_role dispatch"
         cmdStr += " --monitor %s" % monitor_uri
         cmdStr += " --auth trust --no-ssl"
         logger.info(cmdStr)
@@ -194,7 +192,7 @@ class GpCAF:
         cmd.run(validateAfter=True)
         gp.wait_for_server_ready(node.hostname, node.datadir, final_status)
 
-    def _deconfig_node(self, host, datadir):
+    def _unregister_node(self, host, datadir):
         cmdStr = ""
         cmdStr += ". %s/greenplum_path.sh;" % self.gphome
         cmdStr += " %s/bin/pg_autoctl drop node" % self.gphome
@@ -214,10 +212,10 @@ class GpCAF:
         logger.info(cmd)
         cmd.run(validateAfter=True)
 
-    def _deconfig_single_node(self):
+    def _unregister_single_node(self):
         assert self.single is not None
         name = id_to_name(self.single)
-        logger.info("deconfig %s from monitor" % name)
+        logger.info("unregister %s from monitor" % name)
         monitor_uri = self._get_monitor_uri()
 
         url = dbconn.DbURL(hostname=self.monitor.host, port=self.monitor.port, dbname='pg_auto_failover', username='autoctl_node')
@@ -225,37 +223,37 @@ class GpCAF:
             line = dbconn.queryRow(conn, "select nodehost, pgdata from pgautofailover.node where nodename='%s'" % name)
             logger.debug("host, pgdata = (%s, %s)" % (line.nodehost, line.pgdata))
             try:
-                self._deconfig_node(line.nodehost, line.pgdata)
+                self._unregister_node(line.nodehost, line.pgdata)
             except e:
                 logger.info("Error")
 
     # try to connect to the monitor first, so we can safely
-    # stop & deconfig the standby first, and then coordinator.
+    # stop & unregister the standby first, and then coordinator.
     # If coordinator is stopped first, the standby may be unnecessarily
     # promoted.
-    def _deconfig_nodes(self):
+    def _unregister_nodes(self):
         err_s, err_c, err_m = None, None, None
         node = self.gparray.standbyCoordinator
         if node is not None:
             try:
-                self._deconfig_node(node.hostname, node.datadir)
+                self._unregister_node(node.hostname, node.datadir)
             except e:
 # if the monitor is down, we can't run pg_autoctl drop node
                 err_s = e
-                logger.info("Error in deconfiging standy node: %s" % str(e))
+                logger.info("Error in unregistering standy node: %s" % str(e))
 
         node = self.gparray.coordinator
         try:
-            self._deconfig_node(node.hostname, node.datadir)
+            self._unregister_node(node.hostname, node.datadir)
         except e:
             err_c = e
-            logger.info("Error in deconfiging coordinator node: %s" % str(e))
+            logger.info("Error in unregistering coordinator node: %s" % str(e))
 
         try:
             self._destroy_monitor()
         except e:
             err_m = e
-            logger.info("Error in deconfiging monitor node: %s" % str(e))
+            logger.info("Error in unregistering monitor node: %s" % str(e))
 
         if err_c is None:
             node = self.gparray.coordinator
@@ -297,7 +295,7 @@ class GpCAF:
                 logger.info("   STANDBY DATADIR         = %s" % node.datadir)
             logger.info("============================================")
         else:
-            # config/deconfig a single node
+            # register/unregister a single node
             logger.info("Summary: %s the GPDB cluster for instance dbid=%s" % (self.mode, self.single))
 
     def cleanup(self):
@@ -313,25 +311,25 @@ class GpCAF:
             if not userinput.ask_yesno(None, "\nContinue to run %s?" % self.mode, "N"):
                 raise UserAbortedException()
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        if self.mode == 'config':
-            self._config()
-        elif self.mode == 'deconfig':
+        if self.mode == 'register':
+            self._register()
+        elif self.mode == 'unregister':
             if self.single is not None:
-                self._deconfig_single_node()
+                self._unregister_single_node()
             else:
-                self._deconfig_nodes()
+                self._unregister_nodes()
         signal.signal(signal.SIGINT, signal.default_int_handler)
 
     # ----------------------- Command line option parser ----------------------
     @staticmethod
     def createParser():
         parser = OptParser(option_class=OptChecker,
-                            description='Config/Deconfig GPDB with coordinator auto failover',
+                            description='Register/Unregister GPDB with coordinator auto failover',
                             version='0')
         parser.setHelp([])
-        parser.add_option("-m", "--mode", dest="mode", default="config",
-                          choices=["config", "deconfig"],
-                          help="running mode: config|deconfig")
+        parser.add_option("-m", "--mode", dest="mode", default="register",
+                          choices=["register", "unregister"],
+                          help="running mode: register|unregister")
         parser.add_option("-q", "--quiet",
                           action="store_false", dest="verbose", default=True,
                           help="don't print status messages to stdout")
@@ -342,11 +340,11 @@ class GpCAF:
         parser.add_option('-a', dest="interactive", action='store_false',
                           default=True,
                           help="quiet mode, do not require user input for confirmations")
-        # config single: dbid
-        # deconfig single: dbid
+        # register single: dbid
+        # unregister single: dbid
         parser.add_option('-s', "--single", dest="single",
                           default=None, type=int,
-                          help="config/deconfig for a single node(dbid)")
+                          help="register/unregister for a single node(dbid)")
         parser.add_option("-c", "--coordinator", dest="coordinator",
                           help="host:port of the coordinator")
 
@@ -368,11 +366,11 @@ class GpCAF:
                                                 'localhost', None)
         monitor_host, monitor_port = get_host_port(options.monitor,
                                                     None, None)
-        if not options.mode in ('config', 'deconfig'):
+        if not options.mode in ('register', 'unregister'):
             logger.error("Invalidate mode value: %s, see HELP" % options.mode)
             sys.exit(1)
 
-        return GpCAF(mode=options.mode,
+        return GpAutoctl(mode=options.mode,
                      coordinator_host=coordinator_host,
                      coordinator_port=coordinator_port,
                      monitor_host=monitor_host,
@@ -383,5 +381,5 @@ class GpCAF:
 
 
 if __name__ == '__main__':
-    simple_main(GpCAF.createParser, GpCAF.createProgram)
+    simple_main(GpAutoctl.createParser, GpAutoctl.createProgram)
 

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -133,6 +133,11 @@ def parseargs():
     optgrp.add_option('-M', '--mode', type='string', default='smart',
                       help='use specified mode when stopping the GPDB array.  Default: smart')
 
+    # register this node to the monitor if pg_auto_failover is enabled.
+    optgrp.add_option('', '--monitor', type='string', default=None,
+                      help='specify the monitor to register the new standby for auto failover')
+
+
     parser.add_option_group(optgrp)
 
     
@@ -178,6 +183,13 @@ def parseargs():
             gp.Ping.local('check new standby up', options.standby_host)
         except:
             logger.error('Unable to ping new standby host %s' % options.standby_host)
+            parser.exit(2, None)
+
+    # check for monitor: host,port,datadir
+    if options.monitor:
+        monitor_list = options.monitor.strip().split(',')
+        if not monitor_list or len(monitor_list) != 3:
+            logger.error("Option --monitor format: monitor_host,monitor_port,monitor_datadir")
             parser.exit(2, None)
 
     return options, args
@@ -427,7 +439,10 @@ def create_standby(options):
             gp.start_standbycoordinator(standby.hostname,
                                    standby.datadir,
                                    standby.port)
+            if options.monitor:
+                _run_pg_autoctl(os.environ.get("GPHOME"), array.coordinator, standby, options.monitor)
         except Exception as ex:
+            logger.debug("EX: %s" % str(ex))
             raise GpInitStandbyException('failed to start standby')
 
     except Exception as ex:
@@ -492,6 +507,29 @@ def create_standby(options):
         # Reenable Ctrl-C
         signal.signal(signal.SIGINT,signal.default_int_handler)
             
+#-------------------------------------------------------------------------
+def _run_pg_autoctl(gphome, coordinator, standby, monitor):
+    assert monitor is not None
+    monitor_list = monitor.strip().split(',')
+    logger.debug("monitor info: %s" % (monitor))
+    if not monitor_list or len(monitor_list) != 3:
+        logger.warning("invalid monitor info, ignore to register the newly standby for autofailover")
+        return
+
+    cmdStr="%s/bin/gpautoctl -a -m config" % gphome
+    cmdStr += " --single %d" % standby.dbid
+    cmdStr += " -M %s:%s -D %s" % (monitor_list[0], monitor_list[1], monitor_list[2])
+    cmdStr += " -c %s:%s" % (coordinator.hostname, coordinator.port)
+    try:
+        cmd = base.Command("run gpautoctl for new standby", cmdStr=cmdStr)
+        cmd.run(validateAfter=True)
+        logger.info(cmd.get_results().stdout)
+        logger.info(cmd.get_results().stderr)
+    except Exception as e:
+        logger.warning("Failed to run gpautoctl %s" % str(e))
+        raise e
+
+
 #-------------------------------------------------------------------------
 def update_pg_hba_conf(options, array):
     """Updates the pg_hba.conf file to include the ip addresses of the

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -440,7 +440,7 @@ def create_standby(options):
                                    standby.datadir,
                                    standby.port)
             if options.monitor:
-                _run_pg_autoctl(os.environ.get("GPHOME"), array.coordinator, standby, options.monitor)
+                _run_gpautoctl(os.environ.get("GPHOME"), array.coordinator, standby, options.monitor)
         except Exception as ex:
             logger.debug("EX: %s" % str(ex))
             raise GpInitStandbyException('failed to start standby')
@@ -508,7 +508,7 @@ def create_standby(options):
         signal.signal(signal.SIGINT,signal.default_int_handler)
             
 #-------------------------------------------------------------------------
-def _run_pg_autoctl(gphome, coordinator, standby, monitor):
+def _run_gpautoctl(gphome, coordinator, standby, monitor):
     assert monitor is not None
     monitor_list = monitor.strip().split(',')
     logger.debug("monitor info: %s" % (monitor))
@@ -516,7 +516,7 @@ def _run_pg_autoctl(gphome, coordinator, standby, monitor):
         logger.warning("invalid monitor info, ignore to register the newly standby for autofailover")
         return
 
-    cmdStr="%s/bin/gpautoctl -a -m config" % gphome
+    cmdStr="%s/bin/gpautoctl -a -m register" % gphome
     cmdStr += " --single %d" % standby.dbid
     cmdStr += " -M %s:%s -D %s" % (monitor_list[0], monitor_list[1], monitor_list[2])
     cmdStr += " -c %s:%s" % (coordinator.hostname, coordinator.port)

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -29,6 +29,7 @@ FUNCTIONS=$WORKDIR/lib/gp_bash_functions.sh
 if [ -f $FUNCTIONS ]; then
     . $FUNCTIONS
     . $WORKDIR/lib/gp_bash_version.sh
+    . $WORKDIR/lib/gp_auto_failover.sh
 else
     echo "[FATAL]:-Cannot source $FUNCTIONS file, script Exits!"
     exit 1
@@ -1833,7 +1834,7 @@ SET_MIRROR_MODE() {
 # Main Section
 #******************************************************************************
 trap 'ERROR_EXIT "[FATAL]:-Received INT or TERM signal"' INT TERM
-while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
+while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:AO:" opt
 		do
 		case $opt in
 				v ) print_version ;;
@@ -1854,6 +1855,7 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
 				B ) BATCH_DEFAULT=$OPTARG ;;
 				I ) INPUT_CONFIG=$OPTARG ;;
 				O ) OUTPUT_CONFIG=$OPTARG ;;
+				A ) AUTOFAILOVER_CONFIG='yes' ;;
 				- ) # Long options ...
 					NAME=${OPTARG%%=*}
 					VAL=${OPTARG#*=}
@@ -1988,6 +1990,9 @@ fi
 if [ x"" != x"$STANDBY_HOSTNAME" ];then
 	CREATE_STANDBY_QD
 fi
+
+# configure coordinator auto failover if set
+CONFIG_COORDINATOR_AUTO_FAILOVER
 
 SCAN_LOG
 LOG_MSG "[INFO]:-Greenplum Database instance successfully created" 1

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -100,27 +100,6 @@ class MonitorNode:
     def __str__(self):
         return "%s:%s/%s" % (self.host, self.port, self.datadir)
 
-# start/stop pg_autoctl
-# monitor and the postgres node have the same command line
-# options to start/stop
-class PgautoctlCommand(Command):
-    def __init__(self, action, host, pgdata):
-        if not action in ['start', 'stop', 'restart']:
-            raise Exception('Invalid action: %s' % (action))
-        self.action = action
-        self.host = host
-        self.pgdata = pgdata
-        cmdStr = None
-        if action == 'start':
-            cmdStr = "export PGAUTOCTL_DAEMON=yes; pg_autoctl run --pgdata %s" % (pgdata)
-        elif action == 'stop':
-            cmdStr = 'pg_autoctl stop --pgdata %s' % (pgdata)
-        else:
-            raise Exception('not implemented yet')
-        self.cmdStr = cmdStr
-        name = '%s instance: %s/%s' % (action, host, pgdata)
-        Command.__init__(self, name, self.cmdStr, REMOTE, host)
-
 def wait_for_server_ready(host, pgdata, pmstatus='ready', timeout=120):
     counter = 0
     result = None

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -16,6 +16,7 @@ logger = get_default_logger()
 
 GPHOME=os.environ.get('GPHOME')
 
+# FIXME: Use ReadPostmasterPidFile instead?
 class DbStatus(Command):
     def __init__(self,name,db,ctxt=LOCAL,remoteHost=None):
         self.db=db        
@@ -54,6 +55,57 @@ class ReloadDbConf(Command):
         cmd.run(validateAfter=True)
         return cmd
         
+class ReadPostmasterPidFile(Command):
+    def __init__(self, name, datadir, host=None):
+        self.datadir = datadir
+        self.host = host
+        self.cmdStr = "cat %s/postmaster.pid" % datadir
+        self.reason = None
+        ctxt = LOCAL if host is None else REMOTE
+        Command.__init__(self, name, self.cmdStr, ctxt=ctxt, remoteHost=host)
+
+    def validate(self):
+        if not self.results.completed or self.results.halt:
+            raise ExecutionError("Command did not complete successfully rc: %s" % self.results.rc, self)
+    
+    def getResult(self):
+        if self.results.stderr.find("No such file or directory") != -1:
+            self.reason = 'NotFound'
+            return None
+        if self.results.stdout is None:
+            self.reason = 'NotReady'
+            return None
+
+        lines = self.results.stdout.splitlines()
+        if len(lines) < 8:
+            logger.info("postmaster.pid is not ready %s" % self.host)
+            self.reason = 'NotReady'
+            return None
+
+        pid = int(lines[0].strip())
+
+        ctxt = LOCAL if self.host is None else REMOTE
+        cmd = Command("test pid", "kill -0 %s" % str(pid), ctxt=ctxt, remoteHost=self.host)
+        cmd.run(validateAfter=False)
+        if cmd.results.rc != 0:
+            logger.info("check process %s faild: %s" % (str(pid), cmd.results.stderr))
+            self.reason = 'NotAlive'
+            return None
+
+        result = {}
+        result['pid'] = pid
+        result['datadir'] = lines[1].strip()
+        result['timestamp'] = lines[2].strip()
+        result['port'] = int(lines[3].strip())
+        result['sockdir'] = lines[4].strip()
+        result['listenAddr'] = lines[5].strip()
+        result['shm'] = lines[6].strip()
+        result['pmstatus'] = lines[7].strip()
+        self.reason = 'OK'
+
+        return result
+        
+# FIXME: Use ReadPostmasterPidFile instead?
 class ReadPostmasterTempFile(Command):
     def __init__(self,name,port,ctxt=LOCAL,remoteHost=None):
         self.port=port
@@ -127,6 +179,7 @@ def getProcWithParent(host,targetParentPID,procname):
     return (0,0)
 
 
+# FIXME: Use ReadPostmasterPidFile instead?
 def getPostmasterPID(db):
     datadir = db.getSegmentDataDirectory()
     hostname = db.getSegmentHostName()

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -6,6 +6,7 @@
 # THIS IMPORT MUST COME FIRST
 #
 # import mainUtils FIRST to get python version check
+import logging
 import sys
 from optparse import OptionGroup, SUPPRESS_HELP
 
@@ -64,6 +65,8 @@ class GpStart:
         self.quiet = quiet
         self.coordinatoronly = coordinatoronly
         self.coordinator_datadir = coordinator_datadir
+        self.coordinator_host = 'localhost'
+        self.monitor = gp.MonitorNode.fromEnv()
         self.interactive = interactive
         self.timeout = timeout
         self.wrapper = wrapper
@@ -83,6 +86,7 @@ class GpStart:
         self.dburl = None
         self.max_connections = None
         logger.debug("Setting level of parallelism to: %d" % self.parallel)
+        logger.debug("Monitor: %s" % self.monitor)
 
     ######
     def run(self):
@@ -172,6 +176,44 @@ class GpStart:
 
             # ------------------------------- Internal Helper --------------------------------
 
+    def _start_pgautoctl_node(self, host, pgdata, pmstatus):
+        logger.info("start pg_autoctl for %s - %s, expected pmstatus=%s" % (host, pgdata, pmstatus))
+        cmd = gp.PgautoctlCommand('start', host, pgdata)
+        cmd.run(validateAfter=True)
+        gp.wait_for_server_ready(host, pgdata, pmstatus)
+
+    def _start_pgautoctl_nodes(self):
+        gp_coordinator = self.gparray.coordinator
+        gp_standby = self.gparray.standbyCoordinator
+        logger.info("coordinator node %s" % (gp_coordinator))
+        logger.info("standby node %s" % (gp_standby))
+        coordinator_OK, standby_OK = False, False
+        assert gp_coordinator is not None
+        self._start_pgautoctl_node(gp_coordinator.getSegmentHostName(), gp_coordinator.getSegmentDataDirectory(), pmstatus='dtmready')
+        coordinator_OK = True
+
+        if gp_standby is not None:
+            self._start_pgautoctl_node(gp_standby.getSegmentHostName(), gp_standby.getSegmentDataDirectory(), pmstatus=('ready','standby'))
+            standby_OK = True
+        return coordinator_OK, standby_OK
+
+    def _check_and_run_monitor(self):
+        monitor = self.monitor
+        assert monitor is not None
+        logger.info("start monitor...")
+        try:
+            pgautoctl = gp.PgautoctlCommand('start', monitor.host, monitor.datadir)
+            pgautoctl.run(validateAfter=True)
+            ok = gp.wait_for_server_ready(monitor.host, monitor.datadir, 'ready', timeout=60)
+            if not ok:
+                logger.warning("Failed to start the monitor: %s %s" % (monitor.host, monitor.datadir))
+                logger.warning("Fall back with pg_auto_failover")
+                self.monitor = None
+        except:
+            logger.warning("Failed to start the monitor: %s %s" % (monitor.host, monitor.datadir))
+            logger.warning("Fall back with pg_auto_failover")
+            self.monitor = None
+
     ######
     def _prepare(self):
         logger.info("Gathering information and validating the environment...")
@@ -179,6 +221,8 @@ class GpStart:
 
         self._check_version()
         self._check_coordinator_running()
+        if self.monitor is not None:
+            self._check_and_run_monitor()
 
     ######
     def _basic_setup(self):
@@ -186,8 +230,9 @@ class GpStart:
         if self.coordinator_datadir is None:
             self.coordinator_datadir = gp.get_coordinatordatadir()
         self.user = unix.getUserName()
-        gp.check_permissions(self.user)
-        self._read_postgresqlconf()
+        gp.check_permissions_remote(self.coordinator_host, self.user, self.gphome)
+        self.port = gp.read_postgresqlconf_remote_int(self.coordinator_host, self.coordinator_datadir, 'port')
+        self.max_connections = gp.read_postgresqlconf_remote_int(self.coordinator_host, self.coordinator_datadir, 'max_connections')
 
     ######
     def _read_postgresqlconf(self):
@@ -200,16 +245,19 @@ class GpStart:
 
     ######
     def _check_version(self):
-        self.gpversion = gp.GpVersion.local('local GP software version check', self.gphome)
+        self.gpversion = gp.GpVersion.remote('remote GP software version check',
+                                              self.gphome, self.coordinator_host)
         logger.info("Greenplum Binary Version: '%s'" % self.gpversion)
 
         # It would be nice to work out the catalog version => greenplum version
         # calculation so that we can print out nicer error messages when
         # version doesn't match.
-        bin_catversion = gp.GpCatVersion.local('local GP software catalag version check', self.gphome)
+        bin_catversion = gp.GpCatVersion.remote('remote GP software catalag version check',
+                                                self.gphome, self.coordinator_host)
         logger.info("Greenplum Catalog Version: '%s'" % bin_catversion)
 
-        dir_catversion = gp.GpCatVersionDirectory.local('local GP directory catalog version check', self.coordinator_datadir)
+        dir_catversion = gp.GpCatVersionDirectory.remote('remote GP directory catalog version check',
+                                                self.coordinator_datadir, self.coordinator_host)
 
         if bin_catversion != dir_catversion:
             logger.info("COORDINATOR_DIRECTORY Catalog Version: '%s'" % dir_catversion)
@@ -231,6 +279,7 @@ class GpStart:
                         verbose=logging_is_verbose(),
                         datadir=self.coordinator_datadir,
                         parallel=self.parallel,
+                        ctxt=REMOTE, remoteHost=self.coordinator_host,
                         logfileDirectory=self.logfileDirectory)
         cmd.run()
         logger.debug("results of forcing coordinator shutdown: %s" % cmd)
@@ -400,12 +449,12 @@ class GpStart:
     def _startCoordinator(self):
         logger.info("Starting Coordinator instance in admin mode")
 
-        cmd = gp.CoordinatorStart('coordinator in utility mode', self.coordinator_datadir,
-                             self.port, self.era,
+        cmd = gp.CoordinatorStart.remote('coordinator in utility mode', self.coordinator_datadir,
+                             self.coordinator_host, self.port, self.era,
                              wrapper=self.wrapper, wrapper_args=self.wrapper_args,
                              specialMode=self.specialMode, timeout=self.timeout, utilityMode=True
                              )
-        cmd.run()
+#        cmd.run()
 
         if cmd.get_results().rc != 0:
             logger.fatal("Failed to start Coordinator instance in admin mode")
@@ -464,12 +513,21 @@ class GpStart:
             raise ExceptionNoStackTraceNeeded("Do not have enough valid segments to start the array.")
 
         failedToStart = segmentStartResult.getFailedSegmentObjs()
-        coordinator_result, message = self._start_final_coordinator()
-        if not coordinator_result:
-            return False
 
-        # start standby after coordinator in dispatch mode comes up
-        standby_was_started = self._start_standby()
+        # TODO:
+        # 1. without coordinator auto failover: start coordinator, start standby
+        # 2. with coordinator auto failover: start coordinator and standby under pg_autoctl
+        #       if only one node registered, we don't start standby node
+        if self.monitor is None:
+            coordinator_result, message = self._start_final_coordinator()
+            if not coordinator_result:
+                return False
+
+            # start standby after coordinator in dispatch mode comes up
+            standby_was_started = self._start_standby()
+        else:
+            coordinator_result, standby_was_started = self._start_pgautoctl_nodes()
+            message = None
 
         # report if we complete operations
         return self._check_final_result(
@@ -678,18 +736,19 @@ class GpStart:
         self.gparray.coordinator.hostname, self.coordinator_datadir, restrict_txt))
 
         # attempt to start coordinator
-        gp.CoordinatorStart.local("Starting Coordinator instance",
-                             self.coordinator_datadir, self.port, self.era,
+        gp.CoordinatorStart.remote("Starting Coordinator instance",
+                             self.coordinator_datadir, self.gparray.coordinator.hostname,
+                             self.port, self.era,
                              wrapper=self.wrapper, wrapper_args=self.wrapper_args,
                              specialMode=self.specialMode, restrictedMode=self.restricted, timeout=self.timeout,
                              max_connections=self.max_connections
                              )
 
         # check that coordinator is running now
-        if not pg.DbStatus.local('coordinator instance', self.gparray.coordinator):
-            logger.warning("Command pg_ctl reports Coordinator %s on port %d not running" % (
+        if not pg.DbStatus.remote('coordinator instance', self.gparray.coordinator, self.coordinator_host):
+            logger.warning("Command pg_ctl reports coordinator %s on port %d not running" % (
             self.gparray.coordinator.datadir, self.gparray.coordinator.port))
-            logger.warning("Coordinator could not be started")
+            logger.warning("Master could not be started")
             return False, None
 
         logger.info("Command pg_ctl reports Coordinator %s instance active" % self.gparray.coordinator.hostname)

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -176,11 +176,12 @@ class GpStart:
 
             # ------------------------------- Internal Helper --------------------------------
 
-    def _start_pgautoctl_node(self, host, pgdata, pmstatus):
+    def _start_pgautoctl_node(self, host, pgdata, pmstatus, timeout=120):
         logger.info("start pg_autoctl for %s - %s, expected pmstatus=%s" % (host, pgdata, pmstatus))
-        cmd = gp.PgautoctlCommand('start', host, pgdata)
+        cmdStr = "export PGAUTOCTL_DAEMON=yes; pg_autoctl run --pgdata %s" % pgdata
+        cmd = Command("pg_autoctl to start", cmdStr, REMOTE, host)
         cmd.run(validateAfter=True)
-        gp.wait_for_server_ready(host, pgdata, pmstatus)
+        return gp.wait_for_server_ready(host, pgdata, pmstatus, timeout)
 
     def _start_pgautoctl_nodes(self):
         gp_coordinator = self.gparray.coordinator
@@ -189,12 +190,14 @@ class GpStart:
         logger.info("standby node %s" % (gp_standby))
         coordinator_OK, standby_OK = False, False
         assert gp_coordinator is not None
-        self._start_pgautoctl_node(gp_coordinator.getSegmentHostName(), gp_coordinator.getSegmentDataDirectory(), pmstatus='dtmready')
-        coordinator_OK = True
+        coordinator_OK = self._start_pgautoctl_node(gp_coordinator.getSegmentHostName(),
+                                                    gp_coordinator.getSegmentDataDirectory(),
+                                                    pmstatus='dtmready')
 
         if gp_standby is not None:
-            self._start_pgautoctl_node(gp_standby.getSegmentHostName(), gp_standby.getSegmentDataDirectory(), pmstatus=('ready','standby'))
-            standby_OK = True
+            standby_OK = self._start_pgautoctl_node(gp_standby.getSegmentHostName(),
+                                                    gp_standby.getSegmentDataDirectory(),
+                                                    pmstatus='ready')
         return coordinator_OK, standby_OK
 
     def _check_and_run_monitor(self):
@@ -202,17 +205,13 @@ class GpStart:
         assert monitor is not None
         logger.info("start monitor...")
         try:
-            pgautoctl = gp.PgautoctlCommand('start', monitor.host, monitor.datadir)
-            pgautoctl.run(validateAfter=True)
-            ok = gp.wait_for_server_ready(monitor.host, monitor.datadir, 'ready', timeout=60)
+            ok = self._start_pgautoctl_node(monitor.host, monitor.datadir, 'ready', timeout=60)
             if not ok:
                 logger.warning("Failed to start the monitor: %s %s" % (monitor.host, monitor.datadir))
-                logger.warning("Fall back with pg_auto_failover")
-                self.monitor = None
+                raise Exception("Can't start the monitor")
         except:
             logger.warning("Failed to start the monitor: %s %s" % (monitor.host, monitor.datadir))
-            logger.warning("Fall back with pg_auto_failover")
-            self.monitor = None
+            raise
 
     ######
     def _prepare(self):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -252,7 +252,8 @@ class GpStop:
         if s is not None:
             self._stop_caf_node(s.getSegmentHostName(), s.getSegmentDataDirectory())
     def _stop_caf_node(self, host, pgdata):
-        cmd = gp.PgautoctlCommand('stop', host, pgdata)
+        cmdStr = 'pg_autoctl stop --pgdata %s' % pgdata
+        cmd = Command('pg_autoctl to stop', cmdStr, REMOTE, host)
         cmd.run(validateAfter=False)
 
     #########################

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -99,6 +99,7 @@ class GpStop:
         self.quiet = quiet
         self.pid = 0
         self.coordinatoronly = coordinatoronly
+        self.monitor = gp.MonitorNode.fromEnv()
         self.sighup = sighup
         self.interactive = interactive
         self.stopstandby = stopstandby
@@ -198,8 +199,11 @@ class GpStop:
                     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
                     if self.onlyThisHost is None:
-                        self._stop_coordinator()
-                        self._stop_standby()
+                        if self.monitor is None:
+                            self._stop_coordinator()
+                            self._stop_standby()
+                        else:
+                            self._stop_CMS()
                     self._stop_segments(segs)
                 finally:
                     # Reenable Ctrl-C
@@ -238,6 +242,20 @@ class GpStop:
         return 0
 
     ######
+    def _stop_CMS(self):
+        assert self.monitor is not None
+        self._stop_caf_node(self.monitor.host, self.monitor.datadir)
+        m = self.gparray.coordinator
+        assert m is not None
+        self._stop_caf_node(m.getSegmentHostName(), m.getSegmentDataDirectory())
+        s = self.gparray.standbyCoordinator
+        if s is not None:
+            self._stop_caf_node(s.getSegmentHostName(), s.getSegmentDataDirectory())
+    def _stop_caf_node(self, host, pgdata):
+        cmd = gp.PgautoctlCommand('stop', host, pgdata)
+        cmd.run(validateAfter=False)
+
+    #########################
     def cleanup(self):
         if self.pool:
             self.pool.haltWork()

--- a/gpMgmt/bin/lib/Makefile
+++ b/gpMgmt/bin/lib/Makefile
@@ -8,6 +8,7 @@ SUBDIRS= pexpect
 $(recurse)
 
 PROGRAMS= __init__.py \
+	gp_auto_failover.sh \
 	gp_bash_functions.sh \
 	gp_bash_version.sh \
 	gpconfigurenewsegment \

--- a/gpMgmt/bin/lib/gp_auto_failover.sh
+++ b/gpMgmt/bin/lib/gp_auto_failover.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+CONFIG_COORDINATOR_AUTO_FAILOVER() {
+if [ x"" == x"$AUTOFAILOVER_CONFIG" ]; then
+    return
+fi
+
+LOG_MSG "[INFO]:-Start to configure coordinator auto failover" 1
+LOG_MSG "[INFO]:-Start to configure the monitor"
+
+LOG_MSG "[INFO]: INTERACTIVE = $INTERACTIVE" 1
+# get configuration from gp_segment_configuration
+LOG_MSG "[INFO]:-MONITOR_HOST = '$MONITOR_HOST'" 1
+LOG_MSG "[INFO]:-MONITOR_PORT = '$MONITOR_PORT'" 1
+LOG_MSG "[INFO]:-MONITOR_DATADIR = '$MONITOR_DATADIR'" 1
+if [ -z "$MONITOR_PORT" || -z "$MONITOR_DATADIR" ]; then
+    LOG_MSG "[ERROR]: monitor port/datadir is empty" 1
+    exit 1
+fi
+local opts=""
+if [ x"" == x"$INTERACTIVE" ]; then
+    opts="-a"
+fi
+gpautoctl -m config -M $MONITOR_HOST:$MONITOR_PORT -D $MONITOR_DATADIR -c :$MASTER_PORT $opts
+
+}

--- a/gpMgmt/doc/gpinitstandby_help
+++ b/gpMgmt/doc/gpinitstandby_help
@@ -11,6 +11,8 @@ gpinitstandby { -s <standby_hostname> [-P <port>] | -r | -n }
 
 [-a] [-q] [-D] [-S <standby data directory>] [-l <logfile_directory>]
 
+[--monitor host,port,datadir]
+
 gpinitstandby -? | -v
 
 
@@ -46,6 +48,9 @@ The utility performs the following steps:
 * Sets up the standby coordinator instance on the alternate coordinator host 
 
 * Starts the synchronization process 
+
+* Register the standby coordinator to monitor to join auto failover (if
+  the --monitor option is supplied)
 
 A backup, standby coordinator host serves as a 'warm standby' in the 
 event of the primary coordinator host becoming non-operational. The standby 
@@ -130,6 +135,9 @@ OPTIONS
 --hba-hostnames
 
  Optional. use hostnames instead of CIDR in pg_hba.conf
+
+--monitor
+ Optional. The host, port and datadir of the monitor.
 
 -v
 

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -20,6 +20,7 @@ gpinitsystem -c <gpinitsystem_config>
             [--lc-monetary=<locale>] [--lc-numeric=<locale>] 
             [--lc-time=<locale>] [-e password | --su_password=<password>]
             [--mirror-mode={group|spread}] [-a] [-q] [-l <logfile_directory>] [-D]
+            [-A]
             [-I input_configuration_file]
             [-O output_configuration_file]
 
@@ -250,6 +251,8 @@ OPTIONS
  sufficient number of hosts in the array (number of hosts is greater
  than the number of segment instances).
 
+-A
+ Uses coordinator autofailover.
 
 -v | --version
 

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -87,7 +87,11 @@ test_connect(PG_FUNCTION_ARGS)
 	test_connection = walrcv_connect(conninfo, false, "walrcv_test", &err);
 	MemoryContextSwitchTo(oldcxt);
 
-	PG_RETURN_BOOL(true);
+	if (test_connection == NULL)
+		elog(ERROR, "can't establish connection, conninfo='%s', error: %s",
+				conninfo, err);
+
+	PG_RETURN_BOOL(test_connection != NULL);
 }
 
 Datum


### PR DESCRIPTION
This PR adds utility tool support for pg_auto_failover.
This patch depends on the PR https://github.com/greenplum-db/gpdb/pull/11595
The affected utility tools in this PR are:
* gpinitsystem
* gpstart
* gpstop
* gpinitstandby
* gpautoctl [new]

Running gpstart/gpstop with autofailover depends the environment variables:
`MONITOR_HOST`, `MONITOR_PORT`, `MONITOR_DATADIR`
`gpautoctl` is a new utility tool in this patch. It's used to
register/deregister the node(s) in GPDB to join auto-failover.



- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
