### PR TITLE
gpstate: Do not log ERROR during gpstate if gpexpand.status table does not exists

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1220,9 +1220,16 @@ class _GpExpandStatus(object):
             SELECT status FROM gpexpand.status ORDER BY updated DESC LIMIT 1
         '''
 
+        status_table_exists_sql = """
+            SELECT CASE WHEN to_regclass('gpexpand.status') IS NOT NULL THEN 1 ELSE 0 END
+        """
+
         try:
             dburl = dbconn.DbURL(dbname=self.dbname)
             with dbconn.connect(dburl, encoding='UTF8') as conn:
+                if not dbconn.querySingleton(conn, status_table_exists_sql):
+                    conn.close()
+                    return False
                 status = dbconn.querySingleton(conn, sql)
             conn.close()
         except Exception:


### PR DESCRIPTION
  Make sure gpstate should not log Error message if no expansion is in progress
  resolves https://github.com/greenplum-db/gpdb/issues/11554

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-cm-fix_gpstate_issueno_11554)
