### PR TITLE
Set default gp_role according to the dbib and contentid

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1000,7 +1000,8 @@ PostmasterMain(int argc, char *argv[])
 	{
 		if (GpIdentity.dbid != UNINITIALIZED_GP_IDENTITY_VALUE ||
 			GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE)
-			ereport(FATAL, (errmsg("Invalid gp_dbid(%d) or gp_contentid(%d)",
+			ereport(FATAL, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							errmsg("Invalid gp_dbid(%d) or gp_contentid(%d)",
 									GpIdentity.dbid, GpIdentity.segindex),
 							errhint("Set both gp_dbid and gp_contentid properly, "
 									"or leave them both uninitialized")));

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -999,6 +999,20 @@ PostmasterMain(int argc, char *argv[])
 		ExitPostmaster(2);
 
 	/*
+	 * When the instance runs as utility, its dbid and segindex(content)
+	 * may not be set properly. Mostly, the instance is not part of a GPDB
+	 * cluster. It's better to have the pair of dbid and content different to
+	 * the normal instances(coordinator or segment) in GPDB.
+	 */
+	if (Gp_role == GP_ROLE_UTILITY)
+	{
+		if (GpIdentity.dbid < 0)
+			GpIdentity.dbid = -1;
+		if (GpIdentity.segindex < -1)
+			GpIdentity.segindex = -1;
+	}
+
+	/*
 	 * CDB/MPP/GPDB: Set the processor affinity (may be a no-op on
 	 * some platforms). The port number is nice to use because we know
 	 * that different segments on a single host will not have the same

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -559,6 +559,7 @@ start_postmaster(void)
 #endif							/* WIN32 */
 }
 
+
 static bool
 is_secondary_instance(const char *pg_data)
 {

--- a/src/bin/pg_ctl/t/001_start_stop.pl
+++ b/src/bin/pg_ctl/t/001_start_stop.pl
@@ -39,8 +39,7 @@ else
 close $conf;
 my $ctlcmd = [
 	'pg_ctl', 'start', '-D', "$tempdir/data", '-l',
-	"$TestLib::log_path/001_start_stop_server.log"
-	,'-o', '-c gp_role=utility --gp_dbid=-1 --gp_contentid=-1',
+	"$TestLib::log_path/001_start_stop_server.log",
 ];
 if ($Config{osname} ne 'msys')
 {
@@ -96,7 +95,7 @@ SKIP:
 
 	command_ok(
 		[ 'pg_ctl', 'start', '-D', "$tempdir/data", '-l', $logFileName,
-		  '-o', '-c gp_role=utility --gp_dbid=-1 --gp_contentid=-1 -c log_file_mode=0640',
+		  '-o', '-c log_file_mode=0640',
 		],
 		'start server to check group permissions');
 
@@ -117,8 +116,7 @@ if (not $windows_os)
 
 	# launch the server with the env command as a wrapper
 	command_ok([ 'pg_ctl', 'start', '-D', "$tempdir/data", '-w',
-			'--wrapper=env', "--wrapper-args=$keypair",
-			'-o', '-c gp_role=utility --gp_dbid=-1 --gp_contentid=-1' ],
+			'--wrapper=env', "--wrapper-args=$keypair"],
 		'pg_ctl start --wrapper');
 
 	# read the pid

--- a/src/bin/pg_ctl/t/002_status.pl
+++ b/src/bin/pg_ctl/t/002_status.pl
@@ -18,7 +18,7 @@ command_exit_is([ 'pg_ctl', 'status', '-D', $node->data_dir ],
 	3, 'pg_ctl status with server not running');
 
 system_or_bail 'pg_ctl', '-l', "$tempdir/logfile", '-D',
-  $node->data_dir, '-w', 'start', '-o', '-c gp_role=utility --gp_dbid=-1 --gp_contentid=-1';
+  $node->data_dir, '-w', 'start';
 command_exit_is([ 'pg_ctl', 'status', '-D', $node->data_dir ],
 	0, 'pg_ctl status with server running');
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -735,4 +735,5 @@ extern bool gp_create_table_random_default_distribution;
 /* Functions in guc_gp.c to lookup values in enum GUCs */
 extern const char * lookup_autostats_mode_by_value(GpAutoStatsModeValue val);
 
+extern void set_default_gp_role(void);
 #endif   /* CDBVARS_H */

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -484,6 +484,12 @@ sub init
 	# issues_sql_like() doesn't work if logging_collector is enabled.
 	# Individual tests can override this.
 	print $conf "logging_collector = off\n";
+
+	# We require that both gp_dbid and gp_contentid are properly initialized
+	# or uninitialized. Initializing only one of them is unexpected.
+	# gp_dbid is set below in internal.auto.conf, we should set gp_contentid.
+	# Because the server instance is always start in utility mode, setting
+	# gp_contentid to 0 look good.
 	print $conf "gp_contentid = 0\n";
 
 	# If a setting tends to affect whether tests pass or fail, print it after

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -484,6 +484,7 @@ sub init
 	# issues_sql_like() doesn't work if logging_collector is enabled.
 	# Individual tests can override this.
 	print $conf "logging_collector = off\n";
+	print $conf "gp_contentid = 0\n";
 
 	# If a setting tends to affect whether tests pass or fail, print it after
 	# TEMP_CONFIG.  Otherwise, print it before TEMP_CONFIG, thereby permitting


### PR DESCRIPTION
All PG instances in GPDB cluster should have proper dbid
and content in their configuration file. However, there is
a scenario that the PG instance is not part of the GPDB
cluster, like coordinator or segments. A typical usage is
the monitor node in pg_auto_failover. This patch initializes
these values properly to work and they're different from
the values on any normal instances in the GPDB cluster.

If both the gp_dbid and gp_contentid are uninitialized,
the gp_role is force set to `utility`.
If the gp_role doesn't provided by the command-line options,
set gp_role to `dispatch` or `execute` according to
the dbid and contentid.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
