### PR TITLE
Enable continuous controlled restore point recovery

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2784,6 +2784,18 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
+
+	{
+		{"gp_pause_on_restore_point_replay", PGC_SIGHUP, DEVELOPER_OPTIONS,
+		 gettext_noop("Pause recovery when a restore point is replayed."),
+		 NULL,
+		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_pause_on_restore_point_replay,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -188,6 +188,9 @@ extern PGDLLIMPORT VariableCache ShmemVariableCache;
 extern int xid_stop_limit;
 extern int xid_warn_limit;
 
+/* GPDB-specific */
+extern bool gp_pause_on_restore_point_replay;
+
 /*
  * prototypes for functions in transam/transam.c
  */

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -334,7 +334,6 @@ extern void XLogRequestWalReceiverReply(void);
 
 extern void assign_max_wal_size(int newval, void *extra);
 extern void assign_checkpoint_completion_target(double newval, void *extra);
-
 /*
  * Routines to start, stop, and get status of a base backup.
  */

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302102221
+#define CATALOG_VERSION_NO	302104021
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -6077,7 +6077,6 @@
   proname => 'pg_is_wal_replay_paused', provolatile => 'v',
   prorettype => 'bool', proargtypes => '',
   prosrc => 'pg_is_wal_replay_paused' },
-
 { oid => '2621', descr => 'reload configuration files',
   proname => 'pg_reload_conf', provolatile => 'v', prorettype => 'bool',
   proargtypes => '', prosrc => 'pg_reload_conf' },

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -261,6 +261,7 @@
 		"gp_vmem_limit_per_query",
 		"gp_vmem_protect_limit",
 		"gp_vmem_protect_segworker_cache_limit",
+		"gp_pause_on_restore_point_replay",
 		"gp_workfile_limit_per_segment",
 		"gp_workfile_max_entries",
 		"gp_write_shared_snapshot",

--- a/src/test/recovery/t/101_restore_point_and_startup_pause.pl
+++ b/src/test/recovery/t/101_restore_point_and_startup_pause.pl
@@ -1,0 +1,48 @@
+# test for pausing on startup and on a specified restore point
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 1;
+use File::Copy;
+
+# Initialize primary node with WAL archiving setup
+my $node_primary = get_new_node('primary');
+$node_primary->init(
+    has_archiving    => 1,
+    allows_streaming => 1);
+$node_primary->append_conf('postgresql.conf', "wal_level = 'replica'");
+$node_primary->append_conf('postgresql.conf', "max_wal_senders = 10");
+my $backup_name = 'my_backup';
+
+# Start primary
+$node_primary->start;
+
+# Initialize standby node from backup, fetching WAL from archives
+$node_primary->backup($backup_name);
+my $node_standby = get_new_node('standby');
+$node_standby->init_from_backup($node_primary, $backup_name,
+    has_restoring => 1);
+$node_standby->append_conf('postgresql.conf', "gp_pause_on_restore_point_replay = on");
+
+# Start standby
+$node_standby->start;
+
+# Create a restore point on the primary
+my $restore_point_lsn =
+    $node_primary->safe_psql('postgres', "SELECT pg_create_restore_point('rp')");
+
+# Force archival of WAL file to make it present on standby
+$node_primary->safe_psql('postgres', "SELECT pg_switch_wal()");
+
+# Wait until enough replay has been done on the standby before checking if replay
+# is paused at the restore point
+my $caughtup_query =
+    "SELECT '$restore_point_lsn'::pg_lsn <= pg_last_wal_replay_lsn()";
+$node_standby->poll_query_until('postgres', $caughtup_query)
+    or die "Timed out while waiting for standby to catch up";
+
+my $paused_at_restore_point_query =
+    "SELECT pg_is_wal_replay_paused() and pg_last_wal_replay_lsn() = '$restore_point_lsn'::pg_lsn";
+my $result2 = $node_standby->safe_psql('postgres', $paused_at_restore_point_query);
+is($result2, qq(t), 'check if WAL replay is paused at restore point');


### PR DESCRIPTION
Enable continuous controlled restore point recovery
    
This commit adds the capability to perform continuous (live) controlled
restore point based recovery for GP standbys, especially in an archive
recovery setting. This enables an application to gate recovery at
restore points created with `gp_create_restore_point()`. By gating
recovery at these restore point, eventual cluster consistency can be
achieved. A state of cluster consistency is reached when all of the
standbys in the cluster have replayed to the same restore point.

This commit introduces the `gp_pause_on_restore_point_replay` GUC, which
when set, pauses WAL recovery when a restore point WAL record is
replayed on a standby.

Example (very similar to the TAP test in the commit):

Cluster Setup:
3 primaries replicating to 3 standbys asynchronously via archive based
replication (including the coordinator and standby coordinator).

Set `gp_pause_on_restore_point_replay` ONLY on the standbys. (The GUC
should either be set before startup or set in a session followed by a
`SIGHUP` to the postmaster or a `select pg_reload_conf()` call)

1. Take a restore point on the primaries:
```sql
select gp_create_restore_point('rp');
 gp_create_restore_point
-------------------------
 (-1,0/C00026A)
 (0,0/C000260)
 (1,0/C000260)
 (2,0/C000270)
(4 rows)
```
2. Resume WAL replay on the standbys with `pg_wal_replay_resume()` on each
standby, if replication is paused. (Replication will not be paused the
first time through)

3. Force the restore point to be archived and consequently replayed on
the standbys sooner: `select gp_switch_wal()`. (this step is optional and
is purely meant for faster feedback)

4. Wait until each standby has replayed up to its corresponding
restore point LSN (match by content ID). Each standby will be paused at
that LSN (can be verified with `pg_current_replay_lsn()`).
```
-1 will be paused at 0/C00026A
0  will be paused at 0/C000260
1  will be paused at 0/C000260
2  will be paused at 0/C000270
```
5. Go to 1.

Notes:

* The recovery_target_XXX GUCs cannot be used to realize this feature as
they are only applicable to PITR. This means that once the recovery
target is reached, subsequent updates to these GUCs are ignored in
standby mode.