### PR TITLE
pg_rewind: avoid removing "log" files

### DIFF
--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -251,10 +251,11 @@ process_target_file(const char *path, file_type_t type, size_t size,
 	 * from the target data folder all paths which have been filtered out from
 	 * the source data folder when processing the source files.
 	 *
-	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME is in the excluded file list.
-	 * It should not be copied but also should not be removed. In the future,
-	 * if there are more files that should not be copied but also should not be
-	 * removed, then a separate function for those files would be better.
+	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME and "log" are in the excluded
+	 * file list.  These should not be copied but also should not be
+	 * removed. In the future, if there are more files or directories that
+	 * should not be copied but also should not be removed, then a separate
+	 * function for those would be better.
 	 */
 	{
 		const char *filename = last_dir_separator(path);
@@ -263,6 +264,8 @@ process_target_file(const char *path, file_type_t type, size_t size,
 		else
 			filename++;
 		if (strcmp(filename, GP_INTERNAL_AUTO_CONF_FILE_NAME) == 0)
+			return;
+		if (strstr(path, "log/") == path)
 			return;
 	}
 


### PR DESCRIPTION
"log" is part of excluded directory list. The semantics of exclude
file/directory list is to avoid copy from source to target. But also
as side effect if those files are present in target, they are removed
as well.

This semantic is good for most of things but for "log" directory don't
wish to get them removed. Hence, adding logic to add this exception.

(I am continuing to look into why we even scan and record internal structure files in directories as part of exclude list. Seems avoiding that should help performance as "log" and other directories in that exclude list can have many files. But that's separate problem.)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
