### PR TITLE
Docs - adding dblink new function dblink_connect_no_auth

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -35,9 +35,9 @@
       <p>In this release of Greenplum Database, statements that modify table data cannot use named
         or implicit <codeph>dblink</codeph> connections. Instead, you must provide the connection
         string directly in the <codeph>dblink()</codeph> function. For
-        example:<codeblock>gpadmin=# <b>CREATE TABLE testdbllocal (a int, b text) DISTRIBUTED BY (a);</b>
+        example:<codeblock>gpadmin=# CREATE TABLE testdbllocal (a int, b text) DISTRIBUTED BY (a);
 CREATE TABLE
-gpadmin=# <b>INSERT INTO testdbllocal select * FROM dblink('dbname=postgres', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b>
+gpadmin=# INSERT INTO testdbllocal select * FROM dblink('dbname=postgres', 'SELECT * FROM testdblink') AS dbltab(id int, product text);
 INSERT 0 2</codeblock></p>
       <p>The Greenplum Database version of <codeph>dblink</codeph> disables the following
         asynchronous functions:<ul id="ul_ajr_lsm_bdb">
@@ -58,31 +58,31 @@ INSERT 0 2</codeblock></p>
         <li>Begin by creating a sample table to query using the <codeph>dblink</codeph> functions.
           These commands create a small table in the <codeph>postgres</codeph> database, which you
           will later query from the <codeph>testdb</codeph> database using
-          <codeph>dblink</codeph>:<codeblock>$ <b>psql -d postgres</b>
+          <codeph>dblink</codeph>:<codeblock>$ psql -d postgres
 psql (9.4.20)
 Type "help" for help.
 
-postgres=# <b>CREATE TABLE testdblink (a int, b text) DISTRIBUTED BY (a);</b>
+postgres=# CREATE TABLE testdblink (a int, b text) DISTRIBUTED BY (a);
 CREATE TABLE
-postgres=# <b>INSERT INTO testdblink VALUES (1, 'Cheese'), (2, 'Fish');</b>
+postgres=# INSERT INTO testdblink VALUES (1, 'Cheese'), (2, 'Fish');
 INSERT 0 2
-postgres=# <b>\q
-</b>$</codeblock></li>
+postgres=# \q
+$</codeblock></li>
         <li>Log into a different database as a superuser. In this example, the superuser
             <codeph>gpadmin</codeph> logs into the database <codeph>testdb</codeph>. If the
             <codeph>dblink</codeph> functions are not already available, register the
             <codeph>dblink</codeph> extension in the
-          database:<codeblock>$ <b>psql -d testdb</b>
+          database:<codeblock>$ psql -d testdb
 psql (9.4beta1)
 Type "help" for help.
 
-testdb=# <b>CREATE EXTENSION dblink</b>;
+testdb=# CREATE EXTENSION dblink;
 CREATE EXTENSION</codeblock></li>
         <li>Use the <codeph>dblink_connect()</codeph> function to create either an implicit or a
           named connection to another database. The connection string that you provide should be a
-          <codeph>libpq</codeph>-style keyword/value string. This example creates a connection named
-            <codeph>mylocalconn</codeph> to the <codeph>postgres</codeph> database on the local
-          Greenplum Database system:<codeblock>testdb=# <b>SELECT dblink_connect('mylocalconn', 'dbname=postgres user=gpadmin');</b>
+            <codeph>libpq</codeph>-style keyword/value string. This example creates a connection
+          named <codeph>mylocalconn</codeph> to the <codeph>postgres</codeph> database on the local
+          Greenplum Database system:<codeblock>testdb=# SELECT dblink_connect('mylocalconn', 'dbname=postgres user=gpadmin');
  dblink_connect
 ----------------
  OK
@@ -95,7 +95,7 @@ CREATE EXTENSION</codeblock></li>
           connection. Keep in mind that this function returns a record type, so you must assign the
           columns returned in the <codeph>dblink()</codeph> query. For example, the following
           command uses the named connection to query the table you created
-          earlier:<codeblock>testdb=# <b>SELECT * FROM dblink('mylocalconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b>
+          earlier:<codeblock>testdb=# SELECT * FROM dblink('mylocalconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);
  id | product
 ----+---------
   1 | Cheese
@@ -106,20 +106,20 @@ CREATE EXTENSION</codeblock></li>
         connection string. This example connects to the database as the user
           <codeph>test_user</codeph>. Using <codeph>dblink_connect()</codeph>, a superuser can
         create a connection to another local database without specifying a password.</p>
-      <codeblock>testdb=# <b>SELECT dblink_connect('localconn2', 'dbname=postgres user=test_user');</b></codeblock>
+      <codeblock>testdb=# SELECT dblink_connect('localconn2', 'dbname=postgres user=test_user');</codeblock>
       <p>To make a connection to a remote database system, include host and password information in
         the connection string. For example, to create an implicit <codeph>dblink</codeph> connection
         to a remote
-        system:<codeblock>testdb=# <b>SELECT dblink_connect('host=remotehost port=5432 dbname=postgres user=gpadmin password=secret');</b></codeblock></p>
+        system:<codeblock>testdb=# SELECT dblink_connect('host=remotehost port=5432 dbname=postgres user=gpadmin password=secret');</codeblock></p>
       <section id="dblink_u">
         <title>Using dblink as a Non-Superuser</title>
         <p>To make a connection to a database with <codeph>dblink_connect()</codeph>, non-superusers
           must include host, user, and password information in the connection string. The host,
           user, and password information must be included even when connecting to a local database.
-          There must also be an entry in <codeph>pg_hba.conf</codeph> file for this non-superuser
-          and the target database. For example, the user <codeph>test_user</codeph> can create a
+          You must also include an entry in <codeph>pg_hba.conf</codeph> for this non-superuser and
+          the target database. For example, the user <codeph>test_user</codeph> can create a
             <codeph>dblink</codeph> connection to the local system <codeph>mdw</codeph> with this
-          command:<codeblock>testdb=> <b>SELECT dblink_connect('host=mdw port=5432 dbname=postgres user=test_user password=secret');</b></codeblock></p>
+          command:<codeblock>testdb=> SELECT dblink_connect('host=mdw port=5432 dbname=postgres user=test_user password=secret');</codeblock></p>
         <p>If non-superusers need to create <codeph>dblink</codeph> connections that do not require
           a password, they can use the <codeph>dblink_connect_u()</codeph> function. The
             <codeph>dblink_connect_u()</codeph> function is identical to
@@ -146,10 +146,10 @@ CREATE EXTENSION</codeblock></li>
               <codeph>dblink_connect_u()</codeph> functions in the user database. This example
             grants the privilege to the non-superuser <codeph>test_user</codeph> on the functions
             with the signatures for creating an implicit or a named <codeph>dblink</codeph>
-            connection.<codeblock>testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text) TO test_user;</b>
-testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;</b></codeblock></li>
+            connection.<codeblock>testdb=# GRANT EXECUTE ON FUNCTION dblink_connect_u(text) TO test_user;
+testdb=# GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;</codeblock></li>
           <li>Now <codeph>test_user</codeph> can create a connection to another local database
-            without a password, as long as there is a correctly configured entry in
+            without providing a password, as long as there is a correctly configured entry in
               <codeph>pg_hba.conf</codeph> for the user and target database. For example,
               <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database and
             execute this command to create a connection named <codeph>testconn</codeph> to the local
@@ -162,41 +162,40 @@ testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;
             query using a <codeph>dblink</codeph> connection. For example, this command uses the
               <codeph>dblink</codeph> connection named <codeph>testconn</codeph> created in the
             previous step. <codeph>test_user</codeph> must have appropriate access to the
-            table.<codeblock>testdb=> <b>SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b></codeblock></li>
+            table.<codeblock>testdb=> SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</codeblock></li>
         </ol>
       </section>
       <section>
-        <title>Using dblink as a Non-Superuser with no authentication checks</title>
-        <p>In some cases, there might be the need for allowing certain non-superusers access to
-            <codeph>dblink</codeph> without making any authentication checks. The function
+        <title>Using dblink as a Non-Superuser without Authentication Checks</title>
+        <p>In rare cases you may need to allow non-superusers to acccess to <codeph>dblink</codeph>
+          without making any authentication checks. The function
             <codeph>dblink_connect_no_auth</codeph> provides this functionality as it bypasses the
             <codeph>pg_hba.conf</codeph> file. </p>
-        <note type="warning">This is a high risk functionality so it should be handled with care and
-          only granted to trustworthy users. Also please note that it is not possible to use
-            <codeph>dblink_connect_no_auth</codeph> to connect to a remote database, it will only
-          connect locally within the cluster.</note>
-        <p>Similarly to <codeph>dblink_connect_u</codeph>, the function is not available by default,
-          it needs <codeph>gpadmin</codeph> superuser to grant permission to the non-superuser
-          beforehand:</p>
+        <note type="warning">Using these functions introduces a security risk; ensure that you grant
+          unauthorized access only to trusted user accounts. Also note that
+            <codeph>dblink_connect_no_auth</codeph> functions limit connections to the local
+          cluster, and do not permit connections to a remote database.</note>
+        <p>These functions are not available by default; the <codeph>gpadmin</codeph> superuser must
+          grant permission to the non-superuser beforehand:</p>
         <ol id="ol_agf_qwj_x4b">
           <li>As a superuser, grant the <codeph>EXECUTE</codeph> privilege on the
               <codeph>dblink_connect_no_auth()</codeph> functions in the user database. This example
             grants the privilege to the non-superuser <codeph>test_user</codeph> on the functions
             with the signatures for creating an implicit or a named <codeph>dblink</codeph>
-            connection.<codeblock>testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text) TO test_user;</b>
-testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text, text) TO test_user;</b></codeblock></li>
+            connection.<codeblock>testdb=# GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text) TO test_user;
+testdb=# GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text, text) TO test_user;</codeblock></li>
           <li>Now <codeph>test_user</codeph> can create a connection to another local database
-            without a password, regardless of what is specified in <codeph>pg_hba.conf</codeph>. For
-            example, <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database
-            and execute this command to create a connection named <codeph>testconn</codeph> to the
-            local <codeph>postgres</codeph>
-            database.<codeblock>testdb=> <b>SELECT dblink_connect_no_auth('testconn', 'dbname=postgres user=test_user');</b></codeblock>
+            without providing a password, regardless of what is specified in
+              <codeph>pg_hba.conf</codeph>. For example, <codeph>test_user</codeph> can log into the
+              <codeph>testdb</codeph> database and execute this command to create a connection named
+              <codeph>testconn</codeph> to the local <codeph>postgres</codeph>
+            database.<codeblock>testdb=> SELECT dblink_connect_no_auth('testconn', 'dbname=postgres user=test_user');</codeblock>
           </li>
           <li><codeph>test_user</codeph> can use the <codeph>dblink()</codeph> function to execute a
             query using a <codeph>dblink</codeph> connection. For example, this command uses the
               <codeph>dblink</codeph> connection named <codeph>testconn</codeph> created in the
             previous step. <codeph>test_user</codeph> must have appropriate access to the
-            table.<codeblock>testdb=> <b>SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b></codeblock></li>
+            table.<codeblock>testdb=> SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</codeblock></li>
         </ol>
       </section>
       <section id="dblink_ssl">

--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -153,7 +153,7 @@ testdb=# GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;</c
               <codeph>pg_hba.conf</codeph> for the user and target database. For example,
               <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database and
             execute this command to create a connection named <codeph>testconn</codeph> to the local
-              <codeph>postgres</codeph> database.<codeblock>testdb=> <b>SELECT dblink_connect_u('testconn', 'dbname=postgres user=test_user');</b></codeblock>
+              <codeph>postgres</codeph> database.<codeblock>testdb=> SELECT dblink_connect_u('testconn', 'dbname=postgres user=test_user');</codeblock>
             <note>If a <codeph>user</codeph> is not specified, <codeph>dblink_connect_u()</codeph>
               uses the value of the <codeph>PGUSER</codeph> environment variable when Greenplum
               Database was started. If <codeph>PGUSER</codeph> is not set, the default is the system
@@ -169,11 +169,11 @@ testdb=# GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;</c
         <title>Using dblink as a Non-Superuser without Authentication Checks</title>
         <p>In rare cases you may need to allow non-superusers to acccess to <codeph>dblink</codeph>
           without making any authentication checks. The function
-            <codeph>dblink_connect_no_auth</codeph> provides this functionality as it bypasses the
+            <codeph>dblink_connect_no_auth()</codeph> provides this functionality as it bypasses the
             <codeph>pg_hba.conf</codeph> file. </p>
-        <note type="warning">Using these functions introduces a security risk; ensure that you grant
+        <note type="warning">Using this function introduces a security risk; ensure that you grant
           unauthorized access only to trusted user accounts. Also note that
-            <codeph>dblink_connect_no_auth</codeph> functions limit connections to the local
+            <codeph>dblink_connect_no_auth()</codeph> functions limit connections to the local
           cluster, and do not permit connections to a remote database.</note>
         <p>These functions are not available by default; the <codeph>gpadmin</codeph> superuser must
           grant permission to the non-superuser beforehand:</p>

--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -116,8 +116,9 @@ CREATE EXTENSION</codeblock></li>
         <p>To make a connection to a database with <codeph>dblink_connect()</codeph>, non-superusers
           must include host, user, and password information in the connection string. The host,
           user, and password information must be included even when connecting to a local database.
-          For example, the user <codeph>test_user</codeph> can create a <codeph>dblink</codeph>
-          connection to the local system <codeph>mdw</codeph> with this
+          There must also be an entry in <codeph>pg_hba.conf</codeph> file for this non-superuser
+          and the target database. For example, the user <codeph>test_user</codeph> can create a
+            <codeph>dblink</codeph> connection to the local system <codeph>mdw</codeph> with this
           command:<codeblock>testdb=> <b>SELECT dblink_connect('host=mdw port=5432 dbname=postgres user=test_user password=secret');</b></codeblock></p>
         <p>If non-superusers need to create <codeph>dblink</codeph> connections that do not require
           a password, they can use the <codeph>dblink_connect_u()</codeph> function. The
@@ -148,13 +149,49 @@ CREATE EXTENSION</codeblock></li>
             connection.<codeblock>testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text) TO test_user;</b>
 testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;</b></codeblock></li>
           <li>Now <codeph>test_user</codeph> can create a connection to another local database
-            without a password. For example, <codeph>test_user</codeph> can log into the
-              <codeph>testdb</codeph> database and execute this command to create a connection named
-              <codeph>testconn</codeph> to the local <codeph>postgres</codeph> database.<codeblock>testdb=> <b>SELECT dblink_connect_u('testconn', 'dbname=postgres user=test_user');</b></codeblock>
+            without a password, as long as there is a correctly configured entry in
+              <codeph>pg_hba.conf</codeph> for the user and target database. For example,
+              <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database and
+            execute this command to create a connection named <codeph>testconn</codeph> to the local
+              <codeph>postgres</codeph> database.<codeblock>testdb=> <b>SELECT dblink_connect_u('testconn', 'dbname=postgres user=test_user');</b></codeblock>
             <note>If a <codeph>user</codeph> is not specified, <codeph>dblink_connect_u()</codeph>
               uses the value of the <codeph>PGUSER</codeph> environment variable when Greenplum
               Database was started. If <codeph>PGUSER</codeph> is not set, the default is the system
               user that started Greenplum Database.</note></li>
+          <li><codeph>test_user</codeph> can use the <codeph>dblink()</codeph> function to execute a
+            query using a <codeph>dblink</codeph> connection. For example, this command uses the
+              <codeph>dblink</codeph> connection named <codeph>testconn</codeph> created in the
+            previous step. <codeph>test_user</codeph> must have appropriate access to the
+            table.<codeblock>testdb=> <b>SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b></codeblock></li>
+        </ol>
+      </section>
+      <section>
+        <title>Using dblink as a Non-Superuser with no authentication checks</title>
+        <p>In some cases, there might be the need for allowing certain non-superusers access to
+            <codeph>dblink</codeph> without making any authentication checks. The function
+            <codeph>dblink_connect_no_auth</codeph> provides this functionality as it bypasses the
+            <codeph>pg_hba.conf</codeph> file. </p>
+        <note type="warning">This is a high risk functionality so it should be handled with care and
+          only granted to trustworthy users. Also please note that it is not possible to use
+            <codeph>dblink_connect_no_auth</codeph> to connect to a remote database, it will only
+          connect locally within the cluster.</note>
+        <p>Similarly to <codeph>dblink_connect_u</codeph>, the function is not available by default,
+          it needs <codeph>gpadmin</codeph> superuser to grant permission to the non-superuser
+          beforehand:</p>
+        <ol id="ol_agf_qwj_x4b">
+          <li>As a superuser, grant the <codeph>EXECUTE</codeph> privilege on the
+              <codeph>dblink_connect_no_auth()</codeph> functions in the user database. This example
+            grants the privilege to the non-superuser <codeph>test_user</codeph> on the functions
+            with the signatures for creating an implicit or a named <codeph>dblink</codeph>
+            connection.<codeblock>testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text) TO test_user;</b>
+testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text, text) TO test_user;</b></codeblock></li>
+          <li>Now <codeph>test_user</codeph> can create a connection to another local database
+            without a password, regardless of what is specified in <codeph>pg_hba.conf</codeph>. For
+            example, <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database
+            and execute this command to create a connection named <codeph>testconn</codeph> to the
+            local <codeph>postgres</codeph>
+            database.<codeblock>testdb=> <b>SELECT dblink_connect_no_auth('testconn', 'dbname=postgres user=test_user');</b></codeblock>
+          </li>
           <li><codeph>test_user</codeph> can use the <codeph>dblink()</codeph> function to execute a
             query using a <codeph>dblink</codeph> connection. For example, this command uses the
               <codeph>dblink</codeph> connection named <codeph>testconn</codeph> created in the


### PR DESCRIPTION
Documented the following PR: https://github.com/greenplum-db/gpdb/pull/11566
Added a Warning section to highlight this is a high risk functionality and also mentioned that pg_hba.conf needs to be correctly configured for dblink_connect_u to work.
You can preview the page by using the following link (needs VPN access):
https://mireia-dblink-branded.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/modules/dblink.html