### PR TITLE
DOCS: Remove reference to relationship between the -m flag and synch

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/gpstate.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpstate.xml
@@ -75,8 +75,7 @@
         </plentry>
         <plentry>
           <pt>-m (list mirrors)</pt>
-          <pd>Optional. List the mirror segment instances in the system, their current role, and
-            synchronization status.</pd>
+          <pd>Optional. List the mirror segment instances in the system and their current role.</pd>
         </plentry>
         <plentry>
           <pt>-p (show ports)</pt>


### PR DESCRIPTION
Now that customers can use gprecoverseg to report on both incremental and full recovery they don't need to use gpstate -m to get a progress report.

