### PR TITLE
Remove rest pg_utilitymodedtmredo related code.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -34,7 +34,6 @@ gDatabaseDirectories = [
     "pg_multixact",
     "pg_distributedxidmap",
     "pg_distributedlog",
-    "pg_utilitymodedtmredo",
     "base",
     "pg_tblspc",
     "pg_stat_tmp"

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1927,7 +1927,6 @@ ServerLoop(void)
 		checkPgDir("/base");
 		checkPgDir("/global");
 		checkPgDir("/pg_twophase");
-		checkPgDir("/pg_utilitymodedtmredo");
 		checkPgDir("/pg_distributedlog");
 		checkPgDir("/pg_multixact");
 		checkPgDir("/pg_subtrans");

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -229,7 +229,6 @@ static const char *const subdirs[] = {
 	"pg_logical/mappings",
 /* GPDB needs these directories */
 	"pg_distributedlog",
-	"pg_utilitymodedtmredo",
 	"log"
 };
 


### PR DESCRIPTION
71043c5b1859a2f6340d46e0d7f808cdf35955e8 removed pg_utilitymodedtmredo related
code in kernel, but today I found still there are some related code in
utilities. Let's clean up them.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
