### PR TITLE
Docs - gpfdist guc for 6X_STABLE

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -287,6 +287,7 @@
             <li><xref href="#gp_workfile_limit_files_per_query"/></li>
             <li><xref href="#gp_workfile_limit_per_query"/></li>
             <li><xref href="#gp_workfile_limit_per_segment"/></li>
+            <li><xref href="#gpfdist_retry_timeout" type="section">gpfdist_retry_timeout</xref></li>
             <li>
               <xref href="#gpperfmon_log_alert_level"/>
             </li>
@@ -418,10 +419,6 @@
             <li>
               <xref href="#optimizer_cte_inlining_bound" type="section"
                 >optimizer_cte_inlining_bound</xref>
-            </li>
-            <li>
-              <xref href="#optimizer_dpe_stats" type="section"
-                >optimizer_dpe_stats</xref>
             </li>
             <li><xref href="#optimizer_enable_associativity" type="section"
                 >optimizer_enable_associativity</xref>
@@ -3629,6 +3626,37 @@
       </table>
     </body>
   </topic>
+  <topic id="gpfdist_retry_timeout">
+    <title>gpfdist_retry_timeout</title>
+    <body>
+      <p>Controls the time (in seconds) that Greenplum Database waits before returning an error when
+        Greenplum Database is attempting to connect or write to a <codeph><xref
+            href="../../utility_guide/ref/gpfdist.xml"/></codeph> server and
+          <codeph>gpfdist</codeph> does not respond. The default value is 300 (5 minutes). A value
+        of 0 disables the timeout.</p>
+      <table id="table_fkm_jqp_dmb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 - <codeph>INT_MAX</codeph> (2147483647)</entry>
+              <entry colname="col2">300</entry>
+              <entry colname="col3">local<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="gpperfmon_log_alert_level">
     <title>gpperfmon_log_alert_level</title>
     <body>
@@ -4287,8 +4315,8 @@
         keyword allows a subquery in the <codeph>WITH</codeph> clause of a command to reference
         itself. The default value is <codeph>false</codeph>, the <codeph>RECURSIVE</codeph> keyword
         is not allowed in the <codeph>WITH</codeph> clause of a command.</p>
-      <p>For information about the <codeph>RECURSIVE</codeph> keyword, see the <codeph><xref
-            href="../sql_commands/SELECT.xml">SELECT</xref></codeph> command and <xref
+      <p>For information about the <codeph>RECURSIVE</codeph> keyword (Beta), see the
+            <codeph><xref href="../sql_commands/SELECT.xml">SELECT</xref></codeph> command and <xref
           href="../../admin_guide/query/topics/CTE-query.xml"/>.</p>
       <p>The parameter can be set for a database system, an individual database, or a session or
         query.</p>
@@ -7104,8 +7132,6 @@
       </table>
     </body>
   </topic>
-
-
   <topic id="optimizer_cte_inlining_bound">
     <title>optimizer_cte_inlining_bound</title>
     <body>
@@ -7130,35 +7156,6 @@
             <row>
               <entry colname="col1">Decimal >= 0</entry>
               <entry colname="col2">0</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
-  <topic id="optimizer_dpe_stats">
-    <title>optimizer_dpe_stats</title>
-    <body>
-      <p>When GPORCA is enabled (the default) and this parameter is <codeph>true</codeph> (the default), GPORCA derives statistics that 
-	allow it to more accurately estimate the number of rows to be scanned during dynamic partition elimination.</p>
-      <p>The parameter can be set for a database system, an individual database, or a session or query.</p>
-      <table id="dpe_stats_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">Boolean</entry>
-              <entry colname="col2">true</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -328,9 +328,6 @@
             <p><xref href="guc-list.xml#optimizer_cte_inlining_bound" type="section"
                 >optimizer_cte_inlining_bound</xref>
             </p>
-            <p><xref href="guc-list.xml#optimizer_dpe_stats" type="section"
-                >optimizer_dpe_stats</xref>
-            </p>
             <p><xref href="guc-list.xml#optimizer_enable_associativity" type="section"
                 >optimizer_enable_associativity</xref></p>
             <p><xref href="guc-list.xml#optimizer_enable_dml" type="section"
@@ -1230,7 +1227,11 @@
       <simpletable id="kh164454" frame="none">
         <strow>
           <stentry>
-            <p>
+	    <p>
+              <xref href="guc-list.xml#gpfdist_retry_timeout" type="section"
+                >gpfdist_retry_timeout</xref>
+            </p>
+	    <p>
               <xref href="guc-list.xml#gp_external_enable_exec" type="section"
                 >gp_external_enable_exec</xref>
             </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -169,6 +169,7 @@
             <topicref href="guc-list.xml#gp_workfile_limit_files_per_query"/>
             <topicref href="guc-list.xml#gp_workfile_limit_per_query"/>
             <topicref href="guc-list.xml#gp_workfile_limit_per_segment"/>
+            <topicref href="guc-list.xml#gpfdist_retry_timeout"/>
             <topicref href="guc-list.xml#gpperfmon_port"/>
             <topicref href="guc-list.xml#ignore_checksum_failure"/>
             <topicref href="guc-list.xml#integer_datetimes"/>
@@ -225,7 +226,6 @@
             <topicref href="guc-list.xml#optimizer_control"/>
             <topicref href="guc-list.xml#optimizer_cost_model"/>
             <topicref href="guc-list.xml#optimizer_cte_inlining_bound"/>
-            <topicref href="guc-list.xml#optimizer_dpe_stats"/>
             <topicref href="guc-list.xml#optimizer_enable_associativity"/>
             <topicref href="guc-list.xml#optimizer_enable_dml"/>
             <topicref href="guc-list.xml#optimizer_enable_indexonlyscan"/>

--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -116,8 +116,9 @@ CREATE EXTENSION</codeblock></li>
         <p>To make a connection to a database with <codeph>dblink_connect()</codeph>, non-superusers
           must include host, user, and password information in the connection string. The host,
           user, and password information must be included even when connecting to a local database.
-          For example, the user <codeph>test_user</codeph> can create a <codeph>dblink</codeph>
-          connection to the local system <codeph>mdw</codeph> with this
+          There must also be an entry in <codeph>pg_hba.conf</codeph> file for this non-superuser
+          and the target database. For example, the user <codeph>test_user</codeph> can create a
+            <codeph>dblink</codeph> connection to the local system <codeph>mdw</codeph> with this
           command:<codeblock>testdb=> <b>SELECT dblink_connect('host=mdw port=5432 dbname=postgres user=test_user password=secret');</b></codeblock></p>
         <p>If non-superusers need to create <codeph>dblink</codeph> connections that do not require
           a password, they can use the <codeph>dblink_connect_u()</codeph> function. The
@@ -148,13 +149,49 @@ CREATE EXTENSION</codeblock></li>
             connection.<codeblock>testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text) TO test_user;</b>
 testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;</b></codeblock></li>
           <li>Now <codeph>test_user</codeph> can create a connection to another local database
-            without a password. For example, <codeph>test_user</codeph> can log into the
-              <codeph>testdb</codeph> database and execute this command to create a connection named
-              <codeph>testconn</codeph> to the local <codeph>postgres</codeph> database.<codeblock>testdb=> <b>SELECT dblink_connect_u('testconn', 'dbname=postgres user=test_user');</b></codeblock>
+            without a password, as long as there is a correctly configured entry in
+              <codeph>pg_hba.conf</codeph> for the user and target database. For example,
+              <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database and
+            execute this command to create a connection named <codeph>testconn</codeph> to the local
+              <codeph>postgres</codeph> database.<codeblock>testdb=> <b>SELECT dblink_connect_u('testconn', 'dbname=postgres user=test_user');</b></codeblock>
             <note>If a <codeph>user</codeph> is not specified, <codeph>dblink_connect_u()</codeph>
               uses the value of the <codeph>PGUSER</codeph> environment variable when Greenplum
               Database was started. If <codeph>PGUSER</codeph> is not set, the default is the system
               user that started Greenplum Database.</note></li>
+          <li><codeph>test_user</codeph> can use the <codeph>dblink()</codeph> function to execute a
+            query using a <codeph>dblink</codeph> connection. For example, this command uses the
+              <codeph>dblink</codeph> connection named <codeph>testconn</codeph> created in the
+            previous step. <codeph>test_user</codeph> must have appropriate access to the
+            table.<codeblock>testdb=> <b>SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b></codeblock></li>
+        </ol>
+      </section>
+      <section>
+        <title>Using dblink as a Non-Superuser with no authentication checks</title>
+        <p>In some cases, there might be the need for allowing certain non-superusers access to
+            <codeph>dblink</codeph> without making any authentication checks. The function
+            <codeph>dblink_connect_no_auth</codeph> provides this functionality as it bypasses the
+            <codeph>pg_hba.conf</codeph> file. </p>
+        <note type="warning">This is a high risk functionality so it should be handled with care and
+          only granted to trustworthy users. Also please note that it is not possible to use
+            <codeph>dblink_connect_no_auth</codeph> to connect to a remote database, it will only
+          connect locally within the cluster.</note>
+        <p>Similarly to <codeph>dblink_connect_u</codeph>, the function is not available by default,
+          it needs <codeph>gpadmin</codeph> superuser to grant permission to the non-superuser
+          beforehand:</p>
+        <ol id="ol_agf_qwj_x4b">
+          <li>As a superuser, grant the <codeph>EXECUTE</codeph> privilege on the
+              <codeph>dblink_connect_no_auth()</codeph> functions in the user database. This example
+            grants the privilege to the non-superuser <codeph>test_user</codeph> on the functions
+            with the signatures for creating an implicit or a named <codeph>dblink</codeph>
+            connection.<codeblock>testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text) TO test_user;</b>
+testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_no_auth(text, text) TO test_user;</b></codeblock></li>
+          <li>Now <codeph>test_user</codeph> can create a connection to another local database
+            without a password, regardless of what is specified in <codeph>pg_hba.conf</codeph>. For
+            example, <codeph>test_user</codeph> can log into the <codeph>testdb</codeph> database
+            and execute this command to create a connection named <codeph>testconn</codeph> to the
+            local <codeph>postgres</codeph>
+            database.<codeblock>testdb=> <b>SELECT dblink_connect_no_auth('testconn', 'dbname=postgres user=test_user');</b></codeblock>
+          </li>
           <li><codeph>test_user</codeph> can use the <codeph>dblink()</codeph> function to execute a
             query using a <codeph>dblink</codeph> connection. For example, this command uses the
               <codeph>dblink</codeph> connection named <codeph>testconn</codeph> created in the


### PR DESCRIPTION
Adding guc gpfdist_retry_timeout to the 6X_STABLE branch.
Corresponding PR: https://github.com/greenplum-db/gpdb/pull/11406
Can be viewed here: https://mireia-guc.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/config_params/guc_config.html