### PR TITLE
Docs - Adding GUC gpfdist_retry_timeout to 6X_STABLE

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -287,6 +287,8 @@
             <li><xref href="#gp_workfile_limit_files_per_query"/></li>
             <li><xref href="#gp_workfile_limit_per_query"/></li>
             <li><xref href="#gp_workfile_limit_per_segment"/></li>
+            <li><xref href="#gpfdist_retry_timeout" type="section">gpfdist_retry_timeout</xref>
+            </li>
             <li>
               <xref href="#gpperfmon_log_alert_level"/>
             </li>
@@ -3623,6 +3625,37 @@
               <entry colname="col1">Any valid time expression (number and unit)</entry>
               <entry colname="col2">1sec</entry>
               <entry colname="col3">master<p>system</p><p>restart</p><p>superuser</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gpfdist_retry_timeout">
+    <title>gpfdist_retry_timeout</title>
+    <body>
+      <p>Controls the time (in seconds) that Greenplum Database waits before returning an error when
+        Greenplum Database is attempting to connect or write to a <codeph><xref
+            href="../../utility_guide/ref/gpfdist.xml"/></codeph> server and
+          <codeph>gpfdist</codeph> does not respond. The default value is 300 (5 minutes). A value
+        of 0 disables the timeout.</p>
+      <table id="table_fkm_jqp_dmb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 - <codeph>INT_MAX</codeph> (2147483647)</entry>
+              <entry colname="col2">300</entry>
+              <entry colname="col3">local<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1252,6 +1252,8 @@
             </p>
           </stentry>
           <stentry>
+            <p><xref href="guc-list.xml#gpfdist_retry_timeout" type="section"
+                >gpfdist_retry_timeout</xref></p>
             <p>
               <xref href="guc-list.xml#readable_external_table_timeout" type="section"
                 >readable_external_table_timeout</xref>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -96,6 +96,7 @@
             <topicref href="guc-list.xml#gp_enable_exchange_default_partition"/>
             <topicref href="guc-list.xml#gp_enable_fast_sri"/>
             <topicref href="guc-list.xml#gp_enable_gpperfmon"/>
+            <topicref href="guc-list.xml#gp_enable_groupext_distinct_gather"/>
             <topicref href="guc-list.xml#gp_enable_groupext_distinct_pruning"/>
             <topicref href="guc-list.xml#gp_enable_multiphase_agg"/>
             <topicref href="guc-list.xml#gp_enable_predicate_propagation"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -96,7 +96,6 @@
             <topicref href="guc-list.xml#gp_enable_exchange_default_partition"/>
             <topicref href="guc-list.xml#gp_enable_fast_sri"/>
             <topicref href="guc-list.xml#gp_enable_gpperfmon"/>
-            <topicref href="guc-list.xml#gp_enable_groupext_distinct_gather"/>
             <topicref href="guc-list.xml#gp_enable_groupext_distinct_pruning"/>
             <topicref href="guc-list.xml#gp_enable_multiphase_agg"/>
             <topicref href="guc-list.xml#gp_enable_predicate_propagation"/>
@@ -169,6 +168,7 @@
             <topicref href="guc-list.xml#gp_workfile_limit_files_per_query"/>
             <topicref href="guc-list.xml#gp_workfile_limit_per_query"/>
             <topicref href="guc-list.xml#gp_workfile_limit_per_segment"/>
+            <topicref href="guc-list.xml#gpfdist_retry_timeout"/>
             <topicref href="guc-list.xml#gpperfmon_port"/>
             <topicref href="guc-list.xml#ignore_checksum_failure"/>
             <topicref href="guc-list.xml#integer_datetimes"/>


### PR DESCRIPTION
Adding guc gpfdist_retry_timeout to the 6X_STABLE branch.
Corresponding PR: https://github.com/greenplum-db/gpdb/pull/11406
Can be viewed here: https://mireia-guc-6x.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/config_params/guc-list.html#gpfdist_retry_timeout