### PR TITLE
pg_upgrade: Ignore TOAST for columnar tables

### DIFF
--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -194,24 +194,17 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 		 * If we tried to create a TOAST table anyway, we would have the
 		 * problem that it might take up an OID that will conflict with some
 		 * old-cluster table we haven't seen yet.
-		 *
-		 * Starting GPDB7 don't create TOAST table for CO tables. Prior
-		 * versions created but never inserted any data to these
-		 * tables. Hence, even if binary upgrade provides TOAST table oid
-		 * ignore and avoid creating toast table. Regular code TOAST table
-		 * creation for CO table is avoided by consulting table AM API
-		 * table_relation_needs_toast_table().
 		 */
-		if (RelationIsAoCols(rel))
-			return false;
-
-		Assert(toastOid == InvalidOid);
-		toastOid = GetPreassignedOidForRelation(namespaceid, toast_relname);
-		if (!OidIsValid(toastOid))
-			return false;
-		toast_typid = GetPreassignedOidForType(namespaceid, toast_relname);
-		if (!OidIsValid(toast_typid))
-			return false;
+		if (IsBinaryUpgrade)
+		{
+			Assert(toastOid == InvalidOid);
+			toastOid = GetPreassignedOidForRelation(namespaceid, toast_relname);
+			if (!OidIsValid(toastOid))
+				return false;
+			toast_typid = GetPreassignedOidForType(namespaceid, toast_relname);
+			if (!OidIsValid(toast_typid))
+				return false;
+		}
 	}
 
 	/*


### PR DESCRIPTION
Since columnar tables in GPDB7 do not have toast tables, trying to set
the toast OID confuses pg_upgrade. Have pg_dump omit those values to
avoid the problem.

This fix is on same lines as upstream commit 203749a "pg_upgrade: Ignore TOAST for partitioned tables". Reverting my previous commit made in server to fix this problem as no more needed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
