### PR TITLE
Fix the flaky test of autovacuum

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1772,11 +1772,6 @@ vac_update_datfrozenxid(void)
 
 		heap_inplace_update(relation, tuple);
 		heap_freetuple(tuple);
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-			"vacuum_update_dat_frozen_xid", DDLNotSpecified,
-			NameStr(cached_dbform->datname), "");
-#endif
 	}
 
 	ReleaseSysCache(cached_tuple);

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -1731,6 +1731,12 @@ AutoVacWorkerMain(int argc, char *argv[])
 		recentMulti = ReadNextMultiXactId();
 
 		do_autovacuum();
+
+#ifdef FAULT_INJECTOR
+		FaultInjector_InjectFaultIfSet(
+			"auto_vac_worker_after_do_autovacuum", DDLNotSpecified,
+			dbname, "");
+#endif
 	}
 
 	/*

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -277,6 +277,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 		(IsAutoVacuumWorkerProcess() &&
 		 !(0 == strcmp("vacuum_update_dat_frozen_xid", faultName) ||
 		   0 == strcmp("auto_vac_worker_before_do_autovacuum", faultName) ||
+		   0 == strcmp("auto_vac_worker_after_do_autovacuum", faultName) ||
 		   0 == strcmp("auto_vac_worker_after_report_activity", faultName) ||
 		   0 == strcmp("auto_vac_worker_abort", faultName) ||
 		   0 == strcmp("analyze_after_hold_lock", faultName) ||

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -804,7 +804,7 @@ FaultInjector_SetFaultInjection(
 		case FaultInjectorTypeWaitUntilTriggered:
 		{
 			FaultInjectorEntry_s	*entryLocal;
-			int retry_count = 3000; /* 10 minutes */
+			int retry_count = 9000; /* 30 minutes */
 
 			while ((entryLocal = FaultInjector_LookupHashEntry(entry->faultName)) != NULL &&
 				   entryLocal->faultInjectorState != FaultInjectorStateCompleted &&
@@ -819,7 +819,7 @@ FaultInjector_SetFaultInjection(
 							 errmsg("fault not triggered, fault name:'%s' fault type:'%s' ",
 									entryLocal->faultName,
 									FaultInjectorTypeEnumToString[entry->faultInjectorType]),
-							 errdetail("Timed-out as 10 minutes max wait happens until triggered.")));
+							 errdetail("Timed-out as 30 minutes max wait happens until triggered.")));
 				}
 			}
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -275,8 +275,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 	 */
 	if (IsAutoVacuumLauncherProcess() ||
 		(IsAutoVacuumWorkerProcess() &&
-		 !(0 == strcmp("vacuum_update_dat_frozen_xid", faultName) ||
-		   0 == strcmp("auto_vac_worker_before_do_autovacuum", faultName) ||
+		 !(0 == strcmp("auto_vac_worker_before_do_autovacuum", faultName) ||
 		   0 == strcmp("auto_vac_worker_after_do_autovacuum", faultName) ||
 		   0 == strcmp("auto_vac_worker_after_report_activity", faultName) ||
 		   0 == strcmp("auto_vac_worker_abort", faultName) ||

--- a/src/test/regress/input/autovacuum-segment.source
+++ b/src/test/regress/input/autovacuum-segment.source
@@ -11,6 +11,9 @@ language C;
 \! gpstop -au
 -- end_ignore
 
+-- Show autovacuum_max_workers
+show autovacuum_max_workers;
+
 -- Autovacuum should take care of anti-XID wraparounds of catalog tables.
 -- Because of that, the age of pg_class should not go much above
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).

--- a/src/test/regress/input/autovacuum-segment.source
+++ b/src/test/regress/input/autovacuum-segment.source
@@ -20,8 +20,8 @@ SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
--- track that we've updated the row in pg_database for oldest database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Suspend the autovacuum worker after vacuuming
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
 select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
@@ -29,13 +29,15 @@ select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_seg
 
 SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
 
--- Wait until autovacuum is triggered
-SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Note that autovacuum laucher will continue start new worker for the same database
+-- when the old worker is blocked. There are at most 3(autovacuum_max_workers) workers
+-- Wait until the three autovacuum workers are triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
--- wait until autovacuum worker updates pg_database
-SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- wait until three autovacuum workers finish vacuum
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- catalog table should be young
 SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';

--- a/src/test/regress/input/autovacuum-template0-segment.source
+++ b/src/test/regress/input/autovacuum-template0-segment.source
@@ -44,32 +44,8 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) fr
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
--- template0 should be young
--- Sometimes one trigger of autovacuum doesn't bring down the age for
--- template0, hence wait for few triggers to drop it
-DO $$
-DECLARE young BOOLEAN;
-BEGIN
-     FOR i in 1..300 loop
-	      SELECT age(datfrozenxid) < 200 * 1000000
-	      FROM gp_dist_random('pg_database') WHERE datname='template0' AND gp_segment_id = 0
-	      into young;
-
-	      IF young THEN
-	         raise notice 'Template0 is young now';
-		 EXIT;
-	      END IF;
-	      PERFORM pg_sleep(0.2);
-     END LOOP;
-
-     IF not young THEN
-	raise notice 'Template0 is still old';
-     END IF;
-END$$;
-
--- start_ignore
-select gp_segment_id, datfrozenxid from gp_dist_random('pg_database') where datname='template0';
--- end_ignore
+-- catalog table should be young
+select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
 
 -- start_ignore
 \! gpconfig -r debug_burn_xids --skipvalidation

--- a/src/test/regress/input/autovacuum-template0-segment.source
+++ b/src/test/regress/input/autovacuum-template0-segment.source
@@ -13,6 +13,9 @@ language C;
 \! gpstop -au
 -- end_ignore
 
+-- Show autovacuum_max_workers
+show autovacuum_max_workers;
+
 -- Suspend the autovacuum worker from vacuuming before
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
@@ -27,17 +30,19 @@ select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_
 select gp_segment_id, datfrozenxid from gp_dist_random('pg_database') where datname='template0';
 -- end_ignore
 
--- Wait until autovacuum is triggered
-SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Note that autovacuum laucher will continue start new worker for the same database
+-- when the old worker is blocked. There are at most 3(autovacuum_max_workers) workers
+-- Wait until the three autovacuum workers are triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
--- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Suspend the autovacuum worker after vacuuming
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
--- wait until autovacuum worker updates pg_database
-SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- wait until three autovacuum workers finish vacuum
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- template0 should be young
 -- Sometimes one trigger of autovacuum doesn't bring down the age for

--- a/src/test/regress/input/autovacuum.source
+++ b/src/test/regress/input/autovacuum.source
@@ -8,6 +8,12 @@ set debug_burn_xids=on;
 ALTER SYSTEM SET autovacuum_naptime = 5;
 select * from pg_reload_conf();
 
+-- Vacuum database
+vacuum;
+
+-- Show autovacuum_max_workers
+show autovacuum_max_workers;
+
 -- Autovacuum should take care of anti-XID wraparounds of catalog tables.
 -- Because of that, the age of pg_class should not go much above
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).

--- a/src/test/regress/input/autovacuum.source
+++ b/src/test/regress/input/autovacuum.source
@@ -17,8 +17,8 @@ SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, 1);
 
--- track that we've updated the row in pg_database for oldest database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, 1);
+-- Suspend the autovacuum worker after vacuuming
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, 1);
 
 select test_consume_xids(100 * 1000000);
 select test_consume_xids(100 * 1000000);
@@ -26,13 +26,15 @@ select test_consume_xids(10 * 1000000);
 
 SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
 
--- Wait until autovacuum is triggered
-SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
+-- Note that autovacuum laucher will continue start new worker for the same database
+-- when the old worker is blocked. There are at most 3(autovacuum_max_workers) workers
+-- Wait until the three autovacuum workers are triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, 1);
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
 
--- wait until autovacuum worker updates pg_database
-SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
+-- wait until three autovacuum workers finish vacuum
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, 1);
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', 1);
 
 -- catalog table should be young
 SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';

--- a/src/test/regress/output/autovacuum-segment.source
+++ b/src/test/regress/output/autovacuum-segment.source
@@ -8,6 +8,13 @@ language C;
 \! gpconfig -c autovacuum_naptime -v 5
 \! gpstop -au
 -- end_ignore
+-- Show autovacuum_max_workers
+show autovacuum_max_workers;
+ autovacuum_max_workers 
+------------------------
+ 3
+(1 row)
+
 -- Autovacuum should take care of anti-XID wraparounds of catalog tables.
 -- Because of that, the age of pg_class should not go much above
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).

--- a/src/test/regress/output/autovacuum-segment.source
+++ b/src/test/regress/output/autovacuum-segment.source
@@ -27,8 +27,8 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'r
  Success:
 (1 row)
 
--- track that we've updated the row in pg_database for oldest database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Suspend the autovacuum worker after vacuuming
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:
@@ -60,8 +60,10 @@ SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_
              0 | f
 (3 rows)
 
--- Wait until autovacuum is triggered
-SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Note that autovacuum laucher will continue start new worker for the same database
+-- when the old worker is blocked. There are at most 3(autovacuum_max_workers) workers
+-- Wait until the three autovacuum workers are triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
@@ -73,14 +75,14 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) fr
  Success:
 (1 row)
 
--- wait until autovacuum worker updates pg_database
-SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- wait until three autovacuum workers finish vacuum
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:

--- a/src/test/regress/output/autovacuum-template0-segment.source
+++ b/src/test/regress/output/autovacuum-template0-segment.source
@@ -9,6 +9,13 @@ language C;
 \! gpconfig -c debug_burn_xids -v on --skipvalidation
 \! gpstop -au
 -- end_ignore
+-- Show autovacuum_max_workers
+show autovacuum_max_workers;
+ autovacuum_max_workers 
+------------------------
+ 3
+(1 row)
+
 -- Suspend the autovacuum worker from vacuuming before
 -- ShmemVariableCache->latestCompletedXid is expected to be updated
 SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
@@ -43,15 +50,17 @@ select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_
              0 | f
 (3 rows)
 
--- Wait until autovacuum is triggered
-SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Note that autovacuum laucher will continue start new worker for the same database
+-- when the old worker is blocked. There are at most 3(autovacuum_max_workers) workers
+-- Wait until the three autovacuum workers are triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
--- track that we've updated the row in pg_database for template0
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- Suspend the autovacuum worker after vacuuming
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'suspend', '', 'template0', '', 1, -1, 0, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:
@@ -63,14 +72,14 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) fr
  Success:
 (1 row)
 
--- wait until autovacuum worker updates pg_database
-SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+-- wait until three autovacuum workers finish vacuum
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:

--- a/src/test/regress/output/autovacuum-template0-segment.source
+++ b/src/test/regress/output/autovacuum-template0-segment.source
@@ -85,29 +85,15 @@ SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', dbid) fro
  Success:
 (1 row)
 
--- template0 should be young
--- Sometimes one trigger of autovacuum doesn't bring down the age for
--- template0, hence wait for few triggers to drop it
-DO $$
-DECLARE young BOOLEAN;
-BEGIN
-     FOR i in 1..300 loop
-	      SELECT age(datfrozenxid) < 200 * 1000000
-	      FROM gp_dist_random('pg_database') WHERE datname='template0' AND gp_segment_id = 0
-	      into young;
+-- catalog table should be young
+select gp_segment_id, age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+ gp_segment_id | ?column? 
+---------------+----------
+             0 | t
+             1 | t
+             2 | t
+(3 rows)
 
-	      IF young THEN
-	         raise notice 'Template0 is young now';
-		 EXIT;
-	      END IF;
-	      PERFORM pg_sleep(0.2);
-     END LOOP;
-
-     IF not young THEN
-	raise notice 'Template0 is still old';
-     END IF;
-END$$;
-NOTICE:  Template0 is young now
 -- start_ignore
 \! gpconfig -r debug_burn_xids --skipvalidation
 \! gpconfig -r autovacuum_naptime

--- a/src/test/regress/output/autovacuum.source
+++ b/src/test/regress/output/autovacuum.source
@@ -27,8 +27,8 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'suspend', '', 'r
  Success:
 (1 row)
 
--- track that we've updated the row in pg_database for oldest database
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'skip', '', 'regression', '', 1, -1, 0, 1);
+-- Suspend the autovacuum worker after vacuuming
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'suspend', '', 'regression', '', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:
@@ -58,8 +58,10 @@ SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
  f
 (1 row)
 
--- Wait until autovacuum is triggered
-SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, 1);
+-- Note that autovacuum laucher will continue start new worker for the same database
+-- when the old worker is blocked. There are at most 3(autovacuum_max_workers) workers
+-- Wait until the three autovacuum workers are triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
@@ -71,14 +73,14 @@ SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
  Success:
 (1 row)
 
--- wait until autovacuum worker updates pg_database
-SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
+-- wait until three autovacuum workers finish vacuum
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_do_autovacuum', 3, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
-SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
+SELECT gp_inject_fault('auto_vac_worker_after_do_autovacuum', 'reset', 1);
  gp_inject_fault 
 -----------------
  Success:

--- a/src/test/regress/output/autovacuum.source
+++ b/src/test/regress/output/autovacuum.source
@@ -10,6 +10,15 @@ select * from pg_reload_conf();
  t
 (1 row)
 
+-- Vacuum database
+vacuum;
+-- Show autovacuum_max_workers
+show autovacuum_max_workers;
+ autovacuum_max_workers 
+------------------------
+ 3
+(1 row)
+
 -- Autovacuum should take care of anti-XID wraparounds of catalog tables.
 -- Because of that, the age of pg_class should not go much above
 -- autovacuum_freeze_max_age (we assume the default of 200 million here).


### PR DESCRIPTION
current test case assume there is only one autovacuum worker for a specific
database at the same time. But when the worker is blocked, i.e. by the fault
inject, the autovacuum laucher will start a new worker to vacuum this database.
Discussed in gpdb-dev:
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/8QNIiwtjh2U/m/8TLN2UKjBAAJ
It's better to the autovacuum behavior the same as upstream. Hence, we update
the test case by waiting all the three(decide by GUC autovacuum_max_workers)
workers to be finished.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
