### PR TITLE
[6X Backport] Fix io checking in fts probe (#11586)

### DIFF
--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -53,7 +53,7 @@ checkIODataDirectory(void)
 	errno = 0;
 	bool failure = false;
 
-	fd = BasicOpenFile(FTS_PROBE_FILE_NAME, O_RDWR | PG_O_DIRECT | O_EXCL,
+	fd = BasicOpenFile(FTS_PROBE_FILE_NAME, O_RDWR | PG_O_DIRECT,
                                            S_IRUSR | S_IWUSR);
 	do
 	{
@@ -82,6 +82,15 @@ checkIODataDirectory(void)
 						failure = true;
 					}
 				}
+			}
+			else if (errno == EINVAL)
+			{
+				ereport(WARNING, (errcode_for_file_access(),
+						errmsg("FTS: could not open file \"%s\" (%m)", FTS_PROBE_FILE_NAME),
+						errdetail("Possibly because the file system does not "
+								  "support O_DIRECT (e.g. tmpfs does not). "
+								  "Skipping IO check anyway.")));
+				failure = false;
 			}
 			else
 			{


### PR DESCRIPTION
O_EXCL should be with O_CREAT only since per open(2) man page the behavior of
O_EXCL without O_CREAT is undefined. O_DIRECT is not supported on some file
systems (e.g. tmpfs). open() with O_DIRECT on those file systems returns with
errno EINVAL so let's tolerate this kind of error in fts io checking code
to avoid that the node is marked s down by FTS.

Reviewed by: Ashwin Agrawal <aashwin@vmware.com>
Reviewed-by: Asim R P <pasim@vmware.com>

(cherry picked from commit 4bb42cbcbe9795802f2f0d20c870533af7ae46e3)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
