### PR TITLE
Bring back pg_partitions view

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302102221
+#define CATALOG_VERSION_NO	302103121
 
 #endif

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -577,20 +577,17 @@ alter table alter_aocs_part_table split default partition start(6) inclusive end
 alter table alter_aocs_part_table split default partition start(6) inclusive end(8) exclusive;
 ERROR:  partition "alter_aocs_part_table_1_prt_11" would overlap partition "alter_aocs_part_table_1_prt_1"
 alter table alter_aocs_part_table split default partition start(7) inclusive end(8) exclusive;
-\d+ alter_aocs_part_table
-                  Partitioned table "aocs_addcol.alter_aocs_part_table"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- a      | integer |           |          |         | plain   |              | 
- b      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (b)
-Partitions: alter_aocs_part_table_1_prt_1 FOR VALUES FROM (6) TO (7),
-            alter_aocs_part_table_1_prt_11 FOR VALUES FROM (7) TO (8),
-            alter_aocs_part_table_1_prt_3 FOR VALUES FROM (2) TO (3),
-            alter_aocs_part_table_1_prt_4 FOR VALUES FROM (3) TO (4),
-            alter_aocs_part_table_1_prt_5 FOR VALUES FROM (4) TO (5),
-            alter_aocs_part_table_1_prt_foo DEFAULT
-Distributed by: (a)
+select partitionisdefault, partitionboundary from pg_partitions where tablename = 'alter_aocs_part_table';
+ partitionisdefault |     partitionboundary      
+--------------------+----------------------------
+ f                  | 
+ f                  | FOR VALUES FROM (2) TO (3)
+ f                  | FOR VALUES FROM (3) TO (4)
+ f                  | FOR VALUES FROM (4) TO (5)
+ f                  | FOR VALUES FROM (6) TO (7)
+ f                  | FOR VALUES FROM (7) TO (8)
+ t                  | DEFAULT
+(7 rows)
 
 create table alter_aocs_ao_table (a int, b int) with (appendonly=true) distributed by (a);
 insert into alter_aocs_ao_table values (2,2);

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1197,15 +1197,15 @@ Distributed by: (id)
  count  | integer      |           |          | 
 Distributed by: (id)
 
-select relid,parentrelid,isleaf,level, pg_catalog.pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3512_part'), pg_class where relid = oid;
-        relid         | parentrelid  | isleaf | level |           pg_get_expr            
-----------------------+--------------+--------+-------+----------------------------------
- mpp3512_part         |              | f      |     0 | 
- mpp3512_part_1_prt_1 | mpp3512_part | t      |     1 | FOR VALUES FROM (2001) TO (2002)
- mpp3512_part_1_prt_2 | mpp3512_part | t      |     1 | FOR VALUES FROM (2002) TO (2003)
- mpp3512_part_1_prt_3 | mpp3512_part | t      |     1 | FOR VALUES FROM (2003) TO (2004)
- mpp3512_part_1_prt_4 | mpp3512_part | t      |     1 | FOR VALUES FROM (2004) TO (2005)
- mpp3512_part_1_prt_5 | mpp3512_part | t      |     1 | FOR VALUES FROM (2005) TO (2006)
+select * from pg_partitions where tablename='mpp3512_part';
+  schemaname   |  tablename   | partitionschemaname |  partitiontablename  | partitionname | parentpartitiontablename | parentpartitionname | partitiontype | partitionlevel | partitionisdefault |        partitionboundary         | parenttablespace | partitiontablespace 
+---------------+--------------+---------------------+----------------------+---------------+--------------------------+---------------------+---------------+----------------+--------------------+----------------------------------+------------------+---------------------
+ bfv_partition | mpp3512_part | bfv_partition       | mpp3512_part         |               |                          |                     | range         |              0 | f                  |                                  | pg_default       | pg_default
+ bfv_partition | mpp3512_part | bfv_partition       | mpp3512_part_1_prt_1 | 1             | mpp3512_part             |                     |               |              1 | f                  | FOR VALUES FROM (2001) TO (2002) | pg_default       | pg_default
+ bfv_partition | mpp3512_part | bfv_partition       | mpp3512_part_1_prt_2 | 2             | mpp3512_part             |                     |               |              1 | f                  | FOR VALUES FROM (2002) TO (2003) | pg_default       | pg_default
+ bfv_partition | mpp3512_part | bfv_partition       | mpp3512_part_1_prt_3 | 3             | mpp3512_part             |                     |               |              1 | f                  | FOR VALUES FROM (2003) TO (2004) | pg_default       | pg_default
+ bfv_partition | mpp3512_part | bfv_partition       | mpp3512_part_1_prt_4 | 4             | mpp3512_part             |                     |               |              1 | f                  | FOR VALUES FROM (2004) TO (2005) | pg_default       | pg_default
+ bfv_partition | mpp3512_part | bfv_partition       | mpp3512_part_1_prt_5 | 5             | mpp3512_part             |                     |               |              1 | f                  | FOR VALUES FROM (2005) TO (2006) | pg_default       | pg_default
 (6 rows)
 
 drop table mpp3512;
@@ -2978,6 +2978,12 @@ drop table partition_cleanup1;
 drop schema partition_999 cascade;
 NOTICE:  drop cascades to table partition_cleanup2
 -- These should be empty
+select 'pg_partitions', count(*) from pg_partitions where tablename='partition_cleanup%';
+   ?column?    | count 
+---------------+-------
+ pg_partitions |     0
+(1 row)
+
 select relid, level, template from gp_partition_template where not exists (select oid from pg_class where oid = relid);
  relid | level | template 
 -------+-------+----------

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1007,6 +1007,16 @@ create table i_1_prt_3 (like i);
 -- could be matched by partition name when targeted on an irrelevant table.
 create table i2 (i int) partition by range(i) (start (1) end(3) every(1));
 create table i_1_prt_4 partition of i2 for values from (4) to (5);
+-- i_1_prt_4 should not have partitionname since it not using gpdb partition name pattern
+select * from pg_partitions where tablename = 'i2';
+ schemaname | tablename | partitionschemaname | partitiontablename | partitionname | parentpartitiontablename | parentpartitionname | partitiontype | partitionlevel | partitionisdefault |     partitionboundary      | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+--------------------+---------------+--------------------------+---------------------+---------------+----------------+--------------------+----------------------------+------------------+---------------------
+ public     | i2        | public              | i2                 |               |                          |                     | range         |              0 | f                  |                            | pg_default       | pg_default
+ public     | i2        | public              | i2_1_prt_1         | 1             | i2                       |                     |               |              1 | f                  | FOR VALUES FROM (1) TO (2) | pg_default       | pg_default
+ public     | i2        | public              | i2_1_prt_2         | 2             | i2                       |                     |               |              1 | f                  | FOR VALUES FROM (2) TO (3) | pg_default       | pg_default
+ public     | i2        | public              | i_1_prt_4          |               | i2                       |                     |               |              1 | f                  | FOR VALUES FROM (4) TO (5) | pg_default       | pg_default
+(4 rows)
+
 -- the matechd table name is i_1_prt_3, but it's a normal table, raise error.
 alter table i drop partition "3";
 ERROR:  partition "3" of "i" does not exist
@@ -1052,36 +1062,36 @@ partition p1 start('1') end('10001') every(5000)
 );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'ps_partkey' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select relname, pg_get_expr(relpartbound, oid, false) from pg_class where relname like 'partsupp%';
-                 relname                 |             pg_get_expr              
------------------------------------------+--------------------------------------
- partsupp                                | 
- partsupp_1_prt_p1_1                     | FOR VALUES FROM (1) TO (5001)
- partsupp_1_prt_p1_1_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
- partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_1_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
- partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_1_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
- partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_1_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
- partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2                     | FOR VALUES FROM (5001) TO (10001)
- partsupp_1_prt_p1_2_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
- partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
- partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
- partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
- partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+select tablename, partitiontablename, partitionboundary from pg_partitions where tablename = 'partsupp';
+ tablename |           partitiontablename            |          partitionboundary           
+-----------+-----------------------------------------+--------------------------------------
+ partsupp  | partsupp                                | 
+ partsupp  | partsupp_1_prt_p1_1                     | FOR VALUES FROM (1) TO (5001)
+ partsupp  | partsupp_1_prt_p1_2                     | FOR VALUES FROM (5001) TO (10001)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
 (27 rows)
 
 drop table partsupp;
@@ -1900,17 +1910,15 @@ create table k (i int) partition by range(i)
 (start(0) exclusive end(100) inclusive every(25));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-\d+ k
-                               Partitioned table "public.k"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- i      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (i)
-Partitions: k_1_prt_1 FOR VALUES FROM (1) TO (26),
-            k_1_prt_2 FOR VALUES FROM (26) TO (51),
-            k_1_prt_3 FOR VALUES FROM (51) TO (76),
-            k_1_prt_4 FOR VALUES FROM (76) TO (101)
-Distributed by: (i)
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'k';
+ partitiontablename |       partitionboundary       
+--------------------+-------------------------------
+ k                  | 
+ k_1_prt_1          | FOR VALUES FROM (1) TO (26)
+ k_1_prt_2          | FOR VALUES FROM (26) TO (51)
+ k_1_prt_3          | FOR VALUES FROM (51) TO (76)
+ k_1_prt_4          | FOR VALUES FROM (76) TO (101)
+(5 rows)
 
 insert into k select i from generate_series(1, 100) i;
 drop table k;
@@ -3071,18 +3079,15 @@ EVERY ('1 year 1 mon'::interval)
 PARTITION p1_3 START ('1994-03-31'::date) END ('1995-04-30'::date)
 EVERY ('1 year 1 mon'::interval)
 );
-\d+ mpp6297
-                              Partitioned table "public.mpp6297"
-    Column    |  Type  | Collation | Nullable | Default | Storage | Stats target | Description 
---------------+--------+-----------+----------+---------+---------+--------------+-------------
- l_orderkey   | bigint |           |          |         | plain   |              | 
- l_commitdate | date   |           |          |         | plain   |              | 
-Partition key: RANGE (l_commitdate)
-Partitions: mpp6297_1_prt_p1_1_1 FOR VALUES FROM ('01-31-1992') TO ('02-28-1993'),
-            mpp6297_1_prt_p1_2_1 FOR VALUES FROM ('02-28-1993') TO ('03-28-1994'),
-            mpp6297_1_prt_p1_2_2 FOR VALUES FROM ('03-28-1994') TO ('03-31-1994'),
-            mpp6297_1_prt_p1_3_1 FOR VALUES FROM ('03-31-1994') TO ('04-30-1995')
-Distributed by: (l_orderkey)
+select partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp6297';
+  partitiontablename  | partitionname |                partitionboundary                 
+----------------------+---------------+--------------------------------------------------
+ mpp6297              |               | 
+ mpp6297_1_prt_p1_1_1 | p1_1_1        | FOR VALUES FROM ('01-31-1992') TO ('02-28-1993')
+ mpp6297_1_prt_p1_2_1 | p1_2_1        | FOR VALUES FROM ('02-28-1993') TO ('03-28-1994')
+ mpp6297_1_prt_p1_2_2 | p1_2_2        | FOR VALUES FROM ('03-28-1994') TO ('03-31-1994')
+ mpp6297_1_prt_p1_3_1 | p1_3_1        | FOR VALUES FROM ('03-31-1994') TO ('04-30-1995')
+(5 rows)
 
 drop table mpp6297;
 -- when WITH(tablename=...) is specified, the EVERY is stored as an
@@ -3930,8 +3935,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 alter table mpp10223b alter partition p1 
 split partition for (20) at (25)
 into (partition sp2, partition sp3);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp10223b%';
-           relname            |         pg_get_expr          
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'mpp10223b';
+      partitiontablename      |      partitionboundary       
 ------------------------------+------------------------------
  mpp10223b                    | 
  mpp10223b_1_prt_p1           | FOR VALUES FROM (1) TO (10)
@@ -4088,12 +4093,12 @@ ERROR:  AT clause parameter is not a member of the target partition specificatio
 -- good split
 alter table cov1 split partition p1 at (5,6,7) 
 into (partition p1, partition p2);
-select relname, pg_get_expr(relpartbound, oid, false) from pg_class where relname like 'cov1%';
-    relname    |          pg_get_expr          
----------------+-------------------------------
- cov1          | 
- cov1_1_prt_p1 | FOR VALUES IN (1, 2, 3, 4, 8)
- cov1_1_prt_p2 | FOR VALUES IN (5, 6, 7)
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'cov1';
+ partitiontablename |       partitionboundary       
+--------------------+-------------------------------
+ cov1               | 
+ cov1_1_prt_p1      | FOR VALUES IN (1, 2, 3, 4, 8)
+ cov1_1_prt_p2      | FOR VALUES IN (5, 6, 7)
 (3 rows)
 
 drop table cov1;
@@ -4189,22 +4194,21 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table mpp6979dummy.mpp6979tab(like mpp6979part) with (appendonly=true);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- check that table and all parts in public schema
-select relname, nspname, relispartition from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and relname like ('mpp6979%');
-       relname       |   nspname    | relispartition 
----------------------+--------------+----------------
- mpp6979part         | public       | f
- mpp6979part_1_prt_1 | public       | t
- mpp6979part_1_prt_2 | public       | t
- mpp6979part_1_prt_3 | public       | t
- mpp6979part_1_prt_4 | public       | t
- mpp6979part_1_prt_5 | public       | t
- mpp6979part_1_prt_6 | public       | t
- mpp6979part_1_prt_7 | public       | t
- mpp6979part_1_prt_8 | public       | t
- mpp6979part_1_prt_9 | public       | t
- mpp6979tab          | mpp6979dummy | f
-(11 rows)
+select schemaname, tablename, partitionschemaname, partitiontablename from pg_partitions 
+where tablename like ('mpp6979%');
+ schemaname |  tablename  | partitionschemaname | partitiontablename  
+------------+-------------+---------------------+---------------------
+ public     | mpp6979part | public              | mpp6979part
+ public     | mpp6979part | public              | mpp6979part_1_prt_1
+ public     | mpp6979part | public              | mpp6979part_1_prt_2
+ public     | mpp6979part | public              | mpp6979part_1_prt_3
+ public     | mpp6979part | public              | mpp6979part_1_prt_4
+ public     | mpp6979part | public              | mpp6979part_1_prt_5
+ public     | mpp6979part | public              | mpp6979part_1_prt_6
+ public     | mpp6979part | public              | mpp6979part_1_prt_7
+ public     | mpp6979part | public              | mpp6979part_1_prt_8
+ public     | mpp6979part | public              | mpp6979part_1_prt_9
+(10 rows)
 
 -- note that we have heap partitions in public, and ao table in mpp6979dummy
 select nspname, relname, amname
@@ -4232,22 +4236,21 @@ where relname like ('mpp6979%');
 alter table mpp6979part exchange partition for (1) 
 with table mpp6979dummy.mpp6979tab;
 -- after the exchange, all partitions are still in public
-select relname, nspname, relispartition from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and relname like ('mpp6979%');
-       relname       |   nspname    | relispartition 
----------------------+--------------+----------------
- mpp6979part         | public       | f
- mpp6979part_1_prt_1 | public       | t
- mpp6979part_1_prt_2 | public       | t
- mpp6979part_1_prt_3 | public       | t
- mpp6979part_1_prt_4 | public       | t
- mpp6979part_1_prt_5 | public       | t
- mpp6979part_1_prt_6 | public       | t
- mpp6979part_1_prt_7 | public       | t
- mpp6979part_1_prt_8 | public       | t
- mpp6979part_1_prt_9 | public       | t
- mpp6979tab          | mpp6979dummy | f
-(11 rows)
+select schemaname, tablename, partitionschemaname, partitiontablename from pg_partitions 
+where tablename like ('mpp6979%');
+ schemaname |  tablename  | partitionschemaname | partitiontablename  
+------------+-------------+---------------------+---------------------
+ public     | mpp6979part | public              | mpp6979part
+ public     | mpp6979part | public              | mpp6979part_1_prt_2
+ public     | mpp6979part | public              | mpp6979part_1_prt_3
+ public     | mpp6979part | public              | mpp6979part_1_prt_4
+ public     | mpp6979part | public              | mpp6979part_1_prt_5
+ public     | mpp6979part | public              | mpp6979part_1_prt_6
+ public     | mpp6979part | public              | mpp6979part_1_prt_7
+ public     | mpp6979part | public              | mpp6979part_1_prt_8
+ public     | mpp6979part | public              | mpp6979part_1_prt_9
+ public     | mpp6979part | public              | mpp6979part_1_prt_1
+(10 rows)
 
 -- the rank 1 partition is ao, but still in public, and 
 -- table mpp6979tab is now heap, but still in mpp6979dummy
@@ -5512,29 +5515,23 @@ Distributed by: (a)
 
 alter table mpp7232a rename partition for (1) to alpha;
 alter table mpp7232a rename partition for (2) to bravo;
-\d+ mpp7232a
-                           Partitioned table "public.mpp7232a"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- a      | integer |           |          |         | plain   |              | 
- b      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (b)
-Partitions: mpp7232a_1_prt_alpha FOR VALUES FROM (1) TO (2),
-            mpp7232a_1_prt_bravo FOR VALUES FROM (2) TO (3)
-Distributed by: (a)
+select partitionname, partitionlevel, partitionboundary from pg_partitions where tablename = 'mpp7232a';
+ partitionname | partitionlevel |     partitionboundary      
+---------------+----------------+----------------------------
+               |              0 | 
+ alpha         |              1 | FOR VALUES FROM (1) TO (2)
+ bravo         |              1 | FOR VALUES FROM (2) TO (3)
+(3 rows)
 
 create table mpp7232b (a int, b int) distributed by (a) partition by range (b) (partition alpha start (1) end (3) every (1));
 alter table mpp7232b rename partition for (1) to foo;
-\d+ mpp7232b
-                           Partitioned table "public.mpp7232b"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- a      | integer |           |          |         | plain   |              | 
- b      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (b)
-Partitions: mpp7232b_1_prt_alpha_2 FOR VALUES FROM (2) TO (3),
-            mpp7232b_1_prt_foo FOR VALUES FROM (1) TO (2)
-Distributed by: (a)
+select partitionname, partitionlevel, partitionboundary from pg_partitions where tablename = 'mpp7232b';
+ partitionname | partitionlevel |     partitionboundary      
+---------------+----------------+----------------------------
+               |              0 | 
+ foo           |              1 | FOR VALUES FROM (1) TO (2)
+ alpha_2       |              1 | FOR VALUES FROM (2) TO (3)
+(3 rows)
 
 -- Test .. WITH (tablename = <foo> ..) syntax.
 create table mpp17740 (a integer, b integer, e date) with (appendonly = true, orientation = column)
@@ -5544,22 +5541,22 @@ partition by range(e)
     partition mpp17740_20120523 start ('2012-05-23'::date) inclusive end ('2012-05-24'::date) exclusive with (tablename = 'mpp17740_20120523', appendonly = true),
     partition mpp17740_20120524 start ('2012-05-24'::date) inclusive end ('2012-05-25'::date) exclusive with (tablename = 'mpp17740_20120524', appendonly = true)
 );
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp17740%';
-      relname      |                   pg_get_expr                    
--------------------+--------------------------------------------------
- mpp17740          | 
- mpp17740_20120523 | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
- mpp17740_20120524 | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'mpp17740';
+ partitiontablename |                partitionboundary                 
+--------------------+--------------------------------------------------
+ mpp17740           | 
+ mpp17740_20120523  | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
+ mpp17740_20120524  | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
 (3 rows)
 
 alter table mpp17740 add partition mpp17740_20120520 start ('2012-05-20'::date) inclusive end ('2012-05-21'::date) exclusive with (tablename = 'mpp17740_20120520', appendonly=true);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp17740%';
-      relname      |                   pg_get_expr                    
--------------------+--------------------------------------------------
- mpp17740          | 
- mpp17740_20120520 | FOR VALUES FROM ('05-20-2012') TO ('05-21-2012')
- mpp17740_20120523 | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
- mpp17740_20120524 | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'mpp17740';
+ partitiontablename |                partitionboundary                 
+--------------------+--------------------------------------------------
+ mpp17740           | 
+ mpp17740_20120523  | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
+ mpp17740_20120524  | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
+ mpp17740_20120520  | FOR VALUES FROM ('05-20-2012') TO ('05-21-2012')
 (4 rows)
 
 -- Test mix of add and drop various column before split, and exchange partition at the end
@@ -5686,12 +5683,12 @@ with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
 distributed by (a)
 partition by list(b) (partition s_abc values ('abc') with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1));
 alter table pt_tab_encode add partition "s_xyz" values ('xyz') WITH (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'pt_tab_encode%';
-          relname          |      pg_get_expr      
----------------------------+-----------------------
- pt_tab_encode             | 
- pt_tab_encode_1_prt_s_abc | FOR VALUES IN ('abc')
- pt_tab_encode_1_prt_s_xyz | FOR VALUES IN ('xyz')
+select tablename, partitiontablename, partitionboundary from pg_partitions where tablename = 'pt_tab_encode';
+   tablename   |    partitiontablename     |   partitionboundary   
+---------------+---------------------------+-----------------------
+ pt_tab_encode | pt_tab_encode             | 
+ pt_tab_encode | pt_tab_encode_1_prt_s_abc | FOR VALUES IN ('abc')
+ pt_tab_encode | pt_tab_encode_1_prt_s_xyz | FOR VALUES IN ('xyz')
 (3 rows)
 
 select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -787,17 +787,20 @@ ERROR:  partition "no_start1_1_prt_baz" would overlap partition "no_start1_1_prt
 alter table no_start1 add partition baz end (4);
 -- ok (because starts after baz end)
 alter table no_start1 add partition baz2 start (5);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'no_start%' or relname like 'no_end%';
-       relname        |            pg_get_expr            
-----------------------+-----------------------------------
- no_end1              | 
- no_end1_1_prt_foo    | FOR VALUES FROM (3) TO (MAXVALUE)
- no_end1_1_prt_baz    | FOR VALUES FROM (2) TO (3)
- no_end1_1_prt_baz2   | FOR VALUES FROM (MINVALUE) TO (1)
- no_start1            | 
- no_start1_1_prt_foo  | FOR VALUES FROM (MINVALUE) TO (3)
- no_start1_1_prt_baz  | FOR VALUES FROM (3) TO (4)
- no_start1_1_prt_baz2 | FOR VALUES FROM (5) TO (MAXVALUE)
+select tablename, partitionlevel, parentpartitiontablename,
+partitionname, partitionlevel, partitionboundary from pg_partitions
+where tablename = 'no_start1' or tablename = 'no_end1'
+order by partitiontablename::text, partitionlevel;
+ tablename | partitionlevel | parentpartitiontablename | partitionname | partitionlevel |         partitionboundary         
+-----------+----------------+--------------------------+---------------+----------------+-----------------------------------
+ no_end1   |              0 |                          |               |              0 | 
+ no_end1   |              1 | no_end1                  | baz           |              1 | FOR VALUES FROM (2) TO (3)
+ no_end1   |              1 | no_end1                  | baz2          |              1 | FOR VALUES FROM (MINVALUE) TO (1)
+ no_end1   |              1 | no_end1                  | foo           |              1 | FOR VALUES FROM (3) TO (MAXVALUE)
+ no_start1 |              0 |                          |               |              0 | 
+ no_start1 |              1 | no_start1                | baz           |              1 | FOR VALUES FROM (3) TO (4)
+ no_start1 |              1 | no_start1                | baz2          |              1 | FOR VALUES FROM (5) TO (MAXVALUE)
+ no_start1 |              1 | no_start1                | foo           |              1 | FOR VALUES FROM (MINVALUE) TO (3)
 (8 rows)
 
 drop table no_end1;
@@ -2055,8 +2058,8 @@ PARTITION BY RANGE (date)
  EVERY (INTERVAL '1 day') );
 -- Add unbound partition right before the start succeeds
 alter table mpp13806 add partition test end (date '2008-01-01') exclusive;
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp13806%';
-       relname       |                   pg_get_expr                    
+select partitiontablename, partitionboundary from pg_partitions where tablename like 'mpp13806%' order by partitiontablename::text, partitionlevel;
+ partitiontablename  |                partitionboundary                 
 ---------------------+--------------------------------------------------
  mpp13806            | 
  mpp13806_1_prt_1    | FOR VALUES FROM ('01-01-2008') TO ('01-02-2008')
@@ -2070,8 +2073,8 @@ select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 
 alter TABLE mpp13806 drop partition test;
 -- Add unbound partition with a gap succeeds
 alter table mpp13806 add partition test end (date '2007-12-31') exclusive;
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp13806%';
-       relname       |                   pg_get_expr                    
+select partitiontablename, partitionboundary from pg_partitions where tablename like 'mpp13806%' order by partitiontablename::text, partitionlevel;
+ partitiontablename  |                partitionboundary                 
 ---------------------+--------------------------------------------------
  mpp13806            | 
  mpp13806_1_prt_1    | FOR VALUES FROM ('01-01-2008') TO ('01-02-2008')
@@ -2083,8 +2086,8 @@ select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 
 
 -- Fill the gap succeeds/adding immediately before the first partition succeeds
 alter table mpp13806 add partition test1 start (date '2007-12-31') inclusive end (date '2008-01-01') exclusive;
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp13806%';
-       relname        |                   pg_get_expr                    
+select partitiontablename, partitionboundary from pg_partitions where tablename like 'mpp13806%' order by partitiontablename::text, partitionlevel;
+  partitiontablename  |                partitionboundary                 
 ----------------------+--------------------------------------------------
  mpp13806             | 
  mpp13806_1_prt_1     | FOR VALUES FROM ('01-01-2008') TO ('01-02-2008')
@@ -2137,6 +2140,54 @@ create table mpp14613_range(
  );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check the partition and subpartition details
+select tablename, partitiontablename, partitionname from pg_partitions where tablename in ('mpp14613_list','mpp14613_range');
+   tablename    |             partitiontablename              | partitionname 
+----------------+---------------------------------------------+---------------
+ mpp14613_range | mpp14613_range                              | 
+ mpp14613_range | mpp14613_range_1_prt_others                 | others
+ mpp14613_range | mpp14613_range_1_prt_2                      | 2
+ mpp14613_range | mpp14613_range_1_prt_3                      | 3
+ mpp14613_range | mpp14613_range_1_prt_4                      | 4
+ mpp14613_range | mpp14613_range_1_prt_5                      | 5
+ mpp14613_range | mpp14613_range_1_prt_others_2_prt_subothers | subothers
+ mpp14613_range | mpp14613_range_1_prt_others_2_prt_2         | 2
+ mpp14613_range | mpp14613_range_1_prt_others_2_prt_3         | 3
+ mpp14613_range | mpp14613_range_1_prt_2_2_prt_subothers      | subothers
+ mpp14613_range | mpp14613_range_1_prt_2_2_prt_2              | 2
+ mpp14613_range | mpp14613_range_1_prt_2_2_prt_3              | 3
+ mpp14613_range | mpp14613_range_1_prt_3_2_prt_subothers      | subothers
+ mpp14613_range | mpp14613_range_1_prt_3_2_prt_2              | 2
+ mpp14613_range | mpp14613_range_1_prt_3_2_prt_3              | 3
+ mpp14613_range | mpp14613_range_1_prt_4_2_prt_subothers      | subothers
+ mpp14613_range | mpp14613_range_1_prt_4_2_prt_2              | 2
+ mpp14613_range | mpp14613_range_1_prt_4_2_prt_3              | 3
+ mpp14613_range | mpp14613_range_1_prt_5_2_prt_subothers      | subothers
+ mpp14613_range | mpp14613_range_1_prt_5_2_prt_2              | 2
+ mpp14613_range | mpp14613_range_1_prt_5_2_prt_3              | 3
+ mpp14613_list  | mpp14613_list                               | 
+ mpp14613_list  | mpp14613_list_1_prt_others                  | others
+ mpp14613_list  | mpp14613_list_1_prt_2                       | 2
+ mpp14613_list  | mpp14613_list_1_prt_3                       | 3
+ mpp14613_list  | mpp14613_list_1_prt_4                       | 4
+ mpp14613_list  | mpp14613_list_1_prt_5                       | 5
+ mpp14613_list  | mpp14613_list_1_prt_others_2_prt_subothers  | subothers
+ mpp14613_list  | mpp14613_list_1_prt_others_2_prt_s1         | s1
+ mpp14613_list  | mpp14613_list_1_prt_others_2_prt_s2         | s2
+ mpp14613_list  | mpp14613_list_1_prt_2_2_prt_subothers       | subothers
+ mpp14613_list  | mpp14613_list_1_prt_2_2_prt_s1              | s1
+ mpp14613_list  | mpp14613_list_1_prt_2_2_prt_s2              | s2
+ mpp14613_list  | mpp14613_list_1_prt_3_2_prt_subothers       | subothers
+ mpp14613_list  | mpp14613_list_1_prt_3_2_prt_s1              | s1
+ mpp14613_list  | mpp14613_list_1_prt_3_2_prt_s2              | s2
+ mpp14613_list  | mpp14613_list_1_prt_4_2_prt_subothers       | subothers
+ mpp14613_list  | mpp14613_list_1_prt_4_2_prt_s1              | s1
+ mpp14613_list  | mpp14613_list_1_prt_4_2_prt_s2              | s2
+ mpp14613_list  | mpp14613_list_1_prt_5_2_prt_subothers       | subothers
+ mpp14613_list  | mpp14613_list_1_prt_5_2_prt_s1              | s1
+ mpp14613_list  | mpp14613_list_1_prt_5_2_prt_s2              | s2
+(42 rows)
+
 -- SPLIT partition
 alter table mpp14613_list alter partition others split partition subothers at (10) into (partition b1, partition subothers);
 ERROR:  SPLIT PARTITION is not currently supported when leaf partition is list partitioned in multi level partition table

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1007,6 +1007,16 @@ create table i_1_prt_3 (like i);
 -- could be matched by partition name when targeted on an irrelevant table.
 create table i2 (i int) partition by range(i) (start (1) end(3) every(1));
 create table i_1_prt_4 partition of i2 for values from (4) to (5);
+-- i_1_prt_4 should not have partitionname since it not using gpdb partition name pattern
+select * from pg_partitions where tablename = 'i2';
+ schemaname | tablename | partitionschemaname | partitiontablename | partitionname | parentpartitiontablename | parentpartitionname | partitiontype | partitionlevel | partitionisdefault |     partitionboundary      | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+--------------------+---------------+--------------------------+---------------------+---------------+----------------+--------------------+----------------------------+------------------+---------------------
+ public     | i2        | public              | i2                 |               |                          |                     | range         |              0 | f                  |                            | pg_default       | pg_default
+ public     | i2        | public              | i2_1_prt_1         | 1             | i2                       |                     |               |              1 | f                  | FOR VALUES FROM (1) TO (2) | pg_default       | pg_default
+ public     | i2        | public              | i2_1_prt_2         | 2             | i2                       |                     |               |              1 | f                  | FOR VALUES FROM (2) TO (3) | pg_default       | pg_default
+ public     | i2        | public              | i_1_prt_4          |               | i2                       |                     |               |              1 | f                  | FOR VALUES FROM (4) TO (5) | pg_default       | pg_default
+(4 rows)
+
 -- the matechd table name is i_1_prt_3, but it's a normal table, raise error.
 alter table i drop partition "3";
 ERROR:  partition "3" of "i" does not exist
@@ -1052,36 +1062,36 @@ partition p1 start('1') end('10001') every(5000)
 );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'ps_partkey' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select relname, pg_get_expr(relpartbound, oid, false) from pg_class where relname like 'partsupp%';
-                 relname                 |             pg_get_expr              
------------------------------------------+--------------------------------------
- partsupp                                | 
- partsupp_1_prt_p1_1                     | FOR VALUES FROM (1) TO (5001)
- partsupp_1_prt_p1_1_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
- partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_1_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
- partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_1_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
- partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_1_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
- partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2                     | FOR VALUES FROM (5001) TO (10001)
- partsupp_1_prt_p1_2_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
- partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
- partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
- partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
- partsupp_1_prt_p1_2_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
- partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
- partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+select tablename, partitiontablename, partitionboundary from pg_partitions where tablename = 'partsupp';
+ tablename |           partitiontablename            |          partitionboundary           
+-----------+-----------------------------------------+--------------------------------------
+ partsupp  | partsupp                                | 
+ partsupp  | partsupp_1_prt_p1_1                     | FOR VALUES FROM (1) TO (5001)
+ partsupp  | partsupp_1_prt_p1_2                     | FOR VALUES FROM (5001) TO (10001)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_1         | FOR VALUES FROM (1) TO (66667)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_2         | FOR VALUES FROM (66667) TO (133333)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_3         | FOR VALUES FROM (133333) TO (199999)
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_4         | FOR VALUES FROM (199999) TO (200001)
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_1 | FOR VALUES FROM ('1') TO ('501')
+ partsupp  | partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_2 | FOR VALUES FROM ('501') TO ('1001')
 (27 rows)
 
 drop table partsupp;
@@ -1901,17 +1911,15 @@ create table k (i int) partition by range(i)
 (start(0) exclusive end(100) inclusive every(25));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-\d+ k
-                               Partitioned table "public.k"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- i      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (i)
-Partitions: k_1_prt_1 FOR VALUES FROM (1) TO (26),
-            k_1_prt_2 FOR VALUES FROM (26) TO (51),
-            k_1_prt_3 FOR VALUES FROM (51) TO (76),
-            k_1_prt_4 FOR VALUES FROM (76) TO (101)
-Distributed by: (i)
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'k';
+ partitiontablename |       partitionboundary       
+--------------------+-------------------------------
+ k                  | 
+ k_1_prt_1          | FOR VALUES FROM (1) TO (26)
+ k_1_prt_2          | FOR VALUES FROM (26) TO (51)
+ k_1_prt_3          | FOR VALUES FROM (51) TO (76)
+ k_1_prt_4          | FOR VALUES FROM (76) TO (101)
+(5 rows)
 
 insert into k select i from generate_series(1, 100) i;
 drop table k;
@@ -3072,18 +3080,15 @@ EVERY ('1 year 1 mon'::interval)
 PARTITION p1_3 START ('1994-03-31'::date) END ('1995-04-30'::date)
 EVERY ('1 year 1 mon'::interval)
 );
-\d+ mpp6297
-                              Partitioned table "public.mpp6297"
-    Column    |  Type  | Collation | Nullable | Default | Storage | Stats target | Description 
---------------+--------+-----------+----------+---------+---------+--------------+-------------
- l_orderkey   | bigint |           |          |         | plain   |              | 
- l_commitdate | date   |           |          |         | plain   |              | 
-Partition key: RANGE (l_commitdate)
-Partitions: mpp6297_1_prt_p1_1_1 FOR VALUES FROM ('01-31-1992') TO ('02-28-1993'),
-            mpp6297_1_prt_p1_2_1 FOR VALUES FROM ('02-28-1993') TO ('03-28-1994'),
-            mpp6297_1_prt_p1_2_2 FOR VALUES FROM ('03-28-1994') TO ('03-31-1994'),
-            mpp6297_1_prt_p1_3_1 FOR VALUES FROM ('03-31-1994') TO ('04-30-1995')
-Distributed by: (l_orderkey)
+select partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp6297';
+  partitiontablename  | partitionname |                partitionboundary                 
+----------------------+---------------+--------------------------------------------------
+ mpp6297              |               | 
+ mpp6297_1_prt_p1_1_1 | p1_1_1        | FOR VALUES FROM ('01-31-1992') TO ('02-28-1993')
+ mpp6297_1_prt_p1_2_1 | p1_2_1        | FOR VALUES FROM ('02-28-1993') TO ('03-28-1994')
+ mpp6297_1_prt_p1_2_2 | p1_2_2        | FOR VALUES FROM ('03-28-1994') TO ('03-31-1994')
+ mpp6297_1_prt_p1_3_1 | p1_3_1        | FOR VALUES FROM ('03-31-1994') TO ('04-30-1995')
+(5 rows)
 
 drop table mpp6297;
 -- when WITH(tablename=...) is specified, the EVERY is stored as an
@@ -3931,8 +3936,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 alter table mpp10223b alter partition p1 
 split partition for (20) at (25)
 into (partition sp2, partition sp3);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp10223b%';
-           relname            |         pg_get_expr          
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'mpp10223b';
+      partitiontablename      |      partitionboundary       
 ------------------------------+------------------------------
  mpp10223b                    | 
  mpp10223b_1_prt_p1           | FOR VALUES FROM (1) TO (10)
@@ -4089,12 +4094,12 @@ ERROR:  AT clause parameter is not a member of the target partition specificatio
 -- good split
 alter table cov1 split partition p1 at (5,6,7) 
 into (partition p1, partition p2);
-select relname, pg_get_expr(relpartbound, oid, false) from pg_class where relname like 'cov1%';
-    relname    |          pg_get_expr          
----------------+-------------------------------
- cov1          | 
- cov1_1_prt_p1 | FOR VALUES IN (1, 2, 3, 4, 8)
- cov1_1_prt_p2 | FOR VALUES IN (5, 6, 7)
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'cov1';
+ partitiontablename |       partitionboundary       
+--------------------+-------------------------------
+ cov1               | 
+ cov1_1_prt_p1      | FOR VALUES IN (1, 2, 3, 4, 8)
+ cov1_1_prt_p2      | FOR VALUES IN (5, 6, 7)
 (3 rows)
 
 drop table cov1;
@@ -4190,22 +4195,21 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table mpp6979dummy.mpp6979tab(like mpp6979part) with (appendonly=true);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- check that table and all parts in public schema
-select relname, nspname, relispartition from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and relname like ('mpp6979%');
-       relname       |   nspname    | relispartition 
----------------------+--------------+----------------
- mpp6979part         | public       | f
- mpp6979part_1_prt_1 | public       | t
- mpp6979part_1_prt_2 | public       | t
- mpp6979part_1_prt_3 | public       | t
- mpp6979part_1_prt_4 | public       | t
- mpp6979part_1_prt_5 | public       | t
- mpp6979part_1_prt_6 | public       | t
- mpp6979part_1_prt_7 | public       | t
- mpp6979part_1_prt_8 | public       | t
- mpp6979part_1_prt_9 | public       | t
- mpp6979tab          | mpp6979dummy | f
-(11 rows)
+select schemaname, tablename, partitionschemaname, partitiontablename from pg_partitions 
+where tablename like ('mpp6979%');
+ schemaname |  tablename  | partitionschemaname | partitiontablename  
+------------+-------------+---------------------+---------------------
+ public     | mpp6979part | public              | mpp6979part
+ public     | mpp6979part | public              | mpp6979part_1_prt_1
+ public     | mpp6979part | public              | mpp6979part_1_prt_2
+ public     | mpp6979part | public              | mpp6979part_1_prt_3
+ public     | mpp6979part | public              | mpp6979part_1_prt_4
+ public     | mpp6979part | public              | mpp6979part_1_prt_5
+ public     | mpp6979part | public              | mpp6979part_1_prt_6
+ public     | mpp6979part | public              | mpp6979part_1_prt_7
+ public     | mpp6979part | public              | mpp6979part_1_prt_8
+ public     | mpp6979part | public              | mpp6979part_1_prt_9
+(10 rows)
 
 -- note that we have heap partitions in public, and ao table in mpp6979dummy
 select nspname, relname, amname
@@ -4233,22 +4237,21 @@ where relname like ('mpp6979%');
 alter table mpp6979part exchange partition for (1) 
 with table mpp6979dummy.mpp6979tab;
 -- after the exchange, all partitions are still in public
-select relname, nspname, relispartition from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and relname like ('mpp6979%');
-       relname       |   nspname    | relispartition 
----------------------+--------------+----------------
- mpp6979part         | public       | f
- mpp6979part_1_prt_1 | public       | t
- mpp6979part_1_prt_2 | public       | t
- mpp6979part_1_prt_3 | public       | t
- mpp6979part_1_prt_4 | public       | t
- mpp6979part_1_prt_5 | public       | t
- mpp6979part_1_prt_6 | public       | t
- mpp6979part_1_prt_7 | public       | t
- mpp6979part_1_prt_8 | public       | t
- mpp6979part_1_prt_9 | public       | t
- mpp6979tab          | mpp6979dummy | f
-(11 rows)
+select schemaname, tablename, partitionschemaname, partitiontablename from pg_partitions 
+where tablename like ('mpp6979%');
+ schemaname |  tablename  | partitionschemaname | partitiontablename  
+------------+-------------+---------------------+---------------------
+ public     | mpp6979part | public              | mpp6979part
+ public     | mpp6979part | public              | mpp6979part_1_prt_2
+ public     | mpp6979part | public              | mpp6979part_1_prt_3
+ public     | mpp6979part | public              | mpp6979part_1_prt_4
+ public     | mpp6979part | public              | mpp6979part_1_prt_5
+ public     | mpp6979part | public              | mpp6979part_1_prt_6
+ public     | mpp6979part | public              | mpp6979part_1_prt_7
+ public     | mpp6979part | public              | mpp6979part_1_prt_8
+ public     | mpp6979part | public              | mpp6979part_1_prt_9
+ public     | mpp6979part | public              | mpp6979part_1_prt_1
+(10 rows)
 
 -- the rank 1 partition is ao, but still in public, and 
 -- table mpp6979tab is now heap, but still in mpp6979dummy
@@ -5513,29 +5516,23 @@ Distributed by: (a)
 
 alter table mpp7232a rename partition for (1) to alpha;
 alter table mpp7232a rename partition for (2) to bravo;
-\d+ mpp7232a
-                           Partitioned table "public.mpp7232a"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- a      | integer |           |          |         | plain   |              | 
- b      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (b)
-Partitions: mpp7232a_1_prt_alpha FOR VALUES FROM (1) TO (2),
-            mpp7232a_1_prt_bravo FOR VALUES FROM (2) TO (3)
-Distributed by: (a)
+select partitionname, partitionlevel, partitionboundary from pg_partitions where tablename = 'mpp7232a';
+ partitionname | partitionlevel |     partitionboundary      
+---------------+----------------+----------------------------
+               |              0 | 
+ alpha         |              1 | FOR VALUES FROM (1) TO (2)
+ bravo         |              1 | FOR VALUES FROM (2) TO (3)
+(3 rows)
 
 create table mpp7232b (a int, b int) distributed by (a) partition by range (b) (partition alpha start (1) end (3) every (1));
 alter table mpp7232b rename partition for (1) to foo;
-\d+ mpp7232b
-                           Partitioned table "public.mpp7232b"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- a      | integer |           |          |         | plain   |              | 
- b      | integer |           |          |         | plain   |              | 
-Partition key: RANGE (b)
-Partitions: mpp7232b_1_prt_alpha_2 FOR VALUES FROM (2) TO (3),
-            mpp7232b_1_prt_foo FOR VALUES FROM (1) TO (2)
-Distributed by: (a)
+select partitionname, partitionlevel, partitionboundary from pg_partitions where tablename = 'mpp7232b';
+ partitionname | partitionlevel |     partitionboundary      
+---------------+----------------+----------------------------
+               |              0 | 
+ foo           |              1 | FOR VALUES FROM (1) TO (2)
+ alpha_2       |              1 | FOR VALUES FROM (2) TO (3)
+(3 rows)
 
 -- Test .. WITH (tablename = <foo> ..) syntax.
 create table mpp17740 (a integer, b integer, e date) with (appendonly = true, orientation = column)
@@ -5545,22 +5542,22 @@ partition by range(e)
     partition mpp17740_20120523 start ('2012-05-23'::date) inclusive end ('2012-05-24'::date) exclusive with (tablename = 'mpp17740_20120523', appendonly = true),
     partition mpp17740_20120524 start ('2012-05-24'::date) inclusive end ('2012-05-25'::date) exclusive with (tablename = 'mpp17740_20120524', appendonly = true)
 );
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp17740%';
-      relname      |                   pg_get_expr                    
--------------------+--------------------------------------------------
- mpp17740          | 
- mpp17740_20120523 | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
- mpp17740_20120524 | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'mpp17740';
+ partitiontablename |                partitionboundary                 
+--------------------+--------------------------------------------------
+ mpp17740           | 
+ mpp17740_20120523  | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
+ mpp17740_20120524  | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
 (3 rows)
 
 alter table mpp17740 add partition mpp17740_20120520 start ('2012-05-20'::date) inclusive end ('2012-05-21'::date) exclusive with (tablename = 'mpp17740_20120520', appendonly=true);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'mpp17740%';
-      relname      |                   pg_get_expr                    
--------------------+--------------------------------------------------
- mpp17740          | 
- mpp17740_20120520 | FOR VALUES FROM ('05-20-2012') TO ('05-21-2012')
- mpp17740_20120523 | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
- mpp17740_20120524 | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
+select partitiontablename, partitionboundary from pg_partitions where tablename = 'mpp17740';
+ partitiontablename |                partitionboundary                 
+--------------------+--------------------------------------------------
+ mpp17740           | 
+ mpp17740_20120523  | FOR VALUES FROM ('05-23-2012') TO ('05-24-2012')
+ mpp17740_20120524  | FOR VALUES FROM ('05-24-2012') TO ('05-25-2012')
+ mpp17740_20120520  | FOR VALUES FROM ('05-20-2012') TO ('05-21-2012')
 (4 rows)
 
 -- Test mix of add and drop various column before split, and exchange partition at the end
@@ -5686,12 +5683,12 @@ with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
 distributed by (a)
 partition by list(b) (partition s_abc values ('abc') with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1));
 alter table pt_tab_encode add partition "s_xyz" values ('xyz') WITH (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1);
-select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'pt_tab_encode%';
-          relname          |      pg_get_expr      
----------------------------+-----------------------
- pt_tab_encode             | 
- pt_tab_encode_1_prt_s_abc | FOR VALUES IN ('abc')
- pt_tab_encode_1_prt_s_xyz | FOR VALUES IN ('xyz')
+select tablename, partitiontablename, partitionboundary from pg_partitions where tablename = 'pt_tab_encode';
+   tablename   |    partitiontablename     |   partitionboundary   
+---------------+---------------------------+-----------------------
+ pt_tab_encode | pt_tab_encode             | 
+ pt_tab_encode | pt_tab_encode_1_prt_s_abc | FOR VALUES IN ('abc')
+ pt_tab_encode | pt_tab_encode_1_prt_s_xyz | FOR VALUES IN ('xyz')
 (3 rows)
 
 select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -371,7 +371,7 @@ subpartition by range (y) subpartition template ( start (1) end (2) every (1))
 subpartition by range (z) subpartition template ( start (1) end (2) every (1))
 ( start (1) end (2) every (1));
 alter table multi_part2 rename to m_0000000;
-select relid,parentrelid,isleaf,level, pg_catalog.pg_get_expr(relpartbound, oid) from pg_partition_tree('m_0000000'), pg_class where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'm_0000000';
 alter table m_0000000 rename to multi_part2_0000000;
 select relid,parentrelid,isleaf,level, pg_catalog.pg_get_expr(relpartbound, oid) from pg_partition_tree('multi_part2_0000000'), pg_class where relid = oid;
 alter table multi_part2_0000000 rename partition for (1) to a123456789a123456789a123456789a123456789a123456789a123456789;
@@ -446,13 +446,13 @@ drop table mpp3363;
 CREATE TABLE mpp3059(a int, b int, c int, d int, e int, f int, g int, h int, i int, j int, k int, l int, m int, n int, o int, p int, q int, r int, s int, t int, u int, v int, w int, x int, y int, z int)
 partition by range (a)
 ( partition aa start (1) end (5) every (1) );
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059';
 
 alter table mpp3059 rename to mpp3059_rename; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059_rename') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059_rename';
 
 alter table mpp3059_rename rename to mpp3059; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059';
 
 -- 2 level partition
 CREATE TABLE mpp3059a (
@@ -476,12 +476,12 @@ CREATE TABLE mpp3059a (
 subpartition by range (unique2) subpartition template ( start (0) end (500) every (100) )
 ( start (0) end (500) every (100));
 alter table mpp3059a rename to mpp3059a_rename; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059a_rename') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059a_rename';
 
 create table mpp3216a (id int, rank int, year int, gender char(1), count int) distributed by (id); 
 create table mpp3216 (like mpp3216a) partition by range (year) ( start (2001) end (2006) every (1));
 alter table mpp3216 rename to mpp3216_rename;
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3216_rename') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3216_rename';
 
 CREATE TABLE mpp3059b (f1 time(2) with time zone, f2 char(4))
 partition by list (f2)
@@ -489,7 +489,7 @@ partition by list (f2)
   partition est values ('EST')
 );
 alter table mpp3059b rename partition pst to "pacific time"; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059b') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059b';
 
 CREATE TABLE mpp3059c (f1 time(2) with time zone, f2 char(4))
 partition by list (f2)
@@ -503,7 +503,7 @@ start (time '01:00')
 );
 alter table mpp3059c rename partition pst to pacific;
 alter table mpp3059c rename partition est to "Eastern Time";
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059c') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059c';
 
 CREATE TABLE mpp3059d (f1 time(2) with time zone, f2 char(4), f3 varchar(10))
 partition by list (f2)
@@ -516,7 +516,7 @@ subpartition template (
   partition est values ('EST')
 );
 alter table mpp3059d rename partition pst to pacific;
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059d') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059d';
 
 create table test_khush (a integer, b date, c varchar(30))
 partition by range(b)
@@ -782,9 +782,9 @@ partition by range (q1)
 CREATE TABLE mpp3079a(q1 int2, q2 int2)
 partition by range (q1)
 (start (1) end (10) every (1));
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3079') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3079';
 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3079a') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3079a';
 
 drop table mpp3079;
 drop table mpp3079a;
@@ -798,7 +798,7 @@ insert into mpp3242 values(-1);
 -- automatic.
 alter table mpp3242 add partition zz start ('-1') end (0);
 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3242') as t, pg_class as c where relid = oid;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3242';
 
 drop table mpp3242;
 
@@ -927,7 +927,7 @@ CREATE TABLE mpp3080_numericbig (id int4, val numeric(1000,800))
 partition by range (val)
 (start (1) end (5) every (1));
 -- order 1,5
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3080_numericbig') as t, pg_class as c where relid = oid order by 1,5;
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3080_numericbig' order by 1,5;
 
 create temp TABLE temp_hour_range (f1 time(2))
 partition by range (f1)

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -465,36 +465,36 @@ subpartition by range (y) subpartition template ( start (1) end (2) every (1))
 subpartition by range (z) subpartition template ( start (1) end (2) every (1))
 ( start (1) end (2) every (1));
 alter table multi_part2 rename to m_0000000;
-select relid,parentrelid,isleaf,level, pg_catalog.pg_get_expr(relpartbound, oid) from pg_partition_tree('m_0000000'), pg_class where relid = oid;
-                             relid                             |                          parentrelid                          | isleaf | level |        pg_get_expr         
----------------------------------------------------------------+---------------------------------------------------------------+--------+-------+----------------------------
- m_0000000                                                     |                                                               | f      |     0 | 
- m_0000000_1_prt_1                                             | m_0000000                                                     | f      |     1 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1                                     | m_0000000_1_prt_1                                             | f      |     2 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1                             | m_0000000_1_prt_1_2_prt_1                                     | f      |     3 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1                     | m_0000000_1_prt_1_2_prt_1_3_prt_1                             | f      |     4 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1             | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1                     | f      |     5 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_prt_1     | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1             | f      |     6 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_7_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_prt_1     | f      |     7 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_8_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_7_prt_1 | f      |     8 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_9_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_8_prt_1 | f      |     9 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__10_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_9_prt_1 | f      |    10 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__11_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__10_prt_1 | f      |    11 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__12_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__11_prt_1 | f      |    12 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__13_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__12_prt_1 | f      |    13 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__14_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__13_prt_1 | f      |    14 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__15_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__14_prt_1 | f      |    15 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__16_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__15_prt_1 | f      |    16 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__17_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__16_prt_1 | f      |    17 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__18_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__17_prt_1 | f      |    18 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__19_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__18_prt_1 | f      |    19 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__20_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__19_prt_1 | f      |    20 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__21_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__20_prt_1 | f      |    21 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__22_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__21_prt_1 | f      |    22 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__23_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__22_prt_1 | f      |    23 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__24_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__23_prt_1 | f      |    24 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__25_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__24_prt_1 | f      |    25 | FOR VALUES FROM (1) TO (2)
- m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__26_prt_1 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__25_prt_1 | t      |    26 | FOR VALUES FROM (1) TO (2)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'm_0000000';
+ tablename | partitionlevel |                      partitiontablename                       | partitionname |     partitionboundary      
+-----------+----------------+---------------------------------------------------------------+---------------+----------------------------
+ m_0000000 |              0 | m_0000000                                                     |               | 
+ m_0000000 |              1 | m_0000000_1_prt_1                                             | 1             | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              2 | m_0000000_1_prt_1_2_prt_1                                     | 1             | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              3 | m_0000000_1_prt_1_2_prt_1_3_prt_1                             | 1             | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              4 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1                     | 1             | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              5 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1             | 1             | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              6 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_prt_1     | 1             | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              7 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_7_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              8 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_8_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |              9 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6_p_9_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             10 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__10_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             11 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__11_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             12 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__12_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             13 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__13_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             14 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__14_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             15 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__15_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             16 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__16_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             17 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__17_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             18 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__18_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             19 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__19_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             20 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__20_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             21 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__21_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             22 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__22_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             23 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__23_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             24 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__24_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             25 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__25_prt_1 |               | FOR VALUES FROM (1) TO (2)
+ m_0000000 |             26 | m_0000000_1_prt_1_2_prt_1_3_prt_1_4_prt_1_5_prt_1_6__26_prt_1 |               | FOR VALUES FROM (1) TO (2)
 (27 rows)
 
 alter table m_0000000 rename to multi_part2_0000000;
@@ -1969,36 +1969,36 @@ drop table mpp3363;
 CREATE TABLE mpp3059(a int, b int, c int, d int, e int, f int, g int, h int, i int, j int, k int, l int, m int, n int, o int, p int, q int, r int, s int, t int, u int, v int, w int, x int, y int, z int)
 partition by range (a)
 ( partition aa start (1) end (5) every (1) );
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059') as t, pg_class as c where relid = oid;
-       relid        | parentrelid | isleaf | level |        pg_get_expr         
---------------------+-------------+--------+-------+----------------------------
- mpp3059            |             | f      |     0 | 
- mpp3059_1_prt_aa_1 | mpp3059     | t      |     1 | FOR VALUES FROM (1) TO (2)
- mpp3059_1_prt_aa_2 | mpp3059     | t      |     1 | FOR VALUES FROM (2) TO (3)
- mpp3059_1_prt_aa_3 | mpp3059     | t      |     1 | FOR VALUES FROM (3) TO (4)
- mpp3059_1_prt_aa_4 | mpp3059     | t      |     1 | FOR VALUES FROM (4) TO (5)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059';
+ tablename | partitionlevel | partitiontablename | partitionname |     partitionboundary      
+-----------+----------------+--------------------+---------------+----------------------------
+ mpp3059   |              0 | mpp3059            |               | 
+ mpp3059   |              1 | mpp3059_1_prt_aa_1 | aa_1          | FOR VALUES FROM (1) TO (2)
+ mpp3059   |              1 | mpp3059_1_prt_aa_2 | aa_2          | FOR VALUES FROM (2) TO (3)
+ mpp3059   |              1 | mpp3059_1_prt_aa_3 | aa_3          | FOR VALUES FROM (3) TO (4)
+ mpp3059   |              1 | mpp3059_1_prt_aa_4 | aa_4          | FOR VALUES FROM (4) TO (5)
 (5 rows)
 
 alter table mpp3059 rename to mpp3059_rename; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059_rename') as t, pg_class as c where relid = oid;
-           relid           |  parentrelid   | isleaf | level |        pg_get_expr         
----------------------------+----------------+--------+-------+----------------------------
- mpp3059_rename            |                | f      |     0 | 
- mpp3059_rename_1_prt_aa_1 | mpp3059_rename | t      |     1 | FOR VALUES FROM (1) TO (2)
- mpp3059_rename_1_prt_aa_2 | mpp3059_rename | t      |     1 | FOR VALUES FROM (2) TO (3)
- mpp3059_rename_1_prt_aa_3 | mpp3059_rename | t      |     1 | FOR VALUES FROM (3) TO (4)
- mpp3059_rename_1_prt_aa_4 | mpp3059_rename | t      |     1 | FOR VALUES FROM (4) TO (5)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059_rename';
+   tablename    | partitionlevel |    partitiontablename     | partitionname |     partitionboundary      
+----------------+----------------+---------------------------+---------------+----------------------------
+ mpp3059_rename |              0 | mpp3059_rename            |               | 
+ mpp3059_rename |              1 | mpp3059_rename_1_prt_aa_1 | aa_1          | FOR VALUES FROM (1) TO (2)
+ mpp3059_rename |              1 | mpp3059_rename_1_prt_aa_2 | aa_2          | FOR VALUES FROM (2) TO (3)
+ mpp3059_rename |              1 | mpp3059_rename_1_prt_aa_3 | aa_3          | FOR VALUES FROM (3) TO (4)
+ mpp3059_rename |              1 | mpp3059_rename_1_prt_aa_4 | aa_4          | FOR VALUES FROM (4) TO (5)
 (5 rows)
 
 alter table mpp3059_rename rename to mpp3059; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059') as t, pg_class as c where relid = oid;
-       relid        | parentrelid | isleaf | level |        pg_get_expr         
---------------------+-------------+--------+-------+----------------------------
- mpp3059            |             | f      |     0 | 
- mpp3059_1_prt_aa_1 | mpp3059     | t      |     1 | FOR VALUES FROM (1) TO (2)
- mpp3059_1_prt_aa_2 | mpp3059     | t      |     1 | FOR VALUES FROM (2) TO (3)
- mpp3059_1_prt_aa_3 | mpp3059     | t      |     1 | FOR VALUES FROM (3) TO (4)
- mpp3059_1_prt_aa_4 | mpp3059     | t      |     1 | FOR VALUES FROM (4) TO (5)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059';
+ tablename | partitionlevel | partitiontablename | partitionname |     partitionboundary      
+-----------+----------------+--------------------+---------------+----------------------------
+ mpp3059   |              0 | mpp3059            |               | 
+ mpp3059   |              1 | mpp3059_1_prt_aa_1 | aa_1          | FOR VALUES FROM (1) TO (2)
+ mpp3059   |              1 | mpp3059_1_prt_aa_2 | aa_2          | FOR VALUES FROM (2) TO (3)
+ mpp3059   |              1 | mpp3059_1_prt_aa_3 | aa_3          | FOR VALUES FROM (3) TO (4)
+ mpp3059   |              1 | mpp3059_1_prt_aa_4 | aa_4          | FOR VALUES FROM (4) TO (5)
 (5 rows)
 
 -- 2 level partition
@@ -2023,54 +2023,54 @@ CREATE TABLE mpp3059a (
 subpartition by range (unique2) subpartition template ( start (0) end (500) every (100) )
 ( start (0) end (500) every (100));
 alter table mpp3059a rename to mpp3059a_rename; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059a_rename') as t, pg_class as c where relid = oid;
-              relid              |       parentrelid       | isleaf | level |          pg_get_expr           
----------------------------------+-------------------------+--------+-------+--------------------------------
- mpp3059a_rename                 |                         | f      |     0 | 
- mpp3059a_rename_1_prt_1         | mpp3059a_rename         | f      |     1 | FOR VALUES FROM (0) TO (100)
- mpp3059a_rename_1_prt_2         | mpp3059a_rename         | f      |     1 | FOR VALUES FROM (100) TO (200)
- mpp3059a_rename_1_prt_3         | mpp3059a_rename         | f      |     1 | FOR VALUES FROM (200) TO (300)
- mpp3059a_rename_1_prt_4         | mpp3059a_rename         | f      |     1 | FOR VALUES FROM (300) TO (400)
- mpp3059a_rename_1_prt_5         | mpp3059a_rename         | f      |     1 | FOR VALUES FROM (400) TO (500)
- mpp3059a_rename_1_prt_1_2_prt_1 | mpp3059a_rename_1_prt_1 | t      |     2 | FOR VALUES FROM (0) TO (100)
- mpp3059a_rename_1_prt_1_2_prt_2 | mpp3059a_rename_1_prt_1 | t      |     2 | FOR VALUES FROM (100) TO (200)
- mpp3059a_rename_1_prt_1_2_prt_3 | mpp3059a_rename_1_prt_1 | t      |     2 | FOR VALUES FROM (200) TO (300)
- mpp3059a_rename_1_prt_1_2_prt_4 | mpp3059a_rename_1_prt_1 | t      |     2 | FOR VALUES FROM (300) TO (400)
- mpp3059a_rename_1_prt_1_2_prt_5 | mpp3059a_rename_1_prt_1 | t      |     2 | FOR VALUES FROM (400) TO (500)
- mpp3059a_rename_1_prt_2_2_prt_1 | mpp3059a_rename_1_prt_2 | t      |     2 | FOR VALUES FROM (0) TO (100)
- mpp3059a_rename_1_prt_2_2_prt_2 | mpp3059a_rename_1_prt_2 | t      |     2 | FOR VALUES FROM (100) TO (200)
- mpp3059a_rename_1_prt_2_2_prt_3 | mpp3059a_rename_1_prt_2 | t      |     2 | FOR VALUES FROM (200) TO (300)
- mpp3059a_rename_1_prt_2_2_prt_4 | mpp3059a_rename_1_prt_2 | t      |     2 | FOR VALUES FROM (300) TO (400)
- mpp3059a_rename_1_prt_2_2_prt_5 | mpp3059a_rename_1_prt_2 | t      |     2 | FOR VALUES FROM (400) TO (500)
- mpp3059a_rename_1_prt_3_2_prt_1 | mpp3059a_rename_1_prt_3 | t      |     2 | FOR VALUES FROM (0) TO (100)
- mpp3059a_rename_1_prt_3_2_prt_2 | mpp3059a_rename_1_prt_3 | t      |     2 | FOR VALUES FROM (100) TO (200)
- mpp3059a_rename_1_prt_3_2_prt_3 | mpp3059a_rename_1_prt_3 | t      |     2 | FOR VALUES FROM (200) TO (300)
- mpp3059a_rename_1_prt_3_2_prt_4 | mpp3059a_rename_1_prt_3 | t      |     2 | FOR VALUES FROM (300) TO (400)
- mpp3059a_rename_1_prt_3_2_prt_5 | mpp3059a_rename_1_prt_3 | t      |     2 | FOR VALUES FROM (400) TO (500)
- mpp3059a_rename_1_prt_4_2_prt_1 | mpp3059a_rename_1_prt_4 | t      |     2 | FOR VALUES FROM (0) TO (100)
- mpp3059a_rename_1_prt_4_2_prt_2 | mpp3059a_rename_1_prt_4 | t      |     2 | FOR VALUES FROM (100) TO (200)
- mpp3059a_rename_1_prt_4_2_prt_3 | mpp3059a_rename_1_prt_4 | t      |     2 | FOR VALUES FROM (200) TO (300)
- mpp3059a_rename_1_prt_4_2_prt_4 | mpp3059a_rename_1_prt_4 | t      |     2 | FOR VALUES FROM (300) TO (400)
- mpp3059a_rename_1_prt_4_2_prt_5 | mpp3059a_rename_1_prt_4 | t      |     2 | FOR VALUES FROM (400) TO (500)
- mpp3059a_rename_1_prt_5_2_prt_1 | mpp3059a_rename_1_prt_5 | t      |     2 | FOR VALUES FROM (0) TO (100)
- mpp3059a_rename_1_prt_5_2_prt_2 | mpp3059a_rename_1_prt_5 | t      |     2 | FOR VALUES FROM (100) TO (200)
- mpp3059a_rename_1_prt_5_2_prt_3 | mpp3059a_rename_1_prt_5 | t      |     2 | FOR VALUES FROM (200) TO (300)
- mpp3059a_rename_1_prt_5_2_prt_4 | mpp3059a_rename_1_prt_5 | t      |     2 | FOR VALUES FROM (300) TO (400)
- mpp3059a_rename_1_prt_5_2_prt_5 | mpp3059a_rename_1_prt_5 | t      |     2 | FOR VALUES FROM (400) TO (500)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059a_rename';
+    tablename    | partitionlevel |       partitiontablename        | partitionname |       partitionboundary        
+-----------------+----------------+---------------------------------+---------------+--------------------------------
+ mpp3059a_rename |              0 | mpp3059a_rename                 |               | 
+ mpp3059a_rename |              1 | mpp3059a_rename_1_prt_1         | 1             | FOR VALUES FROM (0) TO (100)
+ mpp3059a_rename |              1 | mpp3059a_rename_1_prt_2         | 2             | FOR VALUES FROM (100) TO (200)
+ mpp3059a_rename |              1 | mpp3059a_rename_1_prt_3         | 3             | FOR VALUES FROM (200) TO (300)
+ mpp3059a_rename |              1 | mpp3059a_rename_1_prt_4         | 4             | FOR VALUES FROM (300) TO (400)
+ mpp3059a_rename |              1 | mpp3059a_rename_1_prt_5         | 5             | FOR VALUES FROM (400) TO (500)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_1_2_prt_1 | 1             | FOR VALUES FROM (0) TO (100)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_1_2_prt_2 | 2             | FOR VALUES FROM (100) TO (200)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_1_2_prt_3 | 3             | FOR VALUES FROM (200) TO (300)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_1_2_prt_4 | 4             | FOR VALUES FROM (300) TO (400)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_1_2_prt_5 | 5             | FOR VALUES FROM (400) TO (500)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_2_2_prt_1 | 1             | FOR VALUES FROM (0) TO (100)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_2_2_prt_2 | 2             | FOR VALUES FROM (100) TO (200)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_2_2_prt_3 | 3             | FOR VALUES FROM (200) TO (300)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_2_2_prt_4 | 4             | FOR VALUES FROM (300) TO (400)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_2_2_prt_5 | 5             | FOR VALUES FROM (400) TO (500)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_3_2_prt_1 | 1             | FOR VALUES FROM (0) TO (100)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_3_2_prt_2 | 2             | FOR VALUES FROM (100) TO (200)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_3_2_prt_3 | 3             | FOR VALUES FROM (200) TO (300)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_3_2_prt_4 | 4             | FOR VALUES FROM (300) TO (400)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_3_2_prt_5 | 5             | FOR VALUES FROM (400) TO (500)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_4_2_prt_1 | 1             | FOR VALUES FROM (0) TO (100)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_4_2_prt_2 | 2             | FOR VALUES FROM (100) TO (200)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_4_2_prt_3 | 3             | FOR VALUES FROM (200) TO (300)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_4_2_prt_4 | 4             | FOR VALUES FROM (300) TO (400)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_4_2_prt_5 | 5             | FOR VALUES FROM (400) TO (500)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_5_2_prt_1 | 1             | FOR VALUES FROM (0) TO (100)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_5_2_prt_2 | 2             | FOR VALUES FROM (100) TO (200)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_5_2_prt_3 | 3             | FOR VALUES FROM (200) TO (300)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_5_2_prt_4 | 4             | FOR VALUES FROM (300) TO (400)
+ mpp3059a_rename |              2 | mpp3059a_rename_1_prt_5_2_prt_5 | 5             | FOR VALUES FROM (400) TO (500)
 (31 rows)
 
 create table mpp3216a (id int, rank int, year int, gender char(1), count int) distributed by (id); 
 create table mpp3216 (like mpp3216a) partition by range (year) ( start (2001) end (2006) every (1));
 alter table mpp3216 rename to mpp3216_rename;
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3216_rename') as t, pg_class as c where relid = oid;
-         relid          |  parentrelid   | isleaf | level |           pg_get_expr            
-------------------------+----------------+--------+-------+----------------------------------
- mpp3216_rename         |                | f      |     0 | 
- mpp3216_rename_1_prt_1 | mpp3216_rename | t      |     1 | FOR VALUES FROM (2001) TO (2002)
- mpp3216_rename_1_prt_2 | mpp3216_rename | t      |     1 | FOR VALUES FROM (2002) TO (2003)
- mpp3216_rename_1_prt_3 | mpp3216_rename | t      |     1 | FOR VALUES FROM (2003) TO (2004)
- mpp3216_rename_1_prt_4 | mpp3216_rename | t      |     1 | FOR VALUES FROM (2004) TO (2005)
- mpp3216_rename_1_prt_5 | mpp3216_rename | t      |     1 | FOR VALUES FROM (2005) TO (2006)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3216_rename';
+   tablename    | partitionlevel |   partitiontablename   | partitionname |        partitionboundary         
+----------------+----------------+------------------------+---------------+----------------------------------
+ mpp3216_rename |              0 | mpp3216_rename         |               | 
+ mpp3216_rename |              1 | mpp3216_rename_1_prt_1 | 1             | FOR VALUES FROM (2001) TO (2002)
+ mpp3216_rename |              1 | mpp3216_rename_1_prt_2 | 2             | FOR VALUES FROM (2002) TO (2003)
+ mpp3216_rename |              1 | mpp3216_rename_1_prt_3 | 3             | FOR VALUES FROM (2003) TO (2004)
+ mpp3216_rename |              1 | mpp3216_rename_1_prt_4 | 4             | FOR VALUES FROM (2004) TO (2005)
+ mpp3216_rename |              1 | mpp3216_rename_1_prt_5 | 5             | FOR VALUES FROM (2005) TO (2006)
 (6 rows)
 
 CREATE TABLE mpp3059b (f1 time(2) with time zone, f2 char(4))
@@ -2079,12 +2079,12 @@ partition by list (f2)
   partition est values ('EST')
 );
 alter table mpp3059b rename partition pst to "pacific time"; 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059b') as t, pg_class as c where relid = oid;
-             relid             | parentrelid | isleaf | level |      pg_get_expr       
--------------------------------+-------------+--------+-------+------------------------
- mpp3059b                      |             | f      |     0 | 
- "mpp3059b_1_prt_pacific time" | mpp3059b    | t      |     1 | FOR VALUES IN ('PST ')
- mpp3059b_1_prt_est            | mpp3059b    | t      |     1 | FOR VALUES IN ('EST ')
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059b';
+ tablename | partitionlevel |      partitiontablename       | partitionname |   partitionboundary    
+-----------+----------------+-------------------------------+---------------+------------------------
+ mpp3059b  |              0 | mpp3059b                      |               | 
+ mpp3059b  |              1 | "mpp3059b_1_prt_pacific time" |               | FOR VALUES IN ('PST ')
+ mpp3059b  |              1 | mpp3059b_1_prt_est            | est           | FOR VALUES IN ('EST ')
 (3 rows)
 
 CREATE TABLE mpp3059c (f1 time(2) with time zone, f2 char(4))
@@ -2099,16 +2099,16 @@ start (time '01:00')
 );
 alter table mpp3059c rename partition pst to pacific;
 alter table mpp3059c rename partition est to "Eastern Time";
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059c') as t, pg_class as c where relid = oid;
-                 relid                 |          parentrelid          | isleaf | level |                    pg_get_expr                     
----------------------------------------+-------------------------------+--------+-------+----------------------------------------------------
- mpp3059c                              |                               | f      |     0 | 
- mpp3059c_1_prt_pacific                | mpp3059c                      | f      |     1 | FOR VALUES IN ('PST ')
- "mpp3059c_1_prt_Eastern Time"         | mpp3059c                      | f      |     1 | FOR VALUES IN ('EST ')
- mpp3059c_1_prt_pacific_2_prt_1        | mpp3059c_1_prt_pacific        | t      |     2 | FOR VALUES FROM ('00:00:00-07') TO ('01:00:00-07')
- mpp3059c_1_prt_pacific_2_prt_2        | mpp3059c_1_prt_pacific        | t      |     2 | FOR VALUES FROM ('01:00:00-07') TO (MAXVALUE)
- "mpp3059c_1_prt_Eastern Time_2_prt_1" | "mpp3059c_1_prt_Eastern Time" | t      |     2 | FOR VALUES FROM ('00:00:00-07') TO ('01:00:00-07')
- "mpp3059c_1_prt_Eastern Time_2_prt_2" | "mpp3059c_1_prt_Eastern Time" | t      |     2 | FOR VALUES FROM ('01:00:00-07') TO (MAXVALUE)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059c';
+ tablename | partitionlevel |          partitiontablename           | partitionname |                 partitionboundary                  
+-----------+----------------+---------------------------------------+---------------+----------------------------------------------------
+ mpp3059c  |              0 | mpp3059c                              |               | 
+ mpp3059c  |              1 | mpp3059c_1_prt_pacific                | pacific       | FOR VALUES IN ('PST ')
+ mpp3059c  |              1 | "mpp3059c_1_prt_Eastern Time"         |               | FOR VALUES IN ('EST ')
+ mpp3059c  |              2 | mpp3059c_1_prt_pacific_2_prt_1        | 1             | FOR VALUES FROM ('00:00:00-07') TO ('01:00:00-07')
+ mpp3059c  |              2 | mpp3059c_1_prt_pacific_2_prt_2        | 2             | FOR VALUES FROM ('01:00:00-07') TO (MAXVALUE)
+ mpp3059c  |              2 | "mpp3059c_1_prt_Eastern Time_2_prt_1" |               | FOR VALUES FROM ('00:00:00-07') TO ('01:00:00-07')
+ mpp3059c  |              2 | "mpp3059c_1_prt_Eastern Time_2_prt_2" |               | FOR VALUES FROM ('01:00:00-07') TO (MAXVALUE)
 (7 rows)
 
 CREATE TABLE mpp3059d (f1 time(2) with time zone, f2 char(4), f3 varchar(10))
@@ -2122,16 +2122,16 @@ subpartition template (
   partition est values ('EST')
 );
 alter table mpp3059d rename partition pst to pacific;
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3059d') as t, pg_class as c where relid = oid;
-                relid                |      parentrelid       | isleaf | level |          pg_get_expr          
--------------------------------------+------------------------+--------+-------+-------------------------------
- mpp3059d                            |                        | f      |     0 | 
- mpp3059d_1_prt_pacific              | mpp3059d               | f      |     1 | FOR VALUES IN ('PST ')
- mpp3059d_1_prt_est                  | mpp3059d               | f      |     1 | FOR VALUES IN ('EST ')
- mpp3059d_1_prt_pacific_2_prt_male   | mpp3059d_1_prt_pacific | t      |     2 | FOR VALUES IN ('Male', 'M')
- mpp3059d_1_prt_pacific_2_prt_female | mpp3059d_1_prt_pacific | t      |     2 | FOR VALUES IN ('Female', 'F')
- mpp3059d_1_prt_est_2_prt_male       | mpp3059d_1_prt_est     | t      |     2 | FOR VALUES IN ('Male', 'M')
- mpp3059d_1_prt_est_2_prt_female     | mpp3059d_1_prt_est     | t      |     2 | FOR VALUES IN ('Female', 'F')
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3059d';
+ tablename | partitionlevel |         partitiontablename          | partitionname |       partitionboundary       
+-----------+----------------+-------------------------------------+---------------+-------------------------------
+ mpp3059d  |              0 | mpp3059d                            |               | 
+ mpp3059d  |              1 | mpp3059d_1_prt_pacific              | pacific       | FOR VALUES IN ('PST ')
+ mpp3059d  |              1 | mpp3059d_1_prt_est                  | est           | FOR VALUES IN ('EST ')
+ mpp3059d  |              2 | mpp3059d_1_prt_pacific_2_prt_male   | male          | FOR VALUES IN ('Male', 'M')
+ mpp3059d  |              2 | mpp3059d_1_prt_pacific_2_prt_female | female        | FOR VALUES IN ('Female', 'F')
+ mpp3059d  |              2 | mpp3059d_1_prt_est_2_prt_male       | male          | FOR VALUES IN ('Male', 'M')
+ mpp3059d  |              2 | mpp3059d_1_prt_est_2_prt_female     | female        | FOR VALUES IN ('Female', 'F')
 (7 rows)
 
 create table test_khush (a integer, b date, c varchar(30))
@@ -2607,34 +2607,34 @@ partition by range (q1)
 CREATE TABLE mpp3079a(q1 int2, q2 int2)
 partition by range (q1)
 (start (1) end (10) every (1));
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3079') as t, pg_class as c where relid = oid;
-      relid      | parentrelid | isleaf | level |           pg_get_expr           
------------------+-------------+--------+-------+---------------------------------
- mpp3079         |             | f      |     0 | 
- mpp3079_1_prt_1 | mpp3079     | t      |     1 | FOR VALUES FROM ('1') TO ('2')
- mpp3079_1_prt_2 | mpp3079     | t      |     1 | FOR VALUES FROM ('2') TO ('3')
- mpp3079_1_prt_3 | mpp3079     | t      |     1 | FOR VALUES FROM ('3') TO ('4')
- mpp3079_1_prt_4 | mpp3079     | t      |     1 | FOR VALUES FROM ('4') TO ('5')
- mpp3079_1_prt_5 | mpp3079     | t      |     1 | FOR VALUES FROM ('5') TO ('6')
- mpp3079_1_prt_6 | mpp3079     | t      |     1 | FOR VALUES FROM ('6') TO ('7')
- mpp3079_1_prt_7 | mpp3079     | t      |     1 | FOR VALUES FROM ('7') TO ('8')
- mpp3079_1_prt_8 | mpp3079     | t      |     1 | FOR VALUES FROM ('8') TO ('9')
- mpp3079_1_prt_9 | mpp3079     | t      |     1 | FOR VALUES FROM ('9') TO ('10')
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3079';
+ tablename | partitionlevel | partitiontablename | partitionname |        partitionboundary        
+-----------+----------------+--------------------+---------------+---------------------------------
+ mpp3079   |              0 | mpp3079            |               | 
+ mpp3079   |              1 | mpp3079_1_prt_1    | 1             | FOR VALUES FROM ('1') TO ('2')
+ mpp3079   |              1 | mpp3079_1_prt_2    | 2             | FOR VALUES FROM ('2') TO ('3')
+ mpp3079   |              1 | mpp3079_1_prt_3    | 3             | FOR VALUES FROM ('3') TO ('4')
+ mpp3079   |              1 | mpp3079_1_prt_4    | 4             | FOR VALUES FROM ('4') TO ('5')
+ mpp3079   |              1 | mpp3079_1_prt_5    | 5             | FOR VALUES FROM ('5') TO ('6')
+ mpp3079   |              1 | mpp3079_1_prt_6    | 6             | FOR VALUES FROM ('6') TO ('7')
+ mpp3079   |              1 | mpp3079_1_prt_7    | 7             | FOR VALUES FROM ('7') TO ('8')
+ mpp3079   |              1 | mpp3079_1_prt_8    | 8             | FOR VALUES FROM ('8') TO ('9')
+ mpp3079   |              1 | mpp3079_1_prt_9    | 9             | FOR VALUES FROM ('9') TO ('10')
 (10 rows)
 
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3079a') as t, pg_class as c where relid = oid;
-      relid       | parentrelid | isleaf | level |           pg_get_expr           
-------------------+-------------+--------+-------+---------------------------------
- mpp3079a         |             | f      |     0 | 
- mpp3079a_1_prt_1 | mpp3079a    | t      |     1 | FOR VALUES FROM ('1') TO ('2')
- mpp3079a_1_prt_2 | mpp3079a    | t      |     1 | FOR VALUES FROM ('2') TO ('3')
- mpp3079a_1_prt_3 | mpp3079a    | t      |     1 | FOR VALUES FROM ('3') TO ('4')
- mpp3079a_1_prt_4 | mpp3079a    | t      |     1 | FOR VALUES FROM ('4') TO ('5')
- mpp3079a_1_prt_5 | mpp3079a    | t      |     1 | FOR VALUES FROM ('5') TO ('6')
- mpp3079a_1_prt_6 | mpp3079a    | t      |     1 | FOR VALUES FROM ('6') TO ('7')
- mpp3079a_1_prt_7 | mpp3079a    | t      |     1 | FOR VALUES FROM ('7') TO ('8')
- mpp3079a_1_prt_8 | mpp3079a    | t      |     1 | FOR VALUES FROM ('8') TO ('9')
- mpp3079a_1_prt_9 | mpp3079a    | t      |     1 | FOR VALUES FROM ('9') TO ('10')
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3079a';
+ tablename | partitionlevel | partitiontablename | partitionname |        partitionboundary        
+-----------+----------------+--------------------+---------------+---------------------------------
+ mpp3079a  |              0 | mpp3079a           |               | 
+ mpp3079a  |              1 | mpp3079a_1_prt_1   | 1             | FOR VALUES FROM ('1') TO ('2')
+ mpp3079a  |              1 | mpp3079a_1_prt_2   | 2             | FOR VALUES FROM ('2') TO ('3')
+ mpp3079a  |              1 | mpp3079a_1_prt_3   | 3             | FOR VALUES FROM ('3') TO ('4')
+ mpp3079a  |              1 | mpp3079a_1_prt_4   | 4             | FOR VALUES FROM ('4') TO ('5')
+ mpp3079a  |              1 | mpp3079a_1_prt_5   | 5             | FOR VALUES FROM ('5') TO ('6')
+ mpp3079a  |              1 | mpp3079a_1_prt_6   | 6             | FOR VALUES FROM ('6') TO ('7')
+ mpp3079a  |              1 | mpp3079a_1_prt_7   | 7             | FOR VALUES FROM ('7') TO ('8')
+ mpp3079a  |              1 | mpp3079a_1_prt_8   | 8             | FOR VALUES FROM ('8') TO ('9')
+ mpp3079a  |              1 | mpp3079a_1_prt_9   | 9             | FOR VALUES FROM ('9') TO ('10')
 (10 rows)
 
 drop table mpp3079;
@@ -2649,20 +2649,20 @@ insert into mpp3242 values(-1);
 -- automatic.
 alter table mpp3242 add partition zz start ('-1') end (0);
 ERROR:  updated partition constraint for default partition "mpp3242_1_prt_default_part" would be violated by some row  (seg2 127.0.1.1:7004 pid=10757)
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3242') as t, pg_class as c where relid = oid;
-           relid            | parentrelid | isleaf | level |         pg_get_expr         
-----------------------------+-------------+--------+-------+-----------------------------
- mpp3242                    |             | f      |     0 | 
- mpp3242_1_prt_aa_1         | mpp3242     | t      |     1 | FOR VALUES FROM (1) TO (2)
- mpp3242_1_prt_aa_2         | mpp3242     | t      |     1 | FOR VALUES FROM (2) TO (3)
- mpp3242_1_prt_aa_3         | mpp3242     | t      |     1 | FOR VALUES FROM (3) TO (4)
- mpp3242_1_prt_aa_4         | mpp3242     | t      |     1 | FOR VALUES FROM (4) TO (5)
- mpp3242_1_prt_aa_5         | mpp3242     | t      |     1 | FOR VALUES FROM (5) TO (6)
- mpp3242_1_prt_aa_6         | mpp3242     | t      |     1 | FOR VALUES FROM (6) TO (7)
- mpp3242_1_prt_aa_7         | mpp3242     | t      |     1 | FOR VALUES FROM (7) TO (8)
- mpp3242_1_prt_aa_8         | mpp3242     | t      |     1 | FOR VALUES FROM (8) TO (9)
- mpp3242_1_prt_aa_9         | mpp3242     | t      |     1 | FOR VALUES FROM (9) TO (10)
- mpp3242_1_prt_default_part | mpp3242     | t      |     1 | DEFAULT
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3242';
+ tablename | partitionlevel |     partitiontablename     | partitionname |      partitionboundary      
+-----------+----------------+----------------------------+---------------+-----------------------------
+ mpp3242   |              0 | mpp3242                    |               | 
+ mpp3242   |              1 | mpp3242_1_prt_aa_1         | aa_1          | FOR VALUES FROM (1) TO (2)
+ mpp3242   |              1 | mpp3242_1_prt_aa_2         | aa_2          | FOR VALUES FROM (2) TO (3)
+ mpp3242   |              1 | mpp3242_1_prt_aa_3         | aa_3          | FOR VALUES FROM (3) TO (4)
+ mpp3242   |              1 | mpp3242_1_prt_aa_4         | aa_4          | FOR VALUES FROM (4) TO (5)
+ mpp3242   |              1 | mpp3242_1_prt_aa_5         | aa_5          | FOR VALUES FROM (5) TO (6)
+ mpp3242   |              1 | mpp3242_1_prt_aa_6         | aa_6          | FOR VALUES FROM (6) TO (7)
+ mpp3242   |              1 | mpp3242_1_prt_aa_7         | aa_7          | FOR VALUES FROM (7) TO (8)
+ mpp3242   |              1 | mpp3242_1_prt_aa_8         | aa_8          | FOR VALUES FROM (8) TO (9)
+ mpp3242   |              1 | mpp3242_1_prt_aa_9         | aa_9          | FOR VALUES FROM (9) TO (10)
+ mpp3242   |              1 | mpp3242_1_prt_default_part | default_part  | DEFAULT
 (11 rows)
 
 drop table mpp3242;
@@ -2806,14 +2806,14 @@ CREATE TABLE mpp3080_numericbig (id int4, val numeric(1000,800))
 partition by range (val)
 (start (1) end (5) every (1));
 -- order 1,5
-select t.*, pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3080_numericbig') as t, pg_class as c where relid = oid order by 1,5;
-           relid            |    parentrelid     | isleaf | level |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         pg_get_expr                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
-----------------------------+--------------------+--------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- mpp3080_numericbig         |                    | f      |     0 | 
- mpp3080_numericbig_1_prt_1 | mpp3080_numericbig | t      |     1 | FOR VALUES FROM (1.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (2.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
- mpp3080_numericbig_1_prt_2 | mpp3080_numericbig | t      |     1 | FOR VALUES FROM (2.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (3.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
- mpp3080_numericbig_1_prt_3 | mpp3080_numericbig | t      |     1 | FOR VALUES FROM (3.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (4.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
- mpp3080_numericbig_1_prt_4 | mpp3080_numericbig | t      |     1 | FOR VALUES FROM (4.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (5.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+select tablename, partitionlevel, partitiontablename, partitionname, partitionboundary from pg_partitions where tablename = 'mpp3080_numericbig' order by 1,5;
+     tablename      | partitionlevel |     partitiontablename     | partitionname |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      partitionboundary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+--------------------+----------------+----------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ mpp3080_numericbig |              1 | mpp3080_numericbig_1_prt_1 | 1             | FOR VALUES FROM (1.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (2.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+ mpp3080_numericbig |              1 | mpp3080_numericbig_1_prt_2 | 2             | FOR VALUES FROM (2.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (3.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+ mpp3080_numericbig |              1 | mpp3080_numericbig_1_prt_3 | 3             | FOR VALUES FROM (3.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (4.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+ mpp3080_numericbig |              1 | mpp3080_numericbig_1_prt_4 | 4             | FOR VALUES FROM (4.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000) TO (5.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+ mpp3080_numericbig |              0 | mpp3080_numericbig         |               | 
 (5 rows)
 
 create temp TABLE temp_hour_range (f1 time(2))

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -336,7 +336,7 @@ alter table alter_aocs_part_table drop partition for (1);
 alter table alter_aocs_part_table split default partition start(6) inclusive end(7) exclusive;
 alter table alter_aocs_part_table split default partition start(6) inclusive end(8) exclusive;
 alter table alter_aocs_part_table split default partition start(7) inclusive end(8) exclusive;
-\d+ alter_aocs_part_table
+select partitionisdefault, partitionboundary from pg_partitions where tablename = 'alter_aocs_part_table';
 create table alter_aocs_ao_table (a int, b int) with (appendonly=true) distributed by (a);
 insert into alter_aocs_ao_table values (2,2);
 alter table alter_aocs_part_table exchange partition for (2) with table alter_aocs_ao_table;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -548,7 +548,7 @@ create table mpp3512a (like mpp3512_part);
 
 \d mpp3512
 \d mpp3512a
-select relid,parentrelid,isleaf,level, pg_catalog.pg_get_expr(relpartbound, oid) from pg_partition_tree('mpp3512_part'), pg_class where relid = oid;
+select * from pg_partitions where tablename='mpp3512_part';
 
 drop table mpp3512;
 drop table mpp3512_part;
@@ -1626,6 +1626,7 @@ drop table partition_cleanup1;
 drop schema partition_999 cascade;
 
 -- These should be empty
+select 'pg_partitions', count(*) from pg_partitions where tablename='partition_cleanup%';
 select relid, level, template from gp_partition_template where not exists (select oid from pg_class where oid = relid);
 
 


### PR DESCRIPTION
After pg12 merge, the below fields are not included in the current
pg_partitions table:
- partitionrank
- partitionlistvalues
- partitionrangestart
- partitionstartinclusive
- partitionrangeend
- partitionendinclusive
- partitioneveryclause

For the 'partitionname' and 'parentpartitionname', if user using pg's
syntax to attach new partition table, the name may not follow the
gpdb's partition table name pattern, then pg_partitions will return
null value for these two fields.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
