### PR TITLE
Support two stage agg for Single-DQA-With-Group.

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -632,7 +632,13 @@ add_first_stage_group_agg_path(PlannerInfo *root,
 
 		dqa_type = recognize_dqa_type(ctx);
 
-		if (dqa_type != SINGLE_DQA)
+		/* For the query:
+		 *     select count(distinct a), sum(b), sum(c) from t;
+		 * If t is distributed by (a), we can also use multi stage
+		 * agg because two same a cannot be in different segments.
+		 * So we should also consider SINGLE_DQA_WITHAGG here.
+		 */
+		if (dqa_type != SINGLE_DQA && dqa_type != SINGLE_DQA_WITHAGG)
 			return;
 
 		fetch_single_dqa_info(root, path, ctx, &info);

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2169,3 +2169,21 @@ explain select count(distinct a) filter (where a > 3),count( distinct b) filter 
  Optimizer: Postgres query optimizer
 (11 rows)
 
+-- single DQA with agg
+-- the following SQL should use two stage agg
+explain select count(distinct a), sum(b), sum(c) from dqa_f1;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=490.45..490.46 rows=1 width=24)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=488.42..490.43 rows=3 width=24)
+         ->  Partial Aggregate  (cost=488.42..488.43 rows=1 width=24)
+               ->  Seq Scan on dqa_f1  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select count(distinct a), sum(b), sum(c) from dqa_f1;
+ count | sum  | sum  
+-------+------+------
+    17 | 2000 | 1000
+(1 row)
+

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2163,3 +2163,21 @@ explain select count(distinct a) filter (where a > 3),count( distinct b) filter 
  Optimizer: Postgres query optimizer
 (11 rows)
 
+-- single DQA with agg
+-- the following SQL should use two stage agg
+explain select count(distinct a), sum(b), sum(c) from dqa_f1;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=24)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=24)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=24)
+               ->  Seq Scan on dqa_f1  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(distinct a), sum(b), sum(c) from dqa_f1;
+ count | sum  | sum  
+-------+------+------
+    17 | 2000 | 1000
+(1 row)
+

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -346,3 +346,9 @@ explain select sum(distinct a) filter (where a in (select x from dqa_f2 where x 
 explain select sum(distinct a) filter (where a in (select x from dqa_f2 where x = a)), sum(distinct b) filter (where a > 0) from dqa_f1 group by c;
 
 explain select count(distinct a) filter (where a > 3),count( distinct b) filter (where a > 4), sum(distinct b) filter( where a > 4) from dqa_f1;
+
+
+-- single DQA with agg
+-- the following SQL should use two stage agg
+explain select count(distinct a), sum(b), sum(c) from dqa_f1;
+select count(distinct a), sum(b), sum(c) from dqa_f1;


### PR DESCRIPTION
For the following query:

   create table t(a int, b int, c int) distributed by (a);
   select count(distinct a), sum(b), sum(c) from t;

Planner will gather first gather all tuples into QD and
then do a single agg. However, ORCA and 6X's planner will
choose two-stage agg. If the data is huge and first stage
can remove much data, two-stage agg plan is much faster.

It seems such regression is because we forget the Single-DQA-With-Group
case in the function add_first_stage_group_agg_path. This commit
adds back two stage agg plan for this kind of query.
