### PR TITLE
 Extend use of DbgPrintMixin to more classes 

### DIFF
--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
@@ -32,7 +32,8 @@ using namespace gpos;
 //		Parameters in GPDB cost model
 //
 //---------------------------------------------------------------------------
-class CCostModelParamsGPDB : public ICostModelParams
+class CCostModelParamsGPDB : public ICostModelParams,
+							 public DbgPrintMixin<CCostModelParamsGPDB>
 {
 public:
 	// enumeration of cost model params

--- a/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
@@ -16,6 +16,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CCostModelParamsGPDB);
+
 // sequential i/o bandwidth
 const CDouble CCostModelParamsGPDB::DSeqIOBandwidthVal = 1024.0;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
@@ -50,7 +50,7 @@ class CCTEReq;
 //		CTE map that is derived as part of plan properties
 //
 //---------------------------------------------------------------------------
-class CCTEMap : public CRefCount
+class CCTEMap : public CRefCount, public DbgPrintMixin<CCTEMap>
 {
 public:
 	// CTE types
@@ -73,7 +73,7 @@ private:
 	//		the plan rooted by producer node.
 	//
 	//---------------------------------------------------------------------------
-	class CCTEMapEntry : public CRefCount
+	class CCTEMapEntry : public CRefCount, public DbgPrintMixin<CCTEMapEntry>
 	{
 	private:
 		// cte id

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
@@ -35,7 +35,7 @@ using namespace gpos;
 //		CTE requirements
 //
 //---------------------------------------------------------------------------
-class CCTEReq : public CRefCount
+class CCTEReq : public CRefCount, public DbgPrintMixin<CCTEReq>
 {
 private:
 	//---------------------------------------------------------------------------
@@ -46,7 +46,7 @@ private:
 	//		A single entry in the CTE requirement
 	//
 	//---------------------------------------------------------------------------
-	class CCTEReqEntry : public CRefCount
+	class CCTEReqEntry : public CRefCount, public DbgPrintMixin<CCTEReqEntry>
 	{
 	private:
 		// cte id

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
@@ -48,7 +48,7 @@ typedef CHashMap<INT, CColRef, gpos::HashValue<INT>, gpos::Equals<INT>,
 //		member functions inaccessible
 //
 //---------------------------------------------------------------------------
-class CColRefSet : public CBitSet
+class CColRefSet : public CBitSet, public DbgPrintMixin<CColRefSet>
 {
 	// bitset iter needs to access internals
 	friend class CColRefSetIter;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -58,7 +58,7 @@ typedef CHashMap<ULONG, CConstraint, gpos::HashValue<ULONG>,
 //		Base class for representing constraints
 //
 //---------------------------------------------------------------------------
-class CConstraint : public CRefCount
+class CConstraint : public CRefCount, public DbgPrintMixin<CConstraint>
 {
 public:
 	enum EConstraintType

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
@@ -51,7 +51,7 @@ typedef const CCostContext *CONST_COSTCTXT_PTR;
 //		Cost context
 //
 //---------------------------------------------------------------------------
-class CCostContext : public CRefCount
+class CCostContext : public CRefCount, public DbgPrintMixin<CCostContext>
 {
 public:
 	// states of cost context

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CRefCount.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 
 namespace gpopt
@@ -62,7 +63,7 @@ typedef CDynamicPtrArray<CDrvdProp, CleanupRelease> CDrvdPropArray;
 //		CExpressionHandle::DeriveProps().
 //
 //---------------------------------------------------------------------------
-class CDrvdProp : public CRefCount
+class CDrvdProp : public CRefCount, public DbgPrintMixin<CDrvdProp>
 {
 public:
 	// types of derived properties

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
@@ -35,7 +35,7 @@ class CReqdPropPlan;
 //		Abstract base class for all enforceable properties.
 //
 //---------------------------------------------------------------------------
-class CEnfdProp : public CRefCount
+class CEnfdProp : public CRefCount, public DbgPrintMixin<CEnfdProp>
 {
 public:
 	// Definition of property enforcing type for a given operator.

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionProp.h
@@ -29,7 +29,7 @@ using namespace gpmd;
 //		Representation of function properties
 //
 //---------------------------------------------------------------------------
-class CFunctionProp : public CRefCount
+class CFunctionProp : public CRefCount, public DbgPrintMixin<CFunctionProp>
 {
 private:
 	// function stability

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
@@ -37,7 +37,8 @@ using namespace gpos;
 //		Functional dependency representation
 //
 //---------------------------------------------------------------------------
-class CFunctionalDependency : public CRefCount
+class CFunctionalDependency : public CRefCount,
+							  public DbgPrintMixin<CFunctionalDependency>
 {
 private:
 	// the left hand side of the FD

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
@@ -30,7 +30,7 @@ using namespace gpos;
 //		Captures sets of keys for a relation
 //
 //---------------------------------------------------------------------------
-class CKeyCollection : public CRefCount
+class CKeyCollection : public CRefCount, public DbgPrintMixin<CKeyCollection>
 {
 private:
 	// array of key sets

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
@@ -13,6 +13,7 @@
 #define GPOPT_COptimizationContext_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/task/CAutoTraceFlag.h"
 
 #include "gpopt/base/CReqdPropPlan.h"
@@ -48,7 +49,8 @@ typedef CDynamicPtrArray<COptimizationContext, CleanupRelease>
 //		Optimization context
 //
 //---------------------------------------------------------------------------
-class COptimizationContext : public CRefCount
+class COptimizationContext : public CRefCount,
+							 public DbgPrintMixin<COptimizationContext>
 {
 public:
 	// states of optimization context

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
@@ -38,7 +38,7 @@ class CPartConstraint;
 //		Derived partition information at the logical level
 //
 //---------------------------------------------------------------------------
-class CPartInfo : public CRefCount
+class CPartInfo : public CRefCount, public DbgPrintMixin<CPartInfo>
 {
 private:
 	//---------------------------------------------------------------------------
@@ -49,7 +49,8 @@ private:
 	//		A single entry of the CPartInfo
 	//
 	//---------------------------------------------------------------------------
-	class CPartInfoEntry : public CRefCount
+	class CPartInfoEntry : public CRefCount,
+						   public DbgPrintMixin<CPartInfoEntry>
 	{
 	private:
 		// scan id

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
@@ -34,7 +34,7 @@ typedef CDynamicPtrArray<CPartKeys, CleanupRelease> CPartKeysArray;
 //		A collection of partitioning keys for a partitioned table
 //
 //---------------------------------------------------------------------------
-class CPartKeys : public CRefCount
+class CPartKeys : public CRefCount, public DbgPrintMixin<CPartKeys>
 {
 private:
 	// partitioning keys

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPropConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPropConstraint.h
@@ -33,7 +33,7 @@ class CExpression;
 //		Representation of constraint property
 //
 //---------------------------------------------------------------------------
-class CPropConstraint : public CRefCount
+class CPropConstraint : public CRefCount, public DbgPrintMixin<CPropConstraint>
 {
 private:
 	// array of equivalence classes

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h
@@ -31,7 +31,7 @@ class CReqdPropPlan;
 //		Property specification
 //
 //---------------------------------------------------------------------------
-class CPropSpec : public CRefCount
+class CPropSpec : public CRefCount, public DbgPrintMixin<CPropSpec>
 {
 public:
 	// property type
@@ -83,6 +83,8 @@ operator<<(IOstream &os, const CPropSpec &ospec)
 }
 
 }  // namespace gpopt
+
+FORCE_GENERATE_DBGSTR(gpopt::CPropSpec);
 
 #endif	// !GPOPT_CPropSpec_H
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
@@ -48,7 +48,7 @@ using namespace gpos;
 //
 //
 //---------------------------------------------------------------------------
-class CQueryContext
+class CQueryContext : public DbgPrintMixin<CQueryContext>
 {
 private:
 	// required plan properties in optimizer's produced plan

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
@@ -44,7 +44,7 @@ class IComparator;
 //		Representation of a range of values
 //
 //---------------------------------------------------------------------------
-class CRange : public CRefCount
+class CRange : public CRefCount, public DbgPrintMixin<CRange>
 {
 public:
 	enum ERangeInclusion

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CRefCount.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CDrvdProp.h"
 
@@ -64,7 +65,7 @@ typedef CDynamicPtrArray<CReqdProp, CleanupRelease> CReqdPropArray;
 //		children.
 //
 //---------------------------------------------------------------------------
-class CReqdProp : public CRefCount
+class CReqdProp : public CRefCount, public DbgPrintMixin<CReqdProp>
 {
 public:
 	// types of required properties

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
@@ -34,7 +34,7 @@ using namespace gpos;
 //		Description of window frame
 //
 //---------------------------------------------------------------------------
-class CWindowFrame : public CRefCount
+class CWindowFrame : public CRefCount, public DbgPrintMixin<CWindowFrame>
 {
 public:
 	// specification method

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CEngine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CEngine.h
@@ -42,7 +42,7 @@ class CEnumeratorConfig;
 //		Optimization engine; owns entire optimization workflow
 //
 //---------------------------------------------------------------------------
-class CEngine
+class CEngine : public DbgPrintMixin<CEngine>
 {
 private:
 	// memory pool

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
@@ -31,7 +31,8 @@ using namespace gpmd;
 //		column descriptor;
 //
 //---------------------------------------------------------------------------
-class CColumnDescriptor : public CRefCount
+class CColumnDescriptor : public CRefCount,
+						  public DbgPrintMixin<CColumnDescriptor>
 {
 private:
 	// type information

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
@@ -33,7 +33,8 @@ using namespace gpmd;
 //		Base class for index descriptor
 //
 //---------------------------------------------------------------------------
-class CIndexDescriptor : public CRefCount
+class CIndexDescriptor : public CRefCount,
+						 public DbgPrintMixin<CIndexDescriptor>
 {
 private:
 	// mdid of the index

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CName.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CName.h
@@ -13,6 +13,7 @@
 #define GPOPT_CName_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/string/CWStringConst.h"
 
 #define GPOPT_NAME_QUOTE_BEGIN "\""
@@ -34,7 +35,7 @@ using namespace gpos;
 //		enforced is zero termination of string;
 //
 //---------------------------------------------------------------------------
-class CName
+class CName : public DbgPrintMixin<CName>
 {
 private:
 	// actual name

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
@@ -46,7 +46,7 @@ typedef CHashMapIter<ULONG, CPartConstraint, gpos::HashValue<ULONG>,
 //		metadata abstraction for tables
 //
 //---------------------------------------------------------------------------
-class CPartConstraint : public CRefCount
+class CPartConstraint : public CRefCount, public DbgPrintMixin<CPartConstraint>
 {
 private:
 	// constraints for different levels

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -41,7 +41,8 @@ typedef CDynamicPtrArray<CBitSet, CleanupRelease> CBitSetArray;
 //		metadata abstraction for tables
 //
 //---------------------------------------------------------------------------
-class CTableDescriptor : public CRefCount
+class CTableDescriptor : public CRefCount,
+						 public DbgPrintMixin<CTableDescriptor>
 {
 private:
 	// memory pool

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -46,7 +46,7 @@ typedef CHashMap<CColRef, CColRef, CColRef::HashValue, CColRef::Equals,
 //		base class for all operators
 //
 //---------------------------------------------------------------------------
-class COperator : public CRefCount
+class COperator : public CRefCount, public DbgPrintMixin<COperator>
 {
 private:
 protected:

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -70,7 +70,7 @@ enum EOptimizationLevel
 //		Group of equivalent expressions in the Memo structure
 //
 //---------------------------------------------------------------------------
-class CGroup : public CRefCount
+class CGroup : public CRefCount, public DbgPrintMixin<CGroup>
 {
 	friend class CGroupProxy;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -34,7 +34,8 @@ using namespace gpos;
 //		Expression representation inside Memo structure
 //
 //---------------------------------------------------------------------------
-class CGroupExpression : public CRefCount
+class CGroupExpression : public CRefCount,
+						 public DbgPrintMixin<CGroupExpression>
 {
 public:
 #ifdef GPOS_DEBUG

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
@@ -13,6 +13,7 @@
 
 #include "gpos/base.h"
 #include "gpos/common/CList.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/task/ITask.h"
 
 namespace gpopt
@@ -78,7 +79,7 @@ class CSchedulerContext;
 //		about how job are scheduled.
 //
 //---------------------------------------------------------------------------
-class CJob
+class CJob : public DbgPrintMixin<CJob>
 {
 	// friends
 	friend class CJobFactory;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
@@ -38,7 +38,7 @@ typedef CDynamicPtrArray<CSearchStage, CleanupDelete> CSearchStageArray;
 //		Search stage
 //
 //---------------------------------------------------------------------------
-class CSearchStage
+class CSearchStage : public DbgPrintMixin<CSearchStage>
 {
 private:
 	// set of xforms to be applied during stage

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
@@ -32,7 +32,7 @@ using namespace gpos;
 //		Helper class for creating compact join orders
 //
 //---------------------------------------------------------------------------
-class CJoinOrder
+class CJoinOrder : public DbgPrintMixin<CJoinOrder>
 {
 public:
 	enum EPosition
@@ -51,7 +51,7 @@ public:
 	//		Struct to capture edge
 	//
 	//---------------------------------------------------------------------------
-	struct SEdge : public CRefCount
+	struct SEdge : public CRefCount, public DbgPrintMixin<SEdge>
 	{
 		// cover of edge
 		CBitSet *m_pbs;
@@ -88,7 +88,7 @@ public:
 	//		Struct to capture component
 	//
 	//---------------------------------------------------------------------------
-	struct SComponent : public CRefCount
+	struct SComponent : public CRefCount, public DbgPrintMixin<SComponent>
 	{
 		// cover
 		CBitSet *m_pbs;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -44,7 +44,7 @@ using namespace gpos;
 //		base class for all transformations
 //
 //---------------------------------------------------------------------------
-class CXform : public CRefCount
+class CXform : public CRefCount, public DbgPrintMixin<CXform>
 {
 private:
 	// pattern

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
@@ -27,7 +27,7 @@ using namespace gpos;
 //		result container
 //
 //---------------------------------------------------------------------------
-class CXformResult : public CRefCount
+class CXformResult : public CRefCount, public DbgPrintMixin<CXformResult>
 {
 private:
 	// set of alternatives

--- a/src/backend/gporca/libgpopt/src/base/CCTEMap.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEMap.cpp
@@ -17,6 +17,9 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CCTEMap);
+FORCE_GENERATE_DBGSTR(CCTEMap::CCTEMapEntry);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CCTEMap::CCTEMap

--- a/src/backend/gporca/libgpopt/src/base/CCTEReq.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEReq.cpp
@@ -17,6 +17,9 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CCTEReq);
+FORCE_GENERATE_DBGSTR(CCTEReq::CCTEReqEntry);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CCTEReq::CCTEReqEntry::CCTEReqEntry

--- a/src/backend/gporca/libgpopt/src/base/CColRefSet.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRefSet.cpp
@@ -19,6 +19,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CColRefSet);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
@@ -36,6 +36,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CConstraint);
+
 // initialize constant true
 BOOL CConstraint::m_fTrue(true);
 

--- a/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
@@ -35,6 +35,8 @@
 using namespace gpopt;
 using namespace gpnaucrates;
 
+FORCE_GENERATE_DBGSTR(CCostContext);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CCostContext::CCostContext

--- a/src/backend/gporca/libgpopt/src/base/CDrvdProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdProp.cpp
@@ -21,6 +21,8 @@
 #include "gpopt/base/COptCtxt.h"
 #endif	// GPOS_DEBUG
 
+FORCE_GENERATE_DBGSTR(gpopt::CDrvdProp);
+
 namespace gpopt
 {
 CDrvdProp::CDrvdProp() = default;

--- a/src/backend/gporca/libgpopt/src/base/CEnfdProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CEnfdProp.cpp
@@ -19,6 +19,8 @@
 #include "gpopt/base/COptCtxt.h"
 #endif	// GPOS_DEBUG
 
+FORCE_GENERATE_DBGSTR(gpopt::CEnfdProp);
+
 namespace gpopt
 {
 IOstream &

--- a/src/backend/gporca/libgpopt/src/base/CFunctionProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CFunctionProp.cpp
@@ -15,6 +15,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CFunctionProp);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CFunctionProp::CFunctionProp

--- a/src/backend/gporca/libgpopt/src/base/CFunctionalDependency.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CFunctionalDependency.cpp
@@ -18,6 +18,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CFunctionalDependency);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
@@ -17,6 +17,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CKeyCollection);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CKeyCollection::CKeyCollection

--- a/src/backend/gporca/libgpopt/src/base/COptimizationContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COptimizationContext.cpp
@@ -28,6 +28,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(COptimizationContext);
 
 // invalid optimization context
 const COptimizationContext COptimizationContext::m_ocInvalid;

--- a/src/backend/gporca/libgpopt/src/base/CPartInfo.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartInfo.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPartInfo);
+FORCE_GENERATE_DBGSTR(CPartInfo::CPartInfoEntry);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CPartKeys.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartKeys.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPartKeys);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPartKeys::CPartKeys

--- a/src/backend/gporca/libgpopt/src/base/CPropConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPropConstraint.cpp
@@ -20,6 +20,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPropConstraint);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPropConstraint::CPropConstraint

--- a/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
@@ -22,6 +22,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CQueryContext);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CRange.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CRange.cpp
@@ -21,6 +21,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CRange);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CRange::CRange

--- a/src/backend/gporca/libgpopt/src/base/CReqdProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CReqdProp.cpp
@@ -23,6 +23,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CReqdProp);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CReqdProp::CReqdProp

--- a/src/backend/gporca/libgpopt/src/base/CWindowFrame.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CWindowFrame.cpp
@@ -17,6 +17,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CWindowFrame);
+
 // string encoding of frame specification
 const CHAR rgszFrameSpec[][10] = {"Rows", "Range"};
 GPOS_CPL_ASSERT(CWindowFrame::EfsSentinel == GPOS_ARRAY_SIZE(rgszFrameSpec));

--- a/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
@@ -64,6 +64,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CEngine);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CEngine::CEngine

--- a/src/backend/gporca/libgpopt/src/metadata/CColumnDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CColumnDescriptor.cpp
@@ -18,6 +18,8 @@
 using namespace gpopt;
 using namespace gpmd;
 
+FORCE_GENERATE_DBGSTR(CColumnDescriptor);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CColumnDescriptor::CColumnDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CIndexDescriptor);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CIndexDescriptor::CIndexDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CName.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CName.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CName);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CName::CName

--- a/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
@@ -20,6 +20,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPartConstraint);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPartConstraint::CPartConstraint

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -24,6 +24,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CTableDescriptor);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CTableDescriptor::CTableDescriptor

--- a/src/backend/gporca/libgpopt/src/operators/COperator.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/COperator.cpp
@@ -20,6 +20,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(COperator);
+
 // generate unique operator ids
 ULONG COperator::m_aulOpIdCounter(0);
 

--- a/src/backend/gporca/libgpopt/src/search/CGroup.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroup.cpp
@@ -37,6 +37,8 @@
 using namespace gpnaucrates;
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CGroup);
+
 #define GPOPT_OPTCTXT_HT_BUCKETS 100
 
 

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -30,6 +30,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CGroupExpression);
+
 #define GPOPT_COSTCTXT_HT_BUCKETS 100
 
 // invalid group expression

--- a/src/backend/gporca/libgpopt/src/search/CJob.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJob.cpp
@@ -19,6 +19,7 @@
 using namespace gpopt;
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CJob);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/search/CSearchStage.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSearchStage.cpp
@@ -16,6 +16,8 @@
 using namespace gpopt;
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CSearchStage);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CSearchStage::CSearchStage

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
@@ -27,6 +27,10 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CJoinOrder);
+FORCE_GENERATE_DBGSTR(CJoinOrder::SEdge);
+FORCE_GENERATE_DBGSTR(CJoinOrder::SComponent);
+
 
 // ctor
 CJoinOrder::SComponent::SComponent(CMemoryPool *mp, CExpression *pexpr,

--- a/src/backend/gporca/libgpopt/src/xforms/CXform.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXform.cpp
@@ -18,6 +18,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CXform);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/xforms/CXformResult.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformResult.cpp
@@ -15,6 +15,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CXformResult);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
@@ -15,6 +15,7 @@
 #include "gpos/common/CBitVector.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CList.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 
 namespace gpos
@@ -27,7 +28,7 @@ namespace gpos
 //		Linked list of CBitSetLink's
 //
 //---------------------------------------------------------------------------
-class CBitSet : public CRefCount
+class CBitSet : public CRefCount, public DbgPrintMixin<CBitSet>
 {
 	// bitset iter needs to access internals
 	friend class CBitSetIter;

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -7,26 +7,30 @@
 
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/io/COstreamStdString.h"
-#include "gpos/task/CTask.h"
 
 namespace gpos
 {
-/// A Mixin class that adds debug printing to a type.
-///
-/// To use it to add DbgStr() and friends to a type U, simply add this as a
-/// public base:
-/// \code
-/// namespace ns {
-/// class U : public gpos::DbgPrintMixin<U> { ... };
-/// }
-/// \endcode
-///
-/// Also drop this snippet into the U.cpp file at the top level:
-///
-/// \code FORCE_GENERATE_DBGSTR(ns::U); \endcode
-///
-/// The FORCE_GENERATE_DBGSTR macro ensures code generation for the unused
-/// functions so that we can call them in a debugger
+// A Mixin class that adds debug printing to a type.
+//
+// To use it to add DbgStr() and friends to a type U, simply add this as a
+// public base:
+// namespace ns {
+// class U : public gpos::DbgPrintMixin<U> { ... };
+// }
+//
+// Also drop this snippet into the U.cpp file at the top level:
+//
+// FORCE_GENERATE_DBGSTR(ns::U);
+//
+// The FORCE_GENERATE_DBGSTR macro ensures code generation for the unused
+// functions so that we can call them in a debugger
+//
+// Use the following printing multi-line messages in your favorite debugger:
+//
+// (lldb) setting set escape-non-printables false
+// (lldb) p x->DbgStr()
+//
+// (gdb) printf x->DbgStr()
 template <class T>
 struct DbgPrintMixin
 {
@@ -35,7 +39,9 @@ struct DbgPrintMixin
 	void
 	DbgPrint() const
 	{
-		CAutoTrace at(CTask::Self()->Pmp());
+		CMemoryPool *mp =
+			CMemoryPoolManager::GetMemoryPoolMgr()->GetGlobalMemoryPool();
+		CAutoTrace at(mp);
 		static_cast<const T *>(this)->OsPrint(at.Os());
 	}
 

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessage.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessage.h
@@ -17,6 +17,7 @@
 
 #include "gpos/assert.h"
 #include "gpos/common/CSyncHashtable.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/common/clibwrapper.h"
 #include "gpos/types.h"
 
@@ -34,7 +35,7 @@ namespace gpos
 //		Corresponds to individual message as defined in config file
 //
 //---------------------------------------------------------------------------
-class CMessage
+class CMessage : public DbgPrintMixin<CMessage>
 {
 private:
 	// severity
@@ -91,7 +92,7 @@ public:
 
 #ifdef GPOS_DEBUG
 	// debug print function
-	IOstream &OsPrint(IOstream &);
+	IOstream &OsPrint(IOstream &) const;
 #endif	// GPOS_DEBUG
 
 };	// class CMessage

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -53,9 +53,6 @@ private:
 	// are allocated
 	CMemoryPool *m_global_memory_pool;
 
-	// are allocations using global new operator allowed?
-	BOOL m_allow_global_new;
-
 	// hash table to maintain created pools
 	CSyncHashtable<CMemoryPool, ULONG_PTR> *m_ht_all_pools;
 
@@ -155,27 +152,6 @@ public:
 	}
 
 	virtual ~CMemoryPoolManager() = default;
-
-	// are allocations using global new operator allowed?
-	BOOL
-	IsGlobalNewAllowed() const
-	{
-		return m_allow_global_new;
-	}
-
-	// disable allocations using global new operator
-	void
-	DisableGlobalNew()
-	{
-		m_allow_global_new = false;
-	}
-
-	// enable allocations using global new operator
-	void
-	EnableGlobalNew()
-	{
-		m_allow_global_new = true;
-	}
 
 	// return total allocated size in bytes
 	ULLONG TotalAllocatedSize();

--- a/src/backend/gporca/libgpos/src/common/CBitSet.cpp
+++ b/src/backend/gporca/libgpos/src/common/CBitSet.cpp
@@ -24,6 +24,7 @@
 
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CBitSet);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpos/src/error/CMessage.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessage.cpp
@@ -16,6 +16,8 @@
 
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CMessage);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMessage::CMessage
@@ -114,7 +116,7 @@ CMessage::FormatMessage(CWStringStatic *str, ULONG major, ULONG minor, ...)
 //
 //---------------------------------------------------------------------------
 IOstream &
-CMessage::OsPrint(IOstream &os)
+CMessage::OsPrint(IOstream &os) const
 {
 	os << "Message No: " << m_exception.Major() << "-" << m_exception.Minor()
 	   << std::endl

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
@@ -35,7 +35,6 @@ CMemoryPoolManager *CMemoryPoolManager::m_memory_pool_mgr = nullptr;
 CMemoryPoolManager::CMemoryPoolManager(CMemoryPool *internal,
 									   EMemoryPoolType memory_pool_type)
 	: m_internal_memory_pool(internal),
-	  m_allow_global_new(true),
 	  m_ht_all_pools(nullptr),
 	  m_memory_pool_type(memory_pool_type)
 {

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
@@ -70,12 +70,6 @@ CMemoryPoolTracker::NewImpl(const ULONG bytes, const CHAR *file,
 {
 	GPOS_ASSERT(bytes <= GPOS_MEM_ALLOC_MAX);
 	GPOS_ASSERT(bytes <= gpos::ulong_max);
-	GPOS_ASSERT_IMP(
-		(nullptr != CMemoryPoolManager::GetMemoryPoolMgr()) &&
-			(this ==
-			 CMemoryPoolManager::GetMemoryPoolMgr()->GetGlobalMemoryPool()),
-		CMemoryPoolManager::GetMemoryPoolMgr()->IsGlobalNewAllowed() &&
-			"Use of new operator without target memory pool is prohibited, use New(...) instead");
 
 	ULONG alloc_size = GPOS_MEM_BYTES_TOTAL(bytes);
 

--- a/src/backend/gporca/libgpos/src/test/CUnittest.cpp
+++ b/src/backend/gporca/libgpos/src/test/CUnittest.cpp
@@ -433,9 +433,6 @@ CUnittest::Init(CUnittest *rgut, ULONG ulUtCnt, void (*pfConfig)(),
 	m_ulTests = ulUtCnt;
 	m_pfConfig = pfConfig;
 	m_pfCleanup = pfCleanup;
-
-	// disable allocations using global new operator
-	CMemoryPoolManager::GetMemoryPoolMgr()->DisableGlobalNew();
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDouble.h"
 #include "gpos/common/CHashMap.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/string/CWStringConst.h"
 
 #include "naucrates/md/IMDId.h"
@@ -39,7 +40,7 @@ typedef CHashMap<ULONG, IDatum, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 //		Base abstract class for datum representation inside optimizer
 //
 //---------------------------------------------------------------------------
-class IDatum : public CRefCount
+class IDatum : public CRefCount, public DbgPrintMixin<IDatum>
 {
 private:
 public:

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -18,6 +18,7 @@
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CHashSet.h"
 #include "gpos/common/CHashSetIter.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/string/CWStringConst.h"
 
 #include "naucrates/dxl/gpdb_types.h"
@@ -48,7 +49,7 @@ static const INT default_type_modifier = -1;
 //		Abstract class for representing metadata objects ids
 //
 //---------------------------------------------------------------------------
-class IMDId : public CRefCount
+class IMDId : public CRefCount, public DbgPrintMixin<IMDId>
 {
 private:
 	// number of deletion locks -- each MDAccessor adds a new deletion lock if it uses
@@ -180,7 +181,7 @@ typedef CHashSetIter<IMDId, IMDId::MDIdHash, IMDId::MDIdCompare,
 	MdidHashSetIter;
 }  // namespace gpmd
 
-
+FORCE_GENERATE_DBGSTR(gpmd::IMDId);
 
 #endif	// !GPMD_IMDId_H
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
@@ -34,7 +34,7 @@ using namespace gpopt;
 //	@doc:
 //		One dimensional point in the datum space
 //---------------------------------------------------------------------------
-class CPoint : public CRefCount
+class CPoint : public CRefCount, public DbgPrintMixin<CPoint>
 {
 private:
 	// datum corresponding to the point

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -56,7 +56,7 @@ typedef CHashMapIter<ULONG, ULongPtrArray, gpos::HashValue<ULONG>,
 //	@doc:
 //		Abstract statistics API
 //---------------------------------------------------------------------------
-class CStatistics : public IStatistics
+class CStatistics : public IStatistics, public DbgPrintMixin<CStatistics>
 {
 public:
 	// method used to compute for columns of each source it corresponding

--- a/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
@@ -17,6 +17,8 @@
 using namespace gpnaucrates;
 using namespace gpmd;
 
+FORCE_GENERATE_DBGSTR(gpmd::IDatum);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		IDatum::StatsAreEqual

--- a/src/backend/gporca/libnaucrates/src/statistics/CPoint.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CPoint.cpp
@@ -19,6 +19,8 @@
 using namespace gpnaucrates;
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPoint);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPoint::CPoint

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -36,6 +36,8 @@ using namespace gpmd;
 using namespace gpdxl;
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CStatistics);
+
 // default number of rows in relation
 const CDouble CStatistics::DefaultRelationRows(1000.0);
 


### PR DESCRIPTION
The commit that introduced the Mixin ( 914445a ) implemented it for some
classes. However many were missed that already implement OsPrint(). This
commits adds to that list.

T::DbgPrint() and T::DbgStr() should work for class such as:

COperator CJob CPropSpec CReqdProp CDrvdProp IDatum IMdid CJoinOrder
CEnfdProp CConstraint CColRefSet CGroup CGroupExpression
COptimizationContext CSearchStage CXform CXformResult CCostContext
CQueryContext CEngine CMessage CCostModelParamsGPDB CCTEMap CCTEReq
CFunctionalDependency CFunctionProp CKeyCollection CPartInfo CPartKeys
CPropConstraint CPartConstraint CWindowFrame CColumnDescriptor
CIndexDescriptor CName CTableDescriptor CRange CPoint CStatistics

Note the following classes were intentionally skipped, mainly because a
DbgPrint doesn't add much value: CMemoryPool CMemoryPoolManager
CPrintPrefix CUpperBoundNDVs

To support this CBitSet, I had to rewrite the mixin without including CTask.h. See
the separate commit for more details.

Finally, I also added some tips to the comments in DbgPrintMixin.h on how to enable
multi-line output for lldb & gdb.

NB: I tried to as many classes that already implement OsPrint() as I could. I might
have missed some. But this can be extended to more classes in future PRs.