### PR TITLE
Fix dbconn connections to be closed correctly

### DIFF
--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -9,6 +9,7 @@ import os
 import sys
 import signal
 from optparse import OptionGroup
+from contextlib import closing
 
 # import GPDB modules
 try:
@@ -194,7 +195,7 @@ def getTablespaceDirs():
     gettblspclocs_sql = "select c.hostname, t.tblspc_loc from gp_tablespace_location(%s) t, gp_segment_configuration c where t.gp_segment_id = c.content group by c.hostname, t.tblspc_loc"
 
     # Get the tablespace oids
-    with dbconn.connect(dbconn.DbURL()) as conn:
+    with closing(dbconn.connect(dbconn.DbURL())) as conn:
         tblspcoids = dbconn.query(conn, gettblspcoids_sql).fetchall()
 
         # Use the tablespace oids to get the tablespace locations
@@ -206,7 +207,6 @@ def getTablespaceDirs():
                    tblspclocs[query_result[0]].append(query_result[1])
                 else:
                    tblspclocs[query_result[0]] = [query_result[1]]
-    conn.close()
 
     return tblspclocs
 

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -14,6 +14,7 @@ import pipes
 import subprocess
 
 import re, socket
+from contextlib import closing
 
 from gppylib.gplog import *
 from gppylib.db import dbconn
@@ -1226,12 +1227,10 @@ class _GpExpandStatus(object):
 
         try:
             dburl = dbconn.DbURL(dbname=self.dbname)
-            with dbconn.connect(dburl, encoding='UTF8') as conn:
+            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
                 if not dbconn.querySingleton(conn, status_table_exists_sql):
-                    conn.close()
                     return False
                 status = dbconn.querySingleton(conn, sql)
-            conn.close()
         except Exception:
             # schema table not found
             return False
@@ -1256,10 +1255,9 @@ class _GpExpandStatus(object):
 
         try:
             dburl = dbconn.DbURL(dbname=self.dbname)
-            with dbconn.connect(dburl, encoding='UTF8') as conn:
+            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
                 cursor = dbconn.query(conn, sql)
                 rows = cursor.fetchall()
-            conn.close()
         except Exception:
             return False
 

--- a/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
+++ b/gpMgmt/bin/gppylib/db/test/unit/test_cluster_dbconn.py
@@ -63,20 +63,20 @@ class ConnectTestCase(unittest.TestCase):
 
     def test_secure_search_path_set(self):
 
-        with dbconn.connect(self.url) as conn:
+        with closing(dbconn.connect(self.url)) as conn:
             result = dbconn.querySingleton(conn, "SELECT setting FROM pg_settings WHERE name='search_path'")
 
         self.assertEqual(result, '')
 
     def test_secure_search_path_not_set(self):
 
-        with dbconn.connect(self.url, unsetSearchPath=False) as conn:
+        with closing(dbconn.connect(self.url, unsetSearchPath=False)) as conn:
             result = dbconn.querySingleton(conn, "SELECT setting FROM pg_settings WHERE name='search_path'")
 
         self.assertEqual(result, '"$user", public')
 
     def test_search_path_cve_2018_1058(self):
-        with dbconn.connect(self.url) as conn:
+        with closing(dbconn.connect(self.url)) as conn:
             dbconn.execSQL(conn, "CREATE TABLE public.Names (name VARCHAR(255))")
             dbconn.execSQL(conn, "INSERT INTO public.Names VALUES ('AAA')")
 

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -1418,7 +1418,7 @@ class GpArray:
                     if segPair.mirrorDB and segPair.mirrorDB.dbid in self.recoveredSegmentDbids:
                         recovered_contents.append((segPair.primaryDB.content, segPair.primaryDB.dbid, segPair.mirrorDB.dbid))
 
-        with dbconn.connect(dbURL, True, allowSystemTableMods = True) as conn:
+        with closing(dbconn.connect(dbURL, True, allowSystemTableMods = True)) as conn:
             for (content_id, primary_dbid, mirror_dbid) in recovered_contents:
                 sql = "UPDATE gp_segment_configuration SET role=preferred_role where content = %d" % content_id
                 dbconn.executeUpdateOrInsert(conn, sql, 2)
@@ -1433,7 +1433,6 @@ class GpArray:
 
                 # We could attempt to update the segments-array.
                 # But the caller will re-read the configuration from the catalog.
-        conn.close()
 
     # --------------------------------------------------------------------
     def addExpansionSeg(self, content, preferred_role, dbid, role,

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -20,7 +20,7 @@ from gppylib.mainUtils import *
 
 from optparse import OptionGroup
 import os, sys, signal, time
-
+from contextlib import closing
 
 from gppylib import gparray, gplog, userinput, utils
 from gppylib.util import gp_utils
@@ -111,11 +111,9 @@ class RemoteQueryCommand(Command):
     def run(self):
         logger.debug('Executing query (%s:%s) for segment (%s:%s) on database (%s)' % (
             self.qname, self.query, self.hostname, self.port, self.dbname))
-        with dbconn.connect(dbconn.DbURL(hostname=self.hostname, port=self.port, dbname=self.dbname),
-                            utility=True) as conn:
+        with closing(dbconn.connect(dbconn.DbURL(hostname=self.hostname, port=self.port, dbname=self.dbname),
+                            utility=True)) as conn:
             self.res = dbconn.query(conn, self.query).fetchall()
-        conn.close()
-
 # -------------------------------------------------------------------------
 
 class GpRecoverSegmentProgram:
@@ -533,10 +531,9 @@ class GpRecoverSegmentProgram:
 
     def _get_dblist(self):
         # template0 does not accept any connections so we exclude it
-        with dbconn.connect(dbconn.DbURL()) as conn:
+        with closing(dbconn.connect(dbconn.DbURL())) as conn:
             res = dbconn.query(conn, "SELECT datname FROM PG_DATABASE WHERE datname != 'template0'")
-        conn.close()
-        return res.fetchall()
+            return res.fetchall()
 
     def run(self):
         if self.__options.parallelDegree < 1 or self.__options.parallelDegree > 64:

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -3,6 +3,8 @@ import signal
 import subprocess
 import time
 
+from contextlib import closing
+
 from behave import given, when, then
 from test.behave_utils import utils
 from test.behave_utils.utils import wait_for_unblocked_transactions
@@ -28,9 +30,8 @@ def _run_sql(sql, opts=None):
     ], env=env)
 
 def change_hostname(content, preferred_role, hostname):
-    with dbconn.connect(dbconn.DbURL(dbname="template1"), allowSystemTableMods=True, unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname="template1"), allowSystemTableMods=True, unsetSearchPath=False)) as conn:
         dbconn.execSQL(conn, "UPDATE gp_segment_configuration SET hostname = '{0}', address = '{0}' WHERE content = {1} AND preferred_role = '{2}'".format(hostname, content, preferred_role))
-    conn.close()
 
 @when('the standby host is made unreachable')
 def impl(context):
@@ -93,9 +94,8 @@ def impl(context, seg_type, content):
     else:
         raise Exception("Invalid segment type %s (options are primary and mirror)" % seg_type)
 
-    with dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False)) as conn:
         dbid, hostname = dbconn.queryRow(conn, "SELECT dbid, hostname FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, preferred_role))
-    conn.close()
     if not hasattr(context, 'old_hostnames'):
         context.old_hostnames = {}
     context.old_hostnames[(content, preferred_role)] = hostname
@@ -115,23 +115,20 @@ def impl(context):
         context.execute_steps(u'Then gpstart should print "Marking segment %s down because invalid_host is unreachable" to stdout' % dbid)
 
 def has_expected_status(content, preferred_role, expected_status):
-    with dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False)) as conn:
         status = dbconn.querySingleton(conn, "SELECT status FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, preferred_role))
-    conn.close()
     return status == expected_status
 
 
 def must_have_expected_status(content, preferred_role, expected_status):
-    with dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False)) as conn:
         status = dbconn.querySingleton(conn, "SELECT status FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, preferred_role))
-    conn.close()
     if status != expected_status:
         raise Exception("Expected status for role %s to be %s, but it is %s" % (preferred_role, expected_status, status))
 
 def get_guc_value(guc):
-    with dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname="template1"), unsetSearchPath=False)) as conn:
         value = dbconn.querySingleton(conn, "show %s" % guc)
-    conn.close()
     return value
 
 def set_guc_value(context, guc, value):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -1,4 +1,6 @@
 from os import path
+from contextlib import closing
+
 from gppylib.commands.gp import get_coordinatordatadir
 
 from behave import given, when, then
@@ -87,10 +89,9 @@ def make_data_directory_called(data_directory_name):
 
 
 def _get_mirror_count():
-    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
         sql = """SELECT count(*) FROM gp_segment_configuration WHERE role='m'"""
         count_row = dbconn.query(conn, sql).fetchone()
-    conn.close()
     return count_row[0]
 
 # take the item in search_item_list, search pg_hba if it contains atleast one entry

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -41,16 +41,14 @@ def query_sql(dbname, sql):
 def execute_sql(dbname, sql):
     result = None
 
-    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
         dbconn.execSQL(conn, sql)
-    conn.close()
 
 def execute_sql_singleton(dbname, sql):
     result = None
-    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
         result = dbconn.querySingleton(conn, sql)
 
-    conn.close()
     if result is None:
         raise Exception("error running query: %s" % sql)
 


### PR DESCRIPTION
In 6X, the "with" statement context manager closes the connection.

In 7X, with py3 and PyGreSQL 5.2.2 and our dbconn wrapper, we need to explicitly close these connections correctly, since the exit function for "with" context doesn't close it anymore.
Fixing these cases by using contextlib.closing to keep 7X code semantically similar to 6X
Fixing additional cases in gpMgmt where connections aren't closed correctly

Concourse pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/fix_dbconn