### PR TITLE
Use default GCC/Clang toolchain from Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,13 @@ addons:
     apt:
         config:
             retries: true
-        sources: &common_sources
-            - ubuntu-toolchain-r-test
         packages: &common_packages
-            - gcc-8
             - libxml2
             - libxml2-dev
             - libxerces-c-dev
             - libevent-dev
             - libperl-dev
             - libuv1-dev
-            - g++-8
             - python3
             - python3-dev
             - python-dev
@@ -46,36 +42,20 @@ matrix:
         # to fail. Set these environment variables to the system's locale.
         # ----------------------------------------------------------------
         #
-        # Ubuntu Bionic, gcc 8
+        # Ubuntu Bionic, gcc 7
         - os: linux
           dist: bionic
           compiler: gcc
           env:
               - T=debug C=""
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
               - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
-          addons:
-              apt:
-                  sources:
-                      - *common_sources
-                  packages:
-                      - *common_packages
-        # Ubuntu Xenial, clang 7
+        # Ubuntu Bionic, clang 7
         - os: linux
-          dist: xenial
+          dist: bionic
           compiler: clang
           env:
               - T=debug C=""
-              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
               - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
-          addons:
-              apt:
-                  sources:
-                      - *common_sources
-                      - llvm-toolchain-xenial-7
-                  packages:
-                      - *common_packages
-                      - clang-7
         # macOS, XCode11
         - os: osx
           compiler: clang
@@ -96,13 +76,8 @@ matrix:
           compiler: gcc
           env:
               - T=debug C="--without-zlib --without-libbz2 --without-zstd --without-quicklz"
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
               - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
-          addons:
-              apt:
-                  sources: *common_sources
-                  packages: *common_packages
-        # ARM64, Ubuntu Bionic, gcc 8, unit tests
+        # ARM64, Ubuntu Bionic, gcc 7, unit tests
         # For arm64, disable orca to avoid job timeouts
         - os: linux
           arch: arm64
@@ -110,34 +85,21 @@ matrix:
           compiler: gcc
           env:
               - tests=unit T=debug C="--disable-orca"
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
               - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
-          addons:
-              apt:
-                  sources: *common_sources
-                  packages: *common_packages
-        # ARM64, Ubuntu Bionic, gcc 8, installcheck
+        # ARM64, Ubuntu Bionic, gcc 7, installcheck
         - os: linux
           arch: arm64
           dist: bionic
           compiler: gcc
           env:
               - tests=installcheck T=debug C="--disable-orca"
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
               - LC_CTYPE="en_US.utf8" LC_ALL="en_US.utf8" # see NOTE above
-          addons:
-              apt:
-                  sources: *common_sources
-                  packages: *common_packages
 
         - name: clang-tidy
           os: linux
           dist: focal
           addons:
             apt:
-              sources:
-                - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
-                  key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
               packages:
                 - ninja-build
                 - clang-11


### PR DESCRIPTION
This commit removes the ubuntu-toolchain-r-test repo from our Travis CI
environment, and reverts the choice of GCC-8 to whatever Ubuntu provides
from its main repository. In general, the ubuntu-toolchain-r-test repo
is unstable, but it only recently manifests itself as a package conflict
in the xenial+clang job in the matrix.  The folklore of having to add
ubuntu-toolchain-r-test was a relic from the olden days of Ubuntu 12.04
and 14.04, when running mildly modern version of Clang (3.3?) needed a
backport of glibc from ubuntu-toolchain-r-test. Starting from Ubuntu
16.04 (Xenial) this is no longer true.

Note I also had to bump up the OS to Ubuntu Bionic for the Clang 7 build
because libstdc++ from GCC 5 (the version shipped in Ubuntu Xenial) has
a bug (https://wg21.link/N4387) that's only fixed in GCC 6+ (without the
bug fix our build will error out).

While I was at it, also remove the unnecessary additional LLVM sources
from the job given that Ubuntu Focal (20.04) does provide an LLVM-11
package.

