### PR TITLE
6X backport: gpstate: Avoid logging ERROR if no expansion is in progress 

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1206,9 +1206,16 @@ class _GpExpandStatus(object):
             SELECT status FROM gpexpand.status ORDER BY updated DESC LIMIT 1
         '''
 
+        status_table_exists_sql = """
+            SELECT CASE WHEN to_regclass('gpexpand.status') IS NOT NULL THEN 1 ELSE 0 END
+        """
+
         try:
             dburl = dbconn.DbURL(dbname=self.dbname)
             with dbconn.connect(dburl, encoding='UTF8') as conn:
+                if not dbconn.querySingleton(conn, status_table_exists_sql):
+                    conn.close()
+                    return False
                 status = dbconn.execSQLForSingleton(conn, sql)
         except Exception:
             # schema table not found

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1213,7 +1213,7 @@ class _GpExpandStatus(object):
         try:
             dburl = dbconn.DbURL(dbname=self.dbname)
             with dbconn.connect(dburl, encoding='UTF8') as conn:
-                if not dbconn.querySingleton(conn, status_table_exists_sql):
+                if not dbconn.execSQLForSingleton(conn, status_table_exists_sql):
                     conn.close()
                     return False
                 status = dbconn.execSQLForSingleton(conn, sql)


### PR DESCRIPTION
Make sure gpstate should not log Error message if no expansion is in progress
resolves #11554

backport of https://github.com/greenplum-db/gpdb/pull/11615

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-cm-fix_gpstate_6X?group=all)