### PR TITLE
docs - gphdfs to pxf migration doc updates for pxf v6

### DIFF
--- a/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
+++ b/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
@@ -7,7 +7,7 @@ You may be using the `gphdfs` external table protocol in a Greenplum Database ve
 To migrate your `gphdfs` external tables to use the `pxf` external table protocol, you:
 
 1. [Prepare](#prepare) for the migration.
-2. Map configuration properties and [initialize, configure, and start PXF] (#id_cfg_prop).
+2. Map configuration properties and [configure and start PXF] (#id_cfg_prop).
 3. [Create](#create_pxf_ext_table) a new `pxf` external table to replace each `gphdfs` external table.
 4. [Verify](#verify_pxf) access to Hadoop files with the `pxf` external tables.
 5. [Remove](#remove_gphdfs_ext_table) the `gphdfs` external tables.
@@ -21,7 +21,7 @@ To migrate your `gphdfs` external tables to use the `pxf` external table protoco
 <li>Greenplum 4: <a href="#prepare">Prepare</a> for the migration.</li>
 <li>Greenplum 6:<ol>
   <li>Install and configure the Greenplum 6 software.</li>
-  <li>Map configuration properties and <a href="#id_cfg_prop">initialize, configure, and start PXF</a>.</li>
+  <li>Map configuration properties and <a href="#id_cfg_prop">configure and start PXF</a>.</li>
   <li><a href="#create_pxf_ext_table">Create</a> a new <code>pxf</code> external table to replace each <code>gphdfs</code> external table.</li>
   <li><a href="#verify_pxf">Verify</a> access to Hadoop files with the <code>pxf</code> external tables.</li></ol>
 <li>Greenplum 4:<ol>
@@ -69,14 +69,14 @@ As you prepare for migrating from `gphdfs` to PXF:
 3. Save the information that you gathered above.
 
 
-## <a id="id_cfg_prop"></a>Initializing, Configuring, and Starting PXF
+## <a id="id_cfg_prop"></a>Configuring and Starting PXF
 
 PXF does not use the following `gphdfs` configuration options:
 
 | gphdfs Configuration Option | Description |  pxf Consideration |
 |----------+---------------+------------|
 | HADOOP_HOME | Environment variable that identifies the Hadoop installation directory | Not applicable; PXF is bundled with the required dependent Hadoop libraries and JARs | 
-| CLASSPATH | Environment variable that identifies the locations of Hadoop JAR and configuration files | Not applicable, PXF automatically includes the Hadoop libraries, JARs, and configuration files that it bundles in the `CLASSPATH`. PXF also automatically includes user-registered dependencies found in the `$PXF_CONF/lib` directory in the `CLASSPATH`. | 
+| CLASSPATH | Environment variable that identifies the locations of Hadoop JAR and configuration files | Not applicable, PXF automatically includes the Hadoop libraries, JARs, and configuration files that it bundles in the `CLASSPATH`. PXF also automatically includes in the `CLASSPATH` user-registered dependencies found in the `$PXF_CONF/lib` (PXF 5.x) or `$PXF_BASE/lib` (PXF 6.x) directory. |
 | gp_hadoop_target_version | Server configuration parameter that identifies the Hadoop distribution | Not applicable, PXF works out-of-the-box with the different Hadoop distributions | 
 | gp_hadoop_home | Server configuration parameter that identifies the Hadoop installation directory | Not applicable, PXF works out-of-the-box with the different Hadoop distributions | 
 
@@ -85,20 +85,25 @@ Configuration properties required by PXF, and the `gphdfs` equivalent, if applic
 
 | Configuration Item | Description | gphdfs Config | pxf Config |
 |----------+-------------+---------------+------------|
-| JAVA_HOME | Environment variable that identifies the Java installation directory | Set `JAVA_HOME` on each segment host | Set `JAVA_HOME` on each segment host | 
-| JVM option settings | Options with which to start the JVM | Set options in the `GP_JAVA_OPT` environment variable in `hadoop_env.sh` | Set options in the `PXF_JVM_OPTS` environment variable in `$PXF_CONF/conf/pxf-env.sh` | 
+| JAVA_HOME | Environment variable that identifies the Java installation directory | Set `JAVA_HOME` on each segment host | Set `JAVA_HOME` in the `$PXF_CONF/conf/pxf-env.sh`<br>(PXF 5.x) or `$PXF_BASE/conf/pxf-env.sh`<br>(PXF 6.x) configuration file. |
+| JVM option settings | Options with which to start the JVM | Set options in the `GP_JAVA_OPT` environment variable in `hadoop_env.sh` | Set options in the `PXF_JVM_OPTS` environment variable in `$PXF_CONF/conf/pxf-env.sh`<br>(PXF 5.x) or `$PXF_BASE/conf/pxf-env.sh`<br>(PXF 6.x). |
 | PXF Server | PXF server configuration for Hadoop | Not applicable | Configure a PXF server for Hadoop | 
 | Privileges | The Greenplum Database privileges required to create external tables in the given protocol | Grant `SELECT` and `INSERT` privileges on the `gphdfs` protocol to appropriate users | Grant `SELECT` and `INSERT` privileges on the `pxf` protocol to appropriate users | 
 
 After you determine the equivalent PXF configuration properties, you will:
 
-1. Update the Java version installed on each Greenplum Database host, if necessary. PXF supports Java version 8. If your Greenplum Database cluster hosts are running Java 7, upgrade to Java version 8 as described in [Installing Java for PXF](../../pxf/5-15/install_java.html).
+1. (Optional) [Install](../../pxf/6-0/installing_pxf.html) the newest version of PXF on your Greenplum Database hosts. You may also choose to use the PXF version 5.15.1 embedded in your Greenplum Database 6.x installation.
+1. Update the Java version installed on each Greenplum Database host, if necessary. PXF supports Java version 8 and 11. If your Greenplum Database cluster hosts are running Java 7, upgrade to Java version 8 or 11 as described in [Installing Java for PXF](../../pxf/5-15/install_java.html).
 
-2. Initialize PXF as described in [Initializing PXF](../../pxf/5-15/init_pxf.html).
+2. The next step depends upon the version of PXF to which you are migrating:
+    - If you are migrating to PXF 5.x, initialize PXF as described in [Initializing PXF](../../pxf/5-15/init_pxf.html). You must initialize PXF 5.x before you can access Hadoop.
+    - If you just installed or are migrating to PXF 6.x, register the PXF extension with Greenplum Datatabase:
 
-    You must initialize PXF before you can access Hadoop.
+        ```shell
+        gpadmin@gpmaster$ pxf cluster register
+        ```
 
-3. [Configure the PXF Hadoop Connectors](../../pxf/5-15/client_instcfg.html). This procedure creates a PXF server configuration that provides PXF the information that it requires to access Hadoop.
+3. [Configure the PXF Hadoop Connectors](../../pxf/5-15/client_instcfg.html). This procedure creates a PXF server configuration that provides PXF the information that it requires to access Hadoop. This procedure also synchronizes the configuration changes to all hosts in your Greenplum cluster.
 
 4. Start PXF in your Greenplum Database cluster as described in [Starting PXF](../../pxf/5-15/cfginitstart_pxf.html#start_pxf).
 

--- a/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
+++ b/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
@@ -7,7 +7,7 @@ You may be using the `gphdfs` external table protocol in a Greenplum Database ve
 To migrate your `gphdfs` external tables to use the `pxf` external table protocol, you:
 
 1. [Prepare](#prepare) for the migration.
-2. Map configuration properties and [configure and start PXF] (#id_cfg_prop).
+2. Map configuration properties, then [configure and start PXF] (#id_cfg_prop).
 3. [Create](#create_pxf_ext_table) a new `pxf` external table to replace each `gphdfs` external table.
 4. [Verify](#verify_pxf) access to Hadoop files with the `pxf` external tables.
 5. [Remove](#remove_gphdfs_ext_table) the `gphdfs` external tables.
@@ -21,7 +21,7 @@ To migrate your `gphdfs` external tables to use the `pxf` external table protoco
 <li>Greenplum 4: <a href="#prepare">Prepare</a> for the migration.</li>
 <li>Greenplum 6:<ol>
   <li>Install and configure the Greenplum 6 software.</li>
-  <li>Map configuration properties and <a href="#id_cfg_prop">configure and start PXF</a>.</li>
+  <li>Map configuration properties, then <a href="#id_cfg_prop">configure and start PXF</a>.</li>
   <li><a href="#create_pxf_ext_table">Create</a> a new <code>pxf</code> external table to replace each <code>gphdfs</code> external table.</li>
   <li><a href="#verify_pxf">Verify</a> access to Hadoop files with the <code>pxf</code> external tables.</li></ol>
 <li>Greenplum 4:<ol>


### PR DESCRIPTION
updates to the gphdfs migration document for the upcoming pxf v6.0.0 release:
- config file locations have changed, add a v6 variant
- pxf 5.15.1 is embedded in greenplum 6, add an optional step to install pxf 6.
- changes to config/start procedure depending on which version of pxf migrating to.

since pxf 5.15.1 is embedded in pxf, that is the version of the pxf docs that are linked to from this page.  if the user has installed a pxf rpm, it is likely a different version (5.16+ or soon-to-be 6.0), they will manually need to switch the version on the pxf doc site.  i don't think there aren't major changes to these topics between the versions, so seems ok?  

doc review site link:  http://docs-lisa-gphdfs-pxf6.cfapps.io/7-0/pxf/gphdfs-pxf-migrate.html
