### PR TITLE
Docs: discourage use of gppkg --migrate option

### DIFF
--- a/gpdb-doc/dita/install_guide/upgrading.xml
+++ b/gpdb-doc/dita/install_guide/upgrading.xml
@@ -124,20 +124,20 @@
 $ ln -s /usr/local/greenplum-db-&lt;new_version> /usr/local/greenplum-db</codeblock></li>
         <li class="- topic/li ">Source the environment file you just edited. For
           example:<codeblock>$ source ~/.bashrc</codeblock></li>
+        <li class="- topic/li ">After all segment hosts have been upgraded, log in as the
+            <codeph>gpadmin</codeph> user and restart your Greenplum Database
+          system:<codeblock># su - gpadmin
+$ gpstart</codeblock></li>
         <li class="- topic/li " otherprops="pivotal">Use the Greenplum Database
             <codeph>gppkg</codeph> utility to re-install Greenplum Database extensions. If you were
           previously using any Greenplum Database extensions such as pgcrypto, PL/R, PL/Java, or
           PostGIS, download the corresponding packages from <xref
             href="https://network.pivotal.io/products/pivotal-gpdb" scope="external" format="html"
-            class="- topic/xref ">VMware Tanzu Network</xref>, and install using this utility. See the
-          extension documentation for details.<p>Also copy any files that are used by the extensions
-            (such as JAR files, shared object files, and libraries) from the previous version
-            installation directory to the new version installation directory on the coordinator and
-            segment host systems. </p></li>
-        <li class="- topic/li ">After all segment hosts have been upgraded, log in as the
-            <codeph>gpadmin</codeph> user and restart your Greenplum Database
-          system:<codeblock># su - gpadmin
-$ gpstart</codeblock></li>
+            class="- topic/xref ">VMware Tanzu Network</xref>, and install using this utility. See
+          the extension documentation for details.<p>Also copy any files that are used by the
+            extensions (such as JAR files, shared object files, and libraries) from the previous
+            version installation directory to the new version installation directory on the
+            coordinator and segment host systems. </p></li>
         <li>If you configured PXF in your previous Greenplum Database installation, you may
           need to install PXF in your new Greenplum installation, and you may be required to
           re-initialize the PXF service after you upgrade Greenplum Database. Refer to the <xref

--- a/gpdb-doc/dita/utility_guide/ref/gppkg.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gppkg.xml
@@ -69,6 +69,12 @@
                     <pd>For example: <codeph>gppkg --migrate
                             /usr/local/greenplum-db-&lt;old-version>
                             /usr/local/greenplum-db-&lt;new-version></codeph></pd>
+                    <pd>
+                        <note>In general, it is best to avoid using the <codeph>--migrate</codeph>
+                            option, and packages should be reinstalled, not migrated. See <xref
+                                href="../../install_guide/upgrading.xml#topic17">Upgrading from 6.x
+                                to a Newer 6.x Release</xref>.</note>
+                    </pd>
                     <pd>When migrating packages, these requirements must be met.<ul
                             id="ul_sx3_hwx_41b">
                             <li>At least the coordinator instance of the destination Greenplum Database


### PR DESCRIPTION
This PR also updates the "Upgrading from an Earlier Greenplum 6 Release" topic so that gppkg is not used to reinstall extensions until after GPDB is restarted.