### PR TITLE
5X: Coerce unknown-type literals to type text instead of cstring

### DIFF
--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -59,13 +59,19 @@ Datum		create_empty_extension(PG_FUNCTION_ARGS);
 
 Datum		view_has_anyarray_casts(PG_FUNCTION_ARGS);
 
+Datum		view_has_unknown_casts(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(add_pg_enum_label);
 
 PG_FUNCTION_INFO_V1(create_empty_extension);
 
 PG_FUNCTION_INFO_V1(view_has_anyarray_casts);
 
+PG_FUNCTION_INFO_V1(view_has_unknown_casts);
+
 static bool check_node_anyarray_walker(Node *node, void *context);
+
+static bool check_node_unknown_walker(Node *node, void *context);
 
 Datum
 add_pg_enum_label(PG_FUNCTION_ARGS)
@@ -720,4 +726,68 @@ check_node_anyarray_walker(Node *node, void *context)
 
 	return expression_tree_walker(node, check_node_anyarray_walker,
 								  context);
+}
+
+Datum
+view_has_unknown_casts(PG_FUNCTION_ARGS)
+{
+	Oid			view_oid = PG_GETARG_OID(0);
+	Relation 	rel = try_relation_open(view_oid, AccessShareLock, false);
+	Query		*viewquery;
+	bool		found;
+
+	if (rel == NULL)
+		elog(ERROR, "Could not open relation file for relation oid %u", view_oid);
+
+	if(rel->rd_rel->relkind == RELKIND_VIEW)
+	{
+		viewquery = get_view_query(rel);
+		found = query_tree_walker(viewquery, check_node_unknown_walker, NULL, 0);
+	}
+	else
+		found = false;
+
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_BOOL(found);
+}
+
+static bool
+check_node_unknown_walker(Node *node, void *context)
+{
+	Assert(context == NULL);
+
+	if (node == NULL)
+		return false;
+
+	/*
+	 * Look only at FuncExpr since the GPDB special handling hack for unknown
+	 * types is only applied to FuncExpr. See parse_coerce.c: coerce_type()
+	 */
+	if (IsA(node, FuncExpr))
+	{
+		FuncExpr *fe = (FuncExpr *) node;
+		/*
+		 * Check to see if the FuncExpr has an unknown::cstring cast.
+		 *
+		 * If it has no such cast yet, check its arguments.
+		 */
+		if ((fe->funcresulttype != CSTRINGOID) || !fe->args || (list_length(fe->args) != 1))
+			return expression_tree_walker(node, check_node_unknown_walker, context);
+
+		Node *head = lfirst(((List *)fe->args)->head);
+
+		if (IsA(head, Var) && ((Var *)head)->vartype == UNKNOWNOID)
+			return true;
+		else
+			return expression_tree_walker(node, check_node_unknown_walker, context);
+	}
+	else if (IsA(node, Query))
+	{
+		/* recurse into subselects and ctes */
+		Query *query = (Query *) node;
+		return query_tree_walker(query, check_node_unknown_walker, context, 0);
+	}
+
+	return expression_tree_walker(node, check_node_unknown_walker, context);
 }

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -387,7 +387,7 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(infunc));
 
 			/* do unknownout(Var) */
-			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node), cformat);
+			fe = makeFuncExpr(outfunc, TEXTOID, list_make1(node), cformat);
 			fe->location = location;
 
 			if (location >= 0 &&

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -123,4 +123,26 @@ SELECT pg_get_viewdef('view_with_array_op_expr');
 -----------------------------------------------
  SELECT ('{1}'::integer[] = '{2}'::integer[]);
 (1 row)
- 
+
+-- Coerce unknown-type literals to type text
+CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
+WARNING:  column "field_unknown" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
+\d+ unknown_v2
+                 View "public.unknown_v2"
+    Column     | Type | Modifiers | Storage | Description 
+---------------+------+-----------+---------+-------------
+ field_unknown | date |           | plain   | 
+View definition:
+ SELECT unknown_v1.field_unknown::text::date AS field_unknown
+   FROM unknown_v1;
+
+SELECT * FROM unknown_v2;
+ field_unknown 
+---------------
+ 12-13-2020
+(1 row)
+
+DROP VIEW unknown_v2;
+DROP VIEW unknown_v1;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -68,3 +68,11 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 -- correct internal representation
 CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
 SELECT pg_get_viewdef('view_with_array_op_expr');
+
+-- Coerce unknown-type literals to type text
+CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
+CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
+\d+ unknown_v2
+SELECT * FROM unknown_v2;
+DROP VIEW unknown_v2;
+DROP VIEW unknown_v1;


### PR DESCRIPTION
```
CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS
field_unknown;
CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
```

It would show the definition as this before this commit:
```
SELECT unknown_v1.field_unknown::cstring::date AS field_unknown
  FROM unknown_v1;
```
Which would error out with `ERROR: cannot cast type cstring to date`.

This commit coerces unknown-type literals to type text instead of
cstring while converting stored expressions/querytrees back to source
text.

Upstream also chose text, Greenplum 7 too (PR #9655, #9686), but they
broke behaviors, we could not do that refactor on 6X_STABLE branch.

    commit 1e7c4bb0049732ece651d993d03bb6772e5d281a
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Wed Jan 25 09:17:18 2017 -0500

        Change unknown-type literals to type text in SELECT and RETURNING lists.

        Previously, we left such literals alone if the query or subquery had
        no properties forcing a type decision to be made (such as an ORDER BY or
        DISTINCT clause using that output column).  This meant that "unknown" could
        be an exposed output column type, which has never been a great idea because
        it could result in strange failures later on.  For example, an outer query
        that tried to do any operations on an unknown-type subquery output would
        generally fail with some weird error like "failed to find conversion
        function from unknown to text" or "could not determine which collation to
        use for string comparison".  Also, if the case occurred in a CREATE VIEW's
        query then the view would have an unknown-type column, causing similar
        failures in queries trying to use the view.

        To fix, at the tail end of parse analysis of a query, forcibly convert any
        remaining "unknown" literals in its SELECT or RETURNING list to type text.
        However, provide a switch to suppress that, and use it in the cases of
        SELECT inside a set operation or INSERT command.  In those cases we already
        had type resolution rules that make use of context information from outside
        the subquery proper, and we don't want to change that behavior.

        Also, change creation of an unknown-type column in a relation from a
        warning to a hard error.  The error should be unreachable now in CREATE
        VIEW or CREATE MATVIEW, but it's still possible to explicitly say "unknown"
        in CREATE TABLE or CREATE (composite) TYPE.  We want to forbid that because
        it's nothing but a foot-gun.

        This change creates a pg_upgrade failure case: a matview that contains an
        unknown-type column can't be pg_upgraded, because reparsing the matview's
        defining query will now decide that the column is of type text, which
        doesn't match the cstring-like storage that the old materialized column
        would actually have.  Add a checking pass to detect that.  While at it,
        we can detect tables or composite types that would fail, essentially
        for free.  Those would fail safely anyway later on, but we might as
        well fail earlier.

        This patch is by me, but it owes something to previous investigations
        by Rahila Syed.  Also thanks to Ashutosh Bapat and Michael Paquier for
        review.

        Discussion: https://postgr.es/m/CAH2L28uwwbL9HUM-WR=hromW1Cvamkn7O-g8fPY2m=_7muJ0oA@mail.gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
