### PR TITLE
Docs: added Multiple Distinct Qualified Aggregates to ORCA limitations

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -45,8 +45,8 @@
               <li><cmdname>FIELDSELECT</cmdname></li>
             </ul></li>
           <li>Aggregate functions that take set operators as input arguments.</li>
-          <li>Multiple Distinct Qualified Aggregates, such as <codeph>COUNT (DISTINCT
-              column)</codeph>.</li>
+          <li>Multiple Distinct Qualified Aggregates, such as <codeph>SELECT count(DISTINCT a),
+              sum(DISTINCT b) FROM foo</codeph>.</li>
           <li><cmdname>percentile_*</cmdname> window functions (ordered-set aggregate functions).</li>
           <li>Inverse distribution functions.</li>
           <li>Queries that execute functions that are defined with the <codeph>ON MASTER</codeph> or

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -45,6 +45,8 @@
               <li><cmdname>FIELDSELECT</cmdname></li>
             </ul></li>
           <li>Aggregate functions that take set operators as input arguments.</li>
+          <li>Multiple Distinct Qualified Aggregates, such as <codeph>COUNT (DISTINCT
+              column)</codeph>.</li>
           <li><cmdname>percentile_*</cmdname> window functions (ordered-set aggregate functions).</li>
           <li>Inverse distribution functions.</li>
           <li>Queries that execute functions that are defined with the <codeph>ON MASTER</codeph> or


### PR DESCRIPTION
It was pointed out that "Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer" had not been documented under ORCA limitations. Adding it to the list followed by the example used in that user case.