### PR TITLE
remove ARRAY_NAME variable

### DIFF
--- a/concourse/scripts/configurations/pg_upgrade_gpinitsystem_config
+++ b/concourse/scripts/configurations/pg_upgrade_gpinitsystem_config
@@ -6,9 +6,6 @@
 #### REQUIRED PARAMETERS
 ################################################
 
-#### Name of this Greenplum system enclosed in quotes.
-ARRAY_NAME="EMC Greenplum DW"
-
 #### Naming convention for utility-generated data directories.
 SEG_PREFIX=gpseg
 

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -268,9 +268,6 @@ rm -f ${CLUSTER_CONFIG_POSTGRES_ADDONS}
 #*****************************************************************************************
 
 cat >> $CLUSTER_CONFIG <<-EOF
-	# Set this to anything you like
-	ARRAY_NAME="Demo $HOSTNAME Cluster"
-	
 	# This file must exist in the same directory that you execute gpinitsystem in
 	MACHINE_LIST_FILE=`pwd`/hostfile
 	

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -332,12 +332,6 @@ CHK_PARAMS () {
 		    declare -a MACHINE_LIST=(`$CAT $MACHINE_LIST_FILE|$SORT`)
 		fi
 		# Now process contents for the configuration file
-		if [ ! "$ARRAY_NAME" ]; then
-			LOG_MSG "[WARN]:-ARRAY_NAME variable not set, will provide default value" 1
-			ARRAY_NAME="Greenplum Instance"
-		fi
-		export ARRAY_NAME
-
 		# Make sure that this script is running on the QD host
 		if [ $COORDINATOR_HOSTNAME != `$HOSTNAME` ]; then
 			LOG_MSG "[WARN]:-Coordinator hostname $COORDINATOR_HOSTNAME does not match hostname output" 1
@@ -1037,7 +1031,6 @@ DISPLAY_CONFIG () {
 		LOG_MSG "[INFO]:---------------------------------------" 1
 		LOG_MSG "[INFO]:-Coordinator Configuration" 1
 		LOG_MSG "[INFO]:---------------------------------------" 1
-		LOG_MSG "[INFO]:-Coordinator instance name  = $ARRAY_NAME" 1
 		LOG_MSG "[INFO]:-Coordinator hostname       = $GP_HOSTADDRESS" 1
 		LOG_MSG "[INFO]:-Coordinator port           = $COORDINATOR_PORT" 1
 		LOG_MSG "[INFO]:-Coordinator instance dir   = $GP_DIR" 1
@@ -1373,7 +1366,6 @@ CREATE_SEGMENT () {
 			export LOG_FILE
 			export PARALLEL_STATUS_FILE
 			export TOTAL_SEG
-			export ARRAY_NAME
 			export QE_MAX_CONNECT
 			export QE_SHARED_BUFFERS
 			export SEG_PREFIX
@@ -1584,7 +1576,6 @@ SCAN_LOG () {
 }
 
 DUMP_OUTPUT_CONFIG () {
-    $ECHO "ARRAY_NAME=\"$ARRAY_NAME\"" > $OUTPUT_CONFIG
     if [ x"" != x"$TRUSTED_SHELL" ] ; then
 	$ECHO "TRUSTED_SHELL=$TRUSTED_SHELL" >> $OUTPUT_CONFIG
     fi

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_config
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_config
@@ -6,9 +6,6 @@
 #### REQUIRED PARAMETERS
 ################################################
 
-#### Name of this Greenplum system enclosed in quotes.
-ARRAY_NAME="Greenplum Data Platform"
-
 #### Naming convention for utility-generated data directories.
 SEG_PREFIX=gpseg
 

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_singlenode
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_singlenode
@@ -9,12 +9,6 @@
 # REQUIRED PARAMETERS
 ################################################
 
-# A name for the array you are configuring. You can use any name you 
-# like. Enclose the name in quotes if the name contains spaces.
-
-ARRAY_NAME="GPDB SINGLENODE"
-
-
 # This specifies the file that contains the list of segment host names 
 # that comprise the Greenplum system. For a single-node system, this
 # file contains the local OS-configured hostname (as output by the 

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_test
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_test
@@ -6,9 +6,6 @@
 #### REQUIRED PARAMETERS
 ################################################
 
-#### Name of this Greenplum system enclosed in quotes.
-ARRAY_NAME="Test DW"
-
 #### Naming convention for utility-generated data directories.
 SEG_PREFIX=gpseg
 

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -265,13 +265,6 @@ OPTIONS
 INITIALIZATION CONFIGURATION FILE FORMAT
 *****************************************************
 
-ARRAY_NAME
-
- Required. A name for the array you are configuring. You can use 
- any name you like. Enclose the name in quotes if the name 
- contains spaces.
-
-
 MACHINE_LIST_FILE
 
  Optional. Can be used in place of the -h option. This specifies 

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -63,7 +63,7 @@ Feature: gpinitsystem tests
     Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0
       Given create demo cluster config
           # log a warning
-        And the user runs command "echo 'ARRAY_NAME=' >> ../gpAux/gpdemo/clusterConfigFile"
+        And the user runs command "sed -i.bak 's/^ENCODING.*//g' ../gpAux/gpdemo/clusterConfigFile"
        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
        Then gpinitsystem should return a return code of 0
       Given create demo cluster config

--- a/gpMgmt/test/behave_utils/configs/gpinitconfig_mirror_template
+++ b/gpMgmt/test/behave_utils/configs/gpinitconfig_mirror_template
@@ -1,4 +1,3 @@
-ARRAY_NAME="Expansion Test Base Cluster"
 SEG_PREFIX=gpseg
 PORT_BASE=%PORT_BASE%
 declare -a DATA_DIRECTORY=(%DATA_DIR%)

--- a/gpMgmt/test/behave_utils/configs/gpinitconfig_template
+++ b/gpMgmt/test/behave_utils/configs/gpinitconfig_template
@@ -1,4 +1,3 @@
-ARRAY_NAME="Expansion Test Base Cluster"
 SEG_PREFIX=gpseg
 PORT_BASE=%PORT_BASE%
 declare -a DATA_DIRECTORY=(%DATA_DIR%)

--- a/gpdb-doc/dita/install_guide/init_gpdb.xml
+++ b/gpdb-doc/dita/install_guide/init_gpdb.xml
@@ -142,8 +142,7 @@ sdw4-2</codeblock></li>
                   href="../install_guide/prep_os.xml#topic3" format="dita"/>.</p><p>Here is an
                 example of the <i>required</i> parameters in the
                   <codeph>gpinitsystem_config</codeph> file:
-              </p><codeblock>ARRAY_NAME="Greenplum Data Platform"
-SEG_PREFIX=gpseg
+              </p><codeblock>SEG_PREFIX=gpseg
 PORT_BASE=6000 
 declare -a DATA_DIRECTORY=(/data1/primary /data1/primary /data1/primary /data2/primary /data2/primary /data2/primary)
 MASTER_HOSTNAME=mdw 

--- a/gpdb-doc/dita/utility_guide/ref/gpinitsystem.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpinitsystem.xml
@@ -303,11 +303,6 @@ MIRROR_PORT_BASE = 7000</codeblock>
             </p>
             <parml>
                 <plentry>
-                    <pt>ARRAY_NAME</pt>
-                    <pd><b>Required.</b> A name for the cluster you are configuring. You can use any
-                        name you like. Enclose the name in quotes if the name contains spaces.</pd>
-                </plentry>
-                <plentry>
                     <pt>MACHINE_LIST_FILE</pt>
                     <pd><b>Optional.</b> Can be used in place of the <codeph>-h</codeph> option.
                         This specifies the file that contains the list of the segment host address
@@ -548,8 +543,7 @@ sdw1~sdw1~50001~/gpdata/mirror2/gpseg3~9~3
             <p>The output file uses the <codeph>QD_PRIMARY_ARRAY</codeph> and
                     <codeph>PRIMARY_ARRAY</codeph> parameters to define coordinator and segment
                 hosts:</p>
-            <codeblock>ARRAY_NAME="Greenplum Data Platform"
-TRUSTED_SHELL=ssh
+            <codeblock>TRUSTED_SHELL=ssh
 CHECK_POINT_SEGMENTS=8
 ENCODING=UNICODE
 SEG_PREFIX=gpseg

--- a/src/tools/docker/ubuntu16_ppa-persistent/container_init.sh
+++ b/src/tools/docker/ubuntu16_ppa-persistent/container_init.sh
@@ -28,8 +28,7 @@ fi
 
 if [ ! -f "$DATA_DIR/gpdata/gpinitsystem_singlenode" ]; then
 	echo '========================> Make gpinitsystem_singlenode and hostlist_singlenode'
-	echo 'ARRAY_NAME="GPDB SINGLENODE"' > $DATA_DIR/gpdata/gpinitsystem_singlenode
-	echo 'MACHINE_LIST_FILE='$DATA_DIR'/gpdata/hostlist_singlenode' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
+	echo 'MACHINE_LIST_FILE='$DATA_DIR'/gpdata/hostlist_singlenode' > $DATA_DIR/gpdata/gpinitsystem_singlenode
 	echo 'SEG_PREFIX=gpsne' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
 	echo 'PORT_BASE=40000' >> $DATA_DIR/gpdata/gpinitsystem_singlenode
 	echo 'declare -a DATA_DIRECTORY=('$DATA_DIR'/gpdata/gpdata1 '$DATA_DIR'/gpdata/gpdata2)' >> $DATA_DIR/gpdata/gpinitsystem_singlenode


### PR DESCRIPTION
The ARRAY_NAME variable hasn't been used for anything since 4.2 at the latest.
It still shows up in sample config files and is marked as a required argument in the docs.

Removing the variable from GP7

If ARRAY_NAME is passed in GP7 then gpinitsystem should start the cluster successfully.

