### PR TITLE
Reset QE CurrentExtensionObject

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -45,6 +45,7 @@
 #include "catalog/pg_extension.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_type.h"
+#include "cdb/cdbgang.h"
 #include "commands/alter.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
@@ -978,22 +979,16 @@ execute_extension_script(Node *stmt,
 		if (Gp_role == GP_ROLE_DISPATCH && stmt != NULL)
 		{
 			/*
-			 * We must reset QE CurrentExtensionObject to InvalidOid.
-			 *
-			 * Doing heavy operations like this during exception processing
-			 * is not very cool. Let's at least get out of ErrorContext, to
-			 * leave that free for actual error processing. (Besides, the
-			 * error handling in dispatcher will hit an assertion in
-			 * CopyErrorData(), if another error happens while we're already
-			 * in ErrorContext.)
+			 * Previously, we dispatch a statement with end tag to implement
+			 * the logic of reset QE CurrentExtensionObject to InvalidOid. 
+			 * But this method has a big drawback: since current code is in 
+			 * a Catch block, which means some errors must have happened and 
+			 * QEs may have already been in the Abort State and cannot execute 
+			 * any statement dispatched to them.
+			 * 
+			 * So we simply destroy all QEs here to implment the clear logic.
 			 */
-			MemoryContext oldcxt = MemoryContextSwitchTo(CurTransactionContext);
-			set_end_state(stmt);
-			CdbDispatchUtilityStatement(stmt,
-										DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR | DF_NEED_TWO_PHASE,
-										GetAssignedOidsForDispatch(),
-										NULL);
-			MemoryContextSwitchTo(oldcxt);
+			DisconnectAndDestroyAllGangs(false);
 		}
 		PG_RE_THROW();
 	}

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -65,6 +65,7 @@
 #include "pgstat.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
@@ -1294,6 +1295,7 @@ CreateFunction(ParseState *pstate, CreateFunctionStmt *stmt)
 	char		execLocation;
 	ObjectAddress objAddr;
 
+	SIMPLE_FAULT_INJECTOR("test_for_issue_11304");
 	/* Convert list of names to a name and namespace */
 	namespaceId = QualifiedNameGetCreationNamespace(stmt->funcname,
 													&funcname);


### PR DESCRIPTION
  This is to fix bug 11304, the context is

  1:in cdbdisp_dispatchCommandInternal, if QE return err, the
cdbdisp_destroyDispatcherState which must be called is missing.

  2:QE was set to the wrong state due to the execution error.

  If we call cdbdisp_destroyDispatcherState directly
during error handling in cdbdisp_dispatchCommandInternal,
the original code called CdbDispatchUtilityStatement to
Reset QE CurrentExtensionObject, and QE is likely in abort
state, so the error return to client will be the QE error.

  so we call DisconnectAndDestroyAllGangs to reset QE's state.
and PostgresMain will eventually call to cdbdisp_destroyDispatcherState
by calling AbortCurrentTransaction in the top of try catch stack.

for details [#11304:](https://github.com/greenplum-db/gpdb/issues/11304)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
