### PR TITLE
Reset QE CurrentExtensionObject on qe

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -65,6 +65,7 @@
 #include "pgstat.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
@@ -1294,6 +1295,7 @@ CreateFunction(ParseState *pstate, CreateFunctionStmt *stmt)
 	char		execLocation;
 	ObjectAddress objAddr;
 
+	SIMPLE_FAULT_INJECTOR("create_function_fail");
 	/* Convert list of names to a name and namespace */
 	namespaceId = QualifiedNameGetCreationNamespace(stmt->funcname,
 													&funcname);

--- a/src/test/regress/expected/create_extension_gp_debug_segments.out
+++ b/src/test/regress/expected/create_extension_gp_debug_segments.out
@@ -1,0 +1,23 @@
+--
+-- Tests for return correct error from qe when create extension error
+-- The issue: https://github.com/greenplum-db/gpdb/issues/11304
+--
+--start_ignore
+drop extension if exists gp_debug_numsegments;
+NOTICE:  extension "gp_debug_numsegments" does not exist, skipping
+create extension if not exists gp_inject_fault;
+--end_ignore
+select gp_inject_fault('create_function_fail', 'error', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+create extension gp_debug_numsegments;
+ERROR:  fault triggered, fault name:'create_function_fail' fault type:'error'  (seg0 192.168.106.132:7002 pid=153052)
+select gp_inject_fault('create_function_fail', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -279,4 +279,7 @@ test: gangsize gang_reuse
 # some utilities do not work while doing gpexpand, check them can print correct message
 test: run_utility_gpexpand_phase1
 
+# check correct error message when create extension error on segment
+test: create_extension_gp_debug_segments
+
 # end of tests

--- a/src/test/regress/sql/create_extension_gp_debug_segments.sql
+++ b/src/test/regress/sql/create_extension_gp_debug_segments.sql
@@ -1,0 +1,15 @@
+--
+-- Tests for return correct error from qe when create extension error
+-- The issue: https://github.com/greenplum-db/gpdb/issues/11304
+--
+
+--start_ignore
+drop extension if exists gp_debug_numsegments;
+create extension if not exists gp_inject_fault;
+--end_ignore
+
+select gp_inject_fault('create_function_fail', 'error', 2);
+create extension gp_debug_numsegments;
+
+select gp_inject_fault('create_function_fail', 'reset', 2);
+


### PR DESCRIPTION
  This is to fix bug [#11304](https://github.com/greenplum-db/gpdb/issues/11304) the context is

  1:in cdbdisp_dispatchCommandInternal, if QE return err, the
cdbdisp_destroyDispatcherState which must be called is missing.

  2:QE was set to the wrong state due to the execution error.

  If we call cdbdisp_destroyDispatcherState directly
during error handling in cdbdisp_dispatchCommandInternal,
the original code called CdbDispatchUtilityStatement to
Reset QE CurrentExtensionObject, and QE is likely in abort
state, so the error return to client will be the QE error.

  so we call DisconnectAndDestroyAllGangs to reset QE's state.
and PostgresMain will eventually call to cdbdisp_destroyDispatcherState
by calling AbortCurrentTransaction in the top of try catch stack.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
