### PR TITLE
Remove aix for gpfdist because gpfdist no longer support unix system …

### DIFF
--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -892,7 +892,7 @@ int gfile_open(gfile_t* fd, const char* fpath, int flags, int* response_code, co
 			return 1;
 		}
 
-#if !defined(WIN32) && !defined(_AIX)
+#if !defined(WIN32)
 		/* Restrict only one reader session for each PIPE */
 		if (S_ISFIFO(sta.st_mode) && (flags == GFILE_OPEN_FOR_READ))
 		{

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -12,10 +12,6 @@ OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 # need to link with unnecessary libraries.
 GPFDIST_LIBS = $(EVENT_LIBS)
 
-ifeq ($(PORTNAME),aix)
-  GPFDIST_LIBS += -lbsd
-endif
-
 ifeq ($(have_yaml),yes)
   OBJS += transform.o
   LIBS += $(YAML_LIBS)

--- a/src/bin/gpfdist/remote_regress/README
+++ b/src/bin/gpfdist/remote_regress/README
@@ -8,5 +8,7 @@ Need to export REMOTE_HOST, REMOTE_PORT, REMOTE_USER, REMOTE_KEY
 MASTER_DATA_DIRECTORY, PG_PORT before running these test cases.
 
 The scripts of start_gpfdist_remote_win are used to start and stop gpfdist running on windows.
-If you want to test gpfdist on another os, such as aix, you can create a folder named
-start_gpfdist_remote_aix and add some scripts to start and stop gpfdist.
+
+If you want to test gpfdist on another os, such as darwin, you can create a folder named
+start_gpfdist_remote_darwin and add some scripts to start and stop gpfdist.
+Gpfdist does not support Unix os in gpdb version 7.


### PR DESCRIPTION
…any more.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
