### PR TITLE
(backport to 6X) Reset QE CurrentExtensionObject

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -41,6 +41,7 @@
 #include "catalog/pg_extension.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_type.h"
+#include "cdb/cdbgang.h"
 #include "commands/alter.h"
 #include "commands/comment.h"
 #include "commands/extension.h"
@@ -958,20 +959,16 @@ execute_extension_script(Node *stmt,
 			/*
 			 * We must reset QE CurrentExtensionObject to InvalidOid.
 			 *
-			 * Doing heavy operations like this during exception processing
-			 * is not very cool. Let's at least get out of ErrorContext, to
-			 * leave that free for actual error processing. (Besides, the
-			 * error handling in dispatcher will hit an assertion in
-			 * CopyErrorData(), if another error happens while we're already
-			 * in ErrorContext.)
+			 * Previously, we dispatch a statement with end tag to implement
+			 * the logic of reset QE CurrentExtensionObject to InvalidOid. 
+			 * But this method has a big drawback: since current code is in 
+			 * a Catch block, which means some errors must have happened and 
+			 * QEs may have already been in the Abort State and cannot execute 
+			 * any statement dispatched to them.
+			 * 
+			 * So we simply destroy all QEs here to implement the clear logic.
 			 */
-			MemoryContext oldcxt = MemoryContextSwitchTo(CurTransactionContext);
-			set_end_state(stmt);
-			CdbDispatchUtilityStatement(stmt,
-										DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR | DF_NEED_TWO_PHASE,
-										GetAssignedOidsForDispatch(),
-										NULL);
-			MemoryContextSwitchTo(oldcxt);
+			DisconnectAndDestroyAllGangs(false);
 		}
 		PG_RE_THROW();
 	}

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -61,6 +61,7 @@
 #include "parser/parse_type.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
@@ -1181,6 +1182,7 @@ CreateFunction(CreateFunctionStmt *stmt, const char *queryString)
 	char		execLocation;
 	Oid			funcOid;
 
+	SIMPLE_FAULT_INJECTOR("create_function_fail");
 	/* Convert list of names to a name and namespace */
 	namespaceId = QualifiedNameGetCreationNamespace(stmt->funcname,
 													&funcname);

--- a/src/test/regress/expected/create_extension_gp_debug_segments.out
+++ b/src/test/regress/expected/create_extension_gp_debug_segments.out
@@ -1,0 +1,23 @@
+--
+-- Tests for return correct error from qe when create extension error
+-- The issue: https://github.com/greenplum-db/gpdb/issues/11304
+--
+--start_ignore
+drop extension if exists gp_debug_numsegments;
+NOTICE:  extension "gp_debug_numsegments" does not exist, skipping
+create extension if not exists gp_inject_fault;
+--end_ignore
+select gp_inject_fault('create_function_fail', 'error', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+create extension gp_debug_numsegments;
+ERROR:  fault triggered, fault name:'create_function_fail' fault type:'error'  (seg0 192.168.106.132:7002 pid=153052)
+select gp_inject_fault('create_function_fail', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -270,4 +270,7 @@ test: gangsize gang_reuse
 # some utilities do not work while doing gpexpand, check them can print correct message
 test: run_utility_gpexpand_phase1
 
+# check correct error message when create extension error on segment
+test: create_extension_gp_debug_segments
+
 # end of tests

--- a/src/test/regress/sql/create_extension_gp_debug_segments.sql
+++ b/src/test/regress/sql/create_extension_gp_debug_segments.sql
@@ -1,0 +1,15 @@
+--
+-- Tests for return correct error from qe when create extension error
+-- The issue: https://github.com/greenplum-db/gpdb/issues/11304
+--
+
+--start_ignore
+drop extension if exists gp_debug_numsegments;
+create extension if not exists gp_inject_fault;
+--end_ignore
+
+select gp_inject_fault('create_function_fail', 'error', 2);
+create extension gp_debug_numsegments;
+
+select gp_inject_fault('create_function_fail', 'reset', 2);
+


### PR DESCRIPTION
This is to fix bug 11304, the context is

  1:in cdbdisp_dispatchCommandInternal, if QE return err, the
cdbdisp_destroyDispatcherState which must be called is missing.

  2:QE was set to the wrong state due to the execution error.

  If we call cdbdisp_destroyDispatcherState directly
during error handling in cdbdisp_dispatchCommandInternal,
the original code called CdbDispatchUtilityStatement to
Reset QE CurrentExtensionObject, and QE is likely in abort
state, so the error return to client will be the QE error.

  so we call DisconnectAndDestroyAllGangs to reset QE's state.
and PostgresMain will eventually call to cdbdisp_destroyDispatcherState
by calling AbortCurrentTransaction in the top of try catch stack.

----------------------------

The pr for master branch is already merged https://github.com/greenplum-db/gpdb/pull/11683
This pr backport the commit to 6X.

I confirm manually that without the patch, test case will throw the error `query plan with multiple segworker groups is not supported`. With this patch, it will throw the error like in the case.
