### PR TITLE
[6X Backport]Fix bitmap index scan when concurrent insert update full bitmap page

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -206,7 +206,6 @@ bmgetbitmap(PG_FUNCTION_ARGS)
 	res = _bitmap_firstbatchwords(scan, ForwardScanDirection);
 
 	scanPos = ((BMScanOpaque)scan->opaque)->bm_currPos;
-	scanPos->bm_result.nextTid = 1;
 
 	/* perhaps this should be in a special context? */
 	is = (IndexStream *)palloc0(sizeof(IndexStream));
@@ -842,6 +841,13 @@ words_get_match(BMBatchWords *words, BMIterateResult *result,
 	int newwordno;
 	uint64 start, end;
 
+	/*
+	 * XXX: We assume that BM_HRL_WORD_SIZE is not greater than
+	 * TBM_BITS_PER_BITMAPWORD for tidbitmap.
+	 */
+	Assert(BM_HRL_WORD_SIZE <= TBM_BITS_PER_BITMAPWORD);
+	Assert(nhrlwords >= 1);
+
 restart:
 	/* compute the first and last tid location for 'blockno' */
 	start = ((uint64)blockno) * BM_MAX_TUPLES_PER_PAGE + 1;
@@ -862,72 +868,38 @@ restart:
 		else
 			return true;
 	}
-		
-	/*
-	 * XXX: We assume that BM_HRL_WORD_SIZE is not greater than
-	 * TBM_BITS_PER_BITMAPWORD for tidbitmap.
-	 */
-	Assert(BM_HRL_WORD_SIZE <= TBM_BITS_PER_BITMAPWORD);
-	Assert(nhrlwords >= 1); 
+
 	Assert((result->nextTid - start) % BM_HRL_WORD_SIZE == 0);
 
+	/* Set the next tid we expected to check */
+	result->nextTid = start;
+
 	/*
-	 * find the first tid location in 'words' that is equal to
-	 * 'start'.
+	 * If words->firstTid < result->nextTid, we need to catch up the words
+	 * firstTid for checking to the next tid(start of current block).
+	 * words->firstTid will keep set as result->nextTid before each
+	 * iteration to mark the scanned tids in _bitmap_nextbatchwords.
+	 * Note here that when we read new batchwords from bitmap page, the
+	 * words->firstTid may get set to a tid we already scanned.
+	 * See read_words in bitmapsearch.c.
+	 *
+	 * If the words->firstTid already pass the result->nextTid, then
+	 * we should scan from the words->firstTid. Since the new batchwords's
+	 * start tid exceeds block's start tid.
 	 */
-	while (words->nwords > 0 && result->nextTid < start)
+	if (words->firstTid < result->nextTid)
+		_bitmap_catchup_to_next_tid(words, result);
+	else if (words->firstTid > result->nextTid)
+		result->nextTid = words->firstTid;
+
+	/*
+	 * If the catch up processd all unmatch words that exceed current block's
+	 * end. Then restart for a new block.
+	 */
+	if (result->nextTid > end)
 	{
-		BM_HRL_WORD word = words->cwords[result->lastScanWordNo];
-
-		if (IS_FILL_WORD(words->hwords, result->lastScanWordNo))
-		{
-			uint64	fillLength;
-			
-			if (word == 0)
-				fillLength = 1;
-			else
-				fillLength = FILL_LENGTH(word);
-
-			if (GET_FILL_BIT(word) == 1)
-			{
-				if (start - result->nextTid >= fillLength * BM_HRL_WORD_SIZE)
-				{
-					result->nextTid += fillLength * BM_HRL_WORD_SIZE;
-					result->lastScanWordNo++;
-					words->nwords--;
-				}
-				else
-				{
-					words->cwords[result->lastScanWordNo] -=
-						(start - result->nextTid)/BM_HRL_WORD_SIZE;
-					result->nextTid = start;
-				}
-			}
-			else
-			{
-				/*
-				 * This word represents compressed non-matches. If it
-				 * is sufficiently large, we might be able to skip over a 
-				 * large range of blocks which would have no matches
-				 */
-				result->lastScanWordNo++;
-				words->nwords--;
-				
-				if(fillLength * BM_HRL_WORD_SIZE > end - result->nextTid)
-				{
-					result->nextTid += fillLength * BM_HRL_WORD_SIZE;
-					blockno = result->nextTid / BM_MAX_TUPLES_PER_PAGE;
-					goto restart;
-				}
-				result->nextTid += fillLength * BM_HRL_WORD_SIZE;
-			}
-		}
-		else
-		{
-			result->nextTid += BM_HRL_WORD_SIZE;
-			result->lastScanWordNo++;
-			words->nwords--;
-		}
+		blockno = result->nextTid / BM_MAX_TUPLES_PER_PAGE;
+		goto restart;
 	}
 
 	/*
@@ -940,6 +912,10 @@ restart:
 		return false;
 	}
 
+	/*
+	 * If the the nextTid is the firstTid, then we exam the leading
+	 * 0 fill words. And skip them.
+	 */
 	if (IS_FILL_WORD(words->hwords, result->lastScanWordNo) &&
 		GET_FILL_BIT(words->cwords[result->lastScanWordNo]) == 0)
 	{
@@ -963,7 +939,11 @@ restart:
 			words->nwords--;
 			
 			if(newentry)
+			{
+				/* Mark the scanned tids */
+				words->firstTid = result->nextTid;
 				goto restart;
+			}
 			else
 				return true;
 		}

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -29,6 +29,7 @@
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/snapmgr.h"
+#include "utils/faultinjector.h"
 
 /*
  * The following structure along with BMTIDBuffer are used to buffer
@@ -80,8 +81,6 @@ static void updatesetbit_inpage(Relation rel, uint64 tidnum,
 								bool use_wal);
 static void insertsetbit(Relation rel, BlockNumber lovBlock, OffsetNumber lovOffset,
 			 			 uint64 tidnum, BMTIDBuffer *buf, bool use_wal);
-static uint64 getnumbits(BM_HRL_WORD *contentWords, 
-					     BM_HRL_WORD *headerWords, uint32 nwords);
 static void findbitmappage(Relation rel, BMLOVItem lovitem,
 					   uint64 tidnum,
 					   Buffer *bitmapBufferP, uint64 *firstTidNumberP);
@@ -114,28 +113,6 @@ static uint16 buf_free_mem(Relation rel, BMTIDBuffer *buf,
 static uint16 _bitmap_free_tidbuf(BMTIDBuffer* buf);
 
 #define BUF_INIT_WORDS 8 /* as good a point as any */
-
-
-/*
- * getnumbits() -- return the number of bits included in the given
- * 	bitmap words.
- */
-static uint64
-getnumbits(BM_HRL_WORD *contentWords, BM_HRL_WORD *headerWords, uint32 nwords)
-{
-	uint64	nbits = 0;
-	uint32	i;
-
-	for (i = 0; i < nwords; i++)
-	{
-		if (IS_FILL_WORD(headerWords, i))
-			nbits += FILL_LENGTH(contentWords[i]) * BM_HRL_WORD_SIZE;
-		else
-			nbits += BM_HRL_WORD_SIZE;
-	}
-
-	return nbits;
-}
 
 /*
  * updatesetbit() -- update a set bit in a bitmap.
@@ -948,7 +925,7 @@ updatesetbit_inpage(Relation rel, uint64 tidnum,
 	}
 
 	bitmapOpaque->bm_last_tid_location -=
-		getnumbits(words_left.cwords, words_left.hwords, words_left.curword);
+		GET_NUM_BITS(words_left.cwords, words_left.hwords, words_left.curword);
 
 	if (words_left.curword > 0)
 	{
@@ -976,6 +953,7 @@ updatesetbit_inpage(Relation rel, uint64 tidnum,
 		memcpy(nextBitmap->hwords, words.hwords,
 			   BM_CALC_H_WORDS(nextOpaque->bm_hrl_words_used) * sizeof(BM_HRL_WORD));
 
+		SIMPLE_FAULT_INJECTOR("rearrange_word_to_next_bitmap_page");
 		Assert(new_words.curword == 0);
 	}
 

--- a/src/backend/access/bitmap/bitmapsearch.c
+++ b/src/backend/access/bitmap/bitmapsearch.c
@@ -24,6 +24,8 @@
 #include "parser/parse_oper.h"
 #include "utils/lsyscache.h"
 #include "utils/snapmgr.h"
+#include "utils/faultinjector.h"
+
 
 typedef struct ItemPos
 {
@@ -32,10 +34,12 @@ typedef struct ItemPos
 } ItemPos;
 
 static void next_batch_words(IndexScanDesc scan);
-static void read_words(Relation rel, Buffer lovBuffer, 
-					   OffsetNumber lovOffset, BlockNumber *nextBlockNoP,
-							  BM_HRL_WORD *headerWords, BM_HRL_WORD *words,
-							  uint32 *numOfWordsP, bool *readLastWords);
+static void read_words(Relation rel, Buffer lovBuffer,
+					   OffsetNumber lovOffset,
+					   bool lockLovBuffer,
+					   BMBatchWords *bachWords /* out */,
+					   BlockNumber *nextBlockNoP /* out */,
+					   bool *readLastWords /* out */);
 static void init_scanpos(IndexScanDesc scan, BMVector bmScanPos,
 					 BlockNumber lovBlock, OffsetNumber lovOffset);
 
@@ -144,6 +148,16 @@ _bitmap_nextbatchwords(IndexScanDesc scan,
 		return false;
 
 	/*
+	 * Set firstTid to retrun for the remain batch words. tid < nextTid should
+	 * already scanned. So move firstTid to nextTid.
+	 * The firstTid may get updated when read new batch words if there only one
+	 * bitmap vector matched, see read_words.
+	 */
+	so->bm_currPos->bm_batchWords->firstTid = so->bm_currPos->bm_result.nextTid;
+	elog(DEBUG2, "BitmapIndexScan next batch words start Tid: " INT64_FORMAT,
+		 so->bm_currPos->bm_batchWords->firstTid);
+
+	/*
 	 * If there are some leftover words from the previous scan, simply
 	 * return them.
 	 */
@@ -156,10 +170,6 @@ _bitmap_nextbatchwords(IndexScanDesc scan,
 	 * content and header bitmap words.
 	 */
 	_bitmap_reset_batchwords(so->bm_currPos->bm_batchWords);
-	so->bm_currPos->bm_batchWords->firstTid = so->bm_currPos->bm_result.nextTid;
-	elog(DEBUG2, "BitmapIndexScan next batch words start Tid: " INT64_FORMAT,
-		 so->bm_currPos->bm_batchWords->firstTid);
-
 	next_batch_words(scan);
 
 	return true;
@@ -211,13 +221,12 @@ next_batch_words(IndexScanDesc scan)
 
 			_bitmap_reset_batchwords(batchWords);
 			read_words(scan->indexRelation,
-							  bmScanPos[i].bm_lovBuffer,
-							  bmScanPos[i].bm_lovOffset,
-							  &(bmScanPos[i].bm_nextBlockNo),
-							  batchWords->hwords,
-							  batchWords->cwords,
-						  	  &(batchWords->nwords),
-							  &(bmScanPos[i].bm_readLastWords));
+					   bmScanPos[i].bm_lovBuffer,
+					   bmScanPos[i].bm_lovOffset,
+					   true /* lockLocBuffer */,
+					   batchWords,
+					   &(bmScanPos[i].bm_nextBlockNo),
+					   &(bmScanPos[i].bm_readLastWords));
 		}
 
 		if (bmScanPos[i].bm_batchWords->nwords > 0)
@@ -267,68 +276,112 @@ next_batch_words(IndexScanDesc scan)
  */
 static void
 read_words(Relation rel, Buffer lovBuffer, OffsetNumber lovOffset,
-				  BlockNumber *nextBlockNoP, BM_HRL_WORD *headerWords, 
-				  BM_HRL_WORD *words, uint32 *numOfWordsP, bool *readLastWords)
+		   bool lockLovBuffer, BMBatchWords *batchWords /* out */,
+		   BlockNumber *nextBlockNoP /* out */, bool *readLastWords /* out */)
 {
 	if (BlockNumberIsValid(*nextBlockNoP))
 	{
-		Buffer bitmapBuffer;
-
-		bitmapBuffer = _bitmap_getbuf(rel, *nextBlockNoP, BM_READ);
-
+		Buffer			bitmapBuffer;
 		Page			bitmapPage;
 		BMBitmap		bitmap;
 		BMBitmapOpaque	bo;
+		uint64			totalTidsInPage;
+		bool			readLOV = false;
 
+		if (lockLovBuffer)
+			LockBuffer(lovBuffer, BM_READ);
+
+		bitmapBuffer = _bitmap_getbuf(rel, *nextBlockNoP, BM_READ);
 		bitmapPage = BufferGetPage(bitmapBuffer);
+
+		elog(LOG, "fetch bitmap page");
 
 		bitmap = (BMBitmap) PageGetContentsMaxAligned(bitmapPage);
 		bo = (BMBitmapOpaque)PageGetSpecialPointer(bitmapPage);
 
-		*numOfWordsP = bo->bm_hrl_words_used;
-		memcpy(headerWords, bitmap->hwords,
-				BM_NUM_OF_HEADER_WORDS * sizeof(BM_HRL_WORD));
-		memcpy(words, bitmap->cwords, sizeof(BM_HRL_WORD) * *numOfWordsP);
-
 		*nextBlockNoP = bo->bm_bitmap_next;
-
-		_bitmap_relbuf(bitmapBuffer);
-		
-		*readLastWords = false;
+		batchWords->nwords = bo->bm_hrl_words_used;
 
 		/*
 		 * If this is the last bitmap page and the total number of words
 		 * in this page is less than or equal to
-		 * BM_NUM_OF_HRL_WORDS_PER_PAGE - 2, we read the last two words
-		 * and append them into 'headerWords' and 'words'.
+		 * BM_NUM_OF_HRL_WORDS_PER_PAGE - 2, we read the last two words from LOV
+		 * and append them into 'batchWords->hwords' and 'batchWords->cwords'.
+		 * This requires hold lock on the lovBuffer to avoid concurrent changes
+		 * on it. Otherwise, release the lock ASAP.
 		 */
-
 		if ((!BlockNumberIsValid(*nextBlockNoP)) &&
-			(*numOfWordsP <= BM_NUM_OF_HRL_WORDS_PER_PAGE - 2))
+			(batchWords->nwords <= BM_NUM_OF_HRL_WORDS_PER_PAGE - 2))
+			readLOV = true;
+		else
 		{
-			BM_HRL_WORD	cwords[2];
-			BM_HRL_WORD	hword;
-			BM_HRL_WORD tmp;
-			uint32		nwords;
-			int			offs;
+			if (lockLovBuffer)
+				LockBuffer(lovBuffer, BUFFER_LOCK_UNLOCK);
+		}
 
-			read_words(rel, lovBuffer, lovOffset, nextBlockNoP, &hword, 
-					   cwords, &nwords, readLastWords);
+		/*
+		 * Get real next tid and nwordsread in uncompressed order for a
+		 * bitmap index scan on a bitmap page.
+		 * If current bitmap page get rearranged words from previous page
+		 * after release the previous bitmap page and before acquire lock
+		 * on it for read. The expected next tid for current bitmap scan
+		 * will not equal to the current page's start tid. So set to correct
+		 * value.
+		 * The rearrange happens when doing insert on the table and it will
+		 * update a full bitmap pages(except the last page) and generate
+		 * new words.
+		 * Since the page is full, so it'll rearrange the words and move
+		 * the unfit words to next bitmap page.
+		 * This related to issue: https://github.com/greenplum-db/gpdb/issues/11308.
+		 */
+		totalTidsInPage = GET_NUM_BITS(bitmap->cwords, bitmap->hwords,
+									   bo->bm_hrl_words_used);
+		batchWords->firstTid = bo->bm_last_tid_location - totalTidsInPage + 1;
+		batchWords->nwordsread = batchWords->firstTid / BM_HRL_WORD_SIZE;
 
-			Assert(nwords > 0 && nwords <= 2);
+		memcpy(batchWords->hwords, bitmap->hwords,
+			   BM_NUM_OF_HEADER_WORDS * sizeof(BM_HRL_WORD));
+		memcpy(batchWords->cwords, bitmap->cwords,
+			   sizeof(BM_HRL_WORD) * batchWords->nwords);
 
-			memcpy(words + *numOfWordsP, cwords, nwords * sizeof(BM_HRL_WORD));
+		_bitmap_relbuf(bitmapBuffer);
+		SIMPLE_FAULT_INJECTOR("after_read_one_bitmap_idx_page");
 
-			offs = *numOfWordsP / BM_HRL_WORD_SIZE;
-			tmp = hword >> *numOfWordsP % BM_HRL_WORD_SIZE;
-			headerWords[offs] |= tmp;
+		*readLastWords = false;
 
-			if (*numOfWordsP % BM_HRL_WORD_SIZE == BM_HRL_WORD_SIZE - 1)
+		if (readLOV)
+		{
+			BMBatchWords	tempBWord;
+			BM_HRL_WORD		cwords[2];
+			BM_HRL_WORD		hword;
+			BM_HRL_WORD		tmp;
+			int				offs;
+
+			MemSet(&tempBWord, 0, sizeof(BMBatchWords));
+			tempBWord.cwords = cwords;
+			tempBWord.hwords = &hword;
+
+			read_words(rel, lovBuffer, lovOffset, false /* lockLovBuffer */,
+					   &tempBWord, nextBlockNoP, readLastWords);
+			Assert(tempBWord.nwords > 0 && tempBWord.nwords <= 2);
+
+			// release lock on lovBuffer once we read words from it.
+			if (lockLovBuffer)
+				LockBuffer(lovBuffer, BUFFER_LOCK_UNLOCK);
+
+			memcpy(batchWords->cwords + batchWords->nwords, cwords,
+				   tempBWord.nwords * sizeof(BM_HRL_WORD));
+
+			offs = batchWords->nwords / BM_HRL_WORD_SIZE;
+			tmp = hword >> batchWords->nwords % BM_HRL_WORD_SIZE;
+			batchWords->hwords[offs] |= tmp;
+
+			if (batchWords->nwords % BM_HRL_WORD_SIZE == BM_HRL_WORD_SIZE - 1)
 			{
-				offs = (*numOfWordsP + 1)/BM_HRL_WORD_SIZE;
-				headerWords[offs] |= hword << 1;
+				offs = (batchWords->nwords + 1)/BM_HRL_WORD_SIZE;
+				batchWords->hwords[offs] |= hword << 1;
 			}
-			*numOfWordsP += nwords;
+			batchWords->nwords += tempBWord.nwords;
 		}
 	}
 	else
@@ -336,7 +389,8 @@ read_words(Relation rel, Buffer lovBuffer, OffsetNumber lovOffset,
 		BMLOVItem	lovItem;
 		Page		lovPage;
 
-		LockBuffer(lovBuffer, BM_READ);
+		if (lockLovBuffer)
+			LockBuffer(lovBuffer, BM_READ);
 
 		lovPage = BufferGetPage(lovBuffer);
 		lovItem = (BMLOVItem) PageGetItem(lovPage, 
@@ -344,21 +398,22 @@ read_words(Relation rel, Buffer lovBuffer, OffsetNumber lovOffset,
 
 		if (lovItem->bm_last_compword != LITERAL_ALL_ONE)
 		{
-			*numOfWordsP = 2;
-			headerWords[0] = (((BM_HRL_WORD)lovItem->lov_words_header) <<
+			batchWords->nwords = 2;
+			batchWords->hwords[0] = (((BM_HRL_WORD)lovItem->lov_words_header) <<
 							  (BM_HRL_WORD_SIZE-2));
-			words[0] = lovItem->bm_last_compword;
-			words[1] = lovItem->bm_last_word;
+			batchWords->cwords[0] = lovItem->bm_last_compword;
+			batchWords->cwords[1] = lovItem->bm_last_word;
 		}
 		else
 		{
-			*numOfWordsP = 1;
-			headerWords[0] = (((BM_HRL_WORD)lovItem->lov_words_header) <<
-							  (BM_HRL_WORD_SIZE-1));
-			words[0] = lovItem->bm_last_word;
+			batchWords->nwords = 1;
+			batchWords->hwords[0] = (((BM_HRL_WORD)lovItem->lov_words_header) <<
+									(BM_HRL_WORD_SIZE-1));
+			batchWords->cwords[0] = lovItem->bm_last_word;
 		}
 
-		LockBuffer(lovBuffer, BUFFER_LOCK_UNLOCK);
+		if (lockLovBuffer)
+			LockBuffer(lovBuffer, BUFFER_LOCK_UNLOCK);
 
 		*readLastWords = true;
 	}
@@ -391,6 +446,11 @@ _bitmap_findbitmaps(IndexScanDesc scan, ScanDirection dir  __attribute__((unused
 	scanPos->done = false;
 	MemSet(&scanPos->bm_result, 0, sizeof(BMIterateResult));
 
+	/*
+	 * The tid to return always start from 1 which is the first tid of
+	 * first uncompressed word.
+	 */
+	scanPos->bm_result.nextTid = 1;
 
 	for (keyNo = 0; keyNo < scan->numberOfKeys; keyNo++)
 	{

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -255,6 +255,11 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 	bool done = false;
 
 	result->nextTidLoc = result->numOfTids = 0;
+
+	_bitmap_catchup_to_next_tid(words, result);
+
+	Assert(words->firstTid == result->nextTid);
+
 	while (words->nwords > 0 && result->numOfTids < maxTids && !done)
 	{
 		uint8 oldScanPos = result->lastScanPos;
@@ -289,7 +294,7 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 			{
 				/* explain the fill word */
 				for (bitNo = 0; bitNo < BM_HRL_WORD_SIZE; bitNo++)
-					result->nextTids[result->numOfTids++] = ++result->nextTid;
+					result->nextTids[result->numOfTids++] = result->nextTid++;
 
 				nfillwords--;
 				/* update fill word to reflect expansion */
@@ -324,15 +329,15 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 				w = words->cwords[result->lastScanWordNo];
 				result->lastScanPos = _bitmap_find_bitset(w, oldScanPos);
 
-				/* did we fine a bit set in this word? */
+				/* did we find a bit set in this word? */
 				if (result->lastScanPos != 0)
 				{
-					result->nextTid += (result->lastScanPos - oldScanPos);
-					result->nextTids[result->numOfTids++] = result->nextTid;
+					uint64 tid = result->nextTid + result->lastScanPos -1;
+					result->nextTids[result->numOfTids++] = tid;
 				}
 				else
 				{
-					result->nextTid += BM_HRL_WORD_SIZE - oldScanPos;
+					result->nextTid += BM_HRL_WORD_SIZE;
 					/* start scanning a new word */
 					words->nwords--;
 					result->lastScanWordNo++;
@@ -340,6 +345,85 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 				}
 				oldScanPos = result->lastScanPos;
 			}
+		}
+	}
+}
+
+/*
+ * _bitmap_catchup_to_next_tid - Catch up to the nextTid we need to check
+ * from last iteration.
+ *
+ * Normally words->firstTid should equal to result->nextTid. But there
+ * are exceptions:
+ * 1: When the concurrent insert causes bitmap items from previous full page
+ * to spill over to current page in the window when we (the read transaction)
+ * had released the lock on the previous page and not locked the current page.
+ * More details see read_words in bitmapsearch.c.
+ * Related to issue: https://github.com/greenplum-db/gpdb/issues/11308
+ * 2. Or when running bitmap heap scan path on bitmap index, since we always
+ * try to read from a table block's start tid. See pull_stream.
+ */
+void
+_bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result)
+{
+	if (words->firstTid >= result->nextTid)
+		return;
+
+	/*
+	 * Iterate each word until catch up to the next tid to search.
+	 */
+	for(; result->lastScanWordNo < words->nwords && words->firstTid < result->nextTid;
+		result->lastScanWordNo++)
+	{
+		if (IS_FILL_WORD(words->hwords, result->lastScanWordNo))
+		{
+			BM_HRL_WORD word = words->cwords[result->lastScanWordNo];
+			uint64	fillLength = FILL_LENGTH(word);
+
+			/*
+			 * XXX: weird, why the word marks as compresed but the word is 0?
+			 */
+			if (word == 0)
+			{
+				fillLength = 1;
+				/* Skip all empty bits, this may cause words->firstTid > result->nextTid */
+				words->firstTid = fillLength * BM_HRL_WORD_SIZE;
+				words->nwords--;
+
+				/* reset next tid to skip all empty words */
+				if (words->firstTid > result->nextTid)
+					result->nextTid = words->firstTid;
+				continue;
+			}
+			else
+			{
+				while (fillLength > 0 && words->firstTid < result->nextTid)
+				{
+					/* update fill word to reflect expansion */
+					words->cwords[result->lastScanWordNo]--;
+					words->firstTid += BM_HRL_WORD_SIZE;
+					fillLength--;
+				}
+
+				/* comsume all the fill words, try to fetch next words */
+				if (fillLength == 0)
+				{
+					words->nwords--;
+					continue;
+				}
+
+				/*
+				* Catch up the next tid to search, but there still fill words.
+				* Return current state.
+				*/
+				if (words->firstTid >= result->nextTid)
+					return;
+			}
+		}
+		else
+		{
+			words->firstTid += BM_HRL_WORD_SIZE;
+			words->nwords--;
 		}
 	}
 }
@@ -502,7 +586,7 @@ static uint64
 fast_forward(uint32 nbatches, BMBatchWords **batches, BMBatchWords *result)
 {
 	int i;
-	uint64 min_tid = ~0;
+	uint64 min_fill_len = MAX_FILL_LENGTH;
 	uint64 fast_forward_words = 0;
 
 	Assert(result != NULL);
@@ -510,7 +594,16 @@ fast_forward(uint32 nbatches, BMBatchWords **batches, BMBatchWords *result)
 
 	for (i = 0; i < nbatches; i++)
 	{
-		BM_HRL_WORD word = batches[i]->cwords[batches[i]->startNo];
+		BM_HRL_WORD word;
+
+		/*
+		 * Fast forward the read batch from a rearrage bitmap index page.
+		 * Since words->nwordsread may get set to a new value in read_words().
+		 * See bitmapsearch.c read_words for more details.
+		 */
+		_bitmap_findnextword(batches[i], batches[i]->nextread);
+
+		word = batches[i]->cwords[batches[i]->startNo];
 
 		/* if we find a matching tid in one of the batches, nothing to do */
 		if (CUR_WORD_IS_FILL(batches[i]) && GET_FILL_BIT(word) == 1)
@@ -519,14 +612,13 @@ fast_forward(uint32 nbatches, BMBatchWords **batches, BMBatchWords *result)
 			return batches[0]->nextread;
 		else if (CUR_WORD_IS_FILL(batches[i]) && GET_FILL_BIT(word) == 0)
 		{
-			uint64 batch_tid = batches[i]->firstTid +
-				(FILL_LENGTH(word) * BM_HRL_WORD_SIZE);
+			uint64 fill_len = FILL_LENGTH(word);
 
 			/* adjust down */
-			if (batch_tid < min_tid)
+			if (fill_len < min_fill_len)
 			{
-				min_tid = batch_tid;
-				fast_forward_words = FILL_LENGTH(word);
+				min_fill_len = fill_len;
+				fast_forward_words = fill_len;
 			}
 		}
 	}
@@ -786,7 +878,6 @@ _bitmap_find_bitset(BM_HRL_WORD word, uint8 lastPos)
 void
 _bitmap_begin_iterate(BMBatchWords *words, BMIterateResult *result)
 {
-	result->nextTid = words->firstTid;
 	result->lastScanPos = 0;
 	result->lastScanWordNo = words->startNo;
 	result->numOfTids = 0;

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -42,7 +42,6 @@
 #include "utils/pg_locale.h"
 #include "utils/selfuncs.h"
 
-
 #define IsBooleanOpfamily(opfamily) \
 	((opfamily) == BOOL_BTREE_FAM_OID || (opfamily) == BOOL_HASH_FAM_OID)
 
@@ -796,8 +795,7 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		 * The appendonlyam.c module will optimize fetches in TID order by keeping
 		 * the last decompressed block between fetch calls.
 		 */
-		if (index->amhasgettuple &&
-			rel->relstorage == RELSTORAGE_HEAP)
+		if (index->amhasgettuple && rel->relstorage == RELSTORAGE_HEAP)
 			add_path(rel, (Path *) ipath);
 
 		if (index->amhasgetbitmap &&

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -784,6 +784,7 @@ extern uint64 _bitmap_findnexttid(BMBatchWords *words,
 								  BMIterateResult *result);
 extern void _bitmap_findnexttids(BMBatchWords *words,
 								 BMIterateResult *result, uint32 maxTids);
+extern void _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result);
 #ifdef NOT_USED /* we might use this later */
 extern void _bitmap_intersect(BMBatchWords **batches, uint32 numBatches,
 						   BMBatchWords *result);
@@ -840,6 +841,29 @@ extern bool _bitmap_findvalue(Relation lovHeap, Relation lovIndex,
  */
 extern void bitmap_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void bitmap_desc(StringInfo buf, XLogRecord *record);
+
+/*
+ * GET_NUM_BITS() -- return the number of bits included in the given
+ * bitmap words.
+ */
+static inline uint64
+GET_NUM_BITS(const BM_HRL_WORD *contentWords,
+			 const BM_HRL_WORD *headerWords,
+			 uint32 nwords)
+{
+	uint64	nbits = 0;
+	uint32	i;
+
+	for (i = 0; i < nwords; i++)
+	{
+		if (IS_FILL_WORD(headerWords, i))
+			nbits += FILL_LENGTH(contentWords[i]) * BM_HRL_WORD_SIZE;
+		else
+			nbits += BM_HRL_WORD_SIZE;
+	}
+
+	return nbits;
+}
 
 /* reloptions.c */
 #define BITMAP_MIN_FILLFACTOR		10

--- a/src/test/isolation2/expected/bitmap_index_concurrent.out
+++ b/src/test/isolation2/expected/bitmap_index_concurrent.out
@@ -1,0 +1,347 @@
+--
+-- Concurrent scan on bitmap index when there's insert running in the backend
+-- may cause the bitmap scan read wrong tid.
+-- If a LOV has multiple bitmap pages, and the index insert tries to insert a tid
+-- into a compressed word on a full bitmap page(Let's call the page `PAGE_FULL`).
+-- Then it'll try to find free space on next bitmap page(Let's call the page `PAGE_NEXT`)
+-- and rearrange the words and copy extra words into the next bitmap page.
+-- So when the above insertion happens, imagine below case:
+-- 1. Query on bitmap: A query starts and reads all bitmap pages to `PAGE_FULL`, increase
+-- next tid to fetch, release lock after reading each page.
+-- 2. Concurrent insert: insert a tid into `PAGE_FULL` cause expand compressed words to
+-- new words, and rearrange words into `PAGE_NEXT`.
+-- 3. Query on bitmap: fetch `PAGE_NEXT` and expect the first tid in it should equal the
+-- saved next tid. But actually `PAGE_NEXT` now contains words used to belong in `PAGE_FULL`.
+-- This causes the real next tid less than the expected next tid. But our scan keeps increasing
+-- the wrong tid. And then this leads to a wrong result.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/11308
+--
+
+-- Setup fault injectors
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- Here we use append optimized table to speed up create full bitmap pages
+-- since each transaction use different seg file number. And ao table's AOTupleId
+-- is composed of (seg file number, row number). So this will lead to lots of
+-- compressed words in the first bitmap page.
+-- With the below transacions in each session, on seg0, the bitmap for id=97
+-- will generate two bitmap pages, and the first page is a full page.
+-- Use heap table, delete tuples and then vacuum should be the same. But it needs huge tuples.
+CREATE TABLE bmupdate (id int) with(appendonly = true) DISTRIBUTED BY (id);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+3: begin;
+BEGIN
+4: begin;
+BEGIN
+5: begin;
+BEGIN
+6: begin;
+BEGIN
+7: begin;
+BEGIN
+8: begin;
+BEGIN
+9: begin;
+BEGIN
+10: begin;
+BEGIN
+11: begin;
+BEGIN
+12: begin;
+BEGIN
+13: begin;
+BEGIN
+14: begin;
+BEGIN
+15: begin;
+BEGIN
+16: begin;
+BEGIN
+17: begin;
+BEGIN
+18: begin;
+BEGIN
+19: begin;
+BEGIN
+20: begin;
+BEGIN
+21: begin;
+BEGIN
+22: begin;
+BEGIN
+
+1: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+2: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+3: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+4: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+5: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+6: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+7: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+8: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+9: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+10: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+11: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+12: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+13: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+14: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+15: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+16: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+17: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+18: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+19: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+20: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+21: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+22: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+INSERT 1000000
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+3: commit;
+COMMIT
+4: commit;
+COMMIT
+5: commit;
+COMMIT
+6: commit;
+COMMIT
+7: commit;
+COMMIT
+8: commit;
+COMMIT
+9: commit;
+COMMIT
+10: commit;
+COMMIT
+11: commit;
+COMMIT
+12: commit;
+COMMIT
+13: commit;
+COMMIT
+14: commit;
+COMMIT
+15: commit;
+COMMIT
+16: commit;
+COMMIT
+17: commit;
+COMMIT
+18: commit;
+COMMIT
+19: commit;
+COMMIT
+20: commit;
+COMMIT
+21: commit;
+COMMIT
+22: commit;
+COMMIT
+
+-- Let's check the total tuple count with id=97 without bitmap index.
+SELECT count(*) FROM bmupdate WHERE id = 97;
+ count 
+-------
+ 2200  
+(1 row)
+
+CREATE INDEX idx_bmupdate__id ON bmupdate USING bitmap (id);
+CREATE
+
+--
+-- Test 1, run Bitmap Heap Scan on the bitmap index when there's
+-- backend insert running.
+--
+-- Inject fault after read the first bitmap page when query the table.
+SELECT gp_inject_fault_infinite('after_read_one_bitmap_idx_page', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Inject fault when insert new tid cause rearrange words from current
+-- bitmap page to next bitmap page.
+SELECT gp_inject_fault_infinite('rearrange_word_to_next_bitmap_page', 'skip', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+1: set optimizer = off;
+SET
+1: set enable_seqscan=off;
+SET
+-- Should generate Bitmap Heap Scan on the bitmap index.
+1: EXPLAIN (COSTS OFF) SELECT * FROM bmupdate WHERE id = 97;
+ QUERY PLAN                                        
+---------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)          
+   ->  Bitmap Heap Scan on bmupdate                
+         Recheck Cond: (id = 97)                   
+         ->  Bitmap Index Scan on idx_bmupdate__id 
+               Index Cond: (id = 97)               
+ Optimizer: Postgres query optimizer               
+(6 rows)
+-- Query should suspend on the first fault injection which finish read the first bitmap page.
+1&: SELECT count(*) FROM bmupdate WHERE id = 97;  <waiting ...>
+
+-- Insert will insert new tid in the first bitmap page and cause the word expand
+-- and rearrange exceed words to next bitmap page.
+-- The reason it not insert at the end of bitmap LOV is because right now only one
+-- transaction doing the insert, and it'll insert to small seg file number.
+2: INSERT INTO bmupdate VALUES (97);
+INSERT 1
+
+-- Query should read the first page(buffer lock released), and then INSERT insert to
+-- the first page which will trigger rearrange words.
+SELECT gp_wait_until_triggered_fault('rearrange_word_to_next_bitmap_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('rearrange_word_to_next_bitmap_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Insert triggered rearrange
+SELECT gp_wait_until_triggered_fault('after_read_one_bitmap_idx_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('after_read_one_bitmap_idx_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Should return the correct tuple count with id=97. It used to raise assertion failure for
+-- AO tables. This is because the wrong tid transform to an invalud AOTupleId.
+1<:  <... completed>
+ count 
+-------
+ 2200  
+(1 row)
+
+-- Let's check the total tuple count after the test.
+SELECT count(*) FROM bmupdate WHERE id = 97;
+ count 
+-------
+ 2201  
+(1 row)
+
+--
+-- Test 2, run Bitmap Heap Scan on the bitmap index that match multiple keys when there's backend
+-- insert running.
+--
+
+-- Inject fault after read the first bitmap page when query the table.
+SELECT gp_inject_fault_infinite('after_read_one_bitmap_idx_page', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Inject fault when insert new tid cause rearrange words from current
+-- bitmap page to next bitmap page.
+SELECT gp_inject_fault_infinite('rearrange_word_to_next_bitmap_page', 'skip', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Should generate Bitmap HEAP Scan on the bitmap index that match multiple keys.
+1: EXPLAIN (COSTS OFF) SELECT * FROM bmupdate WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ QUERY PLAN                                            
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)              
+   ->  Bitmap Heap Scan on bmupdate                    
+         Recheck Cond: ((id >= 97) AND (id <= 99))     
+         Filter: (gp_segment_id = 0)                   
+         ->  Bitmap Index Scan on idx_bmupdate__id     
+               Index Cond: ((id >= 97) AND (id <= 99)) 
+ Optimizer: Postgres query optimizer                   
+(7 rows)
+-- Query should suspend on the first fault injection which finish read the first bitmap page.
+1&: SELECT count(*) FROM bmupdate WHERE id >= 97 and id <= 99 and gp_segment_id = 0;  <waiting ...>
+
+-- Insert will insert new tid in the first bitmap page and cause the word expand
+-- and rearrange exceed words to next bitmap page.
+-- The reason it not insert at the end of bitmap LOV is because right now only one
+-- transaction doing the insert, and it'll insert to small seg file number.
+-- Here insert both values to make sure update on full bitmap happens for one LOV.
+2: INSERT INTO bmupdate SELECT 97 FROM generate_series(1, 1000);
+INSERT 1000
+2: INSERT INTO bmupdate SELECT 99 FROM generate_series(1, 1000);
+INSERT 1000
+
+-- Query should read the first page(buffer lock released), and then INSERT insert to
+-- the first page which will trigger rearrange words.
+SELECT gp_wait_until_triggered_fault('rearrange_word_to_next_bitmap_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('rearrange_word_to_next_bitmap_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Insert triggered rearrange
+SELECT gp_wait_until_triggered_fault('after_read_one_bitmap_idx_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('after_read_one_bitmap_idx_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Should return the correct tuple count with id=97. It used to raise assertion failure for
+-- AO tables. This is because the wrong tid transform to an invalud AOTupleId.
+1<:  <... completed>
+ count 
+-------
+ 4401  
+(1 row)
+
+-- Let's check the total tuple count after the test.
+SELECT count(*) FROM bmupdate WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+ count 
+-------
+ 6401  
+(1 row)
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -82,6 +82,7 @@ test: invalidated_toast_index
 test: distributed_snapshot
 test: gp_collation
 test: ao_upgrade
+test: bitmap_index_concurrent
 
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table

--- a/src/test/isolation2/sql/bitmap_index_concurrent.sql
+++ b/src/test/isolation2/sql/bitmap_index_concurrent.sql
@@ -1,0 +1,186 @@
+--
+-- Concurrent scan on bitmap index when there's insert running in the backend
+-- may cause the bitmap scan read wrong tid.
+-- If a LOV has multiple bitmap pages, and the index insert tries to insert a tid
+-- into a compressed word on a full bitmap page(Let's call the page `PAGE_FULL`).
+-- Then it'll try to find free space on next bitmap page(Let's call the page `PAGE_NEXT`)
+-- and rearrange the words and copy extra words into the next bitmap page.
+-- So when the above insertion happens, imagine below case:
+-- 1. Query on bitmap: A query starts and reads all bitmap pages to `PAGE_FULL`, increase
+-- next tid to fetch, release lock after reading each page.
+-- 2. Concurrent insert: insert a tid into `PAGE_FULL` cause expand compressed words to
+-- new words, and rearrange words into `PAGE_NEXT`.
+-- 3. Query on bitmap: fetch `PAGE_NEXT` and expect the first tid in it should equal the
+-- saved next tid. But actually `PAGE_NEXT` now contains words used to belong in `PAGE_FULL`.
+-- This causes the real next tid less than the expected next tid. But our scan keeps increasing
+-- the wrong tid. And then this leads to a wrong result.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/11308
+--
+
+-- Setup fault injectors
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Here we use append optimized table to speed up create full bitmap pages
+-- since each transaction use different seg file number. And ao table's AOTupleId
+-- is composed of (seg file number, row number). So this will lead to lots of
+-- compressed words in the first bitmap page.
+-- With the below transacions in each session, on seg0, the bitmap for id=97
+-- will generate two bitmap pages, and the first page is a full page.
+-- Use heap table, delete tuples and then vacuum should be the same. But it needs huge tuples.
+CREATE TABLE bmupdate (id int) with(appendonly = true) DISTRIBUTED BY (id);
+
+1: begin;
+2: begin;
+3: begin;
+4: begin;
+5: begin;
+6: begin;
+7: begin;
+8: begin;
+9: begin;
+10: begin;
+11: begin;
+12: begin;
+13: begin;
+14: begin;
+15: begin;
+16: begin;
+17: begin;
+18: begin;
+19: begin;
+20: begin;
+21: begin;
+22: begin;
+
+1: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+2: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+3: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+4: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+5: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+6: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+7: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+8: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+9: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+10: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+11: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+12: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+13: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+14: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+15: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+16: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+17: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+18: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+19: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+20: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+21: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+22: INSERT INTO bmupdate SELECT i%10000 FROM generate_series(1, 1000000) AS i;
+
+1: commit;
+2: commit;
+3: commit;
+4: commit;
+5: commit;
+6: commit;
+7: commit;
+8: commit;
+9: commit;
+10: commit;
+11: commit;
+12: commit;
+13: commit;
+14: commit;
+15: commit;
+16: commit;
+17: commit;
+18: commit;
+19: commit;
+20: commit;
+21: commit;
+22: commit;
+
+-- Let's check the total tuple count with id=97 without bitmap index.
+SELECT count(*) FROM bmupdate WHERE id = 97;
+
+CREATE INDEX idx_bmupdate__id ON bmupdate USING bitmap (id);
+
+--
+-- Test 1, run Bitmap Heap Scan on the bitmap index when there's
+-- backend insert running.
+--
+-- Inject fault after read the first bitmap page when query the table.
+SELECT gp_inject_fault_infinite('after_read_one_bitmap_idx_page', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Inject fault when insert new tid cause rearrange words from current
+-- bitmap page to next bitmap page.
+SELECT gp_inject_fault_infinite('rearrange_word_to_next_bitmap_page', 'skip', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+1: set optimizer = off;
+1: set enable_seqscan=off;
+-- Should generate Bitmap Heap Scan on the bitmap index.
+1: EXPLAIN (COSTS OFF) SELECT * FROM bmupdate WHERE id = 97;
+-- Query should suspend on the first fault injection which finish read the first bitmap page.
+1&: SELECT count(*) FROM bmupdate WHERE id = 97;
+
+-- Insert will insert new tid in the first bitmap page and cause the word expand
+-- and rearrange exceed words to next bitmap page.
+-- The reason it not insert at the end of bitmap LOV is because right now only one
+-- transaction doing the insert, and it'll insert to small seg file number.
+2: INSERT INTO bmupdate VALUES (97);
+
+-- Query should read the first page(buffer lock released), and then INSERT insert to
+-- the first page which will trigger rearrange words.
+SELECT gp_wait_until_triggered_fault('rearrange_word_to_next_bitmap_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+SELECT gp_inject_fault('rearrange_word_to_next_bitmap_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Insert triggered rearrange
+SELECT gp_wait_until_triggered_fault('after_read_one_bitmap_idx_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+SELECT gp_inject_fault('after_read_one_bitmap_idx_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Should return the correct tuple count with id=97. It used to raise assertion failure for
+-- AO tables. This is because the wrong tid transform to an invalud AOTupleId.
+1<:
+
+-- Let's check the total tuple count after the test.
+SELECT count(*) FROM bmupdate WHERE id = 97;
+
+--
+-- Test 2, run Bitmap Heap Scan on the bitmap index that match multiple keys when there's backend
+-- insert running.
+--
+
+-- Inject fault after read the first bitmap page when query the table.
+SELECT gp_inject_fault_infinite('after_read_one_bitmap_idx_page', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Inject fault when insert new tid cause rearrange words from current
+-- bitmap page to next bitmap page.
+SELECT gp_inject_fault_infinite('rearrange_word_to_next_bitmap_page', 'skip', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Should generate Bitmap HEAP Scan on the bitmap index that match multiple keys.
+1: EXPLAIN (COSTS OFF) SELECT * FROM bmupdate WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+-- Query should suspend on the first fault injection which finish read the first bitmap page.
+1&: SELECT count(*) FROM bmupdate WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+
+-- Insert will insert new tid in the first bitmap page and cause the word expand
+-- and rearrange exceed words to next bitmap page.
+-- The reason it not insert at the end of bitmap LOV is because right now only one
+-- transaction doing the insert, and it'll insert to small seg file number.
+-- Here insert both values to make sure update on full bitmap happens for one LOV.
+2: INSERT INTO bmupdate SELECT 97 FROM generate_series(1, 1000);
+2: INSERT INTO bmupdate SELECT 99 FROM generate_series(1, 1000);
+
+-- Query should read the first page(buffer lock released), and then INSERT insert to
+-- the first page which will trigger rearrange words.
+SELECT gp_wait_until_triggered_fault('rearrange_word_to_next_bitmap_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+SELECT gp_inject_fault('rearrange_word_to_next_bitmap_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Insert triggered rearrange
+SELECT gp_wait_until_triggered_fault('after_read_one_bitmap_idx_page', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+SELECT gp_inject_fault('after_read_one_bitmap_idx_page', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = 0;
+
+-- Should return the correct tuple count with id=97. It used to raise assertion failure for
+-- AO tables. This is because the wrong tid transform to an invalud AOTupleId.
+1<:
+
+-- Let's check the total tuple count after the test.
+SELECT count(*) FROM bmupdate WHERE id >= 97 and id <= 99 and gp_segment_id = 0;
+


### PR DESCRIPTION
Concurrent scan on bitmap index when there's insert running in the
backend may cause the bitmap scan read wrong tid.
If a LOV has multiple bitmap pages, and the index insert tries to insert
a tid into a compressed word on a full bitmap page(Let's call the page
`PAGE_FULL`).
Then it'll try to find free space on next bitmap page(Let's call the
page `PAGE_NEXT`) and rearrange the words and copy extra words into
the next bitmap page.

So when the above insertion happens, imagine below case:
1. Query on bitmap: A query starts and reads all bitmap pages to
`PAGE_FULL`, increase
next tid to fetch, release lock after reading each page.
2. Concurrent insert: insert a tid into `PAGE_FULL` cause expand
compressed words to
new words, and rearrange words into `PAGE_NEXT`.
3. Query on bitmap: fetch `PAGE_NEXT` and expect the first tid in it
should equal the
saved next tid. But actually `PAGE_NEXT` now contains words used to
belong in `PAGE_FULL`.
This causes the real next tid less than the expected next tid. But our
scan keeps increasing
the wrong tid. And then this leads to a wrong result.
This related to issue: https://github.com/greenplum-db/gpdb/issues/11308

This commit done follow changes:
1. Allow Index Path on bitmap index for AO/AOCS tables. We used only
allow Bitmap Heap Path on AO/AOCS tables to avoid decompressed overhead
for random access data blocks. But Index Path on bitmap index will have
the same access order with Bitmap Heap Path.

2. BMBatchWords.firstTid is not well used in past. Now it always tracks
the first tid for the word to be checked for the current bitmap vector.

3. For BMIterateResult.nextTid, the init value for Bitmap Heap Scan is 1,
but for Index Scan it start from 0. Now make it consistent that always
start from 1. And it tracks the next tid to be checked during scanning.

4. When read BMBatchWords from bitmap page, we should calculate the
firstTid and nwordsread. We used to expect bitmap pages' tids are in
series. But this is not ture when the tid rearrange happens which
discussed above. The logic is in bitmapsearch.c `read_words`.

5. Consider catch up BMBatchWords.firstTid to BMIterateResult.nextTid,
so this could skip the scanned tids.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
