### PR TITLE
[Backport to 6X] pg_rewind: avoid removing "pg_log" files

### DIFF
--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -253,10 +253,11 @@ process_target_file(const char *path, file_type_t type, size_t size,
 	 * from the target data folder all paths which have been filtered out from
 	 * the source data folder when processing the source files.
 	 *
-	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME is in the excluded file list.
-	 * It should not be copied but also should not be removed. In the future,
-	 * if there are more files that should not be copied but also should not be
-	 * removed, then a separate function for those files would be better.
+	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME and "pg_log" are in the excluded
+	 * file list.  These should not be copied but also should not be
+	 * removed. In the future, if there are more files or directories that
+	 * should not be copied but also should not be removed, then a separate
+	 * function for those would be better.
 	 */
 	{
 		const char *filename = last_dir_separator(path);
@@ -265,6 +266,15 @@ process_target_file(const char *path, file_type_t type, size_t size,
 		else
 			filename++;
 		if (strcmp(filename, GP_INTERNAL_AUTO_CONF_FILE_NAME) == 0)
+			return;
+
+		/*
+		 * While `log_directory` guc is declared inside DEFUNCT_OPTIONS group
+		 * (see corresponding entry inside `ConfigureNamesString` global array),
+		 * this guc will preserve its default value 'pg_log' without any
+		 * possibility to change it externally
+		 */
+		if (strstr(path, "pg_log/") == path)
 			return;
 	}
 


### PR DESCRIPTION
Backport of 6f29a6f to 6X.

It's safe to use constant literal `pg_log` defined as default value of `log_directory` guc because `log_directory` is [declared](https://github.com/greenplum-db/gpdb/blob/6.15.0/src/backend/utils/misc/guc.c#L3067) inside `DEFUNCT_OPTIONS` group and hence [cannot be changed externally](https://github.com/greenplum-db/gpdb/blob/6.15.0/src/backend/utils/misc/guc.c#L6014-L6022).