### PR TITLE
Docs: indicate LISTEN, NOTIFY, UNLISTEN support in 6.11

### DIFF
--- a/gpdb-doc/dita/ref_guide/feature_summary.xml
+++ b/gpdb-doc/dita/ref_guide/feature_summary.xml
@@ -805,7 +805,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
             </row>
             <row>
               <entry colname="col1"><codeph>LISTEN</codeph></entry>
-              <entry colname="col2"><b otherprops="red">NO</b></entry>
+              <entry colname="col2">YES</entry>
               <entry colname="col3"/>
             </row>
             <row>
@@ -825,7 +825,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
             </row>
             <row>
               <entry colname="col1"><codeph>NOTIFY</codeph></entry>
-              <entry colname="col2"><b otherprops="red">NO</b></entry>
+              <entry colname="col2">YES</entry>
               <entry colname="col3"/>
             </row>
             <row>
@@ -954,7 +954,7 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
             </row>
             <row>
               <entry colname="col1"><codeph>UNLISTEN</codeph></entry>
-              <entry colname="col2"><b otherprops="red">NO</b></entry>
+              <entry colname="col2">YES</entry>
               <entry colname="col3"/>
             </row>
             <row>


### PR DESCRIPTION
Updates the "SQL Support in Greenplum Database" table to indicate that `LISTEN`, `UNLISTEN`, and `NOTIFY` are supported.