### PR TITLE
Clean stale state directories in analyzedb

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -20,7 +20,7 @@ import shutil
 import fnmatch
 import tempfile
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 import pipes  # for shell-quoting, pipes.quote()
 import fcntl
 
@@ -46,6 +46,8 @@ WRITE_LOCK_FILE_NAME = "write_lock_semaphore"
 ANALYZE_GUCS = "set optimizer_analyze_enable_merge_of_leaf_stats=off; "
 ANALYZE_SQL = """analyze %s"""
 ANALYZE_ROOT_SQL = """analyze rootpartition %s"""
+REPORTS_ARE_STALE_AFTER_N_DAYS = 8
+NUM_REPORTS_TO_SAVE = 3
 
 PG_PARTITIONS_SURROGATE = """
 SELECT n.nspname AS schemaname, cl.relname AS tablename, n2.nspname AS partitionschemaname, cl2.relname AS partitiontablename, cl3.relname AS parentpartitiontablename
@@ -235,7 +237,7 @@ class AnalyzeDb(Operation):
                 logger.warning("Folder %s does not exist. Exiting...")
 
         if self.clean_last:
-            last_analyze_timestamp = get_lastest_analyze_timestamp(self.master_datadir, self.analyze_dir, self.dbname)
+            last_analyze_timestamp = get_latest_analyze_timestamp(self.master_datadir, self.analyze_dir, self.dbname)
             if last_analyze_timestamp is not None:
                 analyze_folder = os.path.join(self.master_datadir, self.analyze_dir, self.dbname,
                                               last_analyze_timestamp)
@@ -442,7 +444,7 @@ class AnalyzeDb(Operation):
                         (len(self.success_list), total_to_analyze))
 
     def read_last_analyzedb_output(self):
-        last_analyze_timestamp = get_lastest_analyze_timestamp(self.master_datadir, self.analyze_dir, self.dbname)
+        last_analyze_timestamp = get_latest_analyze_timestamp(self.master_datadir, self.analyze_dir, self.dbname)
         prev_ao_state = get_prev_ao_state(last_analyze_timestamp, self.master_datadir, self.analyze_dir, self.dbname)
         prev_col_dict = get_prev_col_state(last_analyze_timestamp, self.master_datadir, self.analyze_dir, self.dbname)
         prev_last_op = get_prev_last_op(last_analyze_timestamp, self.master_datadir, self.analyze_dir, self.dbname)
@@ -672,6 +674,7 @@ class AnalyzeDb(Operation):
             fp.write("\n%d out of %d tables are analyzed.\n" % (len(self.success_list), len(target_list)))
             if len(target_list) == len(self.success_list):
                 fp.write("\nanalyzedb finished successfully.\n")
+            self._clean_stale_directories(current_time)
 
     def _get_dirty_lastop_tables(self, curr_last_op, prev_last_op):
         old_pgstatlastoperation_dict = get_pgstatlastoperation_dict(prev_last_op)
@@ -827,6 +830,28 @@ class AnalyzeDb(Operation):
             finally:
                 fcntl.flock(lock_file, fcntl.LOCK_UN)
 
+    def _clean_stale_directories(self, current_time_str):
+        # extract the date and time from the string of the form yyyymmddhhmmss
+        current_analyze_time = datetime.strptime(current_time_str, '%Y%m%d%H%M%S')
+        num_previous_statefiles = 0
+        # Now walk through the log directories and delete those that are more than
+        # REPORTS_ARE_STALE_AFTER_N_DAYS days older than the current analyze timestamp,
+        # but leave at least NUM_REPORTS_TO_SAVE, even if they are older than the threshold
+        analyze_dirs = get_analyze_dirs(self.master_datadir, self.analyze_dir, self.dbname)
+        for saved_analyze_dir in analyze_dirs:
+            try:
+                time_of_saved_analyze = datetime.strptime(os.path.basename(saved_analyze_dir), '%Y%m%d%H%M%S')
+                time_diff = current_analyze_time - time_of_saved_analyze
+                if num_previous_statefiles >= NUM_REPORTS_TO_SAVE and time_diff > timedelta(days=REPORTS_ARE_STALE_AFTER_N_DAYS):
+                    # this directory more than a week older than the most recent valid analyze directory, remove it
+                    if os.path.exists(saved_analyze_dir):
+                        shutil.rmtree(saved_analyze_dir)
+                        logger.info("Deleted archived log directory %s" % saved_analyze_dir)
+                if time_diff > timedelta(seconds=0):
+                    num_previous_statefiles += 1
+            except:
+                logger.info("Ignoring log directory that does not conform to naming convention: %s" % saved_analyze_dir)
+
 
 # Create a Command object that executes a query using psql.
 def create_psql_command(dbname, query):
@@ -889,7 +914,7 @@ def get_heap_tables_set(conn, input_tables_set):
     return dirty_tables
 
 
-def get_lastest_analyze_timestamp(master_datadir, statefile_dir, dbname):
+def get_latest_analyze_timestamp(master_datadir, statefile_dir, dbname):
     analyze_dirs = get_analyze_dirs(master_datadir, statefile_dir, dbname)
 
     for analyze_dir in analyze_dirs:
@@ -1206,9 +1231,9 @@ def create_parser():
     parser.add_option('--full', action='store_true', dest='full_analyze', default=False,
                       help="Analyze without using incremental. All tables requested by the user will be analyzed.")
     parser.add_option('--clean_last', action='store_true', dest='clean_last', default=False,
-                      help="Clean the state files generated by last analyzedb run. All other options except -d will be ignored.")
+                      help="Clean the state files generated by last analyzedb run. All other options except -d and -a will be ignored.")
     parser.add_option('--clean_all', action='store_true', dest='clean_all', default=False,
-                      help="Clean all the state files generated by analyzedb. All other options except -d will be ignored.")
+                      help="Clean all the state files generated by analyzedb. All other options except -d and -a will be ignored.")
     parser.add_option('-h', '-?', '--help', action='help',
                       help='Show this help message and exit.')
     parser.add_option('-v', '--verbose', action='store_true', dest='verbose', help='Print debug messages.')

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -182,6 +182,76 @@ Feature: Incrementally analyze the database
         When the user runs "analyzedb -l -d incr_analyze -t '"my schema"."my ao"'"
         Then analyzedb should print "-"my schema"."my ao" to stdout
 
+    Scenario: Clean all state files
+        Given no state files exist for database "incr_analyze"
+        When the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And the user runs "analyzedb -a -d incr_analyze --clean_all"
+        And the user runs "analyzedb -a -d incr_analyze -l"
+        Then analyzedb should return a return code of 0
+        And output should print "-public.t1_ao" to stdout
+        And "public.t1_ao" should not appear in the latest state files
+        And there should be 0 state directories for database "incr_analyze"
+
+    Scenario: Clean latest state files
+        Given no state files exist for database "incr_analyze"
+        When the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t3_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t3_ao"
+        And the user runs "analyzedb -a -d incr_analyze --clean_last"
+        And the user runs "analyzedb -a -d incr_analyze -l"
+        Then analyzedb should return a return code of 0
+        And analyzedb should print "-public.t3_ao" to stdout
+        And output should not contain "-public.t1_ao"
+        And "public.t1_ao" should appear in the latest state files
+        And "public.t3_ao" should not appear in the latest state files
+        And there should be 1 state directory for database "incr_analyze"
+
+    Scenario: Preserve state files less than 8 days old
+        Given no state files exist for database "incr_analyze"
+        When the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        Then analyzedb should return a return code of 0
+        And there should be 5 state directories for database "incr_analyze"
+
+    Scenario: Automatically clean older state files and leave the current and 3 most recent
+        Given no state files exist for database "incr_analyze"
+        When the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the state files for "incr_analyze" are artificially aged by 10 days
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        And some data is inserted into table "t1_ao" in schema "public" with column type list "int,text,real"
+        And the user waits 1 second
+        And the user runs "analyzedb -a -d incr_analyze -t public.t1_ao"
+        Then analyzedb should return a return code of 0
+        And there should be 4 state directories for database "incr_analyze"
 
     @analyzedb_core @analyzedb_single_table
     Scenario: Incremental analyze, no dirty tables


### PR DESCRIPTION
This is a backport of 6X PR https://github.com/greenplum-db/gpdb/pull/11654.

The analyzedb utility leaves a state directory each time it is run (in
a way that it actually performs ANALYZE commands). These state
directories are stored in a subdirectory db_analyze below the master
data directory.

With this fix we preserve only state directories that less than 8 days
old, with one exception: We also preserve the 3 most recent state
directories regardless of age, plus the current state directory.
All others are removed automatically.

Users should not need to deal with state directories, except when
using the `--clean_last` option that restores the state of the previous
analyzedb run. Leaving at least 3 historic state directories allows to
use this option at least 3 times in a row (more often if the state
directories are less than 8 days old).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
