### PR TITLE
Re-enable INSERT for partitioned tables in GPORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4080,7 +4080,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	// GPDB_12_MERGE_FIXME: Make this an parameter in TranslateDXLTblDescrToRangeTblEntry
 	rte->rellockmode = RowExclusiveLock;
 	rte->requiredPerms |= acl_mode;
-	m_dxl_to_plstmt_context->AddRTE(rte);
+	m_dxl_to_plstmt_context->AddRTE(rte, true);
 
 	CDXLNode *project_list_dxlnode = (*dml_dxlnode)[0];
 	CDXLNode *child_dxlnode = (*dml_dxlnode)[1];
@@ -4151,6 +4151,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	dml->nominalRelation = index;
 	dml->resultRelations = ListMake1Int(index);
 	dml->resultRelIndex = list_length(m_result_rel_list) - 1;
+	dml->rootRelation = md_rel->IsPartitioned() ? index : 0;
 	dml->plans = ListMake1(child_plan);
 
 	dml->fdwPrivLists = ListMake1(NIL);

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3169,14 +3169,6 @@ CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet(const RangeTblEntry *rte,
 		IMDId *part_mdid = (*partition_mdids)[ul];
 		const IMDRelation *partrel = m_md_accessor->RetrieveRel(part_mdid);
 
-		if (partrel->IsPartitioned())
-		{
-			// Multi-level partitioned tables are unsupported - fall back
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-					   GPOS_WSZ_LIT("Multi-level partitioned tables"));
-		}
-
-
 		if (partrel->RetrieveRelStorageType() != rel_storage_type)
 		{
 			if (rel_storage_type == IMDRelation::ErelstorageSentinel)

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
@@ -584,9 +584,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
+      <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.312872" Rows="20.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.312819" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -599,16 +599,16 @@
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="0.24643.1.1" TableName="t_ao">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000372" Rows="20.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000319" Rows="20.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -617,15 +617,15 @@
             <dxl:ProjElem ColId="1" Alias="year">
               <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="0.24643.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000292" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="20.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -635,49 +635,21 @@
                 <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="20.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="id">
-                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="year">
-                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.24587.1.1" TableName="t">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:PartitionSelector>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.24587.1.1" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
@@ -542,9 +542,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="true">
+      <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0" InputSorted="true">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.418333" Rows="20.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.418667" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -564,9 +564,9 @@
             <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Result>
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.001667" Rows="20.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002001" Rows="20.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -576,17 +576,21 @@
               <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.26.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="10" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.001560" Rows="20.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000345" Rows="20.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -596,18 +600,17 @@
                 <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.26.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                <dxl:ConstValue TypeMdid="0.26.1.0" Value="24643"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:PartitionSelector RelationMdid="0.24643.1.1" PartitionLevels="1" ScanId="0">
+            <dxl:OneTimeFilter/>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000319" Rows="20.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="20.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="id">
@@ -616,55 +619,24 @@
                 <dxl:ProjElem ColId="1" Alias="year">
                   <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                  <dxl:PartOid Level="0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:PartEqFilters>
-                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilters>
-              <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartFilters>
-              <dxl:ResidualFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:ResidualFilter>
-              <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-              </dxl:PropagationExpression>
-              <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PrintableFilter>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="20.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="id">
-                    <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="year">
-                    <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.24587.1.1" TableName="t">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:PartitionSelector>
-          </dxl:Sort>
-        </dxl:Result>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.24587.1.1" TableName="t">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="year" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
+        </dxl:Sort>
       </dxl:DMLInsert>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -421,9 +421,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
+      <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023471" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023465" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -436,16 +436,16 @@
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="0.1319741.1.1" TableName="p_parquet">
           <dxl:Columns>
-            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="13" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="14" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -454,15 +454,15 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="0.1319741.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -472,49 +472,21 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1095673.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:PartitionSelector>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.1095673.1.1" TableName="r">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
@@ -367,9 +367,9 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="true">
+      <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0" InputSorted="true">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031288" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031280" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -389,9 +389,9 @@
             <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Result>
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -401,15 +401,19 @@
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.26.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="10" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Result>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
             </dxl:Properties>
@@ -421,18 +425,17 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.26.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                <dxl:ConstValue TypeMdid="0.26.1.0" Value="1319741"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:PartitionSelector RelationMdid="0.1319741.1.1" PartitionLevels="1" ScanId="0">
+            <dxl:OneTimeFilter/>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -441,55 +444,24 @@
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                  <dxl:PartOid Level="0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:PartEqFilters>
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilters>
-              <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartFilters>
-              <dxl:ResidualFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:ResidualFilter>
-              <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-              </dxl:PropagationExpression>
-              <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PrintableFilter>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.1095673.1.1" TableName="r">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:PartitionSelector>
-          </dxl:Sort>
-        </dxl:Result>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.1095673.1.1" TableName="r">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
+        </dxl:Sort>
       </dxl:DMLInsert>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -532,9 +532,9 @@ explain insert into pt2 select * from r;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,2" ActionCol="11" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
+      <dxl:DMLInsert Columns="0,1,2" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031317" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031309" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -550,21 +550,21 @@ explain insert into pt2 select * from r;
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="0.1695223.1.1" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -576,15 +576,15 @@ explain insert into pt2 select * from r;
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="0.1695223.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -597,24 +597,16 @@ explain insert into pt2 select * from r;
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -628,45 +620,22 @@ explain insert into pt2 select * from r;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="c">
-                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.1695445.1.1" TableName="r">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:RedistributeMotion>
-          </dxl:PartitionSelector>
+              <dxl:TableDescriptor Mdid="0.1695445.1.1" TableName="r">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
@@ -532,9 +532,9 @@ explain insert into pt2 select * from r;
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1,2" ActionCol="11" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
+      <dxl:DMLInsert Columns="0,1,2" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031292" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031284" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -550,21 +550,21 @@ explain insert into pt2 select * from r;
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="0.1695223.1.1" TableName="pt2">
           <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="14" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="13" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -576,15 +576,15 @@ explain insert into pt2 select * from r;
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="0.1695223.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -597,53 +597,22 @@ explain insert into pt2 select * from r;
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="c">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1695445.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:PartitionSelector>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.1695445.1.1" TableName="r">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -602,12 +602,6 @@ CTranslatorDXLToExpr::PexprLogicalGet(const CDXLNode *dxlnode)
 					GPOS_WSZ_LIT(
 						"Partitioned table with heterogeneous storage types"));
 			}
-			if (partrel->IsPartitioned())
-			{
-				// Multi-level partitioned tables are unsupported - fall back
-				GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
-						   GPOS_WSZ_LIT("Multi-level partitioned tables"));
-			}
 		}
 
 		// generate a part index id

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1339,7 +1339,7 @@ CXformUtils::PexprLogicalDMLOverProject(CMemoryPool *mp,
 	CColRef *pcrAction = nullptr;
 	CColRef *pcrOid = nullptr;
 
-	if (ptabdesc->IsPartitioned())
+	if (ptabdesc->IsPartitioned() && CLogicalDML::EdmlDelete == edmlop)
 	{
 		// generate a PartitionSelector node which generates OIDs, then add a project
 		// on top of that to add the action column

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -167,7 +167,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_part_singlecol select g, g*2, g*3 from generate_series(1,49) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_part_singlecol values (NULL, NULL);
@@ -430,7 +429,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_bitmap_idx select g, g%5,g%5 from generate_series(1,100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_bitmap_idx values(null, null);
@@ -581,7 +579,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx select g, g%5,g%5 from generate_series(1,100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx values(null, null);
@@ -598,7 +595,6 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx2 select g, g%5,g%5 from generate_series(1,100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into dd_singlecol_part_idx2 values(null, null);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8181,8 +8181,6 @@ partition by list(d) (partition part1 values('a'), partition part2 values('b'));
 insert into orca.t
 	select i, i::char(2), i, i, case when i%2 = 0 then 'a' else 'b' end, i
 	from generate_series(1,100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from orca.t order by 1, 2, 3, 4, 5, 6 limit 4;
  a | b  | to_be_drop | c | d  | e 
 ---+----+------------+---+----+---
@@ -8203,11 +8201,7 @@ select * from orca.t order by 1, 2, 3, 4, 5 limit 4;
 (4 rows)
 
 insert into orca.t (d, a) values('a', 0);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t (a, d) values(0, 'b');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from orca.t order by 1, 2, 3, 4, 5 limit 4;
  a | b  | c | d  | e 
 ---+----+---+----+---
@@ -8231,7 +8225,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into orca.multilevel_p values (1,1), (100,200);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
+DETAIL:  Feature not supported: Multi-level partitioned tables
 select * from orca.multilevel_p;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Multi-level partitioned tables
@@ -8249,8 +8243,6 @@ partition by list(d) (partition part1 values('a') with (appendonly=true, compres
 insert into orca.t
 	select i, i::char(2), i, i, case when i%2 = 0 then 'a' else 'b' end, i
 	from generate_series(1,100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from orca.t order by 1, 2, 3, 4, 5, 6 limit 4;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Partitioned table with heterogeneous storage types
@@ -8277,8 +8269,6 @@ DETAIL:  Feature not supported: Partitioned table with heterogeneous storage typ
 insert into orca.t
 	select i, i::char(2), i, case when i%2 = 0 then 'a' else 'b' end, i
 	from generate_series(1,100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from orca.t order by 1, 2, 3, 4, 5 limit 4;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Partitioned table with heterogeneous storage types
@@ -8296,30 +8286,16 @@ create table orca.t ( timest character varying(6), user_id numeric(16,0) not nul
 distributed by (user_id)
 partition by list (timest) (partition part201203 values('201203') with (appendonly=true, compresslevel=5, orientation=column), partition part201204 values('201204') with (appendonly=true, compresslevel=5, orientation=row), partition part201205 values('201205'));
 insert into orca.t values('201203',0,'drop', 'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 alter table orca.t drop column to_be_drop;
 alter table orca.t add partition part201206 values('201206') with (appendonly=true, compresslevel=5, orientation=column);
 alter table orca.t add partition part201207 values('201207') with (appendonly=true, compresslevel=5, orientation=row);
 alter table orca.t add partition part201208 values('201208');
 insert into orca.t values('201203',1,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t values('201204',2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t values('201205',1,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t values('201206',2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t values('201207',1,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t values('201208',2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 -- test projections
 select * from orca.t order by 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -8384,8 +8360,6 @@ DETAIL:  Feature not supported: Heterogeneous partition storage types
 (7 rows)
 
 insert into orca.t(user_id, timest, tag2) values(3, '201208','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from orca.t order by 1, 2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Heterogeneous partition storage types
@@ -8412,50 +8386,20 @@ alter table orca.t_date add partition part201206 values('01-06-2012'::date);
 alter table orca.t_date add partition part201207 values('01-07-2012'::date);
 alter table orca.t_date add partition part201208 values('01-08-2012'::date);
 insert into orca.t_date values('01-03-2012'::date,0,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,1,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-04-2012'::date,2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-05-2012'::date,1,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-06-2012'::date,2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-07-2012'::date,1,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-08-2012'::date,2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,2,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,3,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,4,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,5,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,6,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,7,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,8,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_date values('01-03-2012'::date,9,'tag1','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 set optimizer_enable_partial_index=on;
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
@@ -8496,50 +8440,20 @@ distributed by (user_id)
 partition by list(tag1) (partition partgood values('good'::text), partition partbad values('bad'::text), partition partugly values('ugly'::text));
 create index user_id_idx on orca.t_text_1_prt_partgood(user_id);
 insert into orca.t_text values('01-03-2012'::date,0,'good','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,1,'bad','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-04-2012'::date,2,'ugly','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-05-2012'::date,1,'good','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-06-2012'::date,2,'bad','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-07-2012'::date,1,'ugly','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-08-2012'::date,2,'good','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,2,'bad','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,3,'ugly','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,4,'good','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,5,'bad','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,6,'ugly','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,7,'good','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,8,'bad','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_text values('01-03-2012'::date,9,'ugly','tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
 explain select * from orca.t_text where user_id=9;
@@ -8575,20 +8489,10 @@ partition by list (category_id)
 	(partition part100 values('100') , partition part101 values('101'), partition part103 values('102'));
 create index user_id_ceeval_ints on orca.t_ceeval_ints_1_prt_part101(user_id);
 insert into orca.t_ceeval_ints values(1, 100, 'tag1', 'tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_ceeval_ints values(2, 100, 'tag1', 'tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_ceeval_ints values(3, 100, 'tag1', 'tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_ceeval_ints values(4, 101, 'tag1', 'tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into orca.t_ceeval_ints values(5, 102, 'tag1', 'tag2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 set optimizer_enable_partial_index=on;
 set optimizer_enable_space_pruning=off;
 set optimizer_enable_constant_expression_evaluation=on;
@@ -9291,8 +9195,6 @@ create table mpp22791(a int, b int) partition by range(b) (default partition d);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mpp22791 values (1, 1), (2, 2), (3, 3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from mpp22791 where b > 1;
  a | b 
 ---+---
@@ -9319,8 +9221,6 @@ create table orca.p1(a int) partition by range(a)(partition pp1 start(1) end(10)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into orca.p1 select * from generate_series(2,15);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select count(*) from (select gp_segment_id,ctid,tableoid from orca.p1 group by gp_segment_id,ctid,tableoid) as foo;
  count 
 -------
@@ -10140,14 +10040,10 @@ create table orca.bm_dyn_test (i int, to_be_dropped char(5), j int, t text) dist
    partition part2 values(2) with (appendonly=true, compresslevel=5, orientation=row),
    partition part3 values(3), partition part4 values(4));
 insert into orca.bm_dyn_test select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 create index bm_dyn_test_idx on orca.bm_dyn_test using bitmap (i);
 alter table orca.bm_dyn_test drop column to_be_dropped;
 alter table orca.bm_dyn_test add partition part5 values(5);
 insert into orca.bm_dyn_test values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 set optimizer_enable_bitmapscan=on;
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test where i=2 and t='2';
@@ -10201,14 +10097,10 @@ create table orca.bm_dyn_test_onepart (i int, to_be_dropped char(5), j int, t te
    partition part2 values(2) with (appendonly=true, compresslevel=5, orientation=row),
    partition part3 values(3), partition part4 values(4));
 insert into orca.bm_dyn_test_onepart select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 create index bm_test_idx_part on orca.bm_dyn_test_onepart_1_prt_part2 using bitmap (i);
 alter table orca.bm_dyn_test_onepart drop column to_be_dropped;
 alter table orca.bm_dyn_test_onepart add partition part5 values(5);
 insert into orca.bm_dyn_test_onepart values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 set optimizer_enable_bitmapscan=on;
 set optimizer_enable_dynamictablescan = off;
 -- gather on 1 segment because of direct dispatch
@@ -10267,7 +10159,7 @@ distributed by (id) partition by range (year)
   ( start (2018) end (2020) every (1) );
 insert into orca.bm_dyn_test_multilvl_part select i, 2018 + (i%2), i%2 + 1, 'usa' from generate_series(1,100)i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
+DETAIL:  Feature not supported: Multi-level partitioned tables
 create index bm_multi_test_idx_part on orca.bm_dyn_test_multilvl_part using bitmap(year);
 analyze orca.bm_dyn_test_multilvl_part;
 -- print name of parent index
@@ -10309,14 +10201,10 @@ create table bm.het_bm (i int, to_be_dropped char(5), j int, t text) distributed
    partition part2 values(2) with (appendonly=true, compresslevel=5, orientation=row),
    partition part3 values(3), partition part4 values(4));
 insert into bm.het_bm select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 create index het_bm_idx on bm.het_bm using bitmap (i);
 alter table bm.het_bm drop column to_be_dropped;
 alter table bm.het_bm add partition part5 values(5);
 insert into bm.het_bm values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select sum(i) i_sum, sum(j) j_sum, sum(t::integer) t_sum from bm.het_bm where i=2 and t='2';
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Heterogeneous partition storage types
@@ -10335,14 +10223,10 @@ create table bm.hom_bm_heap (i int, to_be_dropped char(5), j int, t text) distri
    partition part3 values(3),
    partition part4 values(4));
 insert into bm.hom_bm_heap select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 create index hom_bm_heap_idx on bm.hom_bm_heap using bitmap (i);
 alter table bm.hom_bm_heap drop column to_be_dropped;
 alter table bm.hom_bm_heap add partition part5 values(5);
 insert into bm.hom_bm_heap values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select sum(i) i_sum, sum(j) j_sum, sum(t::integer) t_sum from bm.hom_bm_heap where i=2 and t='2';
  i_sum | j_sum | t_sum 
 -------+-------+-------
@@ -10361,14 +10245,10 @@ distributed by (i) partition by list(j)
    partition part3 values(3),
    partition part4 values(4));
 insert into bm.hom_bm_ao select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 create index hom_bm_ao_idx on bm.hom_bm_ao using bitmap (i);
 alter table bm.hom_bm_ao drop column to_be_dropped;
 alter table bm.hom_bm_ao add partition part5 values(5);
 insert into bm.hom_bm_ao values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select sum(i) i_sum, sum(j) j_sum, sum(t::integer) t_sum from bm.hom_bm_ao where i=2 and t='2';
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Heterogeneous partition storage types
@@ -10389,14 +10269,10 @@ distributed by (i) partition by list(j)
    partition part3 values(3),
    partition part4 values(4));
 insert into bm.hom_bm_aoco select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 create index hom_bm_aoco_idx on bm.hom_bm_aoco using bitmap (i);
 alter table bm.hom_bm_aoco drop column to_be_dropped;
 alter table bm.hom_bm_aoco add partition part5 values(5);
 insert into bm.hom_bm_aoco values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select sum(i) i_sum, sum(j) j_sum, sum(t::integer) t_sum from bm.hom_bm_aoco where i=2 and t='2';
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Heterogeneous partition storage types
@@ -10413,16 +10289,12 @@ create table bm.het_bm (i int, to_be_dropped char(5), j int, t text) distributed
    partition part2 values(2) with (appendonly=true, compresslevel=5, orientation=row),
    partition part3 values(3), partition part4 values(4));
 insert into bm.het_bm select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 -- Create index before dropping a column
 create index het_bm_i_idx on bm.het_bm using bitmap (i);
 create index het_bm_j_idx on bm.het_bm using bitmap (j);
 alter table bm.het_bm drop column to_be_dropped;
 alter table bm.het_bm add partition part5 values(5);
 insert into bm.het_bm values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select sum(i) i_sum, sum(j) j_sum, sum(t::integer) t_sum from bm.het_bm where i=2 and j=2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Heterogeneous partition storage types
@@ -10460,16 +10332,12 @@ create table bm.het_bm (i int, to_be_dropped char(5), j int, t text) distributed
    partition part2 values(2) with (appendonly=true, compresslevel=5, orientation=row),
    partition part3 values(3), partition part4 values(4));
 insert into bm.het_bm select i % 10, 'drop', i % 5, (i % 10)::text  from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 alter table bm.het_bm drop column to_be_dropped;
 alter table bm.het_bm add partition part5 values(5);
 -- Create index after dropping a column but before we insert into newly created part
 create index het_bm_i_idx on bm.het_bm using bitmap (i);
 create index het_bm_j_idx on bm.het_bm using bitmap (j);
 insert into bm.het_bm values(2, 5, '2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select sum(i) i_sum, sum(j) j_sum, sum(t::integer) t_sum from bm.het_bm where j=2 or j=3;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Heterogeneous partition storage types
@@ -11660,11 +11528,7 @@ CREATE TABLE tinnerbitmap(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b)
 CREATE TABLE tinnerbtree(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b) (start (0) end (6) every (3));
 INSERT INTO touter SELECT i, i%6 FROM generate_series(1,10) i;
 INSERT INTO tinnerbitmap select i, i%6 FROM generate_series(1,1000) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 INSERT INTO tinnerbtree select i, i%6 FROM generate_series(1,1000) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 CREATE INDEX tinnerbitmap_ix ON tinnerbitmap USING bitmap(a);
 CREATE INDEX tinnerbtree_ix ON tinnerbtree USING btree(a);
 SELECT * FROM touter LEFT JOIN tinnerbitmap ON touter.a = tinnerbitmap.a;
@@ -11738,8 +11602,6 @@ CREATE TABLE non_part2 (e INT, f INT);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO ds_part SELECT i, i, i FROM generate_series (1, 1000)i; 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i; 
 INSERT INTO non_part2 SELECT i, i FROM generate_series(1, 100)i;
 SET optimizer_enforce_subplans TO ON;
@@ -12157,11 +12019,7 @@ create table part2(a int, b int) partition by range(b) (start(1) end(5) every(1)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into part1 select i, (i % 2) + 1 from generate_series(1, 1000) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 insert into part2 select i, (i % 2) + 1 from generate_series(1, 100) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 -- make sure some child partitions have not been analyzed. This just means that
 -- stats are missing for some child partition but not necessarily that the relation
 -- is empty. So we should not flag this as an empty relation 
@@ -12521,8 +12379,6 @@ NOTICE:  CREATE TABLE will create partition "lossycastrangepart_1_prt_2" for tab
 NOTICE:  CREATE TABLE will create partition "lossycastrangepart_1_prt_3" for table "lossycastrangepart"
 NOTICE:  CREATE TABLE will create partition "lossycastrangepart_1_prt_4" for table "lossycastrangepart"
 insert into lossycastrangepart (values (5.1,5.1), (9.9,9.9), (10.1,10.1), (9.1,9.1), (10.9,10.9), (11.1,11.1), (21.0,21.0)); 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 explain select * from lossycastrangepart where b::int = 10;
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
@@ -12624,8 +12480,6 @@ NOTICE:  CREATE TABLE will create partition "lossycastlistpart_1_prt_l1" for tab
 NOTICE:  CREATE TABLE will create partition "lossycastlistpart_1_prt_l2" for table "lossycastlistpart"
 NOTICE:  CREATE TABLE will create partition "lossycastlistpart_1_prt_l3" for table "lossycastlistpart"
 insert into lossycastlistpart (values (1.0,2.1), (1.0,1.3), (10.1,2.1), (9.1,2.7), (10.9,1.8), (11.1,2.8), (21.0,1.7));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 explain select * from lossycastlistpart where b::int < 2;
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
@@ -12710,8 +12564,6 @@ NOTICE:  CREATE TABLE will create partition "sales_1_prt_31" for table "sales"
 NOTICE:  CREATE TABLE will create partition "sales_1_prt_32" for table "sales"
 NOTICE:  CREATE TABLE will create partition "sales_1_prt_33" for table "sales"
 insert into sales select i, i%100, i%1000, timestamp '2010-01-01 00:00:00' + i * interval '1 day' from generate_series(1,20) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 select * from sales where sales_ts::date != '2010-01-05' order by sales_ts;
  id | prod_id | cust_id |         sales_ts         
 ----+---------+---------+--------------------------
@@ -13754,8 +13606,6 @@ distributed by (hostname);
 insert into asset_records
 select 'u', 'h'||i::text, false, 'o', 'v', 'a', timestamp '2000-03-01 00:00:00' + i * interval '1' minute
 from generate_series(1,100000) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 analyze asset_records;
 explain (costs off)
 select asset_records.uid, asset_records.hostname, asset_records.asset_type, asset_records.os, asset_records.create_ts, 1
@@ -13852,8 +13702,6 @@ CREATE TABLE infer_part_vc (id int, gender varchar(1))
     PARTITION boys VALUES ('M'),
     DEFAULT PARTITION other );
 insert into infer_part_vc select i, substring(i::varchar, 1, 1) from generate_series(1, 1000) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
 analyze infer_part_vc;
 explain (costs off) select * from infer_part_vc inner join infer_txt on (infer_part_vc.gender = infer_txt.a) and infer_txt.a = 'M';
                                  QUERY PLAN                                 

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -1681,7 +1681,6 @@ SET client_min_messages = 'log';
 -- the leaf partitions does not have any stats for it, yet
 ALTER TABLE foo ADD COLUMN c int;
 INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
-LOG:  2020-09-09 14:18:11:716103 PDT,THD000,ERROR,"DXL-to-PlStmt Translation: PartitionSelector not supported",
 -- start_matchsubs
 -- m/gp_acquire_sample_rows([^,]+, [^,]+, .+)/
 -- s/gp_acquire_sample_rows([^,]+, [^,]+, .+)/gp_acquire_sample_rows()/
@@ -1700,10 +1699,8 @@ CREATE TABLE foo (a int, b int, c text, d int)
 		(START (0) END (8) EVERY (4), 
 		DEFAULT PARTITION def_part);
 INSERT INTO foo SELECT i%13, i, 'something'||i::text, i%121 FROM generate_series(1,1000)i;
-LOG:  2020-09-09 14:18:11:864834 PDT,THD000,ERROR,"DXL-to-PlStmt Translation: PartitionSelector not supported",
 ALTER TABLE foo DROP COLUMN b;
 ALTER TABLE foo SPLIT DEFAULT PARTITION START (8) END (12) INTO (PARTITION new_part, default PARTITION);
-LOG:  2020-09-09 14:18:11:960615 PDT,THD000,ERROR,"DXL-to-PlStmt Translation: PartitionSelector not supported",
 set client_min_messages to 'log';
 ANALYZE foo_1_prt_2;
 ANALYZE foo_1_prt_3;

--- a/src/test/regress/expected/orca_static_pruning.out
+++ b/src/test/regress/expected/orca_static_pruning.out
@@ -256,3 +256,48 @@ SELECT * FROM foo JOIN bar on foo.a = bar.a AND foo.b = 11;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_nestloop;
+CREATE TABLE rp_insert (a int, b int) PARTITION BY RANGE (b);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE rp_insert_part_1 PARTITION OF rp_insert FOR VALUES FROM (0) TO (3);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE rp_insert_part_2 PARTITION OF rp_insert FOR VALUES FROM (3) TO (6);
+NOTICE:  table has parent, setting distribution columns to match parent table
+-- The INSERT plans should no longer contain Partition Selector DMLs.
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert VALUES (1, 1), (3, 3);
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Insert on orca_static_pruning.rp_insert
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: "*VALUES*".column1, "*VALUES*".column2
+         Hash Key: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*"
+               Output: "*VALUES*".column1, "*VALUES*".column2
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(8 rows)
+
+INSERT INTO rp_insert VALUES (1, 1), (3, 3);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert SELECT * FROM rp_insert;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Insert on orca_static_pruning.rp_insert
+   ->  Append
+         ->  Seq Scan on orca_static_pruning.rp_insert_part_1
+               Output: rp_insert_part_1.a, rp_insert_part_1.b
+         ->  Seq Scan on orca_static_pruning.rp_insert_part_2
+               Output: rp_insert_part_2.a, rp_insert_part_2.b
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(8 rows)
+
+INSERT INTO rp_insert SELECT * FROM rp_insert;
+SELECT * FROM rp_insert;
+ a | b 
+---+---
+ 3 | 3
+ 3 | 3
+ 1 | 1
+ 1 | 1
+(4 rows)
+

--- a/src/test/regress/expected/orca_static_pruning_optimizer.out
+++ b/src/test/regress/expected/orca_static_pruning_optimizer.out
@@ -267,3 +267,51 @@ SELECT * FROM foo JOIN bar on foo.a = bar.a AND foo.b = 11;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_nestloop;
+CREATE TABLE rp_insert (a int, b int) PARTITION BY RANGE (b);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE rp_insert_part_1 PARTITION OF rp_insert FOR VALUES FROM (0) TO (3);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE rp_insert_part_2 PARTITION OF rp_insert FOR VALUES FROM (3) TO (6);
+NOTICE:  table has parent, setting distribution columns to match parent table
+-- The INSERT plans should no longer contain Partition Selector DMLs.
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert VALUES (1, 1), (3, 3);
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Insert on orca_static_pruning.rp_insert
+   ->  Result
+         Output: "Values".column1, "Values".column2
+         ->  Result
+               Output: "Values".column1, "Values".column2
+               ->  Values Scan on "Values"
+                     Output: "Values".column1, "Values".column2
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(9 rows)
+
+INSERT INTO rp_insert VALUES (1, 1), (3, 3);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert SELECT * FROM rp_insert;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Insert on orca_static_pruning.rp_insert
+   ->  Result
+         Output: rp_insert_part_1.a, rp_insert_part_1.b
+         ->  Append
+               ->  Seq Scan on orca_static_pruning.rp_insert_part_1
+                     Output: rp_insert_part_1.a, rp_insert_part_1.b
+               ->  Seq Scan on orca_static_pruning.rp_insert_part_2
+                     Output: rp_insert_part_2.a, rp_insert_part_2.b
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(10 rows)
+
+INSERT INTO rp_insert SELECT * FROM rp_insert;
+SELECT * FROM rp_insert;
+ a | b 
+---+---
+ 3 | 3
+ 3 | 3
+ 1 | 1
+ 1 | 1
+(4 rows)
+

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -128,7 +128,7 @@ PARTITION BY range(b)
 (START(0) END(4) EVERY(2));
 INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: PartitionSelector not supported
+DETAIL:  Feature not supported: Multi-level partitioned tables
 SELECT * FROM ONLY homer;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ONLY in the FROM clause

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -486,7 +486,6 @@ insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 5) i;
 set test_print_direct_dispatch_info=on;
 insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 6) i;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 select count(*) from mpp7638 where a =1;

--- a/src/test/regress/sql/orca_static_pruning.sql
+++ b/src/test/regress/sql/orca_static_pruning.sql
@@ -139,3 +139,13 @@ SELECT * FROM foo JOIN bar on foo.a = bar.a AND foo.b = 11;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_nestloop;
+
+CREATE TABLE rp_insert (a int, b int) PARTITION BY RANGE (b);
+CREATE TABLE rp_insert_part_1 PARTITION OF rp_insert FOR VALUES FROM (0) TO (3);
+CREATE TABLE rp_insert_part_2 PARTITION OF rp_insert FOR VALUES FROM (3) TO (6);
+-- The INSERT plans should no longer contain Partition Selector DMLs.
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert VALUES (1, 1), (3, 3);
+INSERT INTO rp_insert VALUES (1, 1), (3, 3);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert SELECT * FROM rp_insert;
+INSERT INTO rp_insert SELECT * FROM rp_insert;
+SELECT * FROM rp_insert;


### PR DESCRIPTION
INSERT INTO a partitioned table now goes through the same code path as a regular relation during transforms. Hence it no longer needs the partition selector node.
