### PR TITLE
Add a missing IsValid() check before mdid lookup

### DIFF
--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -736,8 +736,8 @@ CTranslatorExprToDXLUtils::PdxlnListFilterPartKey(CMemoryPool *mp,
 	else if (CScalarIdent::FCastedScId(pexprPartKey) ||
 			 CScalarIdent::FAllowedFuncScId(pexprPartKey))
 	{
-		IMDId *pmdidDestElem;
-		IMDId *pmdidArrayCastFunc;
+		IMDId *pmdidDestElem = NULL;
+		IMDId *pmdidArrayCastFunc = NULL;
 		ExtractCastFuncMdids(pexprPartKey->Pop(), &pmdidDestElem,
 							 &pmdidArrayCastFunc);
 		IMDId *pmdidDestArray =
@@ -879,8 +879,9 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterScCmp(
 		mp, md_accessor, ulPartLevel, fLowerBound, pdxlnScalar, cmp_type,
 		pmdidTypePartKey, pmdidTypeOther, pmdidTypeCastExpr, mdid_cast_func);
 
-	if (NULL != mdid_cast_func && md_accessor->RetrieveFunc(mdid_cast_func)
-									  ->IsAllowedForPS())  // is a lossy cast
+	if (NULL != mdid_cast_func && mdid_cast_func->IsValid() &&
+		md_accessor->RetrieveFunc(mdid_cast_func)
+			->IsAllowedForPS())	 // is a lossy cast
 	{
 		// In case of lossy casts, we don't want to eliminate partitions with
 		// exclusive ends when the predicate is on that end
@@ -971,8 +972,9 @@ CTranslatorExprToDXLUtils::PdxlnRangeFilterPartBound(
 		mp, md_accessor, ulPartLevel, fLowerBound, pdxlnScalar, ecmptInc,
 		pmdidTypePartKey, pmdidTypeOther, pmdidTypeCastExpr, mdid_cast_func);
 
-	if (NULL != mdid_cast_func && md_accessor->RetrieveFunc(mdid_cast_func)
-									  ->IsAllowedForPS())  // is a lossy cast
+	if (NULL != mdid_cast_func && mdid_cast_func->IsValid() &&
+		md_accessor->RetrieveFunc(mdid_cast_func)
+			->IsAllowedForPS())	 // is a lossy cast
 	{
 		// In case of lossy casts, we don't want to eliminate partitions with
 		// exclusive ends when the predicate is on that end

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12442,6 +12442,22 @@ select * from sales where sales_ts::date != '2010-01-05' order by sales_ts;
  20 |      20 |      20 | Thu Jan 21 00:00:00 2010
 (19 rows)
 
+-- validate lossy cast logic can handle BCCs
+drop table if exists part_tbl_varchar;
+NOTICE:  table "part_tbl_varchar" does not exist, skipping
+CREATE TABLE part_tbl_varchar(a varchar(15) NOT NULL, b varchar(8) NOT NULL)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(b) (start('v1') end('v5'), start('v5') end('v9'), default partition def);
+NOTICE:  CREATE TABLE will create partition "part_tbl_varchar_1_prt_def" for table "part_tbl_varchar"
+NOTICE:  CREATE TABLE will create partition "part_tbl_varchar_1_prt_2" for table "part_tbl_varchar"
+NOTICE:  CREATE TABLE will create partition "part_tbl_varchar_1_prt_3" for table "part_tbl_varchar"
+insert into part_tbl_varchar values ('v3','v3'), ('v5','v5');
+select * from part_tbl_varchar where b between 'v3' and 'v4';
+ a  | b  
+----+----
+ v3 | v3
+(1 row)
+
 -- test n-ary inner and left joins with outer references
 drop table if exists tcorr1, tcorr2;
 NOTICE:  table "tcorr1" does not exist, skipping

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -12618,6 +12618,22 @@ select * from sales where sales_ts::date != '2010-01-05' order by sales_ts;
  20 |      20 |      20 | Thu Jan 21 00:00:00 2010
 (19 rows)
 
+-- validate lossy cast logic can handle BCCs
+drop table if exists part_tbl_varchar;
+NOTICE:  table "part_tbl_varchar" does not exist, skipping
+CREATE TABLE part_tbl_varchar(a varchar(15) NOT NULL, b varchar(8) NOT NULL)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(b) (start('v1') end('v5'), start('v5') end('v9'), default partition def);
+NOTICE:  CREATE TABLE will create partition "part_tbl_varchar_1_prt_def" for table "part_tbl_varchar"
+NOTICE:  CREATE TABLE will create partition "part_tbl_varchar_1_prt_2" for table "part_tbl_varchar"
+NOTICE:  CREATE TABLE will create partition "part_tbl_varchar_1_prt_3" for table "part_tbl_varchar"
+insert into part_tbl_varchar values ('v3','v3'), ('v5','v5');
+select * from part_tbl_varchar where b between 'v3' and 'v4';
+ a  | b  
+----+----
+ v3 | v3
+(1 row)
+
 -- test n-ary inner and left joins with outer references
 drop table if exists tcorr1, tcorr2;
 NOTICE:  table "tcorr1" does not exist, skipping

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2540,6 +2540,16 @@ every (interval '1 day'));
 insert into sales select i, i%100, i%1000, timestamp '2010-01-01 00:00:00' + i * interval '1 day' from generate_series(1,20) i;
 select * from sales where sales_ts::date != '2010-01-05' order by sales_ts;
 
+-- validate lossy cast logic can handle BCCs
+drop table if exists part_tbl_varchar;
+CREATE TABLE part_tbl_varchar(a varchar(15) NOT NULL, b varchar(8) NOT NULL)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(b) (start('v1') end('v5'), start('v5') end('v9'), default partition def);
+
+insert into part_tbl_varchar values ('v3','v3'), ('v5','v5');
+
+select * from part_tbl_varchar where b between 'v3' and 'v4';
+
 -- test n-ary inner and left joins with outer references
 drop table if exists tcorr1, tcorr2;
 


### PR DESCRIPTION
This fixes https://github.com/greenplum-db/gpdb/issues/11655.

This mdid was potentially a default value of 0.0.0.0. Add a check
so we don't try to look up the invalid mdid and cause an exception
that leads to a fallback.

This happens when we come across a BCC (Binary Coercible Cast),
which has a dummy cast function of 0.0.0.0.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
