### PR TITLE
Fix dynamic partition selection for postgres planner under join when type of partitioning key different from type of search values

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -167,14 +167,14 @@ static bool compare_partn_opfuncid(PartitionNode *partnode,
 					   TupleDesc tupdesc);
 static PartitionNode *selectListPartition(PartitionNode *partnode, Datum *values, bool *isnull,
 					TupleDesc tupdesc, PartitionAccessMethods *accessMethods,
-					Oid *foundOid, PartitionRule **prule, Oid exprTypid);
+					Oid *foundOid, PartitionRule **prule);
 static Oid	get_less_than_oper(Oid lhstypid, Oid rhstypid, bool strictlyless);
 static FmgrInfo *get_less_than_comparator(int keyno, PartitionRangeState *rs, Oid ruleTypeOid, Oid exprTypeOid, bool strictlyless, bool is_direct);
-static int range_test(Datum tupval, Oid ruleTypeOid, Oid exprTypeOid, PartitionRangeState *rs, int keyno,
+static int range_test(Datum tupval, Oid exprTypeOid, PartitionRangeState *rs, int keyno,
 		   PartitionRule *rule);
 static PartitionNode *selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 					 TupleDesc tupdesc, PartitionAccessMethods *accessMethods,
-					 Oid *foundOid, int *pSearch, PartitionRule **prule, Oid exprTypid);
+					 Oid *foundOid, int *pSearch, PartitionRule **prule);
 static Oid selectPartition1(PartitionNode *partnode, Datum *values, bool *isnull,
 				 TupleDesc tupdesc, PartitionAccessMethods *accessMethods,
 				 int *pSearch,
@@ -4027,12 +4027,10 @@ compare_partn_opfuncid(PartitionNode *partnode,
  *	accessMethods: PartitionAccessMethods
  *	foundOid: output parameter for matched part Oid
  *	prule: output parameter for matched part PartitionRule
- *	exprTypeOid: type of the expression used to select partition
  */
 static PartitionNode *
 selectListPartition(PartitionNode *partnode, Datum *values, bool *isnull,
-					TupleDesc tupdesc, PartitionAccessMethods *accessMethods, Oid *foundOid, PartitionRule **prule,
-					Oid exprTypeOid)
+					TupleDesc tupdesc, PartitionAccessMethods *accessMethods, Oid *foundOid, PartitionRule **prule)
 {
 	ListCell   *lc;
 	Partition  *part = partnode->part;
@@ -4124,24 +4122,14 @@ selectListPartition(PartitionNode *partnode, Datum *values, bool *isnull,
 						 */
 
 						/*
-						 * The tupdesc tuple descriptor matches the table
-						 * schema, so it has the rule type
+						 * Type of rule is in fact the type of const inside the
+						 * rule object.
+						 * Type of expr is defined by attribute in tuple
+						 * descriptor whose number corresponds to current
+						 * partitioning key in partitioned table
 						 */
-						Oid			rhstypid = tupdesc->attrs[attno - 1]->atttypid;
-
-						/*
-						 * exprTypeOid is passed to us from our caller which
-						 * evaluated the expression. In some cases (e.g legacy
-						 * optimizer doing explicit casting), we don't compute
-						 * specify exprTypeOid. Assume lhstypid = rhstypid in
-						 * those cases
-						 */
-						Oid			lhstypid = exprTypeOid;
-
-						if (!OidIsValid(lhstypid))
-						{
-							lhstypid = rhstypid;
-						}
+						Oid	rhstypid = c->consttype;
+						Oid	lhstypid = tupdesc->attrs[attno - 1]->atttypid;
 
 						List	   *opname = list_make2(makeString("pg_catalog"),
 														makeString("="));
@@ -4295,16 +4283,15 @@ get_less_than_comparator(int keyno, PartitionRangeState *rs, Oid ruleTypeOid, Oi
  *
  *  Input parameters:
  *    tupval: The value of the expression
- *    ruleTypeOid: The type of the partition rule boundaries
- *    exprTypeOid: The type of the expression (can be different from ruleTypeOid
- *      if types can be directly compared with each other)
+ *    exprTypeOid: The type of the expression (can be different from the type of
+ *    	rule if types can be directly compared with each other)
  *    rs: The partition range state
  *    keyno: The index of the partitioning key considered (for composite partitioning keys)
  *    rule: The rule whose boundaries we're testing
  *
  */
 static int
-range_test(Datum tupval, Oid ruleTypeOid, Oid exprTypeOid, PartitionRangeState *rs, int keyno,
+range_test(Datum tupval, Oid exprTypeOid, PartitionRangeState *rs, int keyno,
 		   PartitionRule *rule)
 {
 	Const	   *c = NULL;
@@ -4330,7 +4317,7 @@ range_test(Datum tupval, Oid ruleTypeOid, Oid exprTypeOid, PartitionRangeState *
 		 * Otherwise, we request comparator ruleVal < exprVal ( ==>
 		 * strictly_less = true)
 		 */
-		finfo = get_less_than_comparator(keyno, rs, ruleTypeOid, exprTypeOid, !rule->parrangestartincl /* strictly_less */ , false /* is_direct */ );
+		finfo = get_less_than_comparator(keyno, rs, c->consttype, exprTypeOid, !rule->parrangestartincl /* strictly_less */ , false /* is_direct */ );
 		res = FunctionCall2Coll(finfo, c->constcollid, c->constvalue, tupval);
 
 		if (!DatumGetBool(res))
@@ -4352,7 +4339,7 @@ range_test(Datum tupval, Oid ruleTypeOid, Oid exprTypeOid, PartitionRangeState *
 		 * Otherwise, we request comparator exprVal < ruleVal ( ==>
 		 * strictly_less = true)
 		 */
-		finfo = get_less_than_comparator(keyno, rs, ruleTypeOid, exprTypeOid, !rule->parrangeendincl /* strictly_less */ , true /* is_direct */ );
+		finfo = get_less_than_comparator(keyno, rs, c->consttype, exprTypeOid, !rule->parrangeendincl /* strictly_less */ , true /* is_direct */ );
 		res = FunctionCall2Coll(finfo, c->constcollid, tupval, c->constvalue);
 
 		if (!DatumGetBool(res))
@@ -4364,13 +4351,14 @@ range_test(Datum tupval, Oid ruleTypeOid, Oid exprTypeOid, PartitionRangeState *
 }
 
 /*
- * Given a partition specific part, a tuple as represented by values and isnull and
- * a list of rules, return an Oid in *foundOid or the next set of rules.
+ * Given a partition specific part, a tuple as represented by values, isnull and
+ * tupdesc tuple descriptor and a list of rules.
+ * Return an Oid in *foundOid or the next set of rules.
  */
 static PartitionNode *
 selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 					 TupleDesc tupdesc, PartitionAccessMethods *accessMethods,
-					 Oid *foundOid, int *pSearch, PartitionRule **prule, Oid exprTypeOid)
+					 Oid *foundOid, int *pSearch, PartitionRule **prule)
 {
 	List	   *rules = partnode->rules;
 	int			high = list_length(rules) - 1;
@@ -4384,12 +4372,6 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 	MemoryContext oldcxt = NULL;
 
 	Assert(partnode->part->parkind == 'r');
-
-	/*
-	 * For composite partitioning keys, exprTypeOid should always be
-	 * InvalidOid
-	 */
-	AssertImply(partnode->part->parnatts > 1, !OidIsValid(exprTypeOid));
 
 	if (accessMethods && accessMethods->amstate[partnode->part->parlevel])
 		rs = (PartitionRangeState *) accessMethods->amstate[partnode->part->parlevel];
@@ -4466,6 +4448,7 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 		AttrNumber	attno = partnode->part->paratts[0];
 		Datum		exprValue = values[attno - 1];
 		int			ret;
+		Oid			exprTypeOid = tupdesc->attrs[attno - 1]->atttypid;
 
 		mid = low + (high - low) / 2;
 
@@ -4480,20 +4463,7 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 			goto l_fin_range;
 		}
 
-		Oid			ruleTypeOid = tupdesc->attrs[attno - 1]->atttypid;
-
-		if (OidIsValid(exprTypeOid))
-		{
-			ret = range_test(exprValue, ruleTypeOid, exprTypeOid, rs, 0, rule);
-		}
-		else
-		{
-			/*
-			 * In some cases, we don't have an expression type oid. In those
-			 * cases, the expression and partition rules have the same type.
-			 */
-			ret = range_test(exprValue, ruleTypeOid, ruleTypeOid, rs, 0, rule);
-		}
+		ret = range_test(exprValue, exprTypeOid, rs, 0, rule);
 
 		if (ret > 0)
 		{
@@ -4543,6 +4513,7 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 				AttrNumber	attno = partnode->part->paratts[i];
 				Datum		d = values[attno - 1];
 				int			ret;
+				Oid			dTypeOid = tupdesc->attrs[attno - 1]->atttypid;
 
 				if (j != mid)
 					rule = (PartitionRule *) list_nth(rules, j);
@@ -4553,15 +4524,7 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 					goto l_fin_range;
 				}
 
-				Oid			ruleTypeOid = tupdesc->attrs[attno - 1]->atttypid;
-
-				/*
-				 * For composite partition keys, we don't support casting
-				 * comparators, so both sides must be of identical types
-				 */
-				Assert(!OidIsValid(exprTypeOid));
-				ret = range_test(d, ruleTypeOid, ruleTypeOid,
-								 rs, i, rule);
+				ret = range_test(d, dTypeOid, rs, i, rule);
 				if (ret != 0)
 				{
 					matched = false;
@@ -4604,6 +4567,7 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 				AttrNumber	attno = partnode->part->paratts[i];
 				Datum		d = values[attno - 1];
 				int			ret;
+				Oid			dTypeOid = tupdesc->attrs[attno - 1]->atttypid;
 
 				rule = (PartitionRule *) list_nth(rules, j);
 
@@ -4613,14 +4577,7 @@ selectRangePartition(PartitionNode *partnode, Datum *values, bool *isnull,
 					goto l_fin_range;
 				}
 
-				Oid			ruleTypeOid = tupdesc->attrs[attno - 1]->atttypid;
-
-				/*
-				 * For composite partition keys, we don't support casting
-				 * comparators, so both sides must be of identical types
-				 */
-				Assert(!OidIsValid(exprTypeOid));
-				ret = range_test(d, ruleTypeOid, ruleTypeOid, rs, i, rule);
+				ret = range_test(d, dTypeOid, rs, i, rule);
 				if (ret != 0)
 				{
 					matched = false;
@@ -4671,9 +4628,11 @@ l_fin_range:
  * selectPartition1()
  *
  * Given pdata and prules, try and find a suitable partition for the input key.
- * values is an array of datums representing the partitioning key, isnull
- * tells us which of those is NULL. pSearch allows the caller to get the
- * position in the partition range where the key falls (might be hypothetical).
+ * values is an array of datums containing input search values, isnull tells us
+ * which of those is NULL, tupdesc specifies types of values in values and
+ * isnull.
+ * pSearch allows the caller to get the position in the partition range where
+ * the key falls (might be hypothetical).
  */
 static Oid
 selectPartition1(PartitionNode *partnode, Datum *values, bool *isnull,
@@ -4694,11 +4653,11 @@ selectPartition1(PartitionNode *partnode, Datum *values, bool *isnull,
 	{
 		case 'r':				/* range */
 			pn = selectRangePartition(partnode, values, isnull, tupdesc,
-									  accessMethods, &relid, pSearch, &prule, InvalidOid);
+									  accessMethods, &relid, pSearch, &prule);
 			break;
 		case 'l':				/* list */
 			pn = selectListPartition(partnode, values, isnull, tupdesc,
-									 accessMethods, &relid, &prule, InvalidOid);
+									 accessMethods, &relid, &prule);
 			break;
 		default:
 			elog(ERROR, "unrecognized partitioning kind '%c'",
@@ -4765,14 +4724,12 @@ selectPartition(PartitionNode *partnode, Datum *values, bool *isnull,
  * values, isnull: datum values to search for parts
  * tupdesc: TupleDesc for retrieving values
  * accessMethods: PartitionAccessMethods
- * exprTypid: the type of the datum
  *
  * return: PartitionRule of which constraints match the input key
  */
 PartitionRule *
 get_next_level_matched_partition(PartitionNode *partnode, Datum *values, bool *isnull,
-								 TupleDesc tupdesc, PartitionAccessMethods *accessMethods,
-								 Oid exprTypid)
+								 TupleDesc tupdesc, PartitionAccessMethods *accessMethods)
 {
 	Oid			relid = InvalidOid;
 	Partition  *part = partnode->part;
@@ -4783,11 +4740,11 @@ get_next_level_matched_partition(PartitionNode *partnode, Datum *values, bool *i
 	{
 		case 'r':				/* range */
 			selectRangePartition(partnode, values, isnull, tupdesc,
-								 accessMethods, &relid, NULL, &prule, exprTypid);
+								 accessMethods, &relid, NULL, &prule);
 			break;
 		case 'l':				/* list */
 			selectListPartition(partnode, values, isnull, tupdesc,
-								accessMethods, &relid, &prule, exprTypid);
+								accessMethods, &relid, &prule);
 			break;
 		default:
 			elog(ERROR, "unrecognized partitioning kind '%c'",

--- a/src/backend/cdb/partitionselection.c
+++ b/src/backend/cdb/partitionselection.c
@@ -91,14 +91,13 @@ eval_part_qual(ExprContext *econtext, TupleTableSlot *inputTuple, List *qualList
  *		Input parameters:
  *		pn: parent PartitionNode
  *		accessMethods: PartitionAccessMethods
- *		root_oid: root table Oid
  *		value: partition key value
  *		exprTypid: type of the expression
  *
  * ----------------------------------------------------------------
  */
 static PartitionRule *
-partition_selection(PartitionNode *pn, PartitionAccessMethods *accessMethods, Oid root_oid, Datum value, Oid exprTypid, bool isNull)
+partition_selection(PartitionNode *pn, PartitionAccessMethods *accessMethods, Datum value, Oid exprTypid, bool isNull)
 {
 	Assert(NULL != pn);
 	Assert(NULL != accessMethods);
@@ -109,25 +108,30 @@ partition_selection(PartitionNode *pn, PartitionAccessMethods *accessMethods, Oi
 
 	Assert(0 < partAttno);
 
-	Relation	rel = relation_open(root_oid, NoLock);
-	TupleDesc	tupDesc = RelationGetDescr(rel);
-
-	Assert(tupDesc->natts >= partAttno);
-
 	int			i;
 	Datum	   *values = palloc0(partAttno * sizeof(Datum));
 	bool	   *isnull = palloc(partAttno * sizeof(bool));
+	TupleDesc	tupDesc = CreateTemplateTupleDesc(partAttno, false);
 
 	for (i = 0; i < partAttno - 1; i++)
+	{
 		isnull[i] = true;
+
+		/*
+		 * Build tuple descriptor with dummy prefix columns that will not be
+		 * used further in the search of partitions
+		 */
+		TupleDescInitEntry(tupDesc, i+1, NULL, BOOLOID, -1, 0);
+	}
 	isnull[partAttno - 1] = isNull;
 	values[partAttno - 1] = value;
+	TupleDescInitEntry(tupDesc, partAttno, NULL, exprTypid, -1, 0);
 
-	PartitionRule *result = get_next_level_matched_partition(pn, values, isnull, tupDesc, accessMethods, exprTypid);
+	PartitionRule *result = get_next_level_matched_partition(pn, values, isnull,
+			tupDesc, accessMethods);
 
 	pfree(values);
 	pfree(isnull);
-	relation_close(rel, NoLock);
 
 	return result;
 }
@@ -235,7 +239,7 @@ partition_rules_for_equality_predicate(PartitionSelectorState *node, int level,
 		 */
 		Oid			exprTypid = exprType((Node *) exprState->expr);
 
-		PartitionRule *rule = partition_selection(parentNode, node->accessMethods, ps->relid, value, exprTypid, isNull);
+		PartitionRule *rule = partition_selection(parentNode, node->accessMethods, value, exprTypid, isNull);
 		if (rule)
 			rules = list_append_unique(rules, rule);
 	}

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -248,6 +248,6 @@ findPartitionMetadataEntry(List *partsMetadata, Oid partOid, PartitionNode **par
 
 extern PartitionRule*
 get_next_level_matched_partition(PartitionNode *partnode, Datum *values, bool *isnull,
-								TupleDesc tupdesc, PartitionAccessMethods *accessMethods, Oid exprTypid);
+								TupleDesc tupdesc, PartitionAccessMethods *accessMethods);
 
 #endif   /* CDBPARTITION_H */

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -4332,3 +4332,121 @@ DROP USER mpp3641_user;
 DROP ROLE part_acl_owner;
 DROP ROLE part_acl_u1;
 -- end_ignore
+---
+--- Test dynamic partition selector based on projection of input tuple (postgres
+--- planner case) when search values have explicitly comparable but different
+--- types with partitioning keys (e.g., date and timestamp)
+---
+-- SETUP
+SET optimizer TO off;
+CREATE TABLE t_list (a int, b timestamp)
+PARTITION BY LIST (b) (
+    partition t_list_1 VALUES ('2020-06-01', '2020-07-01', '2020-08-01'),
+    partition t_list_2 VALUES ('2020-09-01', '2020-10-01', '2020-11-01')
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_list_1_prt_t_list_1" for table "t_list"
+NOTICE:  CREATE TABLE will create partition "t_list_1_prt_t_list_2" for table "t_list"
+INSERT INTO t_list
+SELECT floor(random() * 1000), ts
+FROM generate_series(1, 1000),
+     generate_series('2020-06-01', '2020-11-01', interval '1 month') ts;
+ANALYZE t_list;
+CREATE TABLE t_range (a int, b timestamp)
+PARTITION BY RANGE (b) (
+    START ('2020-06-01') END ('2020-07-31') EVERY (interval '1 month')
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_range_1_prt_1" for table "t_range"
+NOTICE:  CREATE TABLE will create partition "t_range_1_prt_2" for table "t_range"
+INSERT INTO t_range
+SELECT gen, period
+FROM generate_series(1, 1000) gen,
+     generate_series('2020-06-01', '2020-07-31', interval '1 month') period;
+ANALYZE t_range;
+CREATE TABLE t_multilist (a int, b1 timestamp, b2 timestamp)
+PARTITION BY LIST (b1, b2) (
+    PARTITION t_multilist_1 VALUES (
+        ('2020-06-01', '2020-06-01'),
+        ('2020-07-01', '2020-07-01')),
+    PARTITION t_multilist_2 VALUES (
+        ('2020-08-01', '2020-08-01'),
+        ('2020-09-01', '2020-09-01'))
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_multilist_1_prt_t_multilist_1" for table "t_multilist"
+NOTICE:  CREATE TABLE will create partition "t_multilist_1_prt_t_multilist_2" for table "t_multilist"
+INSERT INTO t_multilist
+SELECT floor(random() * 1000), ts, ts
+FROM generate_series(1, 1000),
+     generate_series('2020-06-01', '2020-09-01', interval '1 month') ts;
+ANALYZE t_multilist;
+CREATE TABLE t_inner_to_join (b date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t_inner_to_join VALUES ('2020-07-01');
+ANALYZE t_inner_to_join;
+CREATE TABLE t_inner_to_multijoin (b1 date, b2 date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t_inner_to_multijoin VALUES ('2020-07-01', '2020-07-01');
+ANALYZE t_inner_to_multijoin;
+-- RUN
+-- Plan has to contain Dynamic Scan in terms of Result node with appropriate
+-- Partition Selector under join:
+--    ->  Nested Loop
+--         Join Filter: <join_condition>
+--         ->  Append
+--               ->  Result
+--                     One-Time Filter: PartSelected
+--                     ->  Seq Scan on t_list_1_prt_t_list_1
+--               ->  Result
+--                     One-Time Filter: PartSelected
+--                     ->  Seq Scan on t_list_1_prt_t_list_2
+--         ->  Materialize
+--               ->  Partition Selector for t_list (dynamic scan id: 1)
+--                     Filter: <join_attributes>
+-- All queries have to return one row
+SELECT COUNT(*) FROM (
+    SELECT DISTINCT b
+    FROM t_inner_to_join
+    WHERE b = '2020-07-01'
+) tf, t_list
+WHERE t_list.b = tf.b;
+ count 
+-------
+  1000
+(1 row)
+
+SELECT COUNT(*) FROM (
+    SELECT DISTINCT b
+    FROM t_inner_to_join
+    WHERE b = '2020-07-01'
+) tf, t_range
+WHERE t_range.b = tf.b;
+ count 
+-------
+  1000
+(1 row)
+
+SELECT COUNT(*) FROM (
+    SELECT DISTINCT b1, b2
+    FROM t_inner_to_multijoin
+    WHERE b1 = '2020-07-01'
+) tf, t_multilist
+WHERE t_multilist.b1 = tf.b1 AND t_multilist.b2 = tf.b2;
+ count 
+-------
+  1000
+(1 row)
+
+-- CLEANUP
+DROP TABLE t_list;
+DROP TABLE t_range;
+DROP TABLE t_multilist;
+DROP TABLE t_inner_to_join;
+DROP TABLE t_inner_to_multijoin;
+RESET optimizer;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -1683,3 +1683,102 @@ DROP USER mpp3641_user;
 DROP ROLE part_acl_owner;
 DROP ROLE part_acl_u1;
 -- end_ignore
+
+
+---
+--- Test dynamic partition selector based on projection of input tuple (postgres
+--- planner case) when search values have explicitly comparable but different
+--- types with partitioning keys (e.g., date and timestamp)
+---
+
+-- SETUP
+SET optimizer TO off;
+
+CREATE TABLE t_list (a int, b timestamp)
+PARTITION BY LIST (b) (
+    partition t_list_1 VALUES ('2020-06-01', '2020-07-01', '2020-08-01'),
+    partition t_list_2 VALUES ('2020-09-01', '2020-10-01', '2020-11-01')
+);
+INSERT INTO t_list
+SELECT floor(random() * 1000), ts
+FROM generate_series(1, 1000),
+     generate_series('2020-06-01', '2020-11-01', interval '1 month') ts;
+ANALYZE t_list;
+
+CREATE TABLE t_range (a int, b timestamp)
+PARTITION BY RANGE (b) (
+    START ('2020-06-01') END ('2020-07-31') EVERY (interval '1 month')
+);
+INSERT INTO t_range
+SELECT gen, period
+FROM generate_series(1, 1000) gen,
+     generate_series('2020-06-01', '2020-07-31', interval '1 month') period;
+ANALYZE t_range;
+
+CREATE TABLE t_multilist (a int, b1 timestamp, b2 timestamp)
+PARTITION BY LIST (b1, b2) (
+    PARTITION t_multilist_1 VALUES (
+        ('2020-06-01', '2020-06-01'),
+        ('2020-07-01', '2020-07-01')),
+    PARTITION t_multilist_2 VALUES (
+        ('2020-08-01', '2020-08-01'),
+        ('2020-09-01', '2020-09-01'))
+);
+INSERT INTO t_multilist
+SELECT floor(random() * 1000), ts, ts
+FROM generate_series(1, 1000),
+     generate_series('2020-06-01', '2020-09-01', interval '1 month') ts;
+ANALYZE t_multilist;
+
+CREATE TABLE t_inner_to_join (b date);
+INSERT INTO t_inner_to_join VALUES ('2020-07-01');
+ANALYZE t_inner_to_join;
+
+CREATE TABLE t_inner_to_multijoin (b1 date, b2 date);
+INSERT INTO t_inner_to_multijoin VALUES ('2020-07-01', '2020-07-01');
+ANALYZE t_inner_to_multijoin;
+
+-- RUN
+-- Plan has to contain Dynamic Scan in terms of Result node with appropriate
+-- Partition Selector under join:
+--    ->  Nested Loop
+--         Join Filter: <join_condition>
+--         ->  Append
+--               ->  Result
+--                     One-Time Filter: PartSelected
+--                     ->  Seq Scan on t_list_1_prt_t_list_1
+--               ->  Result
+--                     One-Time Filter: PartSelected
+--                     ->  Seq Scan on t_list_1_prt_t_list_2
+--         ->  Materialize
+--               ->  Partition Selector for t_list (dynamic scan id: 1)
+--                     Filter: <join_attributes>
+-- All queries have to return one row
+SELECT COUNT(*) FROM (
+    SELECT DISTINCT b
+    FROM t_inner_to_join
+    WHERE b = '2020-07-01'
+) tf, t_list
+WHERE t_list.b = tf.b;
+
+SELECT COUNT(*) FROM (
+    SELECT DISTINCT b
+    FROM t_inner_to_join
+    WHERE b = '2020-07-01'
+) tf, t_range
+WHERE t_range.b = tf.b;
+
+SELECT COUNT(*) FROM (
+    SELECT DISTINCT b1, b2
+    FROM t_inner_to_multijoin
+    WHERE b1 = '2020-07-01'
+) tf, t_multilist
+WHERE t_multilist.b1 = tf.b1 AND t_multilist.b2 = tf.b2;
+
+-- CLEANUP
+DROP TABLE t_list;
+DROP TABLE t_range;
+DROP TABLE t_multilist;
+DROP TABLE t_inner_to_join;
+DROP TABLE t_inner_to_multijoin;
+RESET optimizer;


### PR DESCRIPTION
## Problem description
This fix regards only projection-based implementation of partition selector that works only under postgres planner. The plan has to have the following fragment:
```sql
    Join
     Join Cond: partitioned_table.id = othertable.id
      -> Append
         -> Result
            One-Time Filter: PartSelected
               -> Seq Scan partition1
         -> Result
            One-Time Filter: PartSelected
               -> Seq Scan partition2
         ...
      -> Some materialization point
         -> PartitionSelector for partitioned_table
            Filter: othertable.id
            -> SeqScan othertable
               Filter: <other conditions>
```

Executor under postgres planner performs projection of input tuple to further determine partitions appropriate for dynamic scan node. At the same time, such partition selection mechanics assumes that the type of search tuple after projection has to match to the schema of partitioning table and, as a result, search values inside this tuple must have the same types as in partitioning key. This is so despite of internal comparator used inside partition definition routines allows to compare values with compatible but different types.
Perhaps, this assumption originates from the fact that expressions in the target list of projection have to coerce variables of incoming tuple into values of the same type as at attributes of partitioning key. But there are some data types, e.g. timestamp and date, that are compared directly (there is equality function for them) and aren't cast to the same representation. For these data types planner doesn't build casting functions over attributes and comparator function have to be picked up based on these types. Therefore, the assumption about types of result values after projection equaled to the types of partitioning key is not correct and have to be fixed.

## Query to reproduce
```sql
-- disable ORCA
SET optimizer TO off;

-- create partitioned table with partitioning attribute of timestamp type
CREATE TABLE t_range (a int, b timestamp)
PARTITION BY RANGE (b) (
    START ('2020-06-01') END ('2020-07-31') EVERY (interval '1 month')
);
INSERT INTO t_range
SELECT gen, period
FROM generate_series(1, 1000) gen,
     generate_series('2020-06-01', '2020-07-31', interval '1 month') period;

-- create table for join with date attribute
CREATE TABLE t_inner_to_join (b date);
INSERT INTO t_inner_to_join VALUES ('2020-07-01');

-- perform analyze to build necessary plan
ANALYZE t_range;
ANALYZE t_inner_to_join;

-- query that performs join by timestamp-typed partitioning key and date-typed attribute
-- it have to return 1000 but currently there is returned zero
SELECT COUNT(*) FROM (
    SELECT DISTINCT b
    FROM t_inner_to_join
    WHERE b = '2020-07-01'
) tf, t_range
WHERE t_range.b = tf.b;
```
### Expected result
Plan of last selection has to have the following kind:
```sql
                                              QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
 Aggregate
   ->  Gather Motion 3:1  (slice3; segments: 3)
         ->  Aggregate
               ->  Nested Loop
                     Join Filter: (t_inner_to_join.b = t_range_1_prt_1.b)
                     ->  Append
                           ->  Result
                                 One-Time Filter: PartSelected
                                 ->  Seq Scan on t_range_1_prt_1
                           ->  Result
                                 One-Time Filter: PartSelected
                                 ->  Seq Scan on t_range_1_prt_2
                     ->  Materialize
                           ->  Partition Selector for t_range (dynamic scan id: 1)
                                 Filter: t_inner_to_join.b
                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                       ->  GroupAggregate
                                             Group Key: t_inner_to_join.b
                                             ->  Sort
                                                   Sort Key: t_inner_to_join.b
                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                         Hash Key: t_inner_to_join.b
                                                         ->  GroupAggregate
                                                               Group Key: t_inner_to_join.b
                                                               ->  Seq Scan on t_inner_to_join
                                                                     Filter: (b = '2020-07-01'::date)
 Optimizer: Postgres query optimizer
```
And query has to return non-zero rows.

## Patch description

The current patch remove restriction of projection-based partition selector execution node so that it would be able to apply search values having types different from partitioning key. Also patch contains some refactoring for the second strategy of dynamic partition selection routine based on execution of partitioning level expressions (ORCA case). In particular, it specifies for `tupdesc` argument the role of tuple descriptor for transferable `values` and `isnull` arguments as it's done in the first projection-based strategy. Also it removes `exprTypeOid` argument as unnecessary.

## Affected versions

6X and below