### PR TITLE
Display the number of failed segments in gprecoverseg -r

### DIFF
--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -86,7 +86,7 @@ class GpSegmentRebalanceOperation:
             allSegmentsStopped = (failed_count == 0)
 
             if not allSegmentsStopped:
-                self.logger.warn("%d segments failed to stop.  A full rebalance of the")
+                self.logger.warn("%d segments failed to stop.  A full rebalance of the" % failed_count)
                 self.logger.warn("system is not possible at this time.  Please check the")
                 self.logger.warn("log files, correct the problem, and run gprecoverseg -r")
                 self.logger.warn("again.")


### PR DESCRIPTION
It should format `failed_count` integer, but forgot.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
