### PR TITLE
gprecoverseg -r: change finishing output

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -623,9 +623,6 @@ class GpRecoverSegmentProgram:
                 else:
                     self.logger.info("The rebalance operation has completed with WARNINGS."
                                      " Please review the output in the gprecoverseg log.")
-                self.logger.info("There is a resynchronization running in the background to bring all")
-                self.logger.info("segments in sync.")
-                self.logger.info("Use gpstate -e to check the resynchronization progress.")
                 self.logger.info("******************************************************************")
 
         elif len(mirrorBuilder.getMirrorsToBuild()) == 0:

--- a/src/test/isolation2/expected/dispatcher_fts_error.out
+++ b/src/test/isolation2/expected/dispatcher_fts_error.out
@@ -298,9 +298,6 @@ DO
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-The rebalance operation has completed successfully.
-20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-There is a resynchronization running in the background to bring all
-20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-segments in sync.
-20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use gpstate -e to check the resynchronization progress.
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 
 -- end_ignore

--- a/src/test/isolation2/expected/fts_dns_error.out
+++ b/src/test/isolation2/expected/fts_dns_error.out
@@ -210,9 +210,6 @@ DO
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-The rebalance operation has completed successfully.
-20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-There is a resynchronization running in the background to bring all
-20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-segments in sync.
-20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use gpstate -e to check the resynchronization progress.
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 
 -- end_ignore


### PR DESCRIPTION
gprecoverseg completes resync before finishing.
Updating the output message to not ask the user anymore for checking resync status.

Updating tests expected output eventhough they aren't scheduled anywhere currently.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/recoverseg_change_display_output
