### PR TITLE
6X gprecoverseg -r: change finishing output

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -649,9 +649,6 @@ class GpRecoverSegmentProgram:
                 else:
                     self.logger.info("The rebalance operation has completed with WARNINGS."
                                      " Please review the output in the gprecoverseg log.")
-                self.logger.info("There is a resynchronization running in the background to bring all")
-                self.logger.info("segments in sync.")
-                self.logger.info("Use gpstate -e to check the resynchronization progress.")
                 self.logger.info("******************************************************************")
 
         elif len(mirrorBuilder.getMirrorsToBuild()) == 0:

--- a/src/test/isolation2/expected/dispatcher_fts_error.out
+++ b/src/test/isolation2/expected/dispatcher_fts_error.out
@@ -301,9 +301,6 @@ DO
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-The rebalance operation has completed successfully.
-20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-There is a resynchronization running in the background to bring all
-20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-segments in sync.
-20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use gpstate -e to check the resynchronization progress.
 20180920:05:00:41:030745 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 
 -- end_ignore

--- a/src/test/isolation2/expected/fts_dns_error.out
+++ b/src/test/isolation2/expected/fts_dns_error.out
@@ -213,9 +213,6 @@ DO
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-The rebalance operation has completed successfully.
-20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-There is a resynchronization running in the background to bring all
-20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-segments in sync.
-20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Use gpstate -e to check the resynchronization progress.
 20180815:04:38:01:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-******************************************************************
 
 -- end_ignore

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -320,9 +320,6 @@ select wait_until_segment_synchronized(0);
 20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
 20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
 20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-The rebalance operation has completed successfully.
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-There is a resynchronization running in the background to bring all
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-segments in sync.
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Use gpstate -e to check the resynchronization progress.
 20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
 
 -- end_ignore


### PR DESCRIPTION
gprecoverseg completes resync before finishing.
Updating the output message to not ask the user anymore for checking resync status.

Updating tests expected output.

Tracker story: https://www.pivotaltracker.com/story/show/177353609
7X PR: https://github.com/greenplum-db/gpdb/pull/11713