### PR TITLE
Fix a test case bug caused by #11607

### DIFF
--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -1,9 +1,3 @@
--- start_matchsubs
--- m/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/
--- s/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/xxxx-xx-xx xx:xx:xx.xxxxxx/
--- m/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/
--- s/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/xxx xx xx xx:xx:xx xxxx/
--- end_matchsubs
 --
 -- Tests to exercise the plan caching/invalidation mechanism
 --
@@ -384,55 +378,62 @@ drop table test_mode;
 create table test_prepare_sql_value_function (a int, b timestamp);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-prepare test_sql_value_function as select * from test_prepare_sql_value_function where b < current_timestamp and a < $1;
+prepare test_sql_value_function as select count(*) from test_prepare_sql_value_function where b < current_timestamp and a < $1;
 execute test_sql_value_function(1); -- 1x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 2x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 3x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 4x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 5x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 6x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 7x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 insert into test_prepare_sql_value_function values (1, current_timestamp);
 -- should return one row
 execute test_sql_value_function(100);
- a |                b                
----+---------------------------------
- 1 | Sun Mar 21 20:38:37.337624 2021
+ count 
+-------
+     1
 (1 row)
 
 -- should return one row
-select * from test_prepare_sql_value_function where b < current_timestamp and a < 100;
- a |                b                
----+---------------------------------
- 1 | Sun Mar 21 20:38:37.337624 2021
+select count(*) from test_prepare_sql_value_function where b < current_timestamp and a < 100;
+ count 
+-------
+     1
 (1 row)
 
 drop table test_prepare_sql_value_function;

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -1,9 +1,3 @@
--- start_matchsubs
--- m/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/
--- s/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/xxxx-xx-xx xx:xx:xx.xxxxxx/
--- m/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/
--- s/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/xxx xx xx xx:xx:xx xxxx/
--- end_matchsubs
 --
 -- Tests to exercise the plan caching/invalidation mechanism
 --
@@ -384,55 +378,62 @@ drop table test_mode;
 create table test_prepare_sql_value_function (a int, b timestamp);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-prepare test_sql_value_function as select * from test_prepare_sql_value_function where b < current_timestamp and a < $1;
+prepare test_sql_value_function as select count(*) from test_prepare_sql_value_function where b < current_timestamp and a < $1;
 execute test_sql_value_function(1); -- 1x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 2x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 3x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 4x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 5x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 6x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 execute test_sql_value_function(1); -- 7x
- a | b 
----+---
-(0 rows)
+ count 
+-------
+     0
+(1 row)
 
 insert into test_prepare_sql_value_function values (1, current_timestamp);
 -- should return one row
 execute test_sql_value_function(100);
- a |                b                
----+---------------------------------
- 1 | Sun Mar 21 20:48:35.962858 2021
+ count 
+-------
+     1
 (1 row)
 
 -- should return one row
-select * from test_prepare_sql_value_function where b < current_timestamp and a < 100;
- a |                b                
----+---------------------------------
- 1 | Sun Mar 21 20:48:35.962858 2021
+select count(*) from test_prepare_sql_value_function where b < current_timestamp and a < 100;
+ count 
+-------
+     1
 (1 row)
 
 drop table test_prepare_sql_value_function;

--- a/src/test/regress/sql/plancache.sql
+++ b/src/test/regress/sql/plancache.sql
@@ -1,10 +1,3 @@
--- start_matchsubs
--- m/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/
--- s/(?!0000)[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?/xxxx-xx-xx xx:xx:xx.xxxxxx/
--- m/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/
--- s/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}/xxx xx xx xx:xx:xx xxxx/
--- end_matchsubs
-
 --
 -- Tests to exercise the plan caching/invalidation mechanism
 --
@@ -229,7 +222,7 @@ drop table test_mode;
 --
 
 create table test_prepare_sql_value_function (a int, b timestamp);
-prepare test_sql_value_function as select * from test_prepare_sql_value_function where b < current_timestamp and a < $1;
+prepare test_sql_value_function as select count(*) from test_prepare_sql_value_function where b < current_timestamp and a < $1;
 
 execute test_sql_value_function(1); -- 1x
 execute test_sql_value_function(1); -- 2x
@@ -245,6 +238,6 @@ insert into test_prepare_sql_value_function values (1, current_timestamp);
 execute test_sql_value_function(100);
 
 -- should return one row
-select * from test_prepare_sql_value_function where b < current_timestamp and a < 100;
+select count(*) from test_prepare_sql_value_function where b < current_timestamp and a < 100;
 
 drop table test_prepare_sql_value_function;


### PR DESCRIPTION
In #11607, we optimized single row insertion statements by pre-evaluate SQLValueFunction and added some test to ensure correctness of prepare/execute statements. However, we met a test case failure during the execution. The result is as follows.
```
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3
/tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/plancache.out
/tmp/build/e18b2f02/gpdb_src/src/test/regress/results/plancache.out
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/plancache.out
2021-03-25 08:12:17.579226940 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/plancache.out
2021-03-25 08:12:17.607228586 +0000
@@ -418,15 +418,15 @@
 insert into test_prepare_sql_value_function values (1,
current_timestamp);
 -- should return one row
 execute test_sql_value_function(100);
- a |                b
----+---------------------------------
+ a |               b
+---+--------------------------------
  1 | xxx xx xx xx:xx:xx xxxx
 (1 row)

 -- should return one row
 select * from test_prepare_sql_value_function where b <
current_timestamp and a < 100;
- a |                b
----+---------------------------------
+ a |               b
+---+--------------------------------
  1 | xxx xx xx xx:xx:xx xxxx
 (1 row)
```
It is because that the length of the timestamp is different, so the number of whitespaces before 'b' and the length of dashlines (the next line after character 'b') are different. We just change the sql statement and add a count aggregation to it to ensure the correctness.