### PR TITLE
Fix memory leak in cdb components memory context

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -114,6 +114,8 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 		pfree(segdbDesc->whoami);
 		segdbDesc->whoami = NULL;
 	}
+
+	pfree(segdbDesc);
 }								/* cdbconn_termSegmentDescriptor */
 
 /*


### PR DESCRIPTION
The SegmentDatabaseDescriptor is allocated under CdbComponentsContext.
The CdbComponentsContext will be freed when calling
cdbcomponent_destroyCdbComponents.

If my understanding is correct, cdbcomponent_destroyCdbComponents
will only be called under some special circumstances. For Example,
when a node is down, or a new segment joins the cluster, or 2PC
commit is abnormal. In normal scenarios, SegmentDatabaseDescriptor
will never be released, which will cause memory leaks
