### PR TITLE
fix inner query emit problem of GPDB5

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1717,18 +1717,6 @@ _SPI_prepare_plan(const char *src, SPIPlanPtr plan, ParamListInfo boundParams)
 				}
 			}
 			stmt_list = pg_plan_queries(stmt_list, cursor_options, NULL, false);
-			// GDB: Mark query as spi inner query for extension usage
-			{
-				ListCell *lc;
-
-				foreach (lc, stmt_list)
-				{
-					Node *pstmt = lfirst(lc);
-
-					if (IsA(pstmt, PlannedStmt))
-						((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;
-				}
-			}
 		}
 
 		plansource = (CachedPlanSource *) palloc0(sizeof(CachedPlanSource));
@@ -1834,6 +1822,8 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 				if (IsA(stmt, PlannedStmt))
 				{
 					canSetTag = ((PlannedStmt *) stmt)->canSetTag;
+					// Set SPI_INNER_QUERY flag for GPCC to identify inner query
+					((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
 				}
 				else
 				{

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1189,7 +1189,14 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 		MemoryContextSwitchTo(oldcontext);
 		cplan = NULL;			/* portal shouldn't depend on cplan */
 	}
-
+	/* GPDB: Mark all queries as SPI inner queries for extension usage */
+	ListCell   *lc;
+	foreach(lc, stmt_list)
+	{
+		Node *stmt = (Node *) lfirst(lc);
+		if (IsA(stmt, PlannedStmt))
+			((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
+	}
 	/*
 	 * Set up the portal.
 	 */


### PR DESCRIPTION
This PR fixs a bug in GPDB5 that for SPI queries, sometime gpcc log the inner query text instead of the actual query text.
Because in GPDB5, the flag for inner query was set inside _SPI_prepare_plan instead of _SPI_execute_plan, but sometime the prepare step will be skipped and cause the flag unset.

The code only effects gpcc functionality, and the bug doesn't exist in GPDB6.