### PR TITLE
gpcheck: allow per-mount xfs_mount_options

### DIFF
--- a/gpMgmt/bin/gpcheck
+++ b/gpMgmt/bin/gpcheck
@@ -472,11 +472,20 @@ def testLinuxMounts(host):
     
     for mnt in xfs_mounts:
 
-        if mnt.type != "xfs":
-            printError(host.hostname, "device %s is not XFS and is expected to be so on a %s host" % (mnt.partition, hosttype))
+        device_key = "xfs_mount_options.%s" % mnt.partition
+        key = ""
+        # This device has its own xfs_mount_options specified, so check for that
+        if device_key in gpcheck_config.xfs_mount_options:
+            key = device_key
+        # There is a default xfs_mount_options provided, so check for that
+        elif "xfs_mount_options" in gpcheck_config.xfs_mount_options:
+            key = "xfs_mount_options"
+        # No specific option provided and no default set, don't check this mount point
+        else:
+            printWarning("No xfs_mount_options provided for device %s and no default provided, skipping check")
             continue
 
-        expectedOptions = set(gpcheck_config.xfs_mount_options.split(","))
+        expectedOptions = set(gpcheck_config.xfs_mount_options[key].split(","))
 
         if len(mnt.options) != len(expectedOptions):
             printError(host.hostname, "XFS filesystem on device %s has %d XFS mount options and %d are expected" % (mnt.partition, len(mnt.options), len(expectedOptions)))
@@ -549,15 +558,24 @@ def populateGpCheckLinuxConfigParams():
         printError(None, "%s does not contain a linux section.  Exiting early" % configfilename)
         return True
 
-    requiredOptions = set(['xfs_mount_options'])
-
-    for option in requiredOptions:
-        if not config.has_option('linux', option):
-            printError(None, "%s does not contain required option %s.  Exiting early" % (configfilename, option))
-            return True
-
     global gpcheck_config
-    gpcheck_config.xfs_mount_options = config.get('linux', 'xfs_mount_options')
+
+    xfs_mount_options_list = [option for option in config.options('linux') if option == 'xfs_mount_options' or option.startswith('xfs_mount_options.')]
+    if len(xfs_mount_options_list) == 0:
+        printError(None, "%s does not contain required option xfs_mount_options.  Exiting early" % (configfilename))
+        return True
+
+    # User can pass multiple values for xfs_mount_options for different mount points, separated by a dot.
+    # If a non-dotted key is passed, it will be used as a default for any mount point without its own key.
+    # Otherwise, only mount points with their own keys will be checked.
+    # For example:
+    #
+    # [linux]
+    # xfs_mount_options./data/gpdata = rw
+    # xfs_mount_options./nfs = rw,noatime
+    # xfs_mount_options = defaults
+    #
+    gpcheck_config.xfs_mount_options = {option: config.get('linux', option) for option in xfs_mount_options_list}
 
     if getSysCtlFromConfig('linux'):
         return True

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_gpcheck.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_gpcheck.py
@@ -5,6 +5,7 @@ import os
 
 from gppylib.commands.base import Command, REMOTE
 from gppylib.operations.gpcheck import get_host_for_command, get_command, get_copy_command
+from gppylib.gpcheckutil import GpMount
 from test.unit.gp_unittest import GpTestCase, run_tests
 
 gpcheck_file = os.path.abspath(os.path.dirname(__file__) + "/../../../../gpcheck")
@@ -18,6 +19,21 @@ class GpCheckTestCase(GpTestCase):
         self.gpcheck = imp.load_source('gpcheck', gpcheck_file)
         self.gpcheck.logger = mock.MagicMock(logging.Logger)
         self.gpcheck.gpcheck_config = self.gpcheck.GpCheckConfig()
+
+        self.mock_host = self.gpcheck.GpCheckHost('hostname')
+        self.mock_host.data = mock.MagicMock()
+        self.mock_host.data.mounts = mock.MagicMock()
+        data_mount = GpMount()
+        data_mount.partition = "/data"
+        data_mount.type = "xfs"
+        data_mount.options = set(["defaults"])
+        tmp_mount = GpMount()
+        tmp_mount.partition = "/tmp"
+        tmp_mount.type = "xfs"
+        tmp_mount.options = set(["rw", "noatime"])
+        self.mock_host.data.mounts.entries = {'/data': data_mount, "/tmp": tmp_mount}
+        self.gpcheck.gpcheck_config = self.gpcheck.GpCheckConfig()
+        self.gpcheck.gpcheck_config.xfs_mount_options = {}
 
     def test_get_host_for_command_uses_supplied_remote_host(self):
         cmd = Command('name', 'hostname', ctxt=REMOTE, remoteHost='foo') 
@@ -82,30 +98,162 @@ class GpCheckTestCase(GpTestCase):
 
     def test_sysctl_prints_error_when_config_values_dont_match(self):
         localhost = mock.MagicMock()
-        localhost.hostname = "localhost"
+        localhost.hostname = "hostname"
         localhost.data.sysctl.variables = {'sysctl.net.ipv4.ip_local_port_range': '10000 65535'}
 
         self.gpcheck.gpcheck_config.expectedSysctlValues = {'sysctl.net.ipv4.ip_local_port_range': '1 60000'}
 
         self.gpcheck.testSysctl(localhost)
         self.assertTrue(self.gpcheck.found_errors)
-        self.gpcheck.logger.error.assert_called_once_with("GPCHECK_ERROR host(%s): %s",
-                                                          "localhost",
-                                                          "/etc/sysctl.conf value for key 'sysctl.net.ipv4.ip_local_port_range' has value '10000 65535' and expects '1 60000'")
+        self.assertEquals(self.gpcheck.logger.error.call_count, 1)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("/etc/sysctl.conf value for key 'sysctl.net.ipv4.ip_local_port_range' has value '10000 65535' and expects '1 60000'")
+        ])
 
     def test_sysctl_prints_error_when_config_is_missing(self):
         localhost = mock.MagicMock()
-        localhost.hostname = "localhost"
+        localhost.hostname = "hostname"
         localhost.data.sysctl.variables = {'sysctl.non.existent.setting': '10000 65535'}
 
         self.gpcheck.gpcheck_config.expectedSysctlValues = {'sysctl.net.ipv4.ip_local_port_range': '1 60000'}
 
         self.gpcheck.testSysctl(localhost)
         self.assertTrue(self.gpcheck.found_errors)
-        self.gpcheck.logger.error.assert_called_once_with("GPCHECK_ERROR host(%s): %s",
-                                                          "localhost",
-                                                          "variable not detected in /etc/sysctl.conf: 'sysctl.net.ipv4.ip_local_port_range'")
+        self.assertEquals(self.gpcheck.logger.error.call_count, 1)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("variable not detected in /etc/sysctl.conf: 'sysctl.net.ipv4.ip_local_port_range'")
+        ])
 
+    def test_default_xfs_mount_options_nonexistent_mount_is_ignored(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data./two/dirs'] = "re"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "defaults"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_default_xfs_mount_options_matching_values(self):
+        self.mock_host.data.mounts.entries['/tmp'].options = set(["defaults"])
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "defaults"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_default_xfs_mount_options_mismatched_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "rw"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.assertEquals(self.gpcheck.logger.error.call_count, 2)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'rw'"),
+            gpcheck_call("XFS filesystem on device /tmp has 2 XFS mount options and 1 are expected"),
+        ])
+
+    def test_one_mount_point_xfs_mount_options_matching_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "defaults"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_one_mount_point_xfs_mount_options_mismatched_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "rw,noatime"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.assertEquals(self.gpcheck.logger.error.call_count, 3)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("XFS filesystem on device /data has 1 XFS mount options and 2 are expected"),
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'rw'"),
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'noatime'"),
+        ])
+
+    def test_multiple_mount_points_xfs_mount_options_matching_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "defaults"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp'] = "rw,noatime"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_multiple_mount_points_xfs_mount_options_mismatched_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "rw"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp'] = "rw"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.assertEquals(self.gpcheck.logger.error.call_count, 2)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'rw'"),
+            gpcheck_call("XFS filesystem on device /tmp has 2 XFS mount options and 1 are expected"),
+        ])
+
+    def test_one_mount_point_xfs_mount_options_with_defaults_matching_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "defaults"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "rw,noatime"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_one_mount_point_xfs_mount_options_with_defaults_mismatched_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "rw"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "rw"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.assertEquals(self.gpcheck.logger.error.call_count, 2)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'rw'"),
+            gpcheck_call("XFS filesystem on device /tmp has 2 XFS mount options and 1 are expected"),
+        ])
+
+    def test_multiple_mount_points_xfs_mount_options_with_defaults_matching_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "defaults"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp'] = "rw,noatime"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "rw"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_multiple_mount_points_xfs_mount_options_with_defaults_mismatched_values(self):
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "rw"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp'] = "rw"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options'] = "defaults"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.assertEquals(self.gpcheck.logger.error.call_count, 2)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'rw'"),
+            gpcheck_call("XFS filesystem on device /tmp has 2 XFS mount options and 1 are expected"),
+        ])
+
+    def test_nested_paths_xfs_mount_options_matching_values(self):
+        above_mount = GpMount()
+        above_mount.partition = "/tmp/gpdata"
+        above_mount.type = "xfs"
+        above_mount.options = set(["noatime"])
+        self.mock_host.data.mounts.entries['/tmp/gpdata'] = above_mount
+        below_mount = GpMount()
+        below_mount.partition = "/gpdata/data"
+        below_mount.type = "xfs"
+        below_mount.options = set(["rw"])
+        self.mock_host.data.mounts.entries['/gpdata/data'] = below_mount
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./gpdata/data'] = "rw"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "defaults"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp/gpdata'] = "noatime"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp'] = "rw,noatime"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.gpcheck.logger.error.assert_not_called()
+
+    def test_nested_paths_xfs_mount_options_mismatched_values(self):
+        above_mount = GpMount()
+        above_mount.partition = "/tmp/gpdata"
+        above_mount.type = "xfs"
+        above_mount.options = set(["noatime"])
+        self.mock_host.data.mounts.entries['/tmp/gpdata'] = above_mount
+        below_mount = GpMount()
+        below_mount.partition = "/gpdata/data"
+        below_mount.type = "xfs"
+        below_mount.options = set(["rw"])
+        self.mock_host.data.mounts.entries['/gpdata/data'] = below_mount
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./gpdata/data'] = "noatime"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./data'] = "rw"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp/gpdata'] = "defaults"
+        self.gpcheck.gpcheck_config.xfs_mount_options['xfs_mount_options./tmp'] = "rw"
+        self.gpcheck.testLinuxMounts(self.mock_host)
+        self.assertEquals(self.gpcheck.logger.error.call_count, 4)
+        self.gpcheck.logger.error.assert_has_calls([
+            gpcheck_call("XFS filesystem on device /gpdata/data is missing the recommended mount option 'noatime'"),
+            gpcheck_call("XFS filesystem on device /data is missing the recommended mount option 'rw'"),
+            gpcheck_call("XFS filesystem on device /tmp has 2 XFS mount options and 1 are expected"),
+            gpcheck_call("XFS filesystem on device /tmp/gpdata is missing the recommended mount option 'defaults'"),
+        ])
+
+def gpcheck_call(msg):
+    return mock.call("GPCHECK_ERROR host(%s): %s", "hostname", msg)
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Currently, gpcheck assumes that all XFS filesystems on a user cluster
will use the same mount options, but this is not necessarily the case.

This commit adds the ability for the user to specify different sets of
options in the gpcheck config file by adding the mount point to the end
of xfs_mount_options, separated by a dot.  For example:

    [linux]
    xfs_mount_options./data = rw
    xfs_mount_options./nfs = rw,noatime
    xfs_mount_options = defaults

The standard option is still respected, and will be used as the default
for any mount points that don't have their own options specified.  Not
specifying the default xfs_mount_options allows the user not to check
unspecified mount points if for whatever reason they want to that.

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>
Co-authored-by: Jamie McAtamney <jmcatamney@vmware.com>