### PR TITLE
Remove a merge fixme in ao_truncate_one_rel()

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -237,7 +237,7 @@ mdunlink_ao(RelFileNodeBackend rnode, ForkNumber forkNumber, bool isRedo)
 					(errcode_for_file_access(),
 					 errmsg("could not remove file \"%s\": %m", path)));
 	}
-	/* This storage manager is not concerend with forks other than MAIN_FORK */
+	/* This storage manager is not concerned with forks other than MAIN_FORK */
 	else if (forkNumber == MAIN_FORKNUM)
 	{
 		int pathSize = strlen(path);

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -536,9 +536,6 @@ ao_truncate_one_rel(Relation rel)
 	 *
 	 * Segfile 0 first, ao_foreach_extent_file() doesn't invoke the
 	 * callback for it.
-	 *
-	 * GPDB_12_MERGE_FIXME: shouldn't we unlink, not truncate, the
-	 * other segfiles?
 	 */
 	truncate_ao_perFile(0, &truncateFiles);
 	ao_foreach_extent_file(truncate_ao_perFile, &truncateFiles);


### PR DESCRIPTION
Unlinking the other segfiles doesn't make many differences, just remove
the FIXME.

Ref: https://github.com/greenplum-db/gpdb/pull/11131