### PR TITLE
Fix cases in gpfdist for dual stack solution.

### DIFF
--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -13,7 +13,7 @@ endif
 
 REGRESS_OPTS = --init-file=init_file
 
-installcheck: watchdog
+installcheck: watchdog ipv4v6_ports
 ifeq ($(enable_gpfdist),yes)
 ifeq ($(with_openssl),yes)
 	rm -rf data/gpfdist_ssl/certs_matching
@@ -27,6 +27,9 @@ endif
 
 watchdog:
 	sh test_watchdog.sh
+
+ipv4v6_ports:
+	sh test_ipv4v6_port.sh
 
 clean:
 	rm -rf regression.* sql results expected

--- a/src/bin/gpfdist/regress/test_ipv4v6_port.sh
+++ b/src/bin/gpfdist/regress/test_ipv4v6_port.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+export GPFDIST_WATCHDOG_TIMER=5
+
+NC_IPV6_PID=0
+NC_IPV4_PID=0
+GPFDIST_PID=0
+
+function clear_subprocess()
+{
+	if [ $NC_IPV6_PID -ne 0 ]; then
+		kill -9 $NC_IPV6_PID
+		NC_IPV6_PID=0
+	fi
+
+	if [ $NC_IPV4_PID -ne 0 ]; then
+		kill -9 $NC_IPV4_PID
+		NC_IPV4_PID=0
+	fi
+	sleep 1
+}
+
+function start_nc_ipv4()
+{
+	nc -l 0.0.0.0 8080 &
+	NC_IPV4_PID=$!
+}
+
+function start_nc_ipv6()
+{
+	nc -l :: 8080 &
+	NC_IPV6_PID=$!
+}
+
+function start_gpfdist()
+{
+	gpfdist -v &
+	GPFDIST_PID=$!
+}
+
+# test start gpfdist with nc binded to ipv4 port
+start_nc_ipv4
+sleep 1
+start_gpfdist
+wait $GPFDIST_PID
+if [ $? -eq 1 ]; then #gpfdist failed to start because of ipv4 port already in use
+	echo -e "\033[32m test [gpfdist start with nc binded to ipv4 port] success \033[0m"
+else
+	echo -e "\033[31m test [gpfdist start with nc binded to ipv4 port] failed \033[0m"
+	echo "gpfdist should not start successfully because port ipv4:8080 is used by nc"
+	exit 1
+fi
+clear_subprocess
+
+# test start gpfdist with nc binded to ipv6 port
+start_nc_ipv6
+sleep 1
+start_gpfdist
+wait $GPFDIST_PID
+if [ $? -eq 1 ]; then #gpfdist failed to start because of ipv6 port already in use
+	echo -e "\033[32m test [gpfdist start with nc binded to ipv6 port] success \033[0m"
+else
+	echo -e "\033[31m test [gpfdist start with nc binded to ipv6 port] failed \033[0m"
+	echo "gpfdist should not start successfully because port ipv6:8080 is used by nc"
+	exit 1
+fi
+clear_subprocess
+
+# test start gpfdist with nc binded to ipv4 and ipv6 port
+start_nc_ipv4
+start_nc_ipv6
+sleep 1
+start_gpfdist
+wait $GPFDIST_PID
+if [ $? -eq 1 ]; then #gpfdist failed to start because of ipv4 and ipv6 port already in use
+	echo -e "\033[32m test [gpfdist start with nc binded to ipv4 and ipv6 port] success \033[0m"
+else
+	echo -e "\033[32m test [gpfdist start with nc binded to ipv4 and ipv6 port] failed \033[0m"
+	echo "gpfdist should not start successfully because port ipv4::8080 and ipv6:8080 are used by nc"
+	exit 1
+fi
+clear_subprocess
+
+# test start gpfdist alone without nc binded to ipv4 or ipv6 8080 port
+start_gpfdist
+sleep 1
+wait $GPFDIST_PID
+if [ $? -eq 134 ]; then #gpfdist stoped by watchdog
+	echo -e "\033[32m test [gpfdist starts without ipv4 or ipv6 nc listening] success \033[0m"
+else
+	echo -e "\033[31m test [gpfdist starts without ipv4 or ipv6 nc listening] failed \033[0m"
+	echo "gpfdist should start successfully and stoped by watchdog"
+	exit 1
+fi
+clear_subprocess
+
+echo -e "\n"
+echo -e "\033[32m Test gpfdist binding ipv4/ipv6 ports success\033[0m"
+exit 0


### PR DESCRIPTION
If /proc/sys/net/ipv6/bindv6only is set to 0:
In one case that if process A is already listening on ipv4 8080 port, the gpfdist cannot start successfully. But if process A is listening on ipv6 8080 port, the gpfdist can start successfully and will listen on ipv4 8080 port. But in this situation if one client tries to connect to gpfdist using ipv6 8080 port, it will connect to proccess A. Then the outcome is not what we want.

If /proc/sys/net/ipv6/bindv6only is set to 1:
In one case that if either process A or process B is already listening on either ipv4 8080 port or ipv6 8080 port, the gpfdist can still start successfully. In this situation if one client tries to connect to gpfdist using the port which process A or B is listening on, the outcome is not what we want.

So this commit tries to make sure that only if gpfdist is listening on both ipv4 and ipv6 ports successfully, it will continue to run and try to handle clients requests.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
