### PR TITLE
Docs: added reference to tablespace mapping file for gpexpand utility

### DIFF
--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -105,7 +105,12 @@
                   <codeph>gpexpand</codeph> must have permissions to create directories in them.
                 </p><p>After you have entered all required information, the utility generates an
                 input file and saves it in the current directory. For
-              example:</p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i></codeblock></li>
+                example:</p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i></codeblock><p>If
+                the Greenplum cluster is configured with tablespaces, the utility will automatically
+                generate an additional tablespace mapping file. This will will be later parsed by
+                the utility so make sure it is present before proceeding with the next step. For
+                example:
+              </p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i>.ts</codeblock></li>
           </ol>
         </section>
       </body>

--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -108,7 +108,7 @@
                 example:</p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i></codeblock><p>If
                 the Greenplum cluster is configured with tablespaces, the utility automatically
                 generates an additional tablespace mapping file. This file is required for later
-                parssing by the utility so make sure it is present before proceeding with the next
+                parsing by the utility so make sure it is present before proceeding with the next
                 step. For example:
               </p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i>.ts</codeblock></li>
           </ol>

--- a/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-initialize.xml
@@ -106,10 +106,10 @@
                 </p><p>After you have entered all required information, the utility generates an
                 input file and saves it in the current directory. For
                 example:</p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i></codeblock><p>If
-                the Greenplum cluster is configured with tablespaces, the utility will automatically
-                generate an additional tablespace mapping file. This will will be later parsed by
-                the utility so make sure it is present before proceeding with the next step. For
-                example:
+                the Greenplum cluster is configured with tablespaces, the utility automatically
+                generates an additional tablespace mapping file. This file is required for later
+                parssing by the utility so make sure it is present before proceeding with the next
+                step. For example:
               </p><codeblock>gpexpand_inputfile_yyyymmdd<i>_145134</i>.ts</codeblock></li>
           </ol>
         </section>


### PR DESCRIPTION
Reference to tablespace mapping file being generated by gpexpand utility if the cluster is configured with tablespaces.
