### PR TITLE
Assorted cleanups in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -1024,8 +1024,7 @@ CQueryMutators::NormalizeHaving(CMemoryPool *mp, CMDAccessor *md_accessor,
 
 			new_subquery->targetList =
 				gpdb::LAppend(new_subquery->targetList,
-							  (TargetEntry *) gpdb::CopyObject(
-								  const_cast<TargetEntry *>(target_entry)));
+							  (TargetEntry *) gpdb::CopyObject(target_entry));
 		}
 
 		gpdb::GPDBFree(rte->subquery);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1296,10 +1296,8 @@ CTranslatorDXLToPlStmt::TranslateDXLHashJoin(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(
-		const_cast<CDXLTranslateContext *>(&left_dxl_translate_ctxt));
-	child_contexts->Append(
-		const_cast<CDXLTranslateContext *>(&right_dxl_translate_ctxt));
+	child_contexts->Append(&left_dxl_translate_ctxt);
+	child_contexts->Append(&right_dxl_translate_ctxt);
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
 							   nullptr,	 // translate context for the base table
@@ -1899,10 +1897,8 @@ CTranslatorDXLToPlStmt::TranslateDXLMergeJoin(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(
-		const_cast<CDXLTranslateContext *>(&left_dxl_translate_ctxt));
-	child_contexts->Append(
-		const_cast<CDXLTranslateContext *>(&right_dxl_translate_ctxt));
+	child_contexts->Append(&left_dxl_translate_ctxt);
+	child_contexts->Append(&right_dxl_translate_ctxt);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -2173,7 +2169,7 @@ CTranslatorDXLToPlStmt::TranslateDXLMotion(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -2357,7 +2353,7 @@ CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -2546,7 +2542,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAgg(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -2674,7 +2670,7 @@ CTranslatorDXLToPlStmt::TranslateDXLWindow(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -2931,7 +2927,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSort(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -3181,7 +3177,7 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -3264,7 +3260,7 @@ CTranslatorDXLToPlStmt::TranslateDXLResult(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -3735,7 +3731,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAppend(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(output_context));
+	child_contexts->Append(output_context);
 
 	// translate filter
 	plan->qual = TranslateDXLFilterToQual(
@@ -3795,7 +3791,7 @@ CTranslatorDXLToPlStmt::TranslateDXLMaterialize(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list and filter
 	TranslateProjListAndFilter(project_list_dxlnode, filter_dxlnode,
@@ -3985,7 +3981,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSequence(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list
 	plan->targetlist =
@@ -4449,7 +4445,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAssert(
 
 	CDXLTranslationContextArray *child_contexts =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
-	child_contexts->Append(const_cast<CDXLTranslateContext *>(&child_context));
+	child_contexts->Append(&child_context);
 
 	// translate proj list
 	plan->targetlist =

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2903,8 +2903,7 @@ CTranslatorQueryToDXL::TranslateSetOpChild(Node *child_node,
 		return dxlnode;
 	}
 
-	CHAR *temp_str =
-		(CHAR *) gpdb::NodeToString(const_cast<Node *>(child_node));
+	CHAR *temp_str = (CHAR *) gpdb::NodeToString(child_node);
 	CWStringDynamic *str =
 		CDXLUtils::CreateDynamicStringFromCharArray(m_mp, temp_str);
 
@@ -3064,7 +3063,7 @@ CTranslatorQueryToDXL::TranslateFromClauseToDXL(Node *node)
 		return TranslateJoinExprInFromToDXL((JoinExpr *) node);
 	}
 
-	CHAR *sz = (CHAR *) gpdb::NodeToString(const_cast<Node *>(node));
+	CHAR *sz = (CHAR *) gpdb::NodeToString(node);
 	CWStringDynamic *str =
 		CDXLUtils::CreateDynamicStringFromCharArray(m_mp, sz);
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1331,8 +1331,7 @@ CTranslatorUtils::FixUnknownTypeConstant(Query *old_query,
 			{
 				if (nullptr == new_query)
 				{
-					new_query = (Query *) gpdb::CopyObject(
-						const_cast<Query *>(old_query));
+					new_query = (Query *) gpdb::CopyObject(old_query);
 				}
 
 				TargetEntry *new_target_entry =

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarIsDistinctFrom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarIsDistinctFrom.h
@@ -68,8 +68,7 @@ public:
 	static CScalarIsDistinctFrom *PopConvert(COperator *pop);
 
 	// get commuted scalar IDF operator
-	CScalarIsDistinctFrom *PopCommutedOp(CMemoryPool *mp,
-										 COperator *pop) override;
+	CScalarCmp *PopCommutedOp(CMemoryPool *mp, COperator *pop) override;
 
 };	// class CScalarIsDistinctFrom
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -16,6 +16,9 @@
 #include "gpos/common/CSyncHashtable.h"
 #include "gpos/common/CSyncList.h"
 
+#include "gpopt/base/CCostContext.h"
+#include "gpopt/base/COptimizationContext.h"
+#include "gpopt/base/CReqdPropPlan.h"
 #include "gpopt/operators/CLogical.h"
 #include "gpopt/search/CJobQueue.h"
 #include "gpopt/search/CTreeMap.h"
@@ -33,10 +36,6 @@ class CGroup;
 class CGroupExpression;
 class CDrvdProp;
 class CDrvdPropCtxtPlan;
-class CGroupProxy;
-class COptimizationContext;
-class CCostContext;
-class CReqdPropPlan;
 class CReqdPropRelational;
 class CExpression;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CTreeMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CTreeMap.h
@@ -427,7 +427,7 @@ private:
 	Ptn(const T *value)
 	{
 		GPOS_ASSERT(nullptr != value);
-		CTreeNode *ptn = const_cast<CTreeNode *>(m_ptmap->Find(value));
+		CTreeNode *ptn = m_ptmap->Find(value);
 
 		if (nullptr == ptn)
 		{

--- a/src/backend/gporca/libgpopt/src/base/CCTEInfo.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEInfo.cpp
@@ -444,8 +444,7 @@ CCTEInfo::IncrementConsumers(ULONG ulConsumerId, ULONG ulParentCTEId)
 {
 	// get map of given parent
 	UlongToConsumerCounterMap *phmulconsumermap =
-		const_cast<UlongToConsumerCounterMap *>(
-			m_phmulprodconsmap->Find(&ulParentCTEId));
+		m_phmulprodconsmap->Find(&ulParentCTEId);
 	if (nullptr == phmulconsumermap)
 	{
 		phmulconsumermap = GPOS_NEW(m_mp) UlongToConsumerCounterMap(m_mp);
@@ -455,8 +454,7 @@ CCTEInfo::IncrementConsumers(ULONG ulConsumerId, ULONG ulParentCTEId)
 	}
 
 	// find counter of given consumer inside this map
-	SConsumerCounter *pconsumercounter =
-		const_cast<SConsumerCounter *>(phmulconsumermap->Find(&ulConsumerId));
+	SConsumerCounter *pconsumercounter = phmulconsumermap->Find(&ulConsumerId);
 	if (nullptr == pconsumercounter)
 	{
 		// no existing counter - start a new one
@@ -513,7 +511,7 @@ CCTEInfo::PdrgPexpr(CMemoryPool *mp) const
 	UlongToCTEInfoEntryMapIter hmulei(m_phmulcteinfoentry);
 	while (hmulei.Advance())
 	{
-		CExpression *pexpr = const_cast<CExpression *>(hmulei.Value()->Pexpr());
+		CExpression *pexpr = hmulei.Value()->Pexpr();
 		pexpr->AddRef();
 		pdrgpexpr->Append(pexpr);
 	}
@@ -537,8 +535,7 @@ CCTEInfo::MapComputedToUsedCols(CColumnFactory *col_factory) const
 	UlongToCTEInfoEntryMapIter hmulei(m_phmulcteinfoentry);
 	while (hmulei.Advance())
 	{
-		CExpression *pexprProducer =
-			const_cast<CExpression *>(hmulei.Value()->Pexpr());
+		CExpression *pexprProducer = hmulei.Value()->Pexpr();
 		GPOS_ASSERT(nullptr != pexprProducer);
 		CQueryContext::MapComputedToUsedCols(col_factory, pexprProducer);
 	}
@@ -598,8 +595,7 @@ CCTEInfo::FindConsumersInParent(ULONG ulParentId, CBitSet *pbsUnusedConsumers,
 								CStack<ULONG> *pstack)
 {
 	UlongToConsumerCounterMap *phmulconsumermap =
-		const_cast<UlongToConsumerCounterMap *>(
-			m_phmulprodconsmap->Find(&ulParentId));
+		m_phmulprodconsmap->Find(&ulParentId);
 	if (nullptr == phmulconsumermap)
 	{
 		// no map found for given parent - there are no consumers inside it

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGet.cpp
@@ -251,8 +251,7 @@ CLogicalGet::DeriveNotNullColumns(CMemoryPool *mp,
 	CColRefSetIter crsi(*exprhdl.DeriveOutputColumns());
 	while (crsi.Advance())
 	{
-		CColRefTable *pcrtable =
-			CColRefTable::PcrConvert(const_cast<CColRef *>(crsi.Pcr()));
+		CColRefTable *pcrtable = CColRefTable::PcrConvert(crsi.Pcr());
 		if (pcrtable->IsNullable())
 		{
 			pcrs->Exclude(pcrtable);

--- a/src/backend/gporca/libgpopt/src/operators/CScalarIsDistinctFrom.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarIsDistinctFrom.cpp
@@ -66,7 +66,7 @@ CScalarIsDistinctFrom::Matches(COperator *pop) const
 }
 
 // get commuted scalar IDF operator
-CScalarIsDistinctFrom *
+CScalarCmp *
 CScalarIsDistinctFrom::PopCommutedOp(CMemoryPool *mp, COperator *pop)
 {
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -1287,7 +1287,7 @@ CTranslatorDXLToExpr::PexprLogicalCTEProducer(const CDXLNode *dxlnode)
 			colref = new_colref;
 		}
 
-		colref_array->Append(const_cast<CColRef *>(colref));
+		colref_array->Append(colref);
 		pcrsProducer->Include(colref);
 	}
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExprUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExprUtils.cpp
@@ -238,7 +238,7 @@ CTranslatorDXLToExprUtils::Pdrgpcr(CMemoryPool *mp,
 		colref->MarkAsUsed();
 		GPOS_ASSERT(nullptr != colref);
 
-		colref_array->Append(const_cast<CColRef *>(colref));
+		colref_array->Append(colref);
 	}
 
 	return colref_array;

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3509,8 +3509,8 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 	pdxlnSubPlan->AddChild(inner_dxlnode);
 
 	// add to hashmap
-	BOOL fRes GPOS_ASSERTS_ONLY = m_phmcrdxln->Insert(
-		const_cast<CColRef *>((*pdrgpcrInner)[0]), pdxlnSubPlan);
+	BOOL fRes GPOS_ASSERTS_ONLY =
+		m_phmcrdxln->Insert((*pdrgpcrInner)[0], pdxlnSubPlan);
 	GPOS_ASSERT(fRes);
 
 	return pdxlnSubPlan;
@@ -7169,8 +7169,7 @@ CTranslatorExprToDXL::PdxlnWindow(CExpression *pexprSeqPrj,
 	{
 		CDistributionSpecHashed *pdshashed =
 			CDistributionSpecHashed::PdsConvert(pds);
-		pdrgpexprPartCol =
-			const_cast<CExpressionArray *>(pdshashed->Pdrgpexpr());
+		pdrgpexprPartCol = pdshashed->Pdrgpexpr();
 		const ULONG size = pdrgpexprPartCol->Size();
 		for (ULONG ul = 0; ul < size; ul++)
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1025,10 +1025,10 @@ CXformUtils::SubqueryAllToAgg(
 
 	// generate a group by expression with sum(subquery-test) and sum(inner null indicator) aggreagtes
 	CColRefArray *colref_array = GPOS_NEW(mp) CColRefArray(mp);
-	CColRef *pcrSubqTest = const_cast<CColRef *>(
-		CScalarProjectElement::PopConvert((*(*pexprPrj)[1])[0]->Pop())->Pcr());
-	CColRef *pcrInnerNullTest = const_cast<CColRef *>(
-		CScalarProjectElement::PopConvert((*(*pexprPrj)[1])[1]->Pop())->Pcr());
+	CColRef *pcrSubqTest =
+		CScalarProjectElement::PopConvert((*(*pexprPrj)[1])[0]->Pop())->Pcr();
+	CColRef *pcrInnerNullTest =
+		CScalarProjectElement::PopConvert((*(*pexprPrj)[1])[1]->Pop())->Pcr();
 	colref_array->Append(pcrSubqTest);
 	colref_array->Append(pcrInnerNullTest);
 	CExpression *pexprGbAggSum =
@@ -3868,8 +3868,7 @@ CXformUtils::MapPrjElemsWithDistinctAggs(
 			pexprKey = pexprTrue;
 		}
 
-		CExpressionArray *pdrgpexpr =
-			const_cast<CExpressionArray *>(phmexprdrgpexpr->Find(pexprKey));
+		CExpressionArray *pdrgpexpr = phmexprdrgpexpr->Find(pexprKey);
 		BOOL fExists = (nullptr != pdrgpexpr);
 		if (!fExists)
 		{

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
@@ -123,9 +123,6 @@ private:
 	// id of array type
 	IMDId *m_mdid_array_type;
 
-	// retrieves the address MDId member variable corresponding to the specified token
-	IMDId **GetTokenMDid(Edxltoken token_type);
-
 	// handles a SAX start element event
 	void StartElement(
 		const XMLCh *const element_uri,			// URI of element's namespace

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -226,17 +226,17 @@ public:
 	}
 
 	// inner join with another stats structure
-	CStatistics *CalcInnerJoinStats(
+	IStatistics *CalcInnerJoinStats(
 		CMemoryPool *mp, const IStatistics *other_stats,
 		CStatsPredJoinArray *join_preds_stats) const override;
 
 	// LOJ with another stats structure
-	CStatistics *CalcLOJoinStats(
+	IStatistics *CalcLOJoinStats(
 		CMemoryPool *mp, const IStatistics *other_stats,
 		CStatsPredJoinArray *join_preds_stats) const override;
 
 	// left anti semi join with another stats structure
-	CStatistics *CalcLASJoinStats(
+	IStatistics *CalcLASJoinStats(
 		CMemoryPool *mp, const IStatistics *other_stats,
 		CStatsPredJoinArray *join_preds_stats,
 		BOOL
@@ -245,7 +245,7 @@ public:
 	) const override;
 
 	// semi join stats computation
-	CStatistics *CalcLSJoinStats(
+	IStatistics *CalcLSJoinStats(
 		CMemoryPool *mp, const IStatistics *inner_side_stats,
 		CStatsPredJoinArray *join_preds_stats) const override;
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDPartConstraintGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDPartConstraintGPDB.cpp
@@ -48,8 +48,7 @@ CMDPartConstraintGPDB::CMDPartConstraintGPDB(
 //---------------------------------------------------------------------------
 CMDPartConstraintGPDB::~CMDPartConstraintGPDB()
 {
-	if (nullptr != m_dxl_node)
-		m_dxl_node->Release();
+	CRefCount::SafeRelease(m_dxl_node);
 	m_level_with_default_part_array->Release();
 }
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDType.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDType.cpp
@@ -307,50 +307,6 @@ CParseHandlerMDType::IsBuiltInType(const IMDId *mdid)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CParseHandlerMDType::GetTokenMDid
-//
-//	@doc:
-//		Return the address of the mdid variable corresponding to the dxl token
-//
-//---------------------------------------------------------------------------
-IMDId **
-CParseHandlerMDType::GetTokenMDid(Edxltoken token_type)
-{
-	switch (token_type)
-	{
-		case EdxltokenMDTypeEqOp:
-			return &m_mdid_eq_op;
-
-		case EdxltokenMDTypeNEqOp:
-			return &m_mdid_neq_op;
-
-		case EdxltokenMDTypeLTOp:
-			return &m_mdid_lt_op;
-
-		case EdxltokenMDTypeLEqOp:
-			return &m_mdid_lteq_op;
-
-		case EdxltokenMDTypeGTOp:
-			return &m_mdid_gt_op;
-
-		case EdxltokenMDTypeGEqOp:
-			return &m_mdid_gteq_op;
-
-		case EdxltokenMDTypeCompOp:
-			return &m_mdid_cmp_op;
-
-		case EdxltokenMDTypeArray:
-			return &m_mdid_array_type;
-
-		default:
-			break;
-	}
-	GPOS_ASSERT(!"Unexpected DXL token when parsing MDType");
-	return nullptr;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CParseHandlerMDType::EndElement
 //
 //	@doc:

--- a/src/backend/gporca/libnaucrates/src/statistics/CLeftOuterJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CLeftOuterJoinStatsProcessor.cpp
@@ -30,8 +30,9 @@ CLeftOuterJoinStatsProcessor::CalcLOJoinStatsStatic(
 	const CStatistics *result_stats_inner_side =
 		dynamic_cast<const CStatistics *>(inner_side_stats);
 
-	CStatistics *inner_join_stats = result_stats_outer_side->CalcInnerJoinStats(
-		mp, inner_side_stats, join_preds_stats);
+	CStatistics *inner_join_stats =
+		CStatistics::CastStats(result_stats_outer_side->CalcInnerJoinStats(
+			mp, inner_side_stats, join_preds_stats));
 	CDouble num_rows_inner_join = inner_join_stats->Rows();
 	CDouble num_rows_LASJ(1.0);
 
@@ -97,10 +98,11 @@ CLeftOuterJoinStatsProcessor::MakeLOJHistogram(
 	}
 
 	// for the columns in the outer child, compute the buckets that do not contribute to the inner join
-	CStatistics *LASJ_stats = outer_side_stats->CalcLASJoinStats(
-		mp, inner_side_stats, join_preds_stats,
-		false /* DoIgnoreLASJHistComputation */
-	);
+	CStatistics *LASJ_stats =
+		CStatistics::CastStats(outer_side_stats->CalcLASJoinStats(
+			mp, inner_side_stats, join_preds_stats,
+			false /* DoIgnoreLASJHistComputation */
+			));
 	CDouble num_rows_LASJ(0.0);
 	if (!LASJ_stats->IsEmpty())
 	{

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -395,7 +395,7 @@ CStatistics::IsEmptyJoin(const CStatistics *outer_stats,
 // for deriving the stat objects for the corresponding join operator
 
 //	return statistics object after performing LOJ operation with another statistics structure
-CStatistics *
+IStatistics *
 CStatistics::CalcLOJoinStats(CMemoryPool *mp, const IStatistics *other_stats,
 							 CStatsPredJoinArray *join_preds_stats) const
 {
@@ -406,7 +406,7 @@ CStatistics::CalcLOJoinStats(CMemoryPool *mp, const IStatistics *other_stats,
 
 
 //	return statistics object after performing semi-join with another statistics structure
-CStatistics *
+IStatistics *
 CStatistics::CalcLSJoinStats(CMemoryPool *mp,
 							 const IStatistics *inner_side_stats,
 							 CStatsPredJoinArray *join_preds_stats) const
@@ -418,7 +418,7 @@ CStatistics::CalcLSJoinStats(CMemoryPool *mp,
 
 
 // return statistics object after performing inner join
-CStatistics *
+IStatistics *
 CStatistics::CalcInnerJoinStats(CMemoryPool *mp, const IStatistics *other_stats,
 								CStatsPredJoinArray *join_preds_stats) const
 {
@@ -427,7 +427,7 @@ CStatistics::CalcInnerJoinStats(CMemoryPool *mp, const IStatistics *other_stats,
 }
 
 // return statistics object after performing LASJ
-CStatistics *
+IStatistics *
 CStatistics::CalcLASJoinStats(CMemoryPool *mp, const IStatistics *other_stats,
 							  CStatsPredJoinArray *join_preds_stats,
 							  BOOL DoIgnoreLASJHistComputation) const

--- a/src/backend/gporca/server/include/unittest/dxl/statistics/CCardinalityTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/dxl/statistics/CCardinalityTestUtils.h
@@ -69,7 +69,7 @@ public:
 	static CPoint *PpointDouble(CMemoryPool *mp, OID oid, CDouble value);
 
 	// helper method to print statistics object
-	static void PrintStats(CMemoryPool *mp, const CStatistics *stats);
+	static void PrintStats(CMemoryPool *mp, const IStatistics *stats);
 
 	// helper method to print histogram object
 	static void PrintHist(CMemoryPool *mp, const char *pcPrefix,

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CCardinalityTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CCardinalityTestUtils.cpp
@@ -239,7 +239,7 @@ CCardinalityTestUtils::PrintHist(CMemoryPool *mp, const char *pcPrefix,
 
 // helper function to print the statistics object
 void
-CCardinalityTestUtils::PrintStats(CMemoryPool *mp, const CStatistics *stats)
+CCardinalityTestUtils::PrintStats(CMemoryPool *mp, const IStatistics *stats)
 {
 	CWStringDynamic str(mp);
 	COstreamString oss(&str);

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -274,7 +274,7 @@ CJoinCardinalityTest::EresUnittest_Join()
 		CStatsPredJoinArray *join_preds_stats = pf(mp);
 
 		// calculate the output stats
-		CStatistics *pstatsOutput = nullptr;
+		IStatistics *pstatsOutput = nullptr;
 		if (left_outer_join)
 		{
 			pstatsOutput =
@@ -288,7 +288,7 @@ CJoinCardinalityTest::EresUnittest_Join()
 		GPOS_ASSERT(nullptr != pstatsOutput);
 
 		CStatisticsArray *pdrgpstatOutput = GPOS_NEW(mp) CStatisticsArray(mp);
-		pdrgpstatOutput->Append(pstatsOutput);
+		pdrgpstatOutput->Append(CStatistics::CastStats(pstatsOutput));
 
 		// serialize and compare against expected stats
 		CWStringDynamic *pstrOutput = CDXLUtils::SerializeStatistics(

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -485,7 +485,7 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	CStatsPredJoinArray *join_preds_stats =
 		GPOS_NEW(mp) CStatsPredJoinArray(mp);
 	join_preds_stats->Append(pstatspredjoin);
-	CStatistics *pstats3 =
+	IStatistics *pstats3 =
 		stats->CalcInnerJoinStats(mp, pstats2, join_preds_stats);
 
 	GPOS_TRACE(GPOS_WSZ_LIT("pstats3 = stats JOIN pstats2 on (col2 = col10)"));
@@ -505,7 +505,7 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	CCardinalityTestUtils::PrintStats(mp, pstats4);
 
 	// LASJ stats
-	CStatistics *pstats5 = stats->CalcLASJoinStats(
+	IStatistics *pstats5 = stats->CalcLASJoinStats(
 		mp, pstats2, join_preds_stats, true /* DoIgnoreLASJHistComputation */);
 
 	GPOS_TRACE(GPOS_WSZ_LIT("pstats5 = stats LASJ pstats2 on (col2 = col10)"));


### PR DESCRIPTION
Stumbled upon these while working on my reference count refactoring, see commit messages for detail:

1. Remove covariant return types
2. Remove faux "forward" declarations
3. Replace one conditional `Release()` with `SafeRelease`
4. Remove redundant `const_cast`s

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
