### PR TITLE
[6X Backport]Fix memory leak in cdb components memory context

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -867,11 +867,13 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 	CdbComponentDatabaseInfo	*cdbinfo;
 	MemoryContext				oldContext;	
 	int							maxLen;
+	bool						isWriter;
 
 	Assert(cdb_component_dbs);
 	Assert(CdbComponentsContext);
 
 	cdbinfo = segdbDesc->segment_database_info;
+	isWriter = segdbDesc->isWriter;
 
 	/* update num of active QEs */
 	DECR_COUNT(cdbinfo, numActiveQEs);
@@ -884,11 +886,11 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 	/* If freelist length exceed gp_cached_gang_threshold, destroy it */
 	maxLen = segdbDesc->segindex == -1 ?
 					MAX_CACHED_1_GANGS : gp_cached_gang_threshold;
-	if (!segdbDesc->isWriter && list_length(cdbinfo->freelist) >= maxLen)
+	if (!isWriter && list_length(cdbinfo->freelist) >= maxLen)
 		goto destroy_segdb;
 
 	/* Recycle the QE, put it to freelist */
-	if (segdbDesc->isWriter)
+	if (isWriter)
 	{
 		/* writer is always the header of freelist */
 		segdbDesc->segment_database_info->freelist =
@@ -927,7 +929,7 @@ destroy_segdb:
 
 	cdbconn_termSegmentDescriptor(segdbDesc);
 
-	if (segdbDesc->isWriter)
+	if (isWriter)
 	{
 		markCurrentGxactWriterGangLost();
 	}

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -115,6 +115,8 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 		pfree(segdbDesc->whoami);
 		segdbDesc->whoami = NULL;
 	}
+
+	pfree(segdbDesc);
 }								/* cdbconn_termSegmentDescriptor */
 
 /*


### PR DESCRIPTION
The SegmentDatabaseDescriptor is allocated under CdbComponentsContext.
The CdbComponentsContext will be freed when calling
cdbcomponent_destroyCdbComponents.

If my understanding is correct, cdbcomponent_destroyCdbComponents
will only be called under some special circumstances. For Example,
when a node is down, or a new segment joins the cluster, or 2PC
commit is abnormal. In normal scenarios, SegmentDatabaseDescriptor
will never be released, which will cause memory leaks

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
