### PR TITLE
[6X only] Teach gpcheckcat about zero-column views

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1741,6 +1741,7 @@ def checkPGClass():
     FROM   pg_class tc left outer join
            pg_attribute ta on (tc.oid = ta.attrelid)
     WHERE  ta.attrelid is NULL
+    AND    tc.relnatts > 0
     '''
     err = connect2run(qry, ('relname', 'relkind', 'oid'))
     if not err:

--- a/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
@@ -9,6 +9,8 @@ class ForeignKeyCheck:
     PURPOSE: detect differences between foreign key and reference key values among catalogs
     """
 
+    ZeroColumnViewOids = None
+
     def __init__(self, db_connection, logger, shared_option, autoCast):
         self.db_connection = db_connection
         self.logger = logger
@@ -16,8 +18,23 @@ class ForeignKeyCheck:
         self.autoCast = autoCast
         self.query_filters = dict()
         self.query_filters['pg_appendonly.relid'] = "(relstorage='a' or relstorage='c')"
-        self.query_filters['pg_attribute.attrelid'] = "true"
+        # Views having empty target list are permitted.  Such views
+        # have no entry in pg_attribute.  This filter excludes
+        # zero-column views from foreign key check between
+        # pg_class and pg_attribute.  The NULL check flags cases as
+        # error where pg_class entry is missing but pg_attribute entry
+        # exists.
+        self.query_filters['pg_attribute.attrelid'] = "(relnatts > 0 or relnatts is NULL)"
         self.query_filters["pg_index.indexrelid"] = "(relkind='i')"
+
+    def isZeroColumnView(self, oid):
+        if ForeignKeyCheck.ZeroColumnViewOids is None:
+            ForeignKeyCheck.ZeroColumnViewOids = []
+            curs = self.db_connection.query(
+                "select oid from pg_class where relnatts = 0 and relkind = 'v'")
+            for row in curs.getresult():
+                ForeignKeyCheck.ZeroColumnViewOids.append(row[0]);
+        return oid in ForeignKeyCheck.ZeroColumnViewOids
 
     def runCheck(self, tables):
         foreign_key_issues = dict()
@@ -114,6 +131,17 @@ class ForeignKeyCheck:
             curs = self.db_connection.query(qry)
             nrows = curs.ntuples()
 
+            # Zero column views need to be excluded from pg_rewrite
+            # and pg_attribute foreign key check.  Such views have an
+            # entry in pg_rewrite but no corresponding entry in
+            # pg_attribute.  The row[1] corresponds to
+            # pg_rewrite_ev_class field in the foreign key check
+            # query.  It is the OID of the rule's entry in pg_class.
+            if catname == 'pg_rewrite' and nrows > 0:
+                for row in curs.getresult():
+                    if self.isZeroColumnView(row[1]):
+                        nrows = nrows - 1
+
             if nrows == 0:
                 self.logger.info('[OK] Foreign key check for %s(%s) referencing %s(%s)' %
                                  (catname, fkeystr, pkcatname, pkeystr))
@@ -127,6 +155,8 @@ class ForeignKeyCheck:
                 log_literal(self.logger, logging.ERROR, "    " + " | ".join(fields))
                 for row in curs.getresult():
                     log_literal(self.logger, logging.ERROR, "    " + " | ".join(map(str, row)))
+                self.logger.info("Zero column view OIDs: %s" %
+                                 ' '.join(ForeignKeyCheck.ZeroColumnViewOids))
                 results = curs.getresult()
                 issue_list.append((pkcatname, fields, results))
 

--- a/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
@@ -140,6 +140,7 @@ class ForeignKeyCheck:
             if catname == 'pg_rewrite' and nrows > 0:
                 for row in curs.getresult():
                     if self.isZeroColumnView(row[1]):
+                        self.logger.info("Found zero column view: OID %s" % row[1])
                         nrows = nrows - 1
 
             if nrows == 0:
@@ -155,8 +156,6 @@ class ForeignKeyCheck:
                 log_literal(self.logger, logging.ERROR, "    " + " | ".join(fields))
                 for row in curs.getresult():
                     log_literal(self.logger, logging.ERROR, "    " + " | ".join(map(str, row)))
-                self.logger.info("Zero column view OIDs: %s" %
-                                 ' '.join(ForeignKeyCheck.ZeroColumnViewOids))
                 results = curs.getresult()
                 issue_list.append((pkcatname, fields, results))
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -193,6 +193,7 @@ Feature: gpcheckcat tests
         Given database "fkey_db" is dropped and recreated
         And the path "gpcheckcat.repair.*" is removed from current working directory
         And there is a "heap" table "gpadmin_tbl" in "fkey_db" with data
+        And there is a view without columns in "fkey_db"
         When the entry for the table "gpadmin_tbl" is removed from "pg_catalog.pg_class" with key "oid" in the database "fkey_db"
         Then the user runs "gpcheckcat -E -R missing_extraneous fkey_db"
         And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_class" to stdout

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1595,6 +1595,13 @@ def impl(context, tabletype, tablename, dbname):
 def impl(context, tabletype, table_name, dbname):
     create_partition(context, tablename=table_name, storage_type=tabletype, dbname=dbname, with_data=True)
 
+@given('there is a view without columns in "{dbname}"')
+@then('there is a view without columns in "{dbname}"')
+@when('there is a view without columns in "{dbname}"')
+def impl(context, dbname):
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+        dbconn.execSQL(conn, "create view v_no_cols as select;")
+        conn.commit()
 
 @then('read pid from file "{filename}" and kill the process')
 @when('read pid from file "{filename}" and kill the process')


### PR DESCRIPTION
Views without target list are legal.  Until now, gpcheckcat used to report foriegn key check failures for pg_attribute --> pg_class and pg_rewrite --> pg_attribute checks for such views.  This is because zero-column views have no entry in pg_attribute.  This patch fixes gpcheckcat so that it no longer reports failures in presence of such views.

The behave tests without `@concourse_cluster` tag pass on my laptop with this change.

Note that on master branch, after the v12 merge, we have changed foreign key relationship for `pg_rewrite` such as `pg_rewrite` now references `pg_class` and not `pg_attribute`.  Therefore, the `pg_rewrite` specific change in this patch is not needed on master.