### PR TITLE
Remove an outdated merge fixme in analyzeutils

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1190,10 +1190,6 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 	 * and pg_attribute tuples to avoid overhead cost if there still leaf
 	 * tables not analyzed. Return false once find a leaf table not analyzed.
 	 */
-	/* GPDB_12_MERGE_FIXME: what's the appropriate lock level? AccessShareLock
-	 * is enough to scan the table, but are we updating them, too? If not,
-	 * NoLock might be enough?
-	 */
 	oid_list = find_all_inheritors(attrelid, NoLock, NULL);
 	foreach(lc, oid_list)
 	{


### PR DESCRIPTION
We already changed that lock to NoLock while Postgres 12 merge.

	commit 3afdf90f8cbce5b36c3bb6a757d3b9d08a2837b8
	Author: Heikki Linnakangas <hlinnakangas@pivotal.io>
	Date:   Thu Jul 23 17:18:21 2020 +0300

	    Silence test failure caused by SKIP_LOCKED blocking.

	    It is in fact OK, given the weasel words in the docs. Relax the locking
	    slightly in leaf_parts_analyzed() to make it happen less often, though.