### PR TITLE
Remove the merge fixme about skip_ext_partition

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4358,7 +4358,11 @@ copy_opt_item:
 				}
 			| IGNORE_P EXTERNAL PARTITIONS
 				{
-					$$ = makeDefElem("skip_ext_partition", (Node *)makeInteger(true), @1);
+					$$ = makeDefElem("skip_foreign_partitions", (Node *)makeInteger(true), @1);
+				}
+			| IGNORE_P FOREIGN PARTITIONS
+				{
+					$$ = makeDefElem("skip_foreign_partitions", (Node *)makeInteger(true), @1);
 				}
 		;
 

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -246,7 +246,7 @@ typedef struct CopyStateData
 	List	   *qe_attnumlist;
 	bool		stopped_processing_at_delim;
 
-	bool          skip_ext_partition;  /* skip external partition */
+	bool		skip_foreign_partitions;  /* skip foreign/external partitions */
 
 	bool		on_segment; /* QE save data files locally */
 	bool		ignore_extra_line; /* Don't count CSV header or binary trailer in

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1212,12 +1212,17 @@ CREATE EXTERNAL WEB TABLE ext_dec17(LIKE sales_1_prt_dec17) EXECUTE 'printf "12\
 ALTER TABLE sales EXCHANGE PARTITION dec17 WITH TABLE ext_dec17;
 DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_all' IGNORE EXTERNAL PARTITIONS;
+COPY sales TO PROGRAM 'cat > /tmp/test_sales_with_external';
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_<SEGID>' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 
 -- Verify that the files don't contain the row from the external partition.
 \set QUIET 'on'
 
 CREATE EXTERNAL WEB TABLE pg_temp.read_result(line text) EXECUTE 'cat /tmp/test_sales_all' ON COORDINATOR FORMAT 'text' (DELIMITER 'off');
+SELECT * FROM pg_temp.read_result;
+DROP EXTERNAL TABLE pg_temp.read_result;
+
+CREATE EXTERNAL WEB TABLE pg_temp.read_result(line text) EXECUTE 'cat /tmp/test_sales_with_external' ON COORDINATOR FORMAT 'text' (DELIMITER 'off');
 SELECT * FROM pg_temp.read_result;
 DROP EXTERNAL TABLE pg_temp.read_result;
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1443,6 +1443,8 @@ DROP TABLE
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_all' IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
 COPY 24
+COPY sales TO PROGRAM 'cat > /tmp/test_sales_with_external';
+COPY 25
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_<SEGID>' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
 COPY 24
@@ -1477,6 +1479,38 @@ SELECT * FROM pg_temp.read_result;
  9       09-01-2017      20.00
  9       09-01-2017      20.00
 (24 rows)
+
+DROP EXTERNAL TABLE pg_temp.read_result;
+CREATE EXTERNAL WEB TABLE pg_temp.read_result(line text) EXECUTE 'cat /tmp/test_sales_with_external' ON COORDINATOR FORMAT 'text' (DELIMITER 'off');
+SELECT * FROM pg_temp.read_result;
+             line              
+-------------------------------
+ 1       01-01-2017      20.00
+ 1       01-01-2017      20.00
+ 2       02-01-2017      20.00
+ 2       02-01-2017      20.00
+ 3       03-01-2017      20.00
+ 3       03-01-2017      20.00
+ 4       04-01-2017      20.00
+ 4       04-01-2017      20.00
+ 15      05-01-2017      20.00
+ 15      05-01-2017      20.00
+ 25      05-01-2017      20.00
+ 25      05-01-2017      20.00
+ 5       05-01-2017      20.00
+ 5       05-01-2017      20.00
+ 7       07-01-2017      20.00
+ 7       07-01-2017      20.00
+ 8       08-01-2017      20.00
+ 8       08-01-2017      20.00
+ 18      08-01-2017      20.00
+ 18      08-01-2017      20.00
+ 9       09-01-2017      20.00
+ 9       09-01-2017      20.00
+ 11      11-01-2017      20.00
+ 11      11-01-2017      20.00
+ 12      12-01-2017      21.00
+(25 rows)
 
 DROP EXTERNAL TABLE pg_temp.read_result;
 CREATE EXTERNAL WEB TABLE pg_temp.read_result(line text) EXECUTE 'cat /tmp/test_sales_$GP_SEGMENT_ID' FORMAT 'text' (DELIMITER 'off');


### PR DESCRIPTION
Add a case that proves it works.
Rename the internal variable name to skip_foreign_partitions, which is
more accurate.
Update SQL syntax, IGNORE EXTERNAL PARTITIONS and IGNORE FOREIGN
PARTITIONS are the same thing.