### PR TITLE
Report separate PostgreSQL and Greenplum versions in pg_controldata

### DIFF
--- a/src/backend/utils/misc/pg_controldata.c
+++ b/src/backend/utils/misc/pg_controldata.c
@@ -59,7 +59,15 @@ pg_control_system(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errmsg("calculated CRC checksum does not match value stored in file")));
 
-	values[0] = Int32GetDatum(ControlFile->pg_control_version);
+	/*
+	 * Greenplum: first four digits of pg_control_version are PostgreSQL
+	 * version, followed by four digits of Greenplum version.  Here, we return
+	 * PostgreSQL version only, so as to keep it compatible with thrid-party
+	 * contrib modules.  In future, we may introduce a new UDF that will
+	 * return Greenplum version as a new column, say
+	 * "pg_control_greenplum_verison".  See PG_CONTROL_VERSION.
+	 */
+	values[0] = Int32GetDatum(ControlFile->pg_control_version / 10000);
 	nulls[0] = false;
 
 	values[1] = Int32GetDatum(ControlFile->catalog_version_no);

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -241,7 +241,9 @@ main(int argc, char *argv[])
 				 (unsigned char) ControlFile->mock_authentication_nonce[i]);
 
 	printf(_("pg_control version number:            %u\n"),
-		   ControlFile->pg_control_version);
+		   ControlFile->pg_control_version / 10000);
+	printf(_("pg_control Greenplum version number:  %u\n"),
+		   ControlFile->pg_control_version % 10000);
 	printf(_("Catalog version number:               %u\n"),
 		   ControlFile->catalog_version_no);
 	printf(_("Database system identifier:           %s\n"),

--- a/src/bin/pg_resetwal/pg_resetwal.c
+++ b/src/bin/pg_resetwal/pg_resetwal.c
@@ -931,7 +931,9 @@ PrintControlValues(bool guessed)
 			 ControlFile.system_identifier);
 
 	printf(_("pg_control version number:            %u\n"),
-		   ControlFile.pg_control_version);
+		   ControlFile.pg_control_version / 10000);
+	printf(_("pg_control Greenplum version number:  %u\n"),
+		   ControlFile.pg_control_version % 10000);
 	printf(_("Catalog version number:               %u\n"),
 		   ControlFile.catalog_version_no);
 	printf(_("Database system identifier:           %s\n"),


### PR DESCRIPTION
The version number reported by pg_controldata utility as `pg_control version number:` used to include PostgreSQL as well as Greenplum version numbers combined as a single integer.  This patch separates the two version numbers.  Tools such as pg_upgrade and external modules such as pg_auto_failover expect native PostgreSQL version as an integer (e.g. 833, 942, 1201, etc) in "pg_control version number".  This patch attempts to match that expectation.  Greenplum version is reported on a separate line in similar format (e.g. 700) as `pg_control Greenplum version number`.

