### PR TITLE
Minirepro fixes

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -76,20 +76,23 @@ def dumpTupleCount(cur):
 
 
 def dumpStats(cur, inclHLL):
-    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgt.typname, pgs.* ' \
-        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt ' \
+    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgtn.nspname, pgt.typname, pgs.* ' \
+        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt, pg_namespace pgtn ' \
         'WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN ' + \
         sysnslist + \
         ' and pgc.oid = pgs.starelid ' \
         'and pga.attrelid = pgc.oid ' \
         'and pga.attnum = pgs.staattnum ' \
         'and pga.atttypid = pgt.oid ' \
+        'and pgt.typnamespace = pgtn.oid ' \
         'ORDER BY pgc.relname, pgs.staattnum'
+    # the outline of the DML used to create stats for one column in pg_statistic
     pstring = '--\n' \
         '-- Table: {0}, Attribute: {1}\n' \
         '--\n' \
         'INSERT INTO pg_statistic VALUES (\n' \
         '{2});\n\n'
+    # the types of the columns in the pg_statistic table, except for starelid and stavalues[1-5]
     types = ['smallint',  # staattnum
              'boolean',
              'real',
@@ -119,14 +122,27 @@ def dumpStats(cur, inclHLL):
 
         i = 0
         hll = False
-        if vals[3][0] == '_':
-            rowTypes = types + [vals[3]] * 5
+        typeschema = vals[3]
+        typename = vals[4]
+        if typeschema != "pg_catalog":
+            # a type that is not built-in, qualify it with its schema name
+            # and play it safe by double-quoting the identifiers
+            typename = '"%s"."%s"' % (typeschema, typename)
+
+        # determine the actual types of stavalues[1-5], the columns are defined as "anyarray"
+        if vals[4][0] == '_':
+            # column is an array type, use as is
+            rowTypes = types + [typename] * 5
         else:
-            rowTypes = types + [vals[3] + '[]'] * 5
-        for val, typ in zip(vals[5:], rowTypes):
+            # non-array type, make an array type out of it
+            rowTypes = types + [typename + '[]'] * 5
+
+        # create the content of the VALUES clause
+        for val, typ in zip(vals[6:], rowTypes):
             i = i + 1
             str_val = "'%s'" % val
             if i == 10 and (val == 98 or val == 99):
+                # column stakind5 has value 98 or 99 (HLL stats)
                 if inclHLL == False:
                     val = 0
                 hll = True
@@ -137,6 +153,7 @@ def dumpStats(cur, inclHLL):
                 val = val.replace("'", "''").replace('\\', '\\\\')
                 val = "E'" + val + "'"
             if i == 25 and hll == True:
+                # the actual HLL value in stavalues5
                 if inclHLL == True:
                     rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
                 else:

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -289,7 +289,10 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
             if val is None:
                 val = 'NULL'
             elif isinstance(val, (str, unicode)) and val[0] == '{':
-                val = "E'%s'" % E(val)
+                # use an Escape string for array constants and also add one
+                # more layer of backslash escape symbols, since the string
+                # will go through two layers of escape processing
+                val = "E'%s'" % E(val.replace('\\', '\\\\'))
             if i == 25 and hll == True:
                 # the actual HLL value in stavalues5
                 if inclHLL == True:

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -211,22 +211,26 @@ def dump_tuple_count(cur, oid_str, f_out):
         f_out.writelines(updateStmt)
 
 def dump_stats(cur, oid_str, f_out, inclHLL):
-    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgt.typname, pgs.* ' \
-        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt ' \
+    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgtn.nspname, pgt.typname, pgs.* ' \
+        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt, pg_namespace pgtn ' \
         'WHERE pgc.relnamespace = pgn.oid and pgc.oid in (%s) ' \
         'and pgn.nspname NOT LIKE \'pg_temp_%%\' ' \
         'and pgc.oid = pgs.starelid ' \
         'and pga.attrelid = pgc.oid ' \
         'and pga.attnum = pgs.staattnum ' \
         'and pga.atttypid = pgt.oid ' \
+        'and pgt.typnamespace = pgtn.oid ' \
         'ORDER BY pgc.relname, pgs.staattnum' % (oid_str)
 
+    # the outline of the DML used to create stats for one column in pg_statistic
     pstring = '--\n' \
         '-- Table: {0}, Attribute: {1}\n' \
         '--\n' \
         '{2}DELETE FROM pg_statistic WHERE starelid={3} AND staattnum={4};\n' \
         'INSERT INTO pg_statistic VALUES (\n' \
         '{5});\n\n'
+
+    # the types of the columns in the pg_statistic table, except for starelid and stavalues[1-5]
     types = ['smallint',  # staattnum
              'boolean',
              'real',
@@ -255,17 +259,29 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
         starelid = "'%s.%s'::regclass" % (E(vals[1]), E(vals[0]))
         rowVals = ["\t%s" % (starelid)]
         schemaname = vals[1]
+        typeschema = vals[3]
+        typename = vals[4]
+        if typeschema != "pg_catalog":
+            # a type that is not built-in, qualify it with its schema name
+            # and play it safe by double-quoting the identifiers
+            typename = '"%s"."%s"' % (typeschema, typename)
         i = 0
         hll = False
 
-        if vals[3][0] == '_':
-            rowTypes = types + [vals[3]] * 5
+        # determine the actual types of stavalues[1-5], the columns are defined as "anyarray"
+        if vals[4][0] == '_':
+            # column is an array type, use as is
+            rowTypes = types + [typename] * 5
         else:
-            rowTypes = types + [vals[3] + '[]'] * 5
-        for val, typ in zip(vals[5:], rowTypes):
+            # non-array type, make an array type out of it
+            rowTypes = types + [typename + '[]'] * 5
+
+        # create the content of the VALUES clause
+        for val, typ in zip(vals[6:], rowTypes):
             i = i + 1
             str_val = "'%s'" % val
             if i == 10 and (val == 98 or val == 99):
+                # column stakind5 has value 98 or 99 (HLL stats)
                 if inclHLL == False:
                     val = 0
                 hll = True
@@ -275,6 +291,7 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
             elif isinstance(val, (str, unicode)) and val[0] == '{':
                 val = "E'%s'" % E(val)
             if i == 25 and hll == True:
+                # the actual HLL value in stavalues5
                 if inclHLL == True:
                     rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
                 else:
@@ -288,7 +305,7 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
         if schemaname != 'pg_catalog':
             linecomment = '-- ' # This will comment out the DELETE query
 
-        f_out.writelines(pstring.format(E(vals[0]), E(vals[2]), linecomment, starelid, vals[5], ',\n'.join(rowVals)))
+        f_out.writelines(pstring.format(E(vals[0]), E(vals[2]), linecomment, starelid, vals[6], ',\n'.join(rowVals)))
 
 def main():
     parser = parse_cmd_line()


### PR DESCRIPTION
* Fix minirepro bug with column types that are not built-in

  In the generated SQL, `minirepro` used an unqualified name for the
  type, which didn't work for types like `citext` that usually come
  from a schema other than `pg_catalog` and other than the schema of
  the table to be dumped.

  The fix is to use a qualified name. For example, `citext` becomes
  something like `"public"."citext"`.

* Fix minirepro bug with embedded double quotes and backslashes

  When values in `pg_statistic.stavalues<n>` had embedded double quotes or
  backslashes, minirepro generated a single set of escape characters
  (backslash) but the correct syntax for an embedded double quote in an
  array constant is `\\"`, because it goes through two layers of escape
  processing. For embedded backslashes we need to use `\\\\`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
