### PR TITLE
Fix cases in gpfdist for dual stack solution. (#11728)

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -2374,6 +2374,17 @@ signal_register()
 
 }
 
+static void clear_listen_sock(void)
+{
+	SOCKET sock = -1;
+	while(gcb.listen_sock_count > 0)
+	{
+		sock = gcb.listen_socks[gcb.listen_sock_count-1];
+		closesocket(sock);
+		gcb.listen_socks[gcb.listen_sock_count-1] = -1;
+		gcb.listen_sock_count--;
+	}
+}
 /* Create HTTP port and start to receive request */
 static void
 http_setup(void)
@@ -2388,6 +2399,8 @@ http_setup(void)
 
 	char service[32];
 	const char *hostaddr = NULL;
+	int ipv6only_val = 1;
+	bool create_failed = false;
 
 #ifdef USE_SSL
 	if (opt.ssl)
@@ -2480,8 +2493,8 @@ http_setup(void)
 #endif
 			if (setsockopt(f, SOL_SOCKET, SO_KEEPALIVE, (void*) &on, sizeof(on)) == -1)
 			{
-				closesocket(f);
 				gwarning(NULL, "Setting SO_KEEPALIVE on socket failed");
+				closesocket(f);
 				continue;
 			}
 
@@ -2494,8 +2507,8 @@ http_setup(void)
 #ifndef WIN32
 			if (setsockopt(f, SOL_SOCKET, SO_REUSEADDR, (void*) &on, sizeof(on)) == -1)
 			{
-				closesocket(f);
 				gwarning(NULL, "Setting SO_REUSEADDR on socket failed");
+				closesocket(f);
 				continue;
 			}
 #endif
@@ -2503,9 +2516,18 @@ http_setup(void)
 			linger.l_linger = 5;
 			if (setsockopt(f, SOL_SOCKET, SO_LINGER, (void*) &linger, sizeof(linger)) == -1)
 			{
-				closesocket(f);
 				gwarning(NULL, "Setting SO_LINGER on socket failed");
+				closesocket(f);
 				continue;
+			}
+			if(rp->ai_family == AF_INET6)
+			{
+				if (setsockopt(f, IPPROTO_IPV6, IPV6_V6ONLY, (void*) &ipv6only_val, sizeof(ipv6only_val)) == -1)
+				{
+					gwarning(NULL, "Setting IPV6_V6ONLY on socket failed");
+					closesocket(f);
+					continue;
+				}
 			}
 
 			if (bind(f, rp->ai_addr, rp->ai_addrlen) != 0)
@@ -2526,9 +2548,12 @@ http_setup(void)
 						gwarning(NULL, "%s (errno = %d), port: %d",
 					               		strerror(errno), errno, opt.p);
 					}
+					closesocket(f);
+					create_failed = true;
+					break;
 				}
 				else
-			    {
+				{
 					gwarning(NULL, "%s (errno=%d), port: %d",strerror(errno), errno, opt.p);
 				}
 
@@ -2561,6 +2586,11 @@ http_setup(void)
 		{
 			/* don't need this any more */
 			freeaddrinfo(addrs);
+		}
+		if(create_failed)
+		{
+			clear_listen_sock();
+			create_failed = false;
 		}
 
 		if (gcb.listen_sock_count > 0)

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -13,7 +13,7 @@ endif
 
 REGRESS_OPTS = --init-file=init_file
 
-installcheck: watchdog
+installcheck: watchdog ipv4v6_ports
 ifeq ($(enable_gpfdist),yes)
 ifeq ($(with_openssl),yes)
 	rm -rf data/gpfdist_ssl/certs_matching
@@ -27,6 +27,9 @@ endif
 
 watchdog:
 	sh test_watchdog.sh
+
+ipv4v6_ports:
+	sh test_ipv4v6_port.sh
 
 clean:
 	rm -rf regression.* sql results expected

--- a/src/bin/gpfdist/regress/test_ipv4v6_port.sh
+++ b/src/bin/gpfdist/regress/test_ipv4v6_port.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+export GPFDIST_WATCHDOG_TIMER=5
+
+NC_IPV6_PID=0
+NC_IPV4_PID=0
+GPFDIST_PID=0
+
+function clear_subprocess()
+{
+	if [ $NC_IPV6_PID -ne 0 ]; then
+		kill -9 $NC_IPV6_PID
+		NC_IPV6_PID=0
+	fi
+
+	if [ $NC_IPV4_PID -ne 0 ]; then
+		kill -9 $NC_IPV4_PID
+		NC_IPV4_PID=0
+	fi
+	sleep 1
+}
+
+function start_nc_ipv4()
+{
+	nc -l 0.0.0.0 8080 &
+	NC_IPV4_PID=$!
+}
+
+function start_nc_ipv6()
+{
+	nc -l :: 8080 &
+	NC_IPV6_PID=$!
+}
+
+function start_gpfdist()
+{
+	gpfdist -v &
+	GPFDIST_PID=$!
+}
+
+IPV4_ONLY=0
+ifconfig -a | grep inet6
+if [ $? == 0 ]; then
+	IPV4_ONLY=0
+else
+	IPV4_ONLY=1
+fi
+
+# test start gpfdist with nc binded to ipv4 port
+start_nc_ipv4
+sleep 1
+start_gpfdist
+wait $GPFDIST_PID
+if [ $? -eq 1 ]; then #gpfdist failed to start because of ipv4 port already in use
+	echo -e "\033[32m test [gpfdist start with nc binded to ipv4 port] success \033[0m"
+else
+	echo -e "\033[31m test [gpfdist start with nc binded to ipv4 port] failed \033[0m"
+	echo "gpfdist should not start successfully because port ipv4:8080 is used by nc"
+	exit 1
+fi
+clear_subprocess
+
+if [ $IPV4_ONLY == 0 ]; then
+	# test start gpfdist with nc binded to ipv6 port
+	start_nc_ipv6
+	sleep 1
+	start_gpfdist
+	wait $GPFDIST_PID
+	if [ $? -eq 1 ]; then #gpfdist failed to start because of ipv6 port already in use
+		echo -e "\033[32m test [gpfdist start with nc binded to ipv6 port] success \033[0m"
+	else
+		echo -e "\033[31m test [gpfdist start with nc binded to ipv6 port] failed \033[0m"
+		echo "gpfdist should not start successfully because port ipv6:8080 is used by nc"
+		exit 1
+	fi
+	clear_subprocess
+
+	# test start gpfdist with nc binded to ipv4 and ipv6 port
+	start_nc_ipv4
+	start_nc_ipv6
+	sleep 1
+	start_gpfdist
+	wait $GPFDIST_PID
+	if [ $? -eq 1 ]; then #gpfdist failed to start because of ipv4 and ipv6 port already in use
+		echo -e "\033[32m test [gpfdist start with nc binded to ipv4 and ipv6 port] success \033[0m"
+	else
+		echo -e "\033[32m test [gpfdist start with nc binded to ipv4 and ipv6 port] failed \033[0m"
+		echo "gpfdist should not start successfully because port ipv4::8080 and ipv6:8080 are used by nc"
+		exit 1
+	fi
+	clear_subprocess
+
+	# test start gpfdist alone without nc binded to ipv4 or ipv6 8080 port
+	start_gpfdist
+	sleep 1
+	wait $GPFDIST_PID
+	if [ $? -eq 134 ]; then #gpfdist stoped by watchdog
+		echo -e "\033[32m test [gpfdist starts without ipv4 or ipv6 nc listening] success \033[0m"
+	else
+		echo -e "\033[31m test [gpfdist starts without ipv4 or ipv6 nc listening] failed \033[0m"
+		echo "gpfdist should start successfully and stoped by watchdog"
+		exit 1
+	fi
+	clear_subprocess
+else
+	# test start gpfdist alone without nc binded to ipv4 8080 port
+	start_gpfdist
+	sleep 1
+	wait $GPFDIST_PID
+	if [ $? -eq 134 ]; then #gpfdist stoped by watchdog
+		echo -e "\033[32m test [gpfdist starts without ipv4 nc listening] success \033[0m"
+	else
+		echo -e "\033[31m test [gpfdist starts without ipv4 nc listening] failed \033[0m"
+		echo "gpfdist should start successfully and stoped by watchdog"
+		exit 1
+	fi
+	clear_subprocess
+
+fi
+
+
+echo -e "\n"
+echo -e "\033[32m Test gpfdist binding ipv4/ipv6 ports success\033[0m"
+exit 0


### PR DESCRIPTION
If /proc/sys/net/ipv6/bindv6only is set to 0:
In one case that if process A is already listening on ipv4 8080 port,
the gpfdist cannot start successfully. But if process A is listening on
ipv6 8080 port, the gpfdist can start successfully and will listen on
ipv4 8080 port. But in this situation if one client tries to connect to
gpfdist using ipv6 8080 port, it will connect to proccess A. Then the outcome
is not what we want.

If /proc/sys/net/ipv6/bindv6only is set to 1:
In one case that if either process A or process B is already listening on
either ipv4 8080 port or ipv6 8080 port, the gpfdist can still start
successfully. In this situation if one client tries to connect to
gpfdist using the port which process A or B is listening on, the outcome
is not what we want.

So in an environment which support both ipv4 or ipv6, this commit tries to make
sure that only if gpfdist is listening on both ipv4 and ipv6 ports successfully,
it will continue to run and try to handle clients requests. But there are some
special environments that support only ipv4, in this env we have to make gpfdist
starting successfully and listening on only ipv4 port.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
