### PR TITLE
Remove an assert to prepare synchronous replication

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -489,7 +489,6 @@ SyncRepInitConfig(void)
 	 */
 	if (IS_QUERY_DISPATCHER() && MyWalSnd->is_for_gp_walreceiver)
 	{
-		Assert(priority == 0);
 		priority = 1;
 	}
 


### PR DESCRIPTION
Currently, the GPDB cluster will crash if pg_auto_failover is enable.
To enable synchronous replication, there're lots of work to do.
This patch only works around the assert failure.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
