### PR TITLE
[5X] Bump ORCA version to 3.116 (Disallow subquery in predicate of implementation xforms)

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.115.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.116.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.115.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.116.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12487,7 +12487,7 @@ int
 main ()
 {
 
-return strncmp("3.115.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.116.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12497,7 +12497,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.115.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.116.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.115.0@gpdb/stable
+orca/v3.116.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.115.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.116.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test


### PR DESCRIPTION
Corresponding ORCA commit: Disallow subquery in predicate of implementation xforms (https://github.com/greenplum-db/gporca/pull/617)

This generates an invalid plan for most cases. While we had this logic
in some xforms, we missed a few cases.

This manifested as a crash in some cases as we assumed subqueries had
been handled by time we get to optimization stage.

Additionally, add error handling to PexprScalarExactChild()

This function is only called in places where the exact child must exist,
and returns null otherwise.

However, there have been some cases where we assume the child must
exist, but due to another bug the child does not and we don't handle the
null. This is a defensive change; if we get into this situation we'll
throw an exception and fall back to planner instead of crashing.