### PR TITLE
Disallow subquery in predicate of implementation xforms

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -1,0 +1,833 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+Objective: We should not attempt to generate a bitmapscan with a subquery in the predicate.
+CREATE TABLE abuela (a int, b int) WITH (appendonly=true);
+CREATE TABLE abuelo (c int);
+CREATE TABLE prima (e int);
+CREATE TABLE primo (g int);
+CREATE INDEX idx_abuela_aaa ON abuela (a, b);
+
+INSERT INTO abuela SELECT i, i FROM generate_series(1, 8) i;
+ANALYZE abuela;
+
+EXPLAIN
+SELECT 42 IN (SELECT g FROM primo) AS g
+FROM
+(
+	SELECT a
+	FROM abuela
+	WHERE b = (SELECT 0 FROM prima LIMIT 1)
+) abuela
+JOIN abuelo
+ON a = c
+;
+	]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.305414.1.0" Name="primo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.305414.1.0" Name="primo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="g" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.305408.1.0" Name="abuelo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.305408.1.0" Name="abuelo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.305411.1.0" Name="prima" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.305411.1.0" Name="prima" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="e" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="0.305420.1.0" Name="idx_abuela_aaa" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.305408.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.305408.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.305411.1.0.0" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.305401.1.0.4" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.305414.1.0.0" Name="g" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBFunc Mdid="0.65.1.0" Name="int4eq" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.16.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.305401.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="8.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.305408.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.305401.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.305401.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.142857" DistinctValues="1.142857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.305401.1.0" Name="abuela" Rows="8.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.305401.1.0" Name="abuela" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Hash" DistributionColumns="0" Keys="4,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="0.305420.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="31" ColName="g" TypeMdid="0.16.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="31" Alias="g">
+            <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="23">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.305414.1.0" TableName="primo" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="23" Attno="1" ColName="g" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="25" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="26" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="27" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="28" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="29" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="30" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:SubqueryAny>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalJoin JoinType="Inner">
+          <dxl:LogicalSelect>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ScalarSubquery ColId="14">
+                <dxl:LogicalLimit>
+                  <dxl:SortingColumnList/>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset/>
+                  <dxl:LogicalProject>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="14" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.305411.1.0" TableName="prima" LockMode="1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="6" Attno="1" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="8" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="9" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="10" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="11" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="12" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="13" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                  </dxl:LogicalProject>
+                </dxl:LogicalLimit>
+              </dxl:ScalarSubquery>
+            </dxl:Comparison>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.305401.1.0" TableName="abuela" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalSelect>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.305408.1.0" TableName="abuelo" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="15" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="17" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="20" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="15" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="48688">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2206721.811317" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="30" Alias="g">
+            <dxl:Ident ColId="30" ColName="g" TypeMdid="0.16.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2206721.811313" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="30" Alias="g">
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:Comparison>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2206721.811313" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001217" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:HashJoin JoinType="Inner">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000822" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="13" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="8.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.305401.1.0" TableName="abuela" LockMode="1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="3" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="13" Alias="?column?">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="3.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Limit>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.305411.1.0" TableName="prima" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="5" Attno="1" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="7" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="8" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="10" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="11" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="12" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                      <dxl:LimitCount>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                      </dxl:LimitCount>
+                      <dxl:LimitOffset>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                      </dxl:LimitOffset>
+                    </dxl:Limit>
+                  </dxl:BroadcastMotion>
+                </dxl:Result>
+              </dxl:HashJoin>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="14" Alias="c">
+                    <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.305408.1.0" TableName="abuelo" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="14" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="16" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:HashJoin>
+            <dxl:Materialize Eager="true">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000522" Rows="3.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                  <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000514" Rows="3.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                    <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                      <dxl:If TypeMdid="0.20.1.0">
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                          <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:Comparison>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        <dxl:If TypeMdid="0.20.1.0">
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                            <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="-1"/>
+                          <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
+                        </dxl:If>
+                      </dxl:If>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="37" Alias="ColRef_0037">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                          <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                          <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                            <dxl:If TypeMdid="0.23.1.0">
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="22" ColName="g" TypeMdid="0.23.1.0"/>
+                              </dxl:IsNull>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                            </dxl:If>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="22" Alias="g">
+                              <dxl:Ident ColId="22" ColName="g" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter>
+                            <dxl:Or>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+                                <dxl:Ident ColId="22" ColName="g" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="22" ColName="g" TypeMdid="0.23.1.0"/>
+                              </dxl:IsNull>
+                            </dxl:Or>
+                          </dxl:Filter>
+                          <dxl:TableDescriptor Mdid="0.305414.1.0" TableName="primo" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="22" Attno="1" ColName="g" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:Result>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:BroadcastMotion>
+            </dxl:Materialize>
+          </dxl:NestedLoopJoin>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -275,7 +275,8 @@ public:
 	CExpression *PexprScalarRep() const;
 
 	// return an exact scalar child at given index or return null if not possible
-	CExpression *PexprScalarExactChild(ULONG child_index) const;
+	CExpression *PexprScalarExactChild(ULONG child_index,
+									   BOOL error_on_null_return = false) const;
 
 	// return an exact scalar expression attached to handle or null if not possible
 	CExpression *PexprScalarExact() const;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformDynamicIndexGet2DynamicIndexScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformDynamicIndexGet2DynamicIndexScan.h
@@ -55,12 +55,7 @@ public:
 	}
 
 	// compute xform promise for a given expression handle
-	EXformPromise
-	Exfp(CExpressionHandle &  // exprhdl
-	) const override
-	{
-		return CXform::ExfpHigh;
-	}
+	EXformPromise Exfp(CExpressionHandle &exprhdl) const override;
 
 	// actual transform
 	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementBitmapTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementBitmapTableGet.h
@@ -60,12 +60,7 @@ public:
 	}
 
 	// compute xform promise for a given expression handle
-	EXformPromise
-	Exfp(CExpressionHandle &  // exprhdl
-	) const override
-	{
-		return CXform::ExfpHigh;
-	}
+	EXformPromise Exfp(CExpressionHandle &exprhdl) const override;
 
 	// actual transform
 	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementCorrelatedApply.h
@@ -55,10 +55,13 @@ public:
 	// dtor
 	~CXformImplementCorrelatedApply() override = default;
 
-	// compute xform promise for a given expression handle
 	EXformPromise
-	Exfp(CExpressionHandle &) const override
+	Exfp(CExpressionHandle &exprhdl) const override
 	{
+		if (exprhdl.DeriveHasSubquery(2))
+		{
+			return CXform::ExfpNone;
+		}
 		return CXform::ExfpHigh;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementDynamicBitmapTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementDynamicBitmapTableGet.h
@@ -60,12 +60,7 @@ public:
 	}
 
 	// compute xform promise for a given expression handle
-	EXformPromise
-	Exfp(CExpressionHandle &  // exprhdl
-	) const override
-	{
-		return CXform::ExfpHigh;
-	}
+	EXformPromise Exfp(CExpressionHandle &exprhdl) const override;
 
 	// actual transform
 	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementFullOuterMergeJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementFullOuterMergeJoin.h
@@ -13,6 +13,9 @@ namespace gpopt
 {
 using namespace gpos;
 
+// FIXME: This should derive from CXformImplementation, but there is an unrelated bug
+// with ImplementMergeJoin() that causes us to generate an invalid plan in some
+// cases if we change this without fixing the bug.
 class CXformImplementFullOuterMergeJoin : public CXformExploration
 {
 private:

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
@@ -57,11 +57,13 @@ public:
 		return "CXformImplementIndexApply";
 	}
 
-	// compute xform promise for a given expression handle
 	EXformPromise
-	Exfp(CExpressionHandle &  // exprhdl
-	) const override
+	Exfp(CExpressionHandle &exprhdl) const override
 	{
+		if (exprhdl.DeriveHasSubquery(2))
+		{
+			return ExfpNone;
+		}
 		return ExfpHigh;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementLimit.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementLimit.h
@@ -53,12 +53,7 @@ public:
 	}
 
 	// compute xform promise for a given expression handle
-	EXformPromise
-	Exfp(CExpressionHandle &  // exprhdl
-	) const override
-	{
-		return CXform::ExfpHigh;
-	}
+	EXformPromise Exfp(CExpressionHandle &exprhdl) const override;
 
 	// actual transform
 	void Transform(CXformContext *, CXformResult *,

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -4621,9 +4621,8 @@ CUtils::MakeJoinWithoutInferredPreds(CMemoryPool *mp, CExpression *join_expr)
 
 	CExpressionHandle expression_handle(mp);
 	expression_handle.Attach(join_expr);
-	CExpression *scalar_expr =
-		expression_handle.PexprScalarExactChild(join_expr->Arity() - 1);
-	GPOS_ASSERT(nullptr != scalar_expr);
+	CExpression *scalar_expr = expression_handle.PexprScalarExactChild(
+		join_expr->Arity() - 1, true /*error_on_null_return*/);
 	CExpression *scalar_expr_without_inferred_pred =
 		CPredicateUtils::PexprRemoveImpliedConjuncts(mp, scalar_expr,
 													 expression_handle);

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -1416,22 +1416,37 @@ CExpressionHandle::PexprScalarRep() const
 // return an exact scalar child at given index or return null if not possible
 // (use this where exactness is required, e.g. for constraint derivation)
 CExpression *
-CExpressionHandle::PexprScalarExactChild(ULONG child_index) const
+CExpressionHandle::PexprScalarExactChild(ULONG child_index,
+										 BOOL error_on_null_return) const
 {
+	CExpression *result_expr = nullptr;
 	if (nullptr != m_pgexpr && !(*m_pgexpr)[child_index]->FScalarRepIsExact())
 	{
-		return nullptr;
+		result_expr = nullptr;
 	}
 
-	if (nullptr != m_pexpr && nullptr != (*m_pexpr)[child_index]->Pgexpr() &&
-		!((*m_pexpr)[child_index]->Pgexpr()->Pgroup()->FScalarRepIsExact()))
+	else if (nullptr != m_pexpr &&
+			 nullptr != (*m_pexpr)[child_index]->Pgexpr() &&
+			 !((*m_pexpr)[child_index]
+				   ->Pgexpr()
+				   ->Pgroup()
+				   ->FScalarRepIsExact()))
 	{
 		// the expression does not come from a group, but its child does and
 		// the child group does not have an exact expression
-		return nullptr;
+		result_expr = nullptr;
 	}
 
-	return PexprScalarRepChild(child_index);
+	else
+	{
+		result_expr = PexprScalarRepChild(child_index);
+	}
+	if (nullptr == result_expr && error_on_null_return)
+	{
+		GPOS_RAISE(CException::ExmaInvalid, CException::ExmiInvalid,
+				   GPOS_WSZ_LIT("Generated invalid plan with subquery"));
+	}
+	return result_expr;
 }
 
 // return an exact scalar expression attached to handle or null if not possible

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -215,7 +215,8 @@ CPhysicalFilter::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 	if (CDistributionSpec::EdtHashed == pdsChild->Edt() &&
 		exprhdl.HasOuterRefs())
 	{
-		CExpression *pexprFilterPred = exprhdl.PexprScalarExactChild(1);
+		CExpression *pexprFilterPred =
+			exprhdl.PexprScalarExactChild(1, true /*error_on_null_return*/);
 
 		CDistributionSpecHashed *pdshashedOriginal =
 			CDistributionSpecHashed::PdsConvert(pdsChild);

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
@@ -88,7 +88,8 @@ CPhysicalFullMergeJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 
 	BOOL nulls_collocated = true;
 	if (CPredicateUtils::ExprContainsOnlyStrictComparisons(
-			mp, exprhdl.PexprScalarExactChild(2)))
+			mp,
+			exprhdl.PexprScalarExactChild(2, true /*error_on_null_return*/)))
 	{
 		// There is no need to require NULL rows to be collocated if the merge clauses
 		// only contain STRICT operators. This is because any NULL row will automatically

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerNLJoin.cpp
@@ -132,8 +132,8 @@ CPhysicalInnerNLJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 			if (CDistributionSpec::EdtHashed == pdsOuter->Edt())
 			{
 				// require inner child to have matching hashed distribution
-				CExpression *pexprScPredicate =
-					exprhdl.PexprScalarExactChild(2);
+				CExpression *pexprScPredicate = exprhdl.PexprScalarExactChild(
+					2, true /*error_on_null_return*/);
 				CExpressionArray *pdrgpexpr =
 					CPredicateUtils::PdrgpexprConjuncts(mp, pexprScPredicate);
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLimit.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLimit.cpp
@@ -182,8 +182,8 @@ CPhysicalLimit::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 				CEnfdDistribution::EdmSatisfy);
 		}
 
-		CExpression *pexprOffset =
-			exprhdl.PexprScalarExactChild(1 /*child_index*/);
+		CExpression *pexprOffset = exprhdl.PexprScalarExactChild(
+			1 /*child_index*/, true /*error_on_null_return*/);
 		if (!m_fHasCount && CUtils::FScalarConstIntZero(pexprOffset))
 		{
 			// pass through input distribution if it has no count nor offset and is not

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
@@ -181,8 +181,8 @@ CPhysicalScan::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 		//
 		// This way the equiv spec stays incomplete only as long as it needs to be.
 
-		CExpression *pexprIndexPred =
-			exprhdl.PexprScalarExactChild(0 /*child_index*/);
+		CExpression *pexprIndexPred = exprhdl.PexprScalarExactChild(
+			0 /*child_index*/, true /*error_on_null_return*/);
 
 		CDistributionSpecHashed *pdshashed =
 			CDistributionSpecHashed::PdsConvert(m_pds);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDynamicIndexGet2DynamicIndexScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDynamicIndexGet2DynamicIndexScan.cpp
@@ -42,6 +42,15 @@ CXformDynamicIndexGet2DynamicIndexScan::CXformDynamicIndexGet2DynamicIndexScan(
 {
 }
 
+CXform::EXformPromise
+CXformDynamicIndexGet2DynamicIndexScan::Exfp(CExpressionHandle &exprhdl) const
+{
+	if (exprhdl.DeriveHasSubquery(0))
+	{
+		return CXform::ExfpNone;
+	}
+	return CXform::ExfpHigh;
+}
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -70,10 +79,6 @@ CXformDynamicIndexGet2DynamicIndexScan::Transform(
 
 	// extract components
 	CExpression *pexprIndexCond = (*pexpr)[0];
-	if (pexprIndexCond->DeriveHasSubquery())
-	{
-		return;
-	}
 	pexprIndexCond->AddRef();
 
 	CTableDescriptor *ptabdesc = popIndexGet->Ptabdesc();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementBitmapTableGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementBitmapTableGet.cpp
@@ -45,6 +45,18 @@ CXformImplementBitmapTableGet::CXformImplementBitmapTableGet(CMemoryPool *mp)
 {
 }
 
+CXform::EXformPromise
+CXformImplementBitmapTableGet::Exfp(CExpressionHandle &exprhdl) const
+{
+	if (exprhdl.DeriveHasSubquery(0) || exprhdl.DeriveHasSubquery(1))
+	{
+		return CXform::ExfpNone;
+	}
+
+
+	return CXform::ExfpHigh;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CXformImplementBitmapTableGet::Transform

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementDynamicBitmapTableGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementDynamicBitmapTableGet.cpp
@@ -47,6 +47,17 @@ CXformImplementDynamicBitmapTableGet::CXformImplementDynamicBitmapTableGet(
 {
 }
 
+// compute xform promise for a given expression handle
+CXform::EXformPromise
+CXformImplementDynamicBitmapTableGet::Exfp(CExpressionHandle &exprhdl) const
+{
+	if (exprhdl.DeriveHasSubquery(0) || exprhdl.DeriveHasSubquery(1))
+	{
+		return CXform::ExfpNone;
+	}
+	return CXform::ExfpHigh;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CXformImplementDynamicBitmapTableGet::Transform

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementFullOuterMergeJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementFullOuterMergeJoin.cpp
@@ -32,9 +32,12 @@ CXformImplementFullOuterMergeJoin::CXformImplementFullOuterMergeJoin(
 }
 
 CXform::EXformPromise
-CXformImplementFullOuterMergeJoin::Exfp(CExpressionHandle &	 //exprhdl
-) const
+CXformImplementFullOuterMergeJoin::Exfp(CExpressionHandle &exprhdl) const
 {
+	if (exprhdl.DeriveHasSubquery(2))
+	{
+		return CXform::ExfpNone;
+	}
 	return CXform::ExfpHigh;
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementLimit.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementLimit.cpp
@@ -13,6 +13,7 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CLogicalLimit.h"
 #include "gpopt/operators/CPatternLeaf.h"
 #include "gpopt/operators/CPhysicalLimit.h"
@@ -44,6 +45,17 @@ CXformImplementLimit::CXformImplementLimit(CMemoryPool *mp)
 {
 }
 
+CXform::EXformPromise
+CXformImplementLimit::Exfp(CExpressionHandle &exprhdl) const
+{
+	// Although it is valid SQL for the limit/offset to be a subquery, Orca does
+	// not support it
+	if (exprhdl.DeriveHasSubquery(1) || exprhdl.DeriveHasSubquery(2))
+	{
+		return CXform::ExfpNone;
+	}
+	return CXform::ExfpHigh;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementSplit.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementSplit.cpp
@@ -48,9 +48,12 @@ CXformImplementSplit::CXformImplementSplit(CMemoryPool *mp)
 //
 //---------------------------------------------------------------------------
 CXform::EXformPromise
-CXformImplementSplit::Exfp(CExpressionHandle &	// exprhdl
-) const
+CXformImplementSplit::Exfp(CExpressionHandle &exprhdl) const
 {
+	if (exprhdl.DeriveHasSubquery(1))
+	{
+		return CXform::ExfpNone;
+	}
 	return CXform::ExfpHigh;
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -63,6 +63,11 @@ CXformIndexGet2IndexOnlyScan::Exfp(CExpressionHandle &exprhdl) const
 		return CXform::ExfpNone;
 	}
 
+	if (exprhdl.DeriveHasSubquery(0))
+	{
+		return CXform::ExfpNone;
+	}
+
 	return CXform::ExfpHigh;
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexScan.cpp
@@ -56,6 +56,11 @@ CXformIndexGet2IndexScan::Exfp(CExpressionHandle &exprhdl) const
 		return CXform::ExfpNone;
 	}
 
+	if (exprhdl.DeriveHasSubquery(0))
+	{
+		return CXform::ExfpNone;
+	}
+
 	return CXform::ExfpHigh;
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -3684,9 +3684,9 @@ CXformUtils::FJoinPredOnSingleChild(CMemoryPool *mp, CExpressionHandle &exprhdl)
 		pdrgpcrs->Append(pcrsOutput);
 	}
 
-	GPOS_ASSERT(nullptr != exprhdl.PexprScalarExactChild(arity - 1));
 	CExpressionArray *pdrgpexprPreds = CPredicateUtils::PdrgpexprConjuncts(
-		mp, exprhdl.PexprScalarExactChild(arity - 1));
+		mp, exprhdl.PexprScalarExactChild(arity - 1,
+										  true /*error_on_null_return*/));
 	const ULONG ulPreds = pdrgpexprPreds->Size();
 	BOOL fPredUsesSingleChild = false;
 	for (ULONG ulPred = 0; !fPredUsesSingleChild && ulPred < ulPreds; ulPred++)

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -105,7 +105,7 @@ CIndexScanTest:
 BTreeIndex-Against-InList BTreeIndex-Against-InListLarge BTreeIndex-Against-ScalarSubquery
 IndexScan-AOTable IndexScan-DroppedColumns IndexScan-BoolTrue IndexScan-BoolFalse
 IndexScan-Relabel IndexGet-OuterRefs LogicalIndexGetDroppedCols
-IndexScan-ORPredsNonPart IndexScan-ORPredsAOPart IndexScan-AndedIn;
+IndexScan-ORPredsNonPart IndexScan-ORPredsAOPart IndexScan-AndedIn SubqInIndexPred;
 
 CBitmapScanTest:
 IndexedNLJBitmap BitmapIndex-ChooseHashJoin BitmapTableScan-AO-Btree-PickOnlyHighNDV


### PR DESCRIPTION
This is a forward-port of Disallow subquery in predicate of implementation xforms. There
were some formatting merge conflicts, and I added a check for Index-Only scans. 

This generates an invalid plan for most cases. While we had this logic
in some xforms, we missed a few cases.

This manifested as a crash in some cases as we assumed subqueries had
been handled by time we get to optimization stage.

Additionally, add error handling to PexprScalarExactChild()

This function is only called in places where the exact child must exist,
and returns null otherwise.

However, there have been some cases where we assume the child must
exist, but due to another bug the child does not and we don't handle the
null. This is a defensive change; if we get into this situation we'll
throw an exception and fall back to planner instead of crashing.