### PR TITLE
Create corresponding bitmap operator class for extensions

### DIFF
--- a/contrib/citext/citext--1.5--1.6.sql
+++ b/contrib/citext/citext--1.5--1.6.sql
@@ -10,3 +10,12 @@ LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 
 ALTER OPERATOR FAMILY citext_ops USING hash ADD
     FUNCTION    2   citext_hash_extended(citext, int8);
+
+CREATE OPERATOR CLASS citext_ops
+DEFAULT FOR TYPE CITEXT USING bitmap AS
+    OPERATOR    1   <  (citext, citext),
+    OPERATOR    2   <= (citext, citext),
+    OPERATOR    3   =  (citext, citext),
+    OPERATOR    4   >= (citext, citext),
+    OPERATOR    5   >  (citext, citext),
+    FUNCTION    1   citext_cmp(citext, citext);

--- a/contrib/citext/expected/citext.out
+++ b/contrib/citext/expected/citext.out
@@ -2717,11 +2717,12 @@ SELECT 'a'::citext ~>=~ 'B'::varchar AS t;  -- varchar wins.
 (1 row)
 
 -- Test that has all opclasses
-select amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcname='citext_ops';
- amname 
---------
- btree
- hash
- bitmap
-(3 rows)
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='citext'::regtype;
+      opcname       | amname 
+--------------------+--------
+ citext_pattern_ops | btree
+ citext_ops         | btree
+ citext_ops         | hash
+ citext_ops         | bitmap
+(4 rows)
 

--- a/contrib/citext/expected/citext.out
+++ b/contrib/citext/expected/citext.out
@@ -2716,3 +2716,12 @@ SELECT 'a'::citext ~>=~ 'B'::varchar AS t;  -- varchar wins.
  t
 (1 row)
 
+-- Test that has all opclasses
+select amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcname='citext_ops';
+ amname 
+--------
+ btree
+ hash
+ bitmap
+(3 rows)
+

--- a/contrib/citext/expected/citext_1.out
+++ b/contrib/citext/expected/citext_1.out
@@ -2716,3 +2716,13 @@ SELECT 'a'::citext ~>=~ 'B'::varchar AS t;  -- varchar wins.
  t
 (1 row)
 
+-- Test that has all opclasses
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='citext'::regtype;
+      opcname       | amname 
+--------------------+--------
+ citext_pattern_ops | btree
+ citext_ops         | btree
+ citext_ops         | hash
+ citext_ops         | bitmap
+(4 rows)
+

--- a/contrib/citext/sql/citext.sql
+++ b/contrib/citext/sql/citext.sql
@@ -843,3 +843,6 @@ SELECT 'B'::citext ~<=~ 'a'::varchar AS t;  -- varchar wins.
 
 SELECT 'a'::citext ~>~  'B'::varchar AS t;  -- varchar wins.
 SELECT 'a'::citext ~>=~ 'B'::varchar AS t;  -- varchar wins.
+
+-- Test that has all opclasses
+select amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcname='citext_ops';

--- a/contrib/citext/sql/citext.sql
+++ b/contrib/citext/sql/citext.sql
@@ -845,4 +845,4 @@ SELECT 'a'::citext ~>~  'B'::varchar AS t;  -- varchar wins.
 SELECT 'a'::citext ~>=~ 'B'::varchar AS t;  -- varchar wins.
 
 -- Test that has all opclasses
-select amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcname='citext_ops';
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='citext'::regtype;

--- a/contrib/cube/cube--1.3--1.4.sql
+++ b/contrib/cube/cube--1.3--1.4.sql
@@ -43,3 +43,12 @@ WHERE classid = 'pg_catalog.pg_amproc'::pg_catalog.regclass
 ALTER OPERATOR FAMILY gist_cube_ops USING gist drop function 4 (cube);
 ALTER EXTENSION cube DROP function g_cube_decompress(pg_catalog.internal);
 DROP FUNCTION g_cube_decompress(pg_catalog.internal);
+
+CREATE OPERATOR CLASS cube_ops
+    DEFAULT FOR TYPE cube USING bitmap AS
+        OPERATOR        1       < ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       = ,
+        OPERATOR        4       >= ,
+        OPERATOR        5       > ,
+        FUNCTION        1       cube_cmp(cube, cube);

--- a/contrib/cube/expected/cube.out
+++ b/contrib/cube/expected/cube.out
@@ -1948,3 +1948,12 @@ SELECT c~>(-4), c FROM test_cube ORDER BY c~>(-4) LIMIT 15; -- descending by upp
 (15 rows)
 
 RESET enable_indexscan;
+
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='cube'::regtype;
+    opcname    | amname
+---------------+--------
+ cube_ops      | btree
+ gist_cube_ops | gist
+ cube_ops      | bitmap
+(3 rows)
+

--- a/contrib/cube/sql/cube.sql
+++ b/contrib/cube/sql/cube.sql
@@ -430,3 +430,6 @@ SELECT c~>(-2), c FROM test_cube ORDER BY c~>(-2) LIMIT 15; -- descending by rig
 SELECT c~>(-3), c FROM test_cube ORDER BY c~>(-3) LIMIT 15; -- descending by lower bound
 SELECT c~>(-4), c FROM test_cube ORDER BY c~>(-4) LIMIT 15; -- descending by upper bound
 RESET enable_indexscan;
+
+-- Test that has all opclasses
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='cube'::regtype;

--- a/contrib/ltree/expected/ltree.out
+++ b/contrib/ltree/expected/ltree.out
@@ -7681,3 +7681,12 @@ SELECT count(*) FROM _ltreetest WHERE t ? '{23.*.1,23.*.2}' ;
     15
 (1 row)
 
+-- Test that has all opclasses
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='ltree'::regtype;
+    opcname     | amname 
+----------------+--------
+ ltree_ops      | btree
+ gist_ltree_ops | gist
+ ltree_ops      | bitmap
+(3 rows)
+

--- a/contrib/ltree/ltree--1.0--1.1.sql
+++ b/contrib/ltree/ltree--1.0--1.1.sql
@@ -98,3 +98,12 @@ ALTER FUNCTION _ltree_penalty(internal, internal, internal) PARALLEL SAFE;
 ALTER FUNCTION _ltree_picksplit(internal, internal) PARALLEL SAFE;
 ALTER FUNCTION _ltree_union(internal, internal) PARALLEL SAFE;
 ALTER FUNCTION _ltree_same(ltree_gist, ltree_gist, internal) PARALLEL SAFE;
+
+CREATE OPERATOR CLASS ltree_ops
+    DEFAULT FOR TYPE ltree USING bitmap AS
+        OPERATOR        1       < ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       = ,
+        OPERATOR        4       >= ,
+        OPERATOR        5       > ,
+        FUNCTION        1       ltree_cmp(ltree, ltree);

--- a/contrib/ltree/ltree--1.1.sql
+++ b/contrib/ltree/ltree--1.1.sql
@@ -298,6 +298,17 @@ CREATE OPERATOR CLASS ltree_ops
         OPERATOR        5       > ,
         FUNCTION        1       ltree_cmp(ltree, ltree);
 
+-- Bitmap support
+
+CREATE OPERATOR CLASS ltree_ops
+    DEFAULT FOR TYPE ltree USING bitmap AS
+        OPERATOR        1       < ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       = ,
+        OPERATOR        4       >= ,
+        OPERATOR        5       > ,
+        FUNCTION        1       ltree_cmp(ltree, ltree);
+
 
 --lquery type
 CREATE FUNCTION lquery_in(cstring)

--- a/contrib/ltree/sql/ltree.sql
+++ b/contrib/ltree/sql/ltree.sql
@@ -293,3 +293,6 @@ SELECT count(*) FROM _ltreetest WHERE t ~ '23.*{1}.1' ;
 SELECT count(*) FROM _ltreetest WHERE t ~ '23.*.1' ;
 SELECT count(*) FROM _ltreetest WHERE t ~ '23.*.2' ;
 SELECT count(*) FROM _ltreetest WHERE t ? '{23.*.1,23.*.2}' ;
+
+-- Test that has all opclasses
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='ltree'::regtype;

--- a/contrib/seg/expected/seg.out
+++ b/contrib/seg/expected/seg.out
@@ -1265,3 +1265,12 @@ FROM test_seg WHERE s @> '11.2..11.3' OR s IS NULL ORDER BY s;
            |            |          
 (144 rows)
 
+-- Test that has all opclasses
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='seg'::regtype;
+   opcname    | amname
+--------------+--------
+ seg_ops      | btree
+ gist_seg_ops | gist
+ seg_ops      | bitmap
+(3 rows)
+

--- a/contrib/seg/seg--1.2--1.3.sql
+++ b/contrib/seg/seg--1.2--1.3.sql
@@ -43,3 +43,12 @@ WHERE classid = 'pg_catalog.pg_amproc'::pg_catalog.regclass
 ALTER OPERATOR FAMILY gist_seg_ops USING gist drop function 4 (seg);
 ALTER EXTENSION seg DROP function gseg_decompress(pg_catalog.internal);
 DROP function gseg_decompress(pg_catalog.internal);
+
+CREATE OPERATOR CLASS seg_ops
+    DEFAULT FOR TYPE seg USING bitmap AS
+        OPERATOR        1       < ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       = ,
+        OPERATOR        4       >= ,
+        OPERATOR        5       > ,
+        FUNCTION        1       seg_cmp(seg, seg);

--- a/contrib/seg/sql/seg.sql
+++ b/contrib/seg/sql/seg.sql
@@ -233,3 +233,6 @@ SELECT * FROM test_seg WHERE s @> '11..11.3' GROUP BY s;
 -- Test functions
 SELECT seg_lower(s), seg_center(s), seg_upper(s)
 FROM test_seg WHERE s @> '11.2..11.3' OR s IS NULL ORDER BY s;
+
+-- Test that has all opclasses
+select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='citext'::regtype;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11588,6 +11588,26 @@ select * from tc, tt where c = v;
  1 | b | 1 | b
 (4 rows)
 
+-- bitmap scan on bitmap index
+create index tc_idx on tc using bitmap(c);
+select * from tc where c='a';
+ a | c 
+---+---
+ 1 | a
+ 1 | A
+(2 rows)
+
+explain select * from tc where c='a';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=4.38..34.30 rows=50 width=36)
+   ->  Bitmap Heap Scan on tc  (cost=4.38..33.63 rows=17 width=36)
+         Recheck Cond: (c = 'a'::citext)
+         ->  Bitmap Index Scan on tc_idx  (cost=0.00..4.38 rows=17 width=0)
+               Index Cond: (c = 'a'::citext)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
 -- test gpexpand phase 1
 -- right now, these will fall back to planner
 drop table if exists noexp_hash, gpexp_hash, gpexp_rand, gpexp_repl;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11932,6 +11932,26 @@ select * from tc, tt where c = v;
  1 | b | 1 | b
 (4 rows)
 
+-- bitmap scan on bitmap index
+create index tc_idx on tc using bitmap(c);
+select * from tc where c='a';
+ a | c 
+---+---
+ 1 | a
+ 1 | A
+(2 rows)
+
+explain select * from tc where c='a';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=12)
+   ->  Bitmap Heap Scan on tc  (cost=0.00..391.30 rows=1 width=12)
+         Recheck Cond: (c = 'a'::citext)
+         ->  Bitmap Index Scan on tc_idx  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (c = 'a'::citext)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
 -- test gpexpand phase 1
 -- right now, these will fall back to planner
 drop table if exists noexp_hash, gpexp_hash, gpexp_rand, gpexp_repl;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2400,6 +2400,11 @@ insert into tt values (1, 'b'), (1, 'B');
 
 select * from tc, tt where c = v;
 
+-- bitmap scan on bitmap index
+create index tc_idx on tc using bitmap(c);
+select * from tc where c='a';
+explain select * from tc where c='a';
+
 -- test gpexpand phase 1
 -- right now, these will fall back to planner
 


### PR DESCRIPTION
For some extensions that have types, there are associated btree operator
classes that allow GPDB to use index scans. However, since bitmap
indexes are a GPDB-only feature, the bitmap operator class was not
included. We found this issue when neither orca nor planner would
generate an index scan on a bitmap index for a citext type, but would if
there was a btree index.

Bitmap and btree operator classes define the same strategies. Therefore,
given a btree opclass, we can safely create a bitmap opclass.

We don't currently install/ship the cube, ltree, and seg extensions, but
I added the corresponding opclasses so we don't hit this issue if we
choose to ship them in the future.

These opclasses are added to the latest extension version file. Since
these versions don't conflict with existing versions in GPDB6, it should
be safe to add here. If this version were identical, we would need to
take into consideration extension upgrades.

Note: This will not be backported to 6X.