### PR TITLE
gpconfig: add confirmation to continue for user when a host is down

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -19,6 +19,7 @@ import re
 try:
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.gparray import GpArray
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
     from gppylib.gplog import *
     from gppylib.commands.unix import *
     from gppylib.commands.gp import *
@@ -199,7 +200,8 @@ class Guc:
 
 
 def confirm_user_wants_to_continue():
-    if not ask_yesno('', "Are you sure you want to ignore unreachable hosts?", 'N'):
+    if not ask_yesno('', "One or more segment hosts are not currently reachable. If you continue with gpconfig, "
+                         "GUCs on unreachable segment hosts will not be updated. Do you want to continue?", 'N'):
         LOGGER.info("User Aborted. Exiting...")
         raise Exception("User Aborted. Exiting.")
 
@@ -307,25 +309,39 @@ def do_change(options):
         LOGGER.error(msg)
         raise Exception(msg)
 
+    hosts = [gp_array.coordinator.hostname]
+    if gp_array.standbyCoordinator is not None:
+        hosts.append(gp_array.standbyCoordinator.hostname)
+
+    # if --coordinatoronly, we only need to check coordinator and standby. Else check other hosts too.
+    if not options.coordinatoronly:
+        hosts.extend(gp_array.get_hostlist(includeCoordinator=False))
+
+    unreachable_hosts = get_unreachable_segment_hosts(hosts, len(hosts))
+    if len(unreachable_hosts) > 0:
+        confirm_user_wants_to_continue()
+
     pool = WorkerPool()
     failure = False
     try:
         # do the segments
         if not options.coordinatoronly:
+            reachable_segments = [seg for seg in gp_array.getSegDbList() if seg.hostname not in unreachable_hosts]
             if options.primaryvalue:
-                do_add_config_script(pool, [seg for seg in gp_array.getSegDbList() if seg.isSegmentPrimary()],
+                do_add_config_script(pool, [seg for seg in reachable_segments if seg.isSegmentPrimary()],
                                      options.primaryvalue, options)
 
             if options.mirrorvalue:
-                do_add_config_script(pool, [seg for seg in gp_array.getSegDbList() if seg.isSegmentMirror()],
+                do_add_config_script(pool, [seg for seg in reachable_segments if seg.isSegmentMirror()],
                                      options.mirrorvalue, options)
 
             if not options.primaryvalue and not options.mirrorvalue:
-                do_add_config_script(pool, [seg for seg in gp_array.getSegDbList()], options.value, options)
+                do_add_config_script(pool, [seg for seg in reachable_segments], options.value, options)
 
         # do the coordinator and standby
         if options.coordinatorvalue or options.remove:
-            do_add_config_script(pool, [seg for seg in [gp_array.coordinator, gp_array.standbyCoordinator] if seg is not None], options.coordinatorvalue, options)
+            do_add_config_script(pool, [seg for seg in [gp_array.coordinator, gp_array.standbyCoordinator] if seg is not None and seg.hostname not in unreachable_hosts],
+                                 options.coordinatorvalue, options)
 
         pool.join()
         items = pool.getCompletedItems()
@@ -341,9 +357,9 @@ def do_change(options):
         LOGGER.error('errors in job:')
         LOGGER.error(err.__str__())
         LOGGER.error('exiting early')
-
-    pool.haltWork()
-    pool.joinWorkers()
+    finally:
+        pool.haltWork()
+        pool.joinWorkers()
 
     # Replace literal empty strings with empty quotes, or it will look like the
     # user passed in an incorrect argument, which would be misleading

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -79,7 +79,8 @@ class GpConfig(GpTestCase):
             patch('gpconfig.dbconn.query', return_value=self.cursor),
             patch('gpconfig.dbconn.querySingleton', side_effect=singleton_side_effect),
             patch('gpconfig.GpArray.initFromCatalog', return_value=self.gparray),
-            patch('gpconfig.WorkerPool', return_value=self.pool)
+            patch('gpconfig.WorkerPool', return_value=self.pool),
+            patch('gpconfig.get_unreachable_segment_hosts', return_value=[])
         ])
         sys.argv = ["gpconfig"]  # reset to relatively empty args list
 

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -179,3 +179,39 @@ Feature: gpconfig integration tests
         | application_name             |  string  | bengie     |
         | application_name             |  string  | 'ben gie'  |
         | application_name             |  string  | ''         |
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario Outline: gpconfig when a primary is unreachable
+      Given the database is running
+        And the user runs "gpconfig -c application_name -v 'initialize'"
+        And gpconfig should return a return code of 0
+        And the host for the primary on content 0 is made unreachable
+
+       When the user runs "<cmd>"
+        And gpconfig should return a return code of <return_code>
+       Then gpconfig <should_confirm> print "GUCs on unreachable segment hosts will not be updated. Do you want to continue?" to stdout
+        And gpconfig should print "<print_statement>" to stdout
+
+        And verify that the last line of the file "postgresql.conf" in the coordinator data directory <should_update_coordinator> contain the string "application_name='easy'" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory <should_update_segment> contain the string "application_name='easy'"
+
+      Given the cluster is returned to a good state
+       When the user runs "gpstop -u"
+       Then gpstop should return a return code of 0
+
+        And the user runs "gpconfig -s application_name"
+        And gpconfig should return a return code of 0
+        And gpconfig <should_update_coordinator> print "Coordinator value: easy" to stdout
+        And gpconfig <should_update_segment> print "Segment     value: easy" to stdout
+
+        And the user runs "gpconfig -s application_name --file"
+        And gpconfig should return a return code of 0
+        And gpconfig <should_update_coordinator> print "Coordinator value: 'easy'" to stdout
+        And gpconfig <should_update_segment> print "Segment     value: 'easy'" to stdout
+
+      Examples:
+        | test description                                          | return_code | should_confirm | print_statement        | should_update_coordinator | should_update_segment | cmd                                                                               |
+        | asks for confirmation and completes when user selects yes | 0           | should         | completed successfully | should                    | should                | gpconfig -c application_name -v "easy" < test/behave/mgmt_utils/steps/data/yes.txt|
+        | asks for confirmation and aborts when user selects no     | 1           | should         | User Aborted. Exiting. | should not                | should not            | gpconfig -c application_name -v "easy" < test/behave/mgmt_utils/steps/data/no.txt |
+        | does not ask for confirmation for coordinator only change | 0           | should not     | completed successfully | should                    | should not            | gpconfig -c application_name -v "easy" --coordinatoronly                          |

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -24,20 +24,20 @@ Feature: gpconfig integration tests
        # set same value on coordinator and segments
        When the user runs "gpconfig -c <guc> -v <value>"
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the coordinator data directory contains the string "<guc>=<file_value>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the coordinator data directory should contain the string "<guc>=<file_value>" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory should contain the string "<guc>=<file_value>"
 
        # set value on coordinator only, leaving segments the same
        When the user runs "gpconfig -c <guc> -v <value_coordinator_only> --masteronly "
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the coordinator data directory contains the string "<guc>=<file_value_coordinator_only>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the coordinator data directory should contain the string "<guc>=<file_value_coordinator_only>" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory should contain the string "<guc>=<file_value>"
 
        # set value on coordinator with a different value from the segments
        When the user runs "gpconfig -c <guc> -v <value> -m <value_coordinator>"
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the coordinator data directory contains the string "<guc>=<file_value_coordinator>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the coordinator data directory should contain the string "<guc>=<file_value_coordinator>" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory should contain the string "<guc>=<file_value>"
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s <guc> --file"
@@ -98,7 +98,7 @@ Feature: gpconfig integration tests
         And gpstop should return a return code of 0
 
        When the user writes "<guc>" as "<value>" to the coordinator config file
-       Then verify that the last line of the file "postgresql.conf" in the coordinator data directory contains the string "<guc>=<value>" escaped
+       Then verify that the last line of the file "postgresql.conf" in the coordinator data directory should contain the string "<guc>=<value>" escaped
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s <guc> --file"
@@ -137,7 +137,7 @@ Feature: gpconfig integration tests
         And gpstop should return a return code of 0
 
        When the user runs "gpconfig -c default_text_search_config -v $'a\nb'"
-       Then verify that the last line of the file "postgresql.conf" in the coordinator data directory contains the string "default_text_search_config='a\nb'" escaped
+       Then verify that the last line of the file "postgresql.conf" in the coordinator data directory should contain the string "default_text_search_config='a\nb'" escaped
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s default_text_search_config --file"

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -168,6 +168,7 @@ def impl(context, seg_type, content, expected_status):
 
     must_have_expected_status(content, preferred_role, expected_status)
 
+@given('the cluster is returned to a good state')
 @then('the cluster is returned to a good state')
 def impl(context):
     if not hasattr(context, 'old_hostnames'):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1390,17 +1390,18 @@ def impl(context, filename, output):
     print(contents)
     check_stdout_msg(context, output)
 
-@then('verify that the last line of the file "{filename}" in the coordinator data directory contains the string "{output}" escaped')
-def impl(context, filename, output):
-    find_string_in_coordinator_data_directory(context, filename, output, True)
+@then('verify that the last line of the file "{filename}" in the coordinator data directory {contain} the string "{output}"{escape}')
+def impl(context, filename, contain, output, escape):
+    if contain == 'should contain':
+        valuesShouldExist = True
+    elif contain == 'should not contain':
+        valuesShouldExist = False
+    else:
+        raise Exception("only 'contains' and 'does not contain' are valid inputs")
 
+    find_string_in_coordinator_data_directory(context, filename, output, valuesShouldExist, (escape == ' escaped'))
 
-@then('verify that the last line of the file "{filename}" in the coordinator data directory contains the string "{output}"')
-def impl(context, filename, output):
-    find_string_in_coordinator_data_directory(context, filename, output)
-
-
-def find_string_in_coordinator_data_directory(context, filename, output, escapeStr=False):
+def find_string_in_coordinator_data_directory(context, filename, output, valuesShouldExist, escapeStr=False):
     contents = ''
     file_path = os.path.join(coordinator_data_dir, filename)
 
@@ -1411,8 +1412,11 @@ def find_string_in_coordinator_data_directory(context, filename, output, escapeS
     if escapeStr:
         output = re.escape(output)
     pat = re.compile(output)
-    if not pat.search(contents):
+    if valuesShouldExist and (not pat.search(contents)):
         err_str = "Expected stdout string '%s' and found: '%s'" % (output, contents)
+        raise Exception(err_str)
+    if (not valuesShouldExist) and pat.search(contents):
+        err_str = "Did not expect stdout string '%s' but found: '%s'" % (output, contents)
         raise Exception(err_str)
 
 
@@ -1484,8 +1488,14 @@ def impl(context, filename, some, output):
 
 
 
-@then('verify that the last line of the file "{filename}" in each segment data directory contains the string "{output}"')
-def impl(context, filename, output):
+@then('verify that the last line of the file "{filename}" in each segment data directory {contain} the string "{output}"')
+def impl(context, filename, contain, output):
+    if contain == 'should contain':
+        valuesShouldExist = True
+    elif contain == 'should not contain':
+        valuesShouldExist = False
+    else:
+        raise Exception("only 'should contain' and 'should not contain' are valid inputs")
     segment_info = []
     conn = dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)
     try:
@@ -1505,8 +1515,11 @@ def impl(context, filename, output):
         cmd.run(validateAfter=True)
 
         actual = cmd.get_stdout()
-        if output not in actual:
-            raise Exception('File %s on host %s does not contain "%s"' % (filepath, host, output))
+        if valuesShouldExist and (output not in actual):
+                raise Exception('File %s on host %s does not contain "%s"' % (filepath, host, output))
+        if (not valuesShouldExist) and (output in actual):
+            raise Exception('File %s on host %s contains "%s"' % (filepath, host, output))
+
 
 @given('the gpfdists occupying port {port} on host "{hostfile}"')
 def impl(context, port, hostfile):


### PR DESCRIPTION
When a host is down, and a user runs gpconfig to update any config: we should warn them and ask for confirmation to continue with the config update. Since they might get out of sync config values.

The warning and ask for confirmation were part of gpconfig until 6X, which got removed during py2/3 migration change.

This change adds that warning/ask for confirmation back in. 

Tracker story: https://www.pivotaltracker.com/story/show/177336745
Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/7x_fix_gpconfig_down_host