### PR TITLE
gpconfig: aborting a config update with down host should exit properly

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -19,7 +19,7 @@ import re
 try:
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.gparray import GpArray
-    from gppylib.gphostcache import *
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
     from gppylib.gplog import *
     from gppylib.commands.unix import *
     from gppylib.commands.gp import *
@@ -43,7 +43,7 @@ SAMEVALUE_GUCS = set(["gp_default_storage_options"])
 read_only_gucs = set()  # populated at runtime
 LOGGER = get_default_logger()
 setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
-
+gp_array = None
 
 def parseargs():
     parser = OptParser(option_class=OptChecker)
@@ -191,14 +191,15 @@ class Guc:
 
 
 def confirm_user_wants_to_continue():
-    if not ask_yesno('', "Are you sure you want to ignore unreachable hosts?", 'N'):
+    if not ask_yesno('', "One or more segment hosts are not currently reachable. If you continue with gpconfig, "
+                         "GUCs on unreachable segment hosts will not be updated. Do you want to continue?", 'N'):
         LOGGER.info("User Aborted. Exiting...")
         raise Exception("User Aborted. Exiting.")
 
 
-def print_verbosely(options, normalized_hostname, hostname, directory):
+def print_verbosely(options, hostname, directory):
     if options.verbose:
-        msg = "normalized_host=%s host=%s dir=%s" % (normalized_hostname, hostname, directory)
+        msg = "normalized_host=%s host=%s dir=%s" % (hostname, directory)
         LOGGER.info(msg)
 
 
@@ -265,14 +266,14 @@ def _show_all_segment_values_always(options):
     return options.show == "port"
 
 # FIXME: add value to cmd_name.  We do not just do this due to encoding issues.
-def do_add_config_script(pool, hostname, segs, value, options):
+def do_add_config_script(pool, segs, value, options):
     for seg in segs:
-        print_verbosely(options, hostname, seg.hostname, seg.datadir)
-        cmd_name = "add %s parameter on host %s for seg %s" % (options.entry, hostname, seg.datadir)
+        print_verbosely(options, seg.hostname, seg.datadir)
+        cmd_name = "add %s parameter on host %s for seg %s" % (options.entry, seg.hostname, seg.datadir)
         cmd = GpConfigHelper(cmd_name, seg.datadir, options.entry, value=value,
                              removeParameter=options.remove,
                              ctxt=REMOTE,
-                             remoteHost=hostname)
+                             remoteHost=seg.hostname)
         pool.addCommand(cmd)
 
 
@@ -281,8 +282,6 @@ def do_change(options):
         enable_verbose_logging()
 
     try:
-        gp_array = GpArray.initFromCatalog(dbconn.DbURL(), utility=True)
-
         if not options.skipvalidation:
             conn = dbconn.connect(dbconn.DbURL(), True)
             guc = get_normal_guc(conn, options)
@@ -301,50 +300,39 @@ def do_change(options):
         LOGGER.error(msg)
         raise Exception(msg)
 
-    pool = WorkerPool()
+    hosts = [gp_array.master.hostname]
+    if gp_array.standbyMaster is not None:
+        hosts.append(gp_array.standbyMaster.hostname)
 
-    host_cache = GpHostCache(gp_array, pool)
-    failed_pings = host_cache.ping_hosts(pool)
+    # if --masterronly, we only need to check master and standby. Else check other hosts too.
+    if not options.masteronly:
+        hosts.extend(gp_array.get_hostlist(includeMaster=False))
 
-    if failed_pings:
-        for i in failed_pings:
-            LOGGER.warning('unreachable host: ' + i.hostname)
+    unreachable_hosts = get_unreachable_segment_hosts(hosts, len(hosts))
+    if len(unreachable_hosts) > 0:
         confirm_user_wants_to_continue()
 
+    pool = WorkerPool()
     failure = False
     try:
         # do the segments
         if not options.masteronly:
-            for host in host_cache.get_hosts():
+            reachable_segments = [seg for seg in gp_array.getSegDbList() if seg.hostname not in unreachable_hosts]
+            if options.primaryvalue:
+                do_add_config_script(pool, [seg for seg in reachable_segments if seg.isSegmentPrimary()],
+                                     options.primaryvalue, options)
 
-                if options.primaryvalue:
-                    do_add_config_script(pool, host.hostname, [seg for seg in host.dbs if seg.isSegmentPrimary()],
-                                         options.primaryvalue, options)
+            if options.mirrorvalue:
+                do_add_config_script(pool, [seg for seg in reachable_segments if seg.isSegmentMirror()],
+                                     options.mirrorvalue, options)
 
-                if options.mirrorvalue:
-                    do_add_config_script(pool, host.hostname, [seg for seg in host.dbs if seg.isSegmentMirror()],
-                                         options.mirrorvalue, options)
+            if not options.primaryvalue and not options.mirrorvalue:
+                do_add_config_script(pool, [seg for seg in reachable_segments], options.value, options)
 
-                if not options.primaryvalue and not options.mirrorvalue:
-                    do_add_config_script(pool, host.hostname, host.dbs, options.value, options)
-
-        # do the master
+        # do the master and standby
         if options.mastervalue or options.remove:
-            print_verbosely(options, gp_array.master.hostname, gp_array.master.hostname, gp_array.master.datadir)
-            cmd_name = "remove %s parameter on master host %s" % (options.entry, gp_array.master.hostname)
-            cmd = GpConfigHelper(cmd_name, gp_array.master.datadir, options.entry, value=options.mastervalue,
-                                 removeParameter=options.remove, ctxt=REMOTE, remoteHost=gp_array.master.hostname)
-            pool.addCommand(cmd)
-
-            # do the standby master
-            if gp_array.standbyMaster:
-                print_verbosely(options, gp_array.standbyMaster.hostname, gp_array.standbyMaster.hostname,
-                                gp_array.standbyMaster.datadir)
-                cmd_name = "remove %s parameter on standbymaster host %s" % (options.entry, gp_array.standbyMaster.hostname)
-                cmd = GpConfigHelper(cmd_name, gp_array.standbyMaster.datadir, options.entry,
-                                     value=options.mastervalue, removeParameter=options.remove, ctxt=REMOTE,
-                                     remoteHost=gp_array.standbyMaster.hostname)
-                pool.addCommand(cmd)
+            do_add_config_script(pool, [seg for seg in [gp_array.master, gp_array.standbyMaster] if seg is not None and seg.hostname not in unreachable_hosts],
+                                 options.mastervalue, options)
 
         pool.join()
         items = pool.getCompletedItems()
@@ -360,9 +348,9 @@ def do_change(options):
         LOGGER.error('errors in job:')
         LOGGER.error(err.__str__())
         LOGGER.error('exiting early')
-
-    pool.haltWork()
-    pool.joinWorkers()
+    finally:
+        pool.haltWork()
+        pool.joinWorkers()
 
     # Replace literal empty strings with empty quotes, or it will look like the
     # user passed in an incorrect argument, which would be misleading
@@ -462,16 +450,15 @@ def log_and_raise(err_str):
 
 
 def get_gucs_from_files(guc):
-    hosts, pool = _get_hosts()
+    pool = WorkerPool()
     gucs_found = []
-    for host in hosts:
-        for seg in host.dbs:
-            cmd_name = "get %s parameter on host %s" % (guc, host.hostname)
-            pool.addCommand(
-                GpConfigHelper(cmd_name, seg.datadir, guc,
-                               segInfo=seg, getParameter=True,
-                               ctxt=REMOTE,
-                               remoteHost=host.hostname))
+    for seg in gp_array.getDbList():
+        cmd_name = "get %s parameter on host %s" % (guc, seg.hostname)
+        pool.addCommand(
+            GpConfigHelper(cmd_name, seg.datadir, guc,
+                           segInfo=seg, getParameter=True,
+                           ctxt=REMOTE,
+                           remoteHost=seg.hostname))
 
     failedSegs = False
     pool.join()
@@ -496,18 +483,16 @@ def get_gucs_from_files(guc):
     return gucs_found
 
 
-def _get_hosts():
-    dburl = dbconn.DbURL()
-    gp_array = GpArray.initFromCatalog(dburl, utility=True)
-    pool = WorkerPool()
-    host_cache = GpHostCache(gp_array, pool, withMasters=True)
-    failed_pings = host_cache.ping_hosts(pool)
-    if failed_pings:
-        for i in failed_pings:
-            LOGGER.warning('unreachable host: ' + i.hostname)
-        confirm_user_wants_to_continue()  # todo test me
-    hosts = host_cache.get_hosts()
-    return hosts, pool
+def _set_gparray():
+    try:
+        global gp_array
+        gp_array = GpArray.initFromCatalog(dbconn.DbURL(), utility=True)
+    except DatabaseError as ex:
+        LOGGER.error(ex.__str__())
+        msg = 'Failed to connect to database, exiting without action. ' \
+              'This script can only be run when the database is up.'
+        LOGGER.error(msg)
+        raise Exception(msg)
 
 
 def do_show(options):
@@ -538,6 +523,7 @@ def check_gpexpand():
 
 def do_main():
     options = parseargs()
+    _set_gparray()
     if options.list:
         do_list(options.skipvalidation)
 

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -199,7 +199,7 @@ def confirm_user_wants_to_continue():
 
 def print_verbosely(options, hostname, directory):
     if options.verbose:
-        msg = "normalized_host=%s host=%s dir=%s" % (hostname, directory)
+        msg = "host=%s dir=%s" % (hostname, directory)
         LOGGER.info(msg)
 
 

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -24,20 +24,20 @@ Feature: gpconfig integration tests
        # set same value on master and segments
        When the user runs "gpconfig -c <guc> -v <value>"
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "<guc>=<file_value>" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory should contain the string "<guc>=<file_value>"
 
        # set value on master only, leaving segments the same
        When the user runs "gpconfig -c <guc> -v <value_master_only> --masteronly "
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value_master_only>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "<guc>=<file_value_master_only>" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory should contain the string "<guc>=<file_value>"
 
        # set value on master with a different value from the segments
        When the user runs "gpconfig -c <guc> -v <value> -m <value_master>"
        Then gpconfig should return a return code of 0
-        And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<file_value_master>" escaped
-        And verify that the last line of the file "postgresql.conf" in each segment data directory contains the string "<guc>=<file_value>"
+        And verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "<guc>=<file_value_master>" escaped
+        And verify that the last line of the file "postgresql.conf" in each segment data directory should contain the string "<guc>=<file_value>"
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s <guc> --file"
@@ -98,7 +98,7 @@ Feature: gpconfig integration tests
         And gpstop should return a return code of 0
 
        When the user writes "<guc>" as "<value>" to the master config file
-       Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "<guc>=<value>" escaped
+       Then verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "<guc>=<value>" escaped
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s <guc> --file"
@@ -137,7 +137,7 @@ Feature: gpconfig integration tests
         And gpstop should return a return code of 0
 
        When the user runs "gpconfig -c default_text_search_config -v $'a\nb'"
-       Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "default_text_search_config='a\nb'" escaped
+       Then verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "default_text_search_config='a\nb'" escaped
 
        # now make sure the last changes took full effect as seen by gpconfig
        When the user runs "gpconfig -s default_text_search_config --file"

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -19,8 +19,8 @@ Feature: gpperfmon
         Then gpperfmon_install should return a return code of 0
         Then gpperfmon_install should not print "foo" to stdout
         Then gpperfmon_install should print "\*\*\*\*\*\*" to stdout
-        Then verify that the last line of the file "postgresql.conf" in the master data directory contains the string "gpperfmon_log_alert_level=warning"
-        Then verify that the last line of the file "pg_hba.conf" in the master data directory contains the string "host     all         gpmon         ::1/128    md5"
+        Then verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "gpperfmon_log_alert_level=warning"
+        Then verify that the last line of the file "pg_hba.conf" in the master data directory should contain the string "host     all         gpmon         ::1/128    md5"
         And verify that there is a "heap" table "database_history" in "gpperfmon"
 
     @gpperfmon_run
@@ -169,7 +169,7 @@ Feature: gpperfmon
         # wait until the latest gpperfmon log file contains the line "partition_age turned off"
         Then wait until the results from boolean sql "SELECT count(*) = 7 FROM pg_partitions WHERE tablename = 'diskspace_history'" is "true"
         When the setting "partition_age = 5" is placed in the configuration file "gpperfmon/conf/gpperfmon.conf"
-        Then verify that the last line of the file "gpperfmon/conf/gpperfmon.conf" in the master data directory contains the string "partition_age = 5"
+        Then verify that the last line of the file "gpperfmon/conf/gpperfmon.conf" in the master data directory should contain the string "partition_age = 5"
         When the user runs command "pkill gpmmon"
         Then wait until the process "gpmmon" is up
         And wait until the process "gpsmon" is up

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -167,6 +167,7 @@ def impl(context, seg_type, content, expected_status):
 
     must_have_expected_status(content, preferred_role, expected_status)
 
+@given('the cluster is returned to a good state')
 @then('the cluster is returned to a good state')
 def impl(context):
     if not hasattr(context, 'old_hostnames'):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1393,17 +1393,18 @@ def impl(context, filename, output):
     print contents
     check_stdout_msg(context, output)
 
-@then('verify that the last line of the file "{filename}" in the master data directory contains the string "{output}" escaped')
-def impl(context, filename, output):
-    find_string_in_master_data_directory(context, filename, output, True)
+@then('verify that the last line of the file "{filename}" in the master data directory {contain} the string "{output}"{escape}')
+def impl(context, filename, contain, output, escape):
+    if contain == 'should contain':
+        valuesShouldExist = True
+    elif contain == 'should not contain':
+        valuesShouldExist = False
+    else:
+        raise Exception("only 'should contain' and 'should not contain' are valid inputs")
 
+    find_string_in_coordinator_data_directory(context, filename, output, valuesShouldExist, (escape == ' escaped'))
 
-@then('verify that the last line of the file "{filename}" in the master data directory contains the string "{output}"')
-def impl(context, filename, output):
-    find_string_in_master_data_directory(context, filename, output)
-
-
-def find_string_in_master_data_directory(context, filename, output, escapeStr=False):
+def find_string_in_coordinator_data_directory(context, filename, output, valuesShouldExist, escapeStr=False):
     contents = ''
     file_path = os.path.join(master_data_dir, filename)
 
@@ -1414,8 +1415,11 @@ def find_string_in_master_data_directory(context, filename, output, escapeStr=Fa
     if escapeStr:
         output = re.escape(output)
     pat = re.compile(output)
-    if not pat.search(contents):
+    if valuesShouldExist and (not pat.search(contents)):
         err_str = "Expected stdout string '%s' and found: '%s'" % (output, contents)
+        raise Exception(err_str)
+    if (not valuesShouldExist) and pat.search(contents):
+        err_str = "Did not expect stdout string '%s' but found: '%s'" % (output, contents)
         raise Exception(err_str)
 
 
@@ -1485,8 +1489,14 @@ def impl(context, filename, some, output):
 
 
 
-@then('verify that the last line of the file "{filename}" in each segment data directory contains the string "{output}"')
-def impl(context, filename, output):
+@then('verify that the last line of the file "{filename}" in each segment data directory {contain} the string "{output}"')
+def impl(context, filename, contain, output):
+    if contain == 'should contain':
+        valuesShouldExist = True
+    elif contain == 'should not contain':
+        valuesShouldExist = False
+    else:
+        raise Exception("only 'should contain' and 'should not contain' are valid inputs")
     segment_info = []
     try:
         with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
@@ -1504,8 +1514,11 @@ def impl(context, filename, output):
         cmd.run(validateAfter=True)
 
         actual = cmd.get_stdout().decode('utf-8')
-        if output not in actual:
-            raise Exception('File %s on host %s does not contain "%s"' % (filepath, host, output))
+        if valuesShouldExist and (output not in actual):
+                raise Exception('File %s on host %s does not contain "%s"' % (filepath, host, output))
+        if (not valuesShouldExist) and (output in actual):
+            raise Exception('File %s on host %s contains "%s"' % (filepath, host, output))
+
 
 @given('the gpfdists occupying port {port} on host "{hostfile}"')
 def impl(context, port, hostfile):
@@ -1889,7 +1902,7 @@ def impl(context):
                               When the user runs "gpstart -a"
                               Then gpstart should return a return code of 0
                               And verify that a role "gpmon" exists in database "gpperfmon"
-                              And verify that the last line of the file "postgresql.conf" in the master data directory contains the string "gpperfmon_log_alert_level=warning"
+                              And verify that the last line of the file "postgresql.conf" in the master data directory should contain the string "gpperfmon_log_alert_level=warning"
                               And verify that there is a "heap" table "database_history" in "gpperfmon"
                               Then wait until the process "gpmmon" is up
                               And wait until the process "gpsmon" is up


### PR DESCRIPTION
When a host is down, and a user runs gpconfig to update any config: we warn them and ask for confirmation to continue with the config update. If the user chooses to abort the update, we currently do not exit out properly due to (non daemon) threads staying open when exiting.

This change fixes the abort/exit to close threads

We also remove use of GpHostCache as part of this change and instead use functions from GpArray

Tracker story: https://www.pivotaltracker.com/story/show/177336745
Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6x_fix_gpconfig_down_host