### PR TITLE
Fix TypeError for sig_handler function in gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2329,7 +2329,7 @@ with: gpexpand -i %s
                 """ % (outfile))
 
 
-def sig_handler(sig):
+def sig_handler(sig, arg):
     if _gp_expand is not None:
         _gp_expand.shutdown()
 


### PR DESCRIPTION
When running gpexpand utility to expand the segments, If the process receives a signal.SIGTERM or signal.SIGHUP, the sig_handler function will have an error，as shown below：
        TypeError: sig_handler() takes exactly 1 argument (2 given)
As a result, we can  not clean up correctly for gpexpand.

This change can fix the above error to clean up correctly. 

6X and 5X also have this issue.