### PR TITLE
[6X] Fix TypeError for sig_handler function in gpexpand  #11766

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2360,7 +2360,7 @@ with: gpexpand -i %s
                 """ % (outfile)
 
 
-def sig_handler(sig):
+def sig_handler(sig, arg):
     if _gp_expand is not None:
         _gp_expand.shutdown()
 


### PR DESCRIPTION
This issue also exsits in 6X_STABLE, not only in master branch, as described below.
When running gpexpand utility to expand the segments, If the process receives a signal.SIGTERM or signal.SIGHUP, the sig_handler function will have an error---TypeError: sig_handler() takes exactly 1 argument (2 given).
As a result, we can not clean up correctly for gpexpand.


