### PR TITLE
Remove a merge fixme about GetNewOidForAuthId()

### DIFF
--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -350,7 +350,13 @@ GetNewOrPreassignedOid(Relation relation, Oid indexId, AttrNumber oidcolumn,
 		 */
 		if (oid == InvalidOid)
 		{
-			if (IS_QUERY_DISPATCHER())
+			if (IS_QUERY_DISPATCHER() && IsBinaryUpgrade && Gp_role == GP_ROLE_UTILITY)
+				/*
+				 * If it hits here on the QD, it must be (IsBinaryUpgrade &&
+				 * Gp_role == GP_ROLE_UTILITY) already, however, check those
+				 * too in case we have new GP roles in the future, and for
+				 * better code readability.
+				 */
 				oid = GetNewOidWithIndex(relation, indexId, oidcolumn);
 			else
 				/*

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -350,12 +350,13 @@ GetNewOrPreassignedOid(Relation relation, Oid indexId, AttrNumber oidcolumn,
 		 */
 		if (oid == InvalidOid)
 		{
-			if (IsBinaryUpgrade)
-				oid = GetNewOidWithIndex(relation, indexId, oidcolumn);
-			else
-				elog(ERROR, "no pre-assigned OID for %s tuple \"%s\" (namespace:%u keyOid1:%u keyOid2:%u)",
-					 RelationGetRelationName(relation), searchkey->objname ? searchkey->objname : "",
-					 searchkey->namespaceOid, searchkey->keyOid1, searchkey->keyOid2);
+			/*
+			 * Greenplum requires a pre-assigned OID to keep QD and QEs
+			 * synchronized in binary upgrade mode, so error out here too.
+			 */
+			elog(ERROR, "no pre-assigned OID for %s tuple \"%s\" (namespace:%u keyOid1:%u keyOid2:%u)",
+				 RelationGetRelationName(relation), searchkey->objname ? searchkey->objname : "",
+				 searchkey->namespaceOid, searchkey->keyOid1, searchkey->keyOid2);
 		}
 	}
 	else if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -325,8 +325,8 @@ GetPreassignedOid(OidAssignment *searchkey)
  * memorize the OID for dispatch in the QD, and looks up the
  * pre-assigned OID in QE.
  *
- * When adding a function for a new catalog table, look at indexing.h to see what
- * the unique key columns for the table are.
+ * When adding a function for a new catalog table, look at indexing.h
+ * to see what the unique key columns for the table are.
  * ----------------------------------------------------------------
  */
 static Oid
@@ -350,13 +350,16 @@ GetNewOrPreassignedOid(Relation relation, Oid indexId, AttrNumber oidcolumn,
 		 */
 		if (oid == InvalidOid)
 		{
-			/*
-			 * Greenplum requires a pre-assigned OID to keep QD and QEs
-			 * synchronized in binary upgrade mode, so error out here too.
-			 */
-			elog(ERROR, "no pre-assigned OID for %s tuple \"%s\" (namespace:%u keyOid1:%u keyOid2:%u)",
-				 RelationGetRelationName(relation), searchkey->objname ? searchkey->objname : "",
-				 searchkey->namespaceOid, searchkey->keyOid1, searchkey->keyOid2);
+			if (IS_QUERY_DISPATCHER())
+				oid = GetNewOidWithIndex(relation, indexId, oidcolumn);
+			else
+				/*
+				 * On QE, Greenplum requires a pre-assigned OID to keep QD and
+				 * QEs synchronized, whether in binary upgrade or not.
+				 */
+				elog(ERROR, "no pre-assigned OID for %s tuple \"%s\" (namespace:%u keyOid1:%u keyOid2:%u)",
+					 RelationGetRelationName(relation), searchkey->objname ? searchkey->objname : "",
+					 searchkey->namespaceOid, searchkey->keyOid1, searchkey->keyOid2);
 		}
 	}
 	else if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -619,23 +619,10 @@ CreateRole(ParseState *pstate, CreateRoleStmt *stmt)
 	 * pg_largeobject_metadata contains pg_authid.oid's, so we use the
 	 * binary-upgrade override.
 	 *
-	 * GPDB_12_MERGE_FIXME: GetNewOidForAuthId() will return the pre-assigned
-	 * OID, if any, but should we do something special here to check and error out
-	 * if there was no pre-assigned values in binary upgrade mode.
+	 * GetNewOidForAuthId() / GetNewOrPreassignedOid() will return the
+	 * pre-assigned OID, if any, and error out if there was no pre-assigned
+	 * values in binary upgrade mode.
 	 */
-#if 0
-	if (IsBinaryUpgrade)
-	{
-		if (!OidIsValid(binary_upgrade_next_pg_authid_oid))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("pg_authid OID value not set when in binary upgrade mode")));
-
-		roleid = binary_upgrade_next_pg_authid_oid;
-		binary_upgrade_next_pg_authid_oid = InvalidOid;
-	}
-	else
-#endif
 	{
 		roleid = GetNewOidForAuthId(pg_authid_rel, AuthIdOidIndexId,
 									Anum_pg_authid_oid,

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -139,13 +139,13 @@ binary_upgrade_set_next_pg_enum_oid(PG_FUNCTION_ARGS)
 Datum
 binary_upgrade_set_next_pg_authid_oid(PG_FUNCTION_ARGS)
 {
-	Oid			roleid = PG_GETARG_OID(0);
+	Oid			authoid = PG_GETARG_OID(0);
 	char	   *rolename = GET_STR(PG_GETARG_TEXT_P(1));
 
 	CHECK_IS_BINARY_UPGRADE;
 	if (Gp_role == GP_ROLE_UTILITY)
 	{
-		AddPreassignedOidFromBinaryUpgrade(roleid, AuthIdRelationId, rolename,
+		AddPreassignedOidFromBinaryUpgrade(authoid, AuthIdRelationId, rolename,
 										   InvalidOid, InvalidOid, InvalidOid);
 	}
 

--- a/src/bin/pg_upgrade/README.gpdb
+++ b/src/bin/pg_upgrade/README.gpdb
@@ -1,6 +1,5 @@
-The Greenplum pg_upgrade code is based on pg_upgrade from 9.3 and has
-been extended to work with Greenplum. This README is intended to document the
-changes that have been done.
+The Greenplum pg_upgrade code has been extended to work with Greenplum. This
+README is intended to document the changes that have been done.
 
 Operation of pg_upgrade remains unchanged as are the available command line
 parameters. Upgrading a Greenplum cluster with pg_upgrade is done by first
@@ -15,7 +14,7 @@ so the upgrade must maintain this invariant.  Further, the upgrade must do as
 much as it can in parallel to ensure the cluster is upgraded with as little
 downtime as possible.  To satisfy both requirements, the upgrade process is
 split between QD and QE.  The QD is first upgraded, and the schema dumped and
-restored.  The new datadirectory created as part of the upgrade is transferred
+restored.  The new data directory created as part of the upgrade is transferred
 to all QEs, with the local QE configuration retained.  The QE upgrade can then
 skip the schema dump/reload part and only transfer the files.
 


### PR DESCRIPTION
Greenplum requires a pre-assigned auth id to keep QD and QEs synchronized in
binary upgrade mode, error out if there is no pre-assigned id as the merge
fixme says.