### PR TITLE
[6X only] Fix incorrect group pathkey

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -41,7 +41,6 @@
 static PathKey *make_canonical_pathkey(PlannerInfo *root,
 					   EquivalenceClass *eclass, Oid opfamily,
 					   int strategy, bool nulls_first);
-static bool pathkey_is_redundant(PathKey *new_pathkey, List *pathkeys);
 static bool right_merge_direction(PlannerInfo *root, PathKey *pathkey);
 
 static bool op_in_eclass_opfamily(Oid opno, EquivalenceClass *eclass);
@@ -454,7 +453,7 @@ make_canonical_pathkey(PlannerInfo *root,
  * Because the equivclass.c machinery forms only one copy of any EC per query,
  * pointer comparison is enough to decide whether canonical ECs are the same.
  */
-static bool
+bool
 pathkey_is_redundant(PathKey *new_pathkey, List *pathkeys)
 {
 	EquivalenceClass *new_ec = new_pathkey->pk_eclass;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -5299,10 +5299,10 @@ prepare_sort_from_pathkeys(PlannerInfo *root, Plan *lefttree, List *pathkeys,
 	 * We will need at most list_length(pathkeys) sort columns; possibly less
 	 */
 	numsortkeys = list_length(pathkeys);
-	sortColIdx = (AttrNumber *) palloc(numsortkeys * sizeof(AttrNumber));
-	sortOperators = (Oid *) palloc(numsortkeys * sizeof(Oid));
-	collations = (Oid *) palloc(numsortkeys * sizeof(Oid));
-	nullsFirst = (bool *) palloc(numsortkeys * sizeof(bool));
+	sortColIdx = (AttrNumber *) palloc0(numsortkeys * sizeof(AttrNumber));
+	sortOperators = (Oid *) palloc0(numsortkeys * sizeof(Oid));
+	collations = (Oid *) palloc0(numsortkeys * sizeof(Oid));
+	nullsFirst = (bool *) palloc0(numsortkeys * sizeof(bool));
 
 	numsortkeys = 0;
 

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -257,7 +257,7 @@ static TargetEntry *tlist_member_by_ressortgroupref(List *targetList, int ressor
 
 
 /*
- * Reorder a path key, using given column mappings.
+ * Reorder a path key, using given column mappings and skip the const pathkey.
  */
 static List *
 reorder_pathkeys(PlannerInfo *root,
@@ -290,7 +290,9 @@ reorder_pathkeys(PlannerInfo *root,
 
 		pk = (PathKey *) list_nth(pathkeys, pos);
 
-		result = lappend(result, pk);
+		/* skip the const pathkey */
+		if (!pathkey_is_redundant(pk, result))
+			result = lappend(result, pk);
 	}
 
 	return result;

--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -237,5 +237,6 @@ extern List *truncate_useless_pathkeys(PlannerInfo *root,
 						  RelOptInfo *rel,
 						  List *pathkeys);
 extern bool has_useful_pathkeys(PlannerInfo *root, RelOptInfo *rel);
+extern bool pathkey_is_redundant(PathKey *new_pathkey, List *pathkeys);
 
 #endif   /* PATHS_H */

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -176,6 +176,41 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into foo_gset_const values(0), (1);
 -- const and var in the groupint sets
+explain (costs off)
+select 1, a from foo_gset_const group by grouping sets(1,2);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Append
+         ->  GroupAggregate
+               Group Key: "rollup".a, "rollup".prelim_aggref_1, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"
+                     ->  Sort
+                           Sort Key: share0_ref1.a, share0_ref1.col_2, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: share0_ref1.a, share0_ref1.col_2, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref1.a, share0_ref1.col_2
+                                       ->  Sort
+                                             Sort Key: share0_ref1.a
+                                             ->  Shared Scan (share slice:id 1:0)
+                                                   ->  Materialize
+                                                         ->  Seq Scan on foo_gset_const
+         ->  GroupAggregate
+               Group Key: rollup_1.prelim_aggref_1, rollup_1.a, rollup_1."grouping", rollup_1."group_id"
+               ->  Subquery Scan on rollup_1
+                     ->  Sort
+                           Sort Key: share0_ref2.col_2, share0_ref2.a, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.col_2, share0_ref2.a, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref2.col_2, share0_ref2.a
+                                       ->  Sort
+                                             Sort Key: share0_ref2.a
+                                             ->  Shared Scan (share slice:id 2:0)
+ Optimizer: Postgres query optimizer
+(29 rows)
+
 select 1, a from foo_gset_const group by grouping sets(1,2);
  ?column? | a 
 ----------+---
@@ -183,6 +218,34 @@ select 1, a from foo_gset_const group by grouping sets(1,2);
           | 1
         1 |  
 (3 rows)
+
+explain (costs off)
+select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Append
+   ->  GroupAggregate
+         Group Key: share0_ref1.a, share0_ref1.col_2
+         ->  Sort
+               Sort Key: share0_ref1.a
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     Merge Key: share0_ref1.a
+                     ->  Sort
+                           Sort Key: share0_ref1.a
+                           ->  Shared Scan (share slice:id 1:0)
+                                 ->  Materialize
+                                       ->  Seq Scan on foo_gset_const
+   ->  GroupAggregate
+         Group Key: share0_ref2.col_2, share0_ref2.a
+         ->  Sort
+               Sort Key: share0_ref2.a
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     Merge Key: share0_ref2.a
+                     ->  Sort
+                           Sort Key: share0_ref2.a
+                           ->  Shared Scan (share slice:id 2:0)
+ Optimizer: Postgres query optimizer
+(22 rows)
 
 select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
  ?column? | a | count 
@@ -192,6 +255,39 @@ select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
         1 |   |     2
 (3 rows)
 
+explain (costs off)
+select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grouping sets(1, 2)) ss where x = 1 and sum = 1;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Subquery Scan on ss
+         Filter: ((ss.x = 1) AND (ss.sum = 1))
+         ->  Append
+               ->  HashAggregate
+                     Group Key: "rollup".a, "rollup".prelim_aggref_1, "rollup"."grouping", "rollup"."group_id"
+                     ->  Subquery Scan on "rollup"
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: share0_ref1.a, share0_ref1.col_2, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref1.a, share0_ref1.col_2
+                                       ->  Sort
+                                             Sort Key: share0_ref1.a
+                                             ->  Shared Scan (share slice:id 1:0)
+                                                   ->  Materialize
+                                                         ->  Seq Scan on foo_gset_const
+               ->  HashAggregate
+                     Group Key: rollup_1.prelim_aggref_1, rollup_1.a, rollup_1."grouping", rollup_1."group_id"
+                     ->  Subquery Scan on rollup_1
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.col_2, share0_ref2.a, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref2.col_2, share0_ref2.a
+                                       ->  Sort
+                                             Sort Key: share0_ref2.a
+                                             ->  Shared Scan (share slice:id 2:0)
+ Optimizer: Postgres query optimizer
+(27 rows)
+
 select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grouping sets(1, 2)) ss where x = 1 and sum = 1;
  x | a | sum 
 ---+---+-----
@@ -199,6 +295,30 @@ select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grou
 (1 row)
 
 -- only const in the groupint sets
+explain (costs off)
+select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  GroupAggregate
+         Group Key: partial_aggregation.prelim_aggref_1, partial_aggregation.prelim_aggref_2, partial_aggregation."grouping", partial_aggregation."group_id"
+         ->  Subquery Scan on partial_aggregation
+               ->  Sort
+                     Sort Key: "rollup".prelim_aggref_1, "rollup".prelim_aggref_1, (Grouping)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: "rollup".prelim_aggref_1, "rollup".prelim_aggref_1
+                           ->  GroupAggregate
+                                 Group Key: "rollup"."grouping", "rollup"."group_id", "rollup".prelim_aggref_1, "rollup".prelim_aggref_2
+                                 ->  Subquery Scan on "rollup"
+                                       ->  GroupAggregate
+                                             Group Key: rollup_1.prelim_aggref_1, rollup_1."grouping", rollup_1."group_id", rollup_1.prelim_aggref_2
+                                             ->  Subquery Scan on rollup_1
+                                                   ->  GroupAggregate
+                                                         Group Key: ''::text, ''::text
+                                                         ->  Seq Scan on foo_gset_const
+ Optimizer: Postgres query optimizer
+(18 rows)
+
 select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
  ?column? | ?column? | count 
 ----------+----------+-------
@@ -206,6 +326,26 @@ select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
           |          |     2
           |          |     2
 (3 rows)
+
+explain (costs off)
+select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Append
+   ->  GroupAggregate
+         Group Key: share0_ref1.col_2, share0_ref1.col_3
+         ->  Shared Scan (share slice:id 0:0)
+               ->  Materialize
+                     ->  Gather Motion 3:1  (slice1; segments: 3)
+                           ->  Seq Scan on foo_gset_const
+   ->  GroupAggregate
+         Group Key: share0_ref2.col_2, share0_ref2.col_3
+         ->  Shared Scan (share slice:id 0:0)
+   ->  GroupAggregate
+         Group Key: share0_ref3.col_2, share0_ref3.col_3
+         ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Postgres query optimizer
+(14 rows)
 
 select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
  ?column? | ?column? | count 

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -136,6 +136,7 @@ WHERE location_id = 1;
                      ->  GroupAggregate
                            Group Key: (1), table1_1.city_id
                            ->  Sort
+                                 Sort Key: table1_1.city_id
                                  ->  Subquery Scan on table1_1
                                        ->  Append
                                              ->  Result
@@ -143,7 +144,7 @@ WHERE location_id = 1;
                                              ->  Result
                                              ->  Result
  Optimizer: Postgres query optimizer
-(29 rows)
+(30 rows)
 
 --
 -- Select constant from GROUPING SETS of multiple empty sets
@@ -167,6 +168,54 @@ select 1 from foo group by grouping sets ((), ());
         1
 (2 rows)
 
+--
+-- GROUPING SETS with const in the group by
+--
+create table foo_gset_const(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo_gset_const values(0), (1);
+-- const and var in the groupint sets
+select 1, a from foo_gset_const group by grouping sets(1,2);
+ ?column? | a 
+----------+---
+          | 0
+          | 1
+        1 |  
+(3 rows)
+
+select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
+ ?column? | a | count 
+----------+---+-------
+          | 0 |     1
+          | 1 |     1
+        1 |   |     2
+(3 rows)
+
+select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grouping sets(1, 2)) ss where x = 1 and sum = 1;
+ x | a | sum 
+---+---+-----
+ 1 |   |   1
+(1 row)
+
+-- only const in the groupint sets
+select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
+ ?column? | ?column? | count 
+----------+----------+-------
+          |          |     2
+          |          |     2
+          |          |     2
+(3 rows)
+
+select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
+ ?column? | ?column? | count 
+----------+----------+-------
+          |          |     2
+          |          |     2
+          |          |     2
+(3 rows)
+
+drop table foo_gset_const;
 --
 -- Reset settings
 --

--- a/src/test/regress/sql/aggregate_with_groupingsets.sql
+++ b/src/test/regress/sql/aggregate_with_groupingsets.sql
@@ -107,6 +107,21 @@ select 1 from foo group by grouping sets ((), ());
 select 1 from foo group by grouping sets ((), ());
 
 --
+-- GROUPING SETS with const in the group by
+--
+create table foo_gset_const(a int);
+insert into foo_gset_const values(0), (1);
+-- const and var in the groupint sets
+select 1, a from foo_gset_const group by grouping sets(1,2);
+select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
+select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grouping sets(1, 2)) ss where x = 1 and sum = 1;
+-- only const in the groupint sets
+select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
+select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
+drop table foo_gset_const;
+
+--
 -- Reset settings
 --
 reset optimizer;
+

--- a/src/test/regress/sql/aggregate_with_groupingsets.sql
+++ b/src/test/regress/sql/aggregate_with_groupingsets.sql
@@ -112,11 +112,24 @@ select 1 from foo group by grouping sets ((), ());
 create table foo_gset_const(a int);
 insert into foo_gset_const values(0), (1);
 -- const and var in the groupint sets
+explain (costs off)
 select 1, a from foo_gset_const group by grouping sets(1,2);
+select 1, a from foo_gset_const group by grouping sets(1,2);
+
+explain (costs off)
 select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
+select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
+
+explain (costs off)
+select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grouping sets(1, 2)) ss where x = 1 and sum = 1;
 select * from (select 1 as x, a, sum(a) as sum from foo_gset_const group by grouping sets(1, 2)) ss where x = 1 and sum = 1;
 -- only const in the groupint sets
+explain (costs off)
 select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
+select '' ,'' ,count(1) from foo_gset_const group by rollup(1,2) ;
+
+explain (costs off)
+select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
 select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
 drop table foo_gset_const;
 


### PR DESCRIPTION
For query like 'select 1, a from t group by grouping sets(1,2)', we assume that
there is a one-to-one mapping between the pathkeys in root->group_pathkeys and
the group columns, so we add a workaround to construnct a one-to-one pathkey
list even it contains a constant pathkey. In this case, function
'prepare_sort_from_pathkeys' will consider the pathkey list has no sort column.
To fix this, we remove the constant pathkey and then pass it to
'prepare_sort_from_pathkeys'. We should resolve the GPDB_91_MERGE_FIXME in
'plan_grouping_extension' to come up with a thorough fix.
This issue only exist on 6X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
