### PR TITLE
[GPDB_12_MERGE_FIXME] support toast_tuple_target

### DIFF
--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -881,6 +881,7 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 	{
 		/* Since reloptions for AO table is not permitted, so using TOAST_TUPLE_TARGET */
 		hoff = sizeof(MemTupleData);
+		hoff = MAXALIGN(hoff);
 		maxDataLen = TOAST_TUPLE_TARGET - hoff;
 	}
 

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -876,13 +876,12 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 		hoff = MAXALIGN(hoff);
 		/* now convert to a limit on the tuple data size */
 		maxDataLen = RelationGetToastTupleTarget(rel, TOAST_TUPLE_TARGET) - hoff;
-		maxDataLen = TOAST_TUPLE_TARGET - hoff;
 	}
 	else
 	{
-		// GPDB_12_MERGE_FIXME: use RelationGetToastTupleTarget here too?
-		maxDataLen = toast_tuple_target;
-		hoff = -1; /* keep compiler quiet about using 'hoff' uninitialized */
+		/* Since reloptions for AO table is not permitted, so using TOAST_TUPLE_TARGET */
+		hoff = sizeof(MemTupleData);
+		maxDataLen = TOAST_TUPLE_TARGET - hoff;
 	}
 
 	/*
@@ -1095,15 +1094,7 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 	 * increase the target tuple size, so that 'm' attributes aren't stored
 	 * externally unless really necessary.
 	 */
-	/*
-	 * FIXME: Should we do something like this with memtuples on
-	 * AO tables too? Currently we do not increase the target tuple size for AO
-	 * table, so there are occasions when columns of type 'm' will be stored
-	 * out-of-line but they could otherwise be accommodated in-block
-	 * c.f. upstream Postgres commit ca7c8168de76459380577eda56a3ed09b4f6195c
-	 */
-	if (!ismemtuple)
-		maxDataLen = TOAST_TUPLE_TARGET_MAIN - hoff;
+	maxDataLen = TOAST_TUPLE_TARGET_MAIN - hoff;
 
 	while (compute_dest_tuplen(tupleDesc, pbind, has_nulls,
 							   toast_values, toast_isnull) > maxDataLen &&


### PR DESCRIPTION
Original logic and improvements:
1. heap table
> it ignores the toast_tuple_target setting of reloptions, just using TOAST_TUPLE_TARGET

Improve it to use reloptions, so the user's setting value can take effect (e.g. `alter table T set (toast_tuple_target=5000)` ).


2. ao table
> set it to toast_tuple_target param and all callers pass TOAST_TUPLE_TARGET

Considering reloptions for AO table is not permitted, using TOAST_TUPLE_TARGET to make code clearly (with correct length: target_length - header_len, same as heap table ).


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
