### PR TITLE
gpsd and minirepro fixes from 6X

### DIFF
--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -508,15 +508,21 @@ def Escape(query_str):
     return pgdb.escape_string(query_str)
 
 
+def escapeArrayElement(query_str):
+    # also escape backslashes and double quotes, in addition to the doubling of single quotes
+    return pgdb.escape_string(query_str).replace('\\','\\\\').replace('"','\\"')
+
+
 # Transform Python list to Postgres array literal (of the form: '{...}')
 def format_array_literal(val):
     if len(val) == 0:
         val = "'{}'"
     elif isinstance(val[0], str):
         # Convert ['..', '..', ...] to '{"..", "..", ...}'
-        val = ['"%s"' % Escape(e) for e in val]
+        val = ['"%s"' % escapeArrayElement(e) for e in val]
         val = ','.join(val)
-        val = "'{%s}'" % val
+        # use an escaped string and add one more layer of escape symbols
+        val = "E'{%s}'" % val.replace('\\', '\\\\')
     else:
         # Convert [.., .., ...] to '{.., .., ...}'
         val = str(val)
@@ -531,6 +537,7 @@ def formatInsertValuesList(row, starelid, inclHLL):
 
     rowVals = ["\t%s" % (starelid)]
 
+    # the types of the columns in the pg_statistic table, except for starelid and stavalues[1-5]
     types = ['smallint',  # staattnum
              'boolean',
              'real',
@@ -559,14 +566,22 @@ def formatInsertValuesList(row, starelid, inclHLL):
              ]
     i = 0
     hll = False
+    typeschema = row[3]
+    typename = row[4]
+    if typeschema != "pg_catalog":
+        # a type that is not built-in, qualify it with its schema name
+        # and play it safe by double-quoting the identifiers
+        typename = '"%s"."%s"' % (typeschema, typename)
 
     # Populate types for stavaluesN: infer the type from pg_type.typname
-    if row[3][0] == '_':
-        rowTypes = types + [row[3]] * 5
+    if row[4][0] == '_':
+        # column is an array type, use as is
+        rowTypes = types + [typename] * 5
     else:
-        rowTypes = types + [row[3] + '[]'] * 5
+        # non-array type, make an array type out of it
+        rowTypes = types + [typename + '[]'] * 5
 
-    for val, typ in zip(row[5:], rowTypes):
+    for val, typ in zip(row[6:], rowTypes):
         i = i + 1
         # Check stakind1 to see if slot is a hll slot or a full hll slot
         if i == 10 and (val == 98 or val == 99):

--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -510,7 +510,7 @@ def Escape(query_str):
 
 def escapeArrayElement(query_str):
     # also escape backslashes and double quotes, in addition to the doubling of single quotes
-    return pgdb.escape_string(query_str).replace('\\','\\\\').replace('"','\\"')
+    return pgdb.escape_string(query_str.encode('utf-8')).decode().replace('\\','\\\\').replace('"','\\"')
 
 
 # Transform Python list to Postgres array literal (of the form: '{...}')

--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -35,7 +35,7 @@ def ResultIter(cursor, arraysize=1000):
 
 def getVersion(envOpts):
     cmd = subprocess.Popen('psql --pset footer -Atqc "select version()" template1', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envOpts)
-    if cmd.wait() is not 0:
+    if cmd.wait() != 0:
         sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + cmd.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
     return cmd.communicate()[0].decode('ascii')
@@ -44,7 +44,7 @@ def getVersion(envOpts):
 def dumpSchema(connectionInfo, envOpts):
     dump_cmd = 'pg_dump -h {host} -p {port} -U {user} -s -x -O {database}'.format(**connectionInfo)
     p = subprocess.Popen(dump_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
-    if p.wait() is not 0:
+    if p.wait() != 0:
         sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
 
@@ -52,7 +52,7 @@ def dumpSchema(connectionInfo, envOpts):
 def dumpGlobals(connectionInfo, envOpts):
     dump_cmd = 'pg_dumpall -h {host} -p {port} -U {user} -l {database} -g'.format(**connectionInfo)
     p = subprocess.Popen(dump_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
-    if p.wait() is not 0:
+    if p.wait() != 0:
         sys.stderr.write('\nError while dumping globals.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
 
@@ -75,14 +75,15 @@ def dumpTupleCount(cur):
 
 
 def dumpStats(cur, inclHLL):
-    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgt.typname, pgs.* ' \
-        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt ' \
+    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgtn.nspname, pgt.typname, pgs.* ' \
+        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt, pg_namespace pgtn ' \
         'WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN ' + \
         sysnslist + \
         ' and pgc.oid = pgs.starelid ' \
         'and pga.attrelid = pgc.oid ' \
         'and pga.attnum = pgs.staattnum ' \
         'and pga.atttypid = pgt.oid ' \
+        'and pgt.typnamespace = pgtn.oid ' \
         'ORDER BY pgc.relname, pgs.staattnum'
     pstring = '--\n' \
         '-- Table: {0}, Attribute: {1}\n' \

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -242,7 +242,7 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
         if schemaname != 'pg_catalog':
             linecomment = '-- ' # This will comment out the DELETE query
 
-        f_out.writelines(pstring.format(Escape(vals[0]), Escape(vals[2]), linecomment, starelid, vals[5], ',\n'.join(rowVals)))
+        f_out.writelines(pstring.format(Escape(vals[0]), Escape(vals[2]), linecomment, starelid, vals[6], ',\n'.join(rowVals)))
 
 def main():
     parser = parse_cmd_line()

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -138,7 +138,7 @@ def dump_query(connectionInfo, query_file):
 
     p = subprocess.Popen(query_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ)
 
-    if p.wait() is not 0:
+    if p.wait() != 0:
         errormsg = p.communicate()[1].decode('ascii')
         sys.stderr.writelines('\nError when executing function gp_dump_query_oids.\n\n' + errormsg + '\n\n')
         sys.exit(1)
@@ -185,7 +185,7 @@ def pg_dump_object(mr_query, connectionInfo, envOpts):
         (dmp_cmd, mr_query.relids, mr_query.funcids, Escape(out_file))
     print(dmp_cmd)
     p = subprocess.Popen(dmp_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
-    if p.wait() is not 0:
+    if p.wait() != 0:
         sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
 
@@ -211,14 +211,15 @@ def dump_tuple_count(cur, oid_str, f_out):
         f_out.writelines(updateStmt)
 
 def dump_stats(cur, oid_str, f_out, inclHLL):
-    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgt.typname, pgs.* ' \
-        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt ' \
+    query = 'SELECT pgc.relname, pgn.nspname, pga.attname, pgtn.nspname, pgt.typname, pgs.* ' \
+        'FROM pg_class pgc, pg_statistic pgs, pg_namespace pgn, pg_attribute pga, pg_type pgt, pg_namespace pgtn ' \
         'WHERE pgc.relnamespace = pgn.oid and pgc.oid in (%s) ' \
         'and pgn.nspname NOT LIKE \'pg_temp_%%\' ' \
         'and pgc.oid = pgs.starelid ' \
         'and pga.attrelid = pgc.oid ' \
         'and pga.attnum = pgs.staattnum ' \
         'and pga.atttypid = pgt.oid ' \
+        'and pgt.typnamespace = pgtn.oid ' \
         'ORDER BY pgc.relname, pgs.staattnum' % (oid_str)
 
     pstring = '--\n' \

--- a/src/test/regress/expected/gpsd.out
+++ b/src/test/regress/expected/gpsd.out
@@ -58,6 +58,7 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 insert into gpsd_foo values(1, 'something');
 insert into gpsd_foo values(2, chr(1000));
 insert into gpsd_foo values(3, chr(105));
+insert into gpsd_foo values(4, 'a \ and a "');
 analyze gpsd_foo;
 -- arbitrarily populate stats data values having text (with quotes) in a slot
 -- (without paying heed to the slot's stakind) to test dumpability
@@ -103,12 +104,12 @@ select
     stavalues4,
     stavalues5
 from pg_statistic where starelid IN ('gpsd_foo'::regclass, 'gpsd_foo_1'::regclass);
- staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 |   stavalues1    | stavalues2 |   stavalues3    | stavalues4 | stavalues5 
------------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+-----------------+------------+-----------------+------------+------------
-         1 | t          |           0 |        4 |          -1 |        2 |        0 |        0 |        0 |        0 |     97 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {1,2,3}         |            |                 |            | 
-         2 | t          |           0 |        5 |          -1 |        2 |        0 |        0 |        0 |        0 |    664 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {i,something,Ϩ} |            | {hello,'world'} |            | 
-         1 | f          |           0 |        4 |          -1 |        2 |        3 |        0 |        0 |        0 |     97 |     97 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             | {-0.5}      |             |             |             | {1,2,3}         |            |                 |            | 
-         2 | f          |           0 |        5 |          -1 |        2 |        3 |        0 |        0 |        0 |    664 |    664 |      0 |      0 |      0 |      100 |      100 |        0 |        0 |        0 |             | {-0.5}      |             |             |             | {i,something,Ϩ} |            |                 |            | 
+ staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 |           stavalues1            | stavalues2 |   stavalues3    | stavalues4 | stavalues5 
+-----------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+---------------------------------+------------+-----------------+------------+------------
+         1 | t          |           0 |        4 |          -1 |        2 |        0 |        0 |        0 |        0 |     97 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {1,2,3,4}                       |            |                 |            | 
+         2 | t          |           0 |        6 |          -1 |        2 |        0 |        0 |        0 |        0 |    664 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {"a \\ and a \"",i,something,Ϩ} |            | {hello,'world'} |            | 
+         1 | f          |           0 |        4 |          -1 |        2 |        3 |        0 |        0 |        0 |     97 |     97 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             | {-0.2}      |             |             |             | {1,2,3,4}                       |            |                 |            | 
+         2 | f          |           0 |        6 |          -1 |        2 |        3 |        0 |        0 |        0 |    664 |    664 |      0 |      0 |      0 |      100 |      100 |        0 |        0 |        0 |             | {-0.4}      |             |             |             | {"a \\ and a \"",i,something,Ϩ} |            |                 |            | 
 (4 rows)
 
 --------------------------------------------------------------------------------

--- a/src/test/regress/expected/gpsd.out
+++ b/src/test/regress/expected/gpsd.out
@@ -56,6 +56,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table gpsd_foo_1 partition of gpsd_foo for values from (1) to (5);
 NOTICE:  table has parent, setting distribution columns to match parent table
 insert into gpsd_foo values(1, 'something');
+insert into gpsd_foo values(2, chr(1000));
+insert into gpsd_foo values(3, chr(105));
 analyze gpsd_foo;
 -- arbitrarily populate stats data values having text (with quotes) in a slot
 -- (without paying heed to the slot's stakind) to test dumpability
@@ -101,12 +103,12 @@ select
     stavalues4,
     stavalues5
 from pg_statistic where starelid IN ('gpsd_foo'::regclass, 'gpsd_foo_1'::regclass);
- staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 | stavalues1 | stavalues2 |   stavalues3    | stavalues4 | stavalues5 
------------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+------------+------------+-----------------+------------+------------
-         1 | t          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |                 |            | 
-         1 | f          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |                 |            | 
-         2 | f          |           0 |       10 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |                 |            | 
-         2 | t          |           0 |       10 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            | {hello,'world'} |            | 
+ staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 |   stavalues1    | stavalues2 |   stavalues3    | stavalues4 | stavalues5 
+-----------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+-----------------+------------+-----------------+------------+------------
+         1 | t          |           0 |        4 |          -1 |        2 |        0 |        0 |        0 |        0 |     97 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {1,2,3}         |            |                 |            | 
+         2 | t          |           0 |        5 |          -1 |        2 |        0 |        0 |        0 |        0 |    664 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {i,something,Ϩ} |            | {hello,'world'} |            | 
+         1 | f          |           0 |        4 |          -1 |        2 |        3 |        0 |        0 |        0 |     97 |     97 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             | {-0.5}      |             |             |             | {1,2,3}         |            |                 |            | 
+         2 | f          |           0 |        5 |          -1 |        2 |        3 |        0 |        0 |        0 |    664 |    664 |      0 |      0 |      0 |      100 |      100 |        0 |        0 |        0 |             | {-0.5}      |             |             |             | {i,something,Ϩ} |            |                 |            | 
 (4 rows)
 
 --------------------------------------------------------------------------------

--- a/src/test/regress/sql/gpsd.sql
+++ b/src/test/regress/sql/gpsd.sql
@@ -22,6 +22,7 @@ create table gpsd_foo_1 partition of gpsd_foo for values from (1) to (5);
 insert into gpsd_foo values(1, 'something');
 insert into gpsd_foo values(2, chr(1000));
 insert into gpsd_foo values(3, chr(105));
+insert into gpsd_foo values(4, 'a \ and a "');
 analyze gpsd_foo;
 
 -- arbitrarily populate stats data values having text (with quotes) in a slot

--- a/src/test/regress/sql/gpsd.sql
+++ b/src/test/regress/sql/gpsd.sql
@@ -20,6 +20,8 @@ create database gpsd_db_without_hll;
 create table gpsd_foo(a int, s text) partition by range(a);
 create table gpsd_foo_1 partition of gpsd_foo for values from (1) to (5);
 insert into gpsd_foo values(1, 'something');
+insert into gpsd_foo values(2, chr(1000));
+insert into gpsd_foo values(3, chr(105));
 analyze gpsd_foo;
 
 -- arbitrarily populate stats data values having text (with quotes) in a slot


### PR DESCRIPTION
This is a port from 6X PR https://github.com/greenplum-db/gpdb/pull/11748, but it is not a simple cherry-pick. Two things changed in master:
- The code to format the insert list is now shared between gpsd and minirepro
- In Python3, arrays get returned by PygreSQL as lists, so the code is a bit different

**Fix gpsd and minirepro bug with column types that are not built-in**

In the generated SQL, gpsd and minirepro used an unqualified name for the type, which didn't work for types like `citext` that usually come from a schema other than `pg_catalog` and other than the schema of the table to be dumped.

The fix is to use a qualified name. For example, `citext` becomes something like `"public"."citext"`.

**Fix gpsd and minirepro bug with embedded double quotes and backslashes**

When values in `pg_statistic.stavalues<n>` had embedded double quotes or backslashes, gpsd and minirepro generated un-escaped strings, but the correct syntax for an embedded double quote in an array constant is `\\"`, because it goes through two layers of escape processing. For embedded backslashes we need to use `\\\\`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
