### PR TITLE
[6X Backport] resource group: support CPU ceiling enforcement

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -222,6 +222,7 @@ bool		gp_debug_resqueue_priority = false;
 /* Resource group GUCs */
 int			gp_resource_group_cpu_priority;
 double		gp_resource_group_cpu_limit;
+bool		gp_resource_group_cpu_ceiling_enforcement;
 double		gp_resource_group_memory_limit;
 bool		gp_resource_group_bypass;
 
@@ -3007,6 +3008,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_resource_group_bypass,
 		false,
 		check_gp_resource_group_bypass, NULL, NULL
+	},
+
+	{
+		{"gp_resource_group_cpu_ceiling_enforcement", PGC_POSTMASTER, RESOURCES,
+			gettext_noop("If the value is true, ceiling enforcement of CPU will be enabled"),
+			NULL
+		},
+		&gp_resource_group_cpu_ceiling_enforcement,
+		false, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -133,6 +133,7 @@ static bool detectCgroupMountPoint(void);
 static void initCpu(void);
 static void initCpuSet(void);
 static void createDefaultCpuSetGroup(void);
+static int64 getCfsPeriodUs(ResGroupCompType);
 
 /*
  * currentGroupIdInCGroup & oldCaps are used for reducing redundant
@@ -1343,6 +1344,45 @@ initCpuSet(void)
 	createDefaultCpuSetGroup();
 }
 
+static int64
+getCfsPeriodUs(ResGroupCompType comp)
+{
+	int64		cfs_period_us;
+
+	/*
+	 * calculate cpu rate limit of system.
+	 *
+	 * Ideally the cpu quota is calculated from parent infomation:
+	 *
+	 * system_cfs_quota_us := parent.cfs_period_us * ncores.
+	 *
+	 * However on centos6 we found parent.cfs_period_us can be 0 and is not
+	 * writable.  In the other side, gpdb.cfs_period_us should be equal to
+	 * parent.cfs_period_us because sub dirs inherit parent properties by
+	 * default, so we read it instead.
+	 */
+	cfs_period_us = readInt64(RESGROUP_ROOT_ID, BASETYPE_GPDB,
+							  comp, "cpu.cfs_period_us");
+	if (cfs_period_us == 0LL)
+	{
+		/*
+		 * if gpdb.cfs_period_us is also 0 try to correct it by setting the
+		 * default value 100000 (100ms).
+		 */
+		writeInt64(RESGROUP_ROOT_ID, BASETYPE_GPDB,
+				   comp, "cpu.cfs_period_us", 100000LL);
+
+		/* read again to verify the effect */
+		cfs_period_us = readInt64(RESGROUP_ROOT_ID, BASETYPE_GPDB,
+								  comp, "cpu.cfs_period_us");
+		if (cfs_period_us <= 0LL)
+			CGROUP_CONFIG_ERROR("invalid cpu.cfs_period_us value: "
+								INT64_FORMAT,
+								cfs_period_us);
+	}
+	return cfs_period_us;
+}
+
 /* Return the name for the OS group implementation */
 const char *
 ResGroupOps_Name(void)
@@ -1437,37 +1477,7 @@ ResGroupOps_Bless(void)
 	/* get system cpu cores */
 	ncores = getCpuCores();
 
-	/*
-	 * calculate cpu rate limit of system.
-	 *
-	 * Ideally the cpu quota is calculated from parent infomation:
-	 *
-	 * system_cfs_quota_us := parent.cfs_period_us * ncores.
-	 *
-	 * However on centos6 we found parent.cfs_period_us can be 0 and is not
-	 * writable.  In the other side, gpdb.cfs_period_us should be equal to
-	 * parent.cfs_period_us because sub dirs inherit parent properties by
-	 * default, so we read it instead.
-	 */
-	cfs_period_us = readInt64(RESGROUP_ROOT_ID, BASETYPE_GPDB,
-							  comp, "cpu.cfs_period_us");
-	if (cfs_period_us == 0LL)
-	{
-		/*
-		 * if gpdb.cfs_period_us is also 0 try to correct it by setting the
-		 * default value 100000 (100ms).
-		 */
-		writeInt64(RESGROUP_ROOT_ID, BASETYPE_GPDB,
-				   comp, "cpu.cfs_period_us", 100000LL);
-
-		/* read again to verify the effect */
-		cfs_period_us = readInt64(RESGROUP_ROOT_ID, BASETYPE_GPDB,
-								  comp, "cpu.cfs_period_us");
-		if (cfs_period_us <= 0LL)
-			CGROUP_CONFIG_ERROR("invalid cpu.cfs_period_us value: "
-								INT64_FORMAT,
-								cfs_period_us);
-	}
+	cfs_period_us = getCfsPeriodUs(comp);
 	system_cfs_quota_us = cfs_period_us * ncores;
 
 	/* read cpu rate limit of parent cgroup */
@@ -1729,6 +1739,18 @@ ResGroupOps_SetCpuRateLimit(Oid group, int cpu_rate_limit)
 							 "cpu.shares");
 	writeInt64(group, BASETYPE_GPDB, comp,
 			   "cpu.shares", shares * cpu_rate_limit / 100);
+
+	/* set cpu.cfs_quota_us if hard CPU enforment is enabled */
+	if (gp_resource_group_cpu_ceiling_enforcement)
+	{
+		int64 periods = getCfsPeriodUs(comp);
+		writeInt64(group, BASETYPE_GPDB, comp, "cpu.cfs_quota_us",
+				   periods * ResGroupOps_GetCpuCores() * cpu_rate_limit / 100);
+	}
+	else
+	{
+		writeInt64(group, BASETYPE_GPDB, comp, "cpu.cfs_quota_us", -1);
+	}
 }
 
 /*

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -99,6 +99,7 @@ extern int						memory_spill_ratio;
 
 extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
+extern bool gp_resource_group_cpu_ceiling_enforcement;
 extern double gp_resource_group_memory_limit;
 extern bool gp_resource_group_bypass;
 extern int gp_resource_group_queuing_timeout;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -227,6 +227,7 @@
 		"gp_resource_group_bypass",
 		"gp_resource_group_cpu_limit",
 		"gp_resource_group_cpu_priority",
+		"gp_resource_group_cpu_ceiling_enforcement",
 		"gp_resource_group_memory_limit",
 		"gp_resource_group_queuing_timeout",
 		"gp_resource_manager",

--- a/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
@@ -308,16 +308,199 @@ SELECT * FROM cancel_all;
 22<:
 23<:
 24<:
+
+10q:
+11q:
+12q:
+13q:
+14q:
+
+20q:
+21q:
+22q:
+23q:
+24q:
+-- end_ignore
+
+-- start_ignore
+! gpconfig -c gp_resource_group_cpu_ceiling_enforcement -v on;
+! gpstop -rai;
+-- end_ignore
+
+-- prepare parallel queries in the two groups
+10: SET ROLE TO role1_cpu_test;
+11: SET ROLE TO role1_cpu_test;
+12: SET ROLE TO role1_cpu_test;
+13: SET ROLE TO role1_cpu_test;
+14: SET ROLE TO role1_cpu_test;
+
+20: SET ROLE TO role2_cpu_test;
+21: SET ROLE TO role2_cpu_test;
+22: SET ROLE TO role2_cpu_test;
+23: SET ROLE TO role2_cpu_test;
+24: SET ROLE TO role2_cpu_test;
+
+--
+-- now we get prepared.
+--
+-- on empty load the cpu usage shall be 0%
+--
+
+--
+-- a group should not burst to use all the cpu usage
+-- when it's the only one with running queries.
+--
+-- so the cpu usage shall be 10%
+--
+
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+
+-- start_ignore
+1:TRUNCATE TABLE cpu_usage_samples;
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:TRUNCATE TABLE cpu_usage_samples;
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+-- end_ignore
+
+1:SELECT verify_cpu_usage('rg1_cpu_test', 10, 2);
+
+-- start_ignore
+1:SELECT * FROM cancel_all;
+
+10<:
+11<:
+12<:
+13<:
+14<:
+-- end_ignore
+
+10q:
+11q:
+12q:
+13q:
+14q:
+
+10: SET ROLE TO role1_cpu_test;
+11: SET ROLE TO role1_cpu_test;
+12: SET ROLE TO role1_cpu_test;
+13: SET ROLE TO role1_cpu_test;
+14: SET ROLE TO role1_cpu_test;
+
+--
+-- when there are multiple groups with parallel queries,
+-- they should follow the ceiling enforcement of the cpu usage.
+--
+-- rg1_cpu_test:rg2_cpu_test is 0.1:0.2, so:
+--
+-- - rg1_cpu_test gets 10%;
+-- - rg2_cpu_test gets 20%;
+--
+
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+
+20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+
+-- start_ignore
+1:TRUNCATE TABLE cpu_usage_samples;
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:TRUNCATE TABLE cpu_usage_samples;
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+1:SELECT fetch_sample();
+1:SELECT pg_sleep(1.7);
+-- end_ignore
+
+1:SELECT verify_cpu_usage('rg1_cpu_test', 10, 2);
+1:SELECT verify_cpu_usage('rg2_cpu_test', 20, 2);
+
+-- start_ignore
+1:SELECT * FROM cancel_all;
+
+10<:
+11<:
+12<:
+13<:
+14<:
+
+20<:
+21<:
+22<:
+23<:
+24<:
+
+10q:
+11q:
+12q:
+13q:
+14q:
+
+20q:
+21q:
+22q:
+23q:
+24q:
+
+1q:
+-- end_ignore
+
+-- start_ignore
+! gpconfig -c gp_resource_group_cpu_ceiling_enforcement -v off;
+! gpstop -rai;
 -- end_ignore
 
 -- restore admin_group's cpu_rate_limit
-ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
+2:ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
 
 -- cleanup
-REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
-REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
-DROP ROLE role1_cpu_test;
-DROP ROLE role2_cpu_test;
-DROP RESOURCE GROUP rg1_cpu_test;
-DROP RESOURCE GROUP rg2_cpu_test;
-DROP LANGUAGE plpythonu CASCADE;
+2:REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
+2:REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
+2:DROP ROLE role1_cpu_test;
+2:DROP ROLE role2_cpu_test;
+2:DROP RESOURCE GROUP rg1_cpu_test;
+2:DROP RESOURCE GROUP rg2_cpu_test;
+2:DROP LANGUAGE plpythonu CASCADE;

--- a/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
@@ -462,24 +462,500 @@ ERROR:  canceling statement due to user request
 ERROR:  canceling statement due to user request
 24<:  <... completed>
 ERROR:  canceling statement due to user request
+
+10q: ... <quitting>
+11q: ... <quitting>
+12q: ... <quitting>
+13q: ... <quitting>
+14q: ... <quitting>
+
+20q: ... <quitting>
+21q: ... <quitting>
+22q: ... <quitting>
+23q: ... <quitting>
+24q: ... <quitting>
+-- end_ignore
+
+-- start_ignore
+! gpconfig -c gp_resource_group_cpu_ceiling_enforcement -v on;
+20210405:09:27:21:015004 gpconfig:hubert-gp-centos:huanzhang-[INFO]:-completed successfully with parameters '-c gp_resource_group_cpu_ceiling_enforcement -v on'
+
+! gpstop -rai;
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Starting gpstop with args: -rai
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Gathering information and validating the environment...
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Greenplum Master catalog information
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Segment details from master...
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.13.0+dev.34.gb0932fd788 build dev'
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Master segment instance directory=/home/huanzhang/workspace/gpdb6/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Attempting forceful termination of any leftover master process
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Terminating processes for segment /home/huanzhang/workspace/gpdb6/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210405:09:27:22:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Stopping master standby host hubert-gp-centos mode=fast
+20210405:09:27:23:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown standby process on hubert-gp-centos
+20210405:09:27:23:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210405:09:27:23:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210405:09:27:23:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20210405:09:27:24:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20210405:09:27:24:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210405:09:27:24:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments stopped successfully      = 6
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments with errors during stop   = 0
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Database successfully shutdown with no errors reported
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpmmon process
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpmmon process found
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpsmon processes
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20210405:09:27:25:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover shared memory
+20210405:09:27:26:015397 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Restarting System...
+
+-- end_ignore
+
+-- prepare parallel queries in the two groups
+10: SET ROLE TO role1_cpu_test;
+SET
+11: SET ROLE TO role1_cpu_test;
+SET
+12: SET ROLE TO role1_cpu_test;
+SET
+13: SET ROLE TO role1_cpu_test;
+SET
+14: SET ROLE TO role1_cpu_test;
+SET
+
+20: SET ROLE TO role2_cpu_test;
+SET
+21: SET ROLE TO role2_cpu_test;
+SET
+22: SET ROLE TO role2_cpu_test;
+SET
+23: SET ROLE TO role2_cpu_test;
+SET
+24: SET ROLE TO role2_cpu_test;
+SET
+
+--
+-- now we get prepared.
+--
+-- on empty load the cpu usage shall be 0%
+--
+
+--
+-- a group should not burst to use all the cpu usage
+-- when it's the only one with running queries.
+--
+-- so the cpu usage shall be 10%
+--
+
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+
+-- start_ignore
+1:TRUNCATE TABLE cpu_usage_samples;
+TRUNCATE
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 11.31, "0": 10.33, "2": 10.38, "-1": 9.78}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.12, "0": 0.09, "2": 0.07, "-1": 0.28}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.94, "0": 9.94, "2": 9.94, "-1": 9.91}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.04, "0": 0.04, "2": 0.06, "-1": 0.15}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 10.03, "0": 10.03, "2": 10.03, "-1": 10.0}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.04, "0": 0.04, "2": 0.04, "-1": 0.16}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.94, "0": 9.93, "2": 9.94, "-1": 9.88}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.06, "0": 0.07, "2": 0.06, "-1": 0.29}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.91, "0": 9.91, "2": 9.91, "-1": 9.88}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.06, "0": 0.08, "2": 0.06, "-1": 0.15}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:TRUNCATE TABLE cpu_usage_samples;
+TRUNCATE
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.94, "0": 9.94, "2": 9.94, "-1": 9.92}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.06, "0": 0.06, "2": 0.06, "-1": 0.12}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.97, "0": 9.97, "2": 9.97, "-1": 9.94}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.03, "0": 0.04, "2": 0.03, "-1": 0.14}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.98, "0": 9.98, "2": 9.98, "-1": 9.95}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.05, "0": 0.07, "2": 0.05, "-1": 0.15}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.97, "0": 9.98, "2": 9.97, "-1": 9.95}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.07, "0": 0.06, "2": 0.06, "-1": 0.13}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 10.01, "0": 10.02, "2": 10.02, "-1": 9.98}, "rg2_cpu_test": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}, "admin_group": {"1": 0.08, "0": 0.06, "2": 0.04, "-1": 0.14}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+-- end_ignore
+
+1:SELECT verify_cpu_usage('rg1_cpu_test', 10, 2);
+ verify_cpu_usage 
+------------------
+ t                
+(1 row)
+
+-- start_ignore
+1:SELECT * FROM cancel_all;
+ pg_cancel_backend 
+-------------------
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+(5 rows)
+
+10<:  <... completed>
+ERROR:  canceling statement due to user request
+11<:  <... completed>
+ERROR:  canceling statement due to user request
+12<:  <... completed>
+ERROR:  canceling statement due to user request
+13<:  <... completed>
+ERROR:  canceling statement due to user request
+14<:  <... completed>
+ERROR:  canceling statement due to user request
+-- end_ignore
+
+10q: ... <quitting>
+11q: ... <quitting>
+12q: ... <quitting>
+13q: ... <quitting>
+14q: ... <quitting>
+
+10: SET ROLE TO role1_cpu_test;
+SET
+11: SET ROLE TO role1_cpu_test;
+SET
+12: SET ROLE TO role1_cpu_test;
+SET
+13: SET ROLE TO role1_cpu_test;
+SET
+14: SET ROLE TO role1_cpu_test;
+SET
+
+--
+-- when there are multiple groups with parallel queries,
+-- they should follow the ceiling enforcement of the cpu usage.
+--
+-- rg1_cpu_test:rg2_cpu_test is 0.1:0.2, so:
+--
+-- - rg1_cpu_test gets 10%;
+-- - rg2_cpu_test gets 20%;
+--
+
+10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+
+20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+
+-- start_ignore
+1:TRUNCATE TABLE cpu_usage_samples;
+TRUNCATE
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 10.16, "0": 10.17, "2": 10.05, "-1": 10.25}, "rg2_cpu_test": {"1": 20.04, "0": 20.06, "2": 19.93, "-1": 20.13}, "admin_group": {"1": 0.07, "0": 0.06, "2": 0.05, "-1": 0.15}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.98, "0": 9.98, "2": 9.98, "-1": 9.95}, "rg2_cpu_test": {"1": 19.99, "0": 19.99, "2": 19.99, "-1": 19.93}, "admin_group": {"1": 0.03, "0": 0.03, "2": 0.03, "-1": 0.15}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 10.02, "0": 10.02, "2": 10.02, "-1": 9.99}, "rg2_cpu_test": {"1": 20.0, "0": 20.0, "2": 20.0, "-1": 19.94}, "admin_group": {"1": 0.06, "0": 0.06, "2": 0.06, "-1": 0.12}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 10.08, "0": 10.07, "2": 10.07, "-1": 10.05}, "rg2_cpu_test": {"1": 19.86, "0": 19.85, "2": 19.85, "-1": 19.8}, "admin_group": {"1": 0.03, "0": 0.04, "2": 0.04, "-1": 0.15}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 10.1, "0": 10.1, "2": 10.1, "-1": 10.07}, "rg2_cpu_test": {"1": 19.83, "0": 19.83, "2": 19.83, "-1": 19.76}, "admin_group": {"1": 0.03, "0": 0.03, "2": 0.04, "-1": 0.16}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:TRUNCATE TABLE cpu_usage_samples;
+TRUNCATE
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.87, "0": 9.87, "2": 9.87, "-1": 9.98}, "rg2_cpu_test": {"1": 20.1, "0": 20.1, "2": 20.1, "-1": 19.98}, "admin_group": {"1": 0.05, "0": 0.06, "2": 0.05, "-1": 0.16}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.94, "0": 9.94, "2": 9.94, "-1": 9.91}, "rg2_cpu_test": {"1": 20.07, "0": 20.07, "2": 20.07, "-1": 20.01}, "admin_group": {"1": 0.06, "0": 0.06, "2": 0.02, "-1": 0.12}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.98, "0": 9.98, "2": 9.98, "-1": 10.08}, "rg2_cpu_test": {"1": 19.87, "0": 19.86, "2": 19.86, "-1": 19.84}, "admin_group": {"1": 0.07, "0": 0.07, "2": 0.09, "-1": 0.17}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.99, "0": 9.99, "2": 9.99, "-1": 9.96}, "rg2_cpu_test": {"1": 19.93, "0": 19.93, "2": 19.93, "-1": 19.87}, "admin_group": {"1": 0.05, "0": 0.07, "2": 0.05, "-1": 0.13}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+1:SELECT fetch_sample();
+ fetch_sample                                                                                                                                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"rg1_cpu_test": {"1": 9.85, "0": 9.85, "2": 9.86, "-1": 9.83}, "rg2_cpu_test": {"1": 20.05, "0": 20.06, "2": 20.06, "-1": 20.0}, "admin_group": {"1": 0.06, "0": 0.05, "2": 0.05, "-1": 0.13}, "default_group": {"1": 0.0, "0": 0.0, "2": 0.0, "-1": 0.0}} 
+(1 row)
+1:SELECT pg_sleep(1.7);
+ pg_sleep 
+----------
+          
+(1 row)
+-- end_ignore
+
+1:SELECT verify_cpu_usage('rg1_cpu_test', 10, 2);
+ verify_cpu_usage 
+------------------
+ t                
+(1 row)
+1:SELECT verify_cpu_usage('rg2_cpu_test', 20, 2);
+ verify_cpu_usage 
+------------------
+ t                
+(1 row)
+
+-- start_ignore
+1:SELECT * FROM cancel_all;
+ pg_cancel_backend 
+-------------------
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+ t                 
+(10 rows)
+
+10<:  <... completed>
+ERROR:  canceling statement due to user request
+11<:  <... completed>
+ERROR:  canceling statement due to user request
+12<:  <... completed>
+ERROR:  canceling statement due to user request
+13<:  <... completed>
+ERROR:  canceling statement due to user request
+14<:  <... completed>
+ERROR:  canceling statement due to user request
+
+20<:  <... completed>
+ERROR:  canceling statement due to user request
+21<:  <... completed>
+ERROR:  canceling statement due to user request
+22<:  <... completed>
+ERROR:  canceling statement due to user request
+23<:  <... completed>
+ERROR:  canceling statement due to user request
+24<:  <... completed>
+ERROR:  canceling statement due to user request
+
+10q: ... <quitting>
+11q: ... <quitting>
+12q: ... <quitting>
+13q: ... <quitting>
+14q: ... <quitting>
+
+20q: ... <quitting>
+21q: ... <quitting>
+22q: ... <quitting>
+23q: ... <quitting>
+24q: ... <quitting>
+
+1q: ... <quitting>
+-- end_ignore
+
+-- start_ignore
+! gpconfig -c gp_resource_group_cpu_ceiling_enforcement -v off;
+20210405:09:28:23:017589 gpconfig:hubert-gp-centos:huanzhang-[INFO]:-completed successfully with parameters '-c gp_resource_group_cpu_ceiling_enforcement -v off'
+
+! gpstop -rai;
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Starting gpstop with args: -rai
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Gathering information and validating the environment...
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Greenplum Master catalog information
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Segment details from master...
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.13.0+dev.34.gb0932fd788 build dev'
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Master segment instance directory=/home/huanzhang/workspace/gpdb6/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Attempting forceful termination of any leftover master process
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Terminating processes for segment /home/huanzhang/workspace/gpdb6/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210405:09:28:23:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Stopping master standby host hubert-gp-centos mode=fast
+20210405:09:28:25:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown standby process on hubert-gp-centos
+20210405:09:28:25:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210405:09:28:25:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210405:09:28:25:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments stopped successfully      = 6
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments with errors during stop   = 0
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Database successfully shutdown with no errors reported
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpmmon process
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpmmon process found
+20210405:09:28:26:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpsmon processes
+20210405:09:28:27:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20210405:09:28:27:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover shared memory
+20210405:09:28:28:017985 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Restarting System...
+
 -- end_ignore
 
 -- restore admin_group's cpu_rate_limit
-ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
+2:ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
 ALTER
 
 -- cleanup
-REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
+2:REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
 REVOKE
-REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
+2:REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
 REVOKE
-DROP ROLE role1_cpu_test;
+2:DROP ROLE role1_cpu_test;
 DROP
-DROP ROLE role2_cpu_test;
+2:DROP ROLE role2_cpu_test;
 DROP
-DROP RESOURCE GROUP rg1_cpu_test;
+2:DROP RESOURCE GROUP rg1_cpu_test;
 DROP
-DROP RESOURCE GROUP rg2_cpu_test;
+2:DROP RESOURCE GROUP rg2_cpu_test;
 DROP
-DROP LANGUAGE plpythonu CASCADE;
+2:DROP LANGUAGE plpythonu CASCADE;
 DROP


### PR DESCRIPTION
CPU enforcement in resource group is based on Cgroup. Cgroup supports
two kinds of CPU enforcement: relative shares V.S. ceiling enforcement.

Resource group currently supports relative shares, which enable CPU
bursting to use 100% of CPU when the system is idle.
To avoid the CPU burst, we introduce the ceiling enforment in resource
group as well. User is able to choose the relative shares or
ceiling enforcement based on their requirement.

Reviewed-by: Gang Xiong <gxiong@pivotal.io>

cherry-pick from commit: 2fc4ec7

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
