### PR TITLE
getversion: check for VERSION file

### DIFF
--- a/getversion
+++ b/getversion
@@ -28,6 +28,10 @@ if type git >/dev/null 2>&1 && [ -d '.git' ] ; then
 		VERSION+=+
 		VERSION+=$(git rev-parse --short HEAD)
 	fi
+# If not a git repository and VERSION file exists, use version string from file.
+elif [[ -s ./VERSION ]]; then
+	cat ./VERSION
+	exit 0
 fi
 
 FLAG="${1:-noflag}"


### PR DESCRIPTION
If source is not a git repository and VERSION file exists, use version string from file.

This commit resolve the issue outlined here:
https://groups.google.com/a/greenplum.org/g/gpdb-users/c/74CMXJkZZK4

Currently, compiling Greenplum from the [source tarball provided on the Github release page](https://github.com/greenplum-db/gpdb/releases/tag/6.15.0) will result in the version being reported as **postgres (Greenplum Database) 6.0.0-beta.1 build dev**

Future Github releases will bundle the VERSION file with the source tarball, allowing the build system to inject the proper version when compiling. 
