### PR TITLE
Fix handling of non-ASCII characters in gpsd

### DIFF
--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -510,7 +510,7 @@ def Escape(query_str):
 
 def escapeArrayElement(query_str):
     # also escape backslashes and double quotes, in addition to the doubling of single quotes
-    return pgdb.escape_string(query_str).replace('\\','\\\\').replace('"','\\"')
+    return pgdb.escape_string(query_str.encode(errors='backslashreplace')).decode(errors='backslashreplace').replace('\\','\\\\').replace('"','\\"')
 
 
 # Transform Python list to Postgres array literal (of the form: '{...}')

--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -22,7 +22,6 @@ sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_temp_1', 'pg_catalog', 'informat
 # unset search path due to CVE-2018-1058
 pgoptions = '-c optimizer=off -c gp_role=utility -c search_path='
 
-
 def ResultIter(cursor, arraysize=1000):
     'An iterator that uses fetchmany to keep memory usage down'
     while True:

--- a/src/test/regress/expected/gpsd.out
+++ b/src/test/regress/expected/gpsd.out
@@ -56,6 +56,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table gpsd_foo_1 partition of gpsd_foo for values from (1) to (5);
 NOTICE:  table has parent, setting distribution columns to match parent table
 insert into gpsd_foo values(1, 'something');
+insert into gpsd_foo values(2, chr(1000));
+insert into gpsd_foo values(3, chr(105));
 insert into gpsd_foo values(4, 'a \ and a "');
 analyze gpsd_foo;
 -- arbitrarily populate stats data values having text (with quotes) in a slot
@@ -102,12 +104,12 @@ select
     stavalues4,
     stavalues5
 from pg_statistic where starelid IN ('gpsd_foo'::regclass, 'gpsd_foo_1'::regclass);
- staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 |         stavalues1          | stavalues2 |   stavalues3    | stavalues4 | stavalues5 
------------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+-----------------------------+------------+-----------------+------------+------------
-         1 | t          |           0 |        4 |          -1 |        2 |        0 |        0 |        0 |        0 |     97 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {1,4}                       |            |                 |            | 
-         2 | t          |           0 |       11 |          -1 |        2 |        0 |        0 |        0 |        0 |    664 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {"a \\ and a \"",something} |            | {hello,'world'} |            | 
-         1 | f          |           0 |        4 |          -1 |        2 |        3 |        0 |        0 |        0 |     97 |     97 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             | {-1}        |             |             |             | {1,4}                       |            |                 |            | 
-         2 | f          |           0 |       11 |          -1 |        2 |        3 |        0 |        0 |        0 |    664 |    664 |      0 |      0 |      0 |      100 |      100 |        0 |        0 |        0 |             | {1}         |             |             |             | {"a \\ and a \"",something} |            |                 |            | 
+ staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 |           stavalues1            | stavalues2 |   stavalues3    | stavalues4 | stavalues5 
+-----------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+---------------------------------+------------+-----------------+------------+------------
+         1 | t          |           0 |        4 |          -1 |        2 |        0 |        0 |        0 |        0 |     97 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {1,2,3,4}                       |            |                 |            | 
+         2 | t          |           0 |        6 |          -1 |        2 |        0 |        0 |        0 |        0 |    664 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             | {"a \\ and a \"",i,something,Ϩ} |            | {hello,'world'} |            | 
+         1 | f          |           0 |        4 |          -1 |        2 |        3 |        0 |        0 |        0 |     97 |     97 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             | {-0.2}      |             |             |             | {1,2,3,4}                       |            |                 |            | 
+         2 | f          |           0 |        6 |          -1 |        2 |        3 |        0 |        0 |        0 |    664 |    664 |      0 |      0 |      0 |      100 |      100 |        0 |        0 |        0 |             | {-0.4}      |             |             |             | {"a \\ and a \"",i,something,Ϩ} |            |                 |            | 
 (4 rows)
 
 --------------------------------------------------------------------------------

--- a/src/test/regress/sql/gpsd.sql
+++ b/src/test/regress/sql/gpsd.sql
@@ -20,6 +20,8 @@ create database gpsd_db_without_hll;
 create table gpsd_foo(a int, s text) partition by range(a);
 create table gpsd_foo_1 partition of gpsd_foo for values from (1) to (5);
 insert into gpsd_foo values(1, 'something');
+insert into gpsd_foo values(2, chr(1000));
+insert into gpsd_foo values(3, chr(105));
 insert into gpsd_foo values(4, 'a \ and a "');
 analyze gpsd_foo;
 
@@ -29,7 +31,7 @@ set allow_system_table_mods to on;
 update pg_statistic set stavalues3='{"hello", "''world''"}'::text[] where starelid='gpsd_foo'::regclass and staattnum=2;
 
 -- start_ignore
-\! gpsd gpsd_db_without_hll > data/gpsd-without-hll.sql
+\! PYTHONIOENCODING=utf-8 gpsd gpsd_db_without_hll > data/gpsd-without-hll.sql
 -- end_ignore
 
 \c regression
@@ -95,7 +97,7 @@ set allow_system_table_mods to on;
 update pg_statistic set stavalues3='{"hello", "''world''"}'::text[] where starelid='gpsd_foo'::regclass and staattnum=2;
 
 -- start_ignore
-\! gpsd gpsd_db_with_hll --hll > data/gpsd-with-hll.sql
+\! PYTHONIOENCODING=utf-8 gpsd gpsd_db_with_hll --hll > data/gpsd-with-hll.sql
 -- end_ignore
 
 \c regression


### PR DESCRIPTION
In python 2, unicode strings were represented as a unicode type.  However, in
python 3, this is handled by the default str type. When parsing a unicode
character, we used the escape sequence instead of the literal unicode character
in python 2. To maintain this behavior in python 3, we need additional
encoding/decoding.

The pgdb.escape_string() function expects a string without unicode characters.
Now, we now encode, perform escaping, then decode as utf8 to ensure we're
removing all non-ascii characters. This means the MCV values for that we
populate in pg_statistic using minirepro/gpsd will be the escape sequence for
unicode characters, which is also the 6X behavior.
