### PR TITLE
Add %c to `archive_cleanup_command`

### DIFF
--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -345,6 +345,7 @@ ExecuteRecoveryCommand(const char *command, const char *commandName, bool failOn
 	char	   *endp;
 	const char *sp;
 	int			rc;
+	char		contentid[12];	/* sign, 10 digits and '\0' */
 	XLogSegNo	restartSegNo;
 	XLogRecPtr	restartRedoPtr;
 	TimeLineID	restartTli;
@@ -378,6 +379,14 @@ ExecuteRecoveryCommand(const char *command, const char *commandName, bool failOn
 					/* %r: filename of last restartpoint */
 					sp++;
 					StrNCpy(dp, lastRestartPointFname, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'c':
+					/* GPDB: %c: contentId of segment */
+					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.segindex, contentid);
+					StrNCpy(dp, contentid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -117,7 +117,7 @@ echo "restore_command = 'cp ${ARCHIVE_PREFIX}%c/%f %p'
 recovery_target_name = 'test_restore_point'
 recovery_target_action = 'promote'
 recovery_end_command = 'touch ${!REPLICA_VAR}/recovery_finished'" >> ${!REPLICA_VAR}/postgresql.conf
-  echo "" > ${!REPLICA_VAR}/postgresql.auto.conf
+echo "" > ${!REPLICA_VAR}/postgresql.auto.conf
   touch ${!REPLICA_VAR}/recovery.signal
   pg_ctl start -D ${!REPLICA_VAR} -l /dev/null
 done


### PR DESCRIPTION
This commit introduces the contentId (%c) parameter to
archive_cleanup_command. It will be substituted with the
contentId of the segment involved in the archival/recovery process.
Thus, an archive_cleanup_command = 'pg_archivecleanup /path/to/archive/seg%c %r'
might be substituted by (for a 3 segment cluster):

pg_archivecleanup /path/to/archive/seg-1/00000001000000A900000065
pg_archivecleanup /path/to/archive/seg0/00000001000000A900000065
pg_archivecleanup /path/to/archive/seg1/00000001000000A900000065
pg_archivecleanup /path/to/archive/seg2/00000001000000A900000065

The param will serve as a piece of identifying information for a WAL
stream from a given segment.