### PR TITLE
[5X Only]Replace unused target entry with NULL in RelabelType

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -2357,13 +2357,15 @@ replace_grouping_columns_targetlist(Node *node, replace_grouping_columns_targetl
 	if (node == NULL || IsA(node, Aggref))
 		return node;
 
+	while (IsA(node, RelabelType))
+		node = (Node *) ((RelabelType *) node)->arg;
+
 	Assert(IsA(ctx->grpcols, List));
 
 	foreach (lc, (List*)ctx->grpcols)
 	{
 		Node *grpcol = lfirst(lc);
 		if (equal(node, grpcol)) {
-
 			/* Generate a NULL constant to replace the node. */
 			Const *null = makeNullConst(exprType((Node *)grpcol), -1);
 			return (Node *)null;

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6144,6 +6144,17 @@ select a, b, count(distinct b)+a from replace_col_agg group by grouping sets((a)
  2 |   |        3
 (5 rows)
 
+-- the type cast here will force a RelabelType in the target entry
+select a, b, count(distinct b)::oid = a::oid from replace_col_agg group by grouping sets((a), (b));
+ a | b | ?column? 
+---+---+----------
+   | 3 | 
+   | 4 | 
+   | 2 | 
+ 1 |   | f
+ 2 |   | f
+(5 rows)
+
 select count(distinct a), b + 1 as f, 1 as g from replace_col_agg GROUP BY grouping sets((f,g), (f));
  count | f | g 
 -------+---+---
@@ -6156,3 +6167,132 @@ select count(distinct a), b + 1 as f, 1 as g from replace_col_agg GROUP BY group
 (6 rows)
 
 drop table replace_col_agg;
+CREATE TABLE tbla (
+    aid int,
+    i int
+) DISTRIBUTED BY (aid);
+CREATE TABLE tblb (
+    bid int,
+    c1 int[],
+    c2 int,
+    c3 int,
+    c4 int,
+    c5 int,
+    c6 int
+) DISTRIBUTED BY (c5);
+insert into tbla values (1, 1);
+insert into tbla values (2, 2);
+insert into tbla values (3, 3);
+insert into tblb values (1, '{1, 2, 3}', 1, 1, 1, 1, 1);
+insert into tblb values (2, '{1, 2, 3}', 2, 2, 2, 2, 2);
+insert into tblb values (3, '{1, 2, 3}', 3, 3, 3, 3, 3);
+-- c4 should be replaced with NULL in groping sets (bid,i,c2) and (bid,i,c3) when it wrapped in RelabelType
+set optimizer = off;
+explain SELECT
+	bid, i, c2, c3, c4,
+	(i=c4::oid), COUNT(DISTINCT c5)    -- the type cast here will force RelabelType in expression
+FROM tbla a
+INNER JOIN tblb b
+    ON a.i=ANY(b.c1)
+GROUP BY GROUPING SETS(
+    (bid,i,c2),
+    (bid,i,c3),
+    (bid,i,c4)
+)
+ORDER BY 1,2,3,4;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=7.46..7.47 rows=0 width=0)
+   Merge Key: share0_ref1.bid, share0_ref1.i, "outer".c2, "outer".c3
+   ->  Sort  (cost=7.46..7.47 rows=0 width=0)
+         Sort Key: share0_ref1.bid, share0_ref1.i, "outer".c2, "outer".c3
+         ->  Append  (cost=2.48..7.45 rows=0 width=0)
+               ->  GroupAggregate  (cost=2.48..2.48 rows=0 width=41)
+                     Group By: share0_ref1.bid, share0_ref1.i, share0_ref1.c4
+                     ->  Sort  (cost=2.48..2.48 rows=0 width=20)
+                           Sort Key: share0_ref1.bid, share0_ref1.i, share0_ref1.c4
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2.43..2.47 rows=0 width=20)
+                                 Hash Key: share0_ref1.bid, share0_ref1.i, share0_ref1.c4
+                                 ->  GroupAggregate  (cost=2.43..2.47 rows=0 width=20)
+                                       Group By: share0_ref1.bid, share0_ref1.i, share0_ref1.c4
+                                       ->  Sort  (cost=2.43..2.44 rows=2 width=24)
+                                             Sort Key: share0_ref1.bid, share0_ref1.i, share0_ref1.c4
+                                             ->  Shared Scan (share slice:id 2:0)  (cost=2.20..2.40 rows=2 width=24)
+                                                   ->  Materialize  (cost=2.16..2.20 rows=2 width=24)
+                                                         ->  Nested Loop  (cost=1.01..2.16 rows=2 width=24)
+                                                               Join Filter: a.i = ANY (b.c1)
+                                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                                                     ->  Seq Scan on tbla a  (cost=0.00..1.01 rows=1 width=4)
+                                                               ->  Materialize  (cost=1.01..1.02 rows=1 width=53)
+                                                                     ->  Seq Scan on tblb b  (cost=0.00..1.01 rows=1 width=53)
+               ->  GroupAggregate  (cost=2.48..2.48 rows=0 width=41)
+                     Group By: share0_ref2.bid, share0_ref2.i, share0_ref2.c3
+                     ->  Sort  (cost=2.48..2.48 rows=0 width=20)
+                           Sort Key: share0_ref2.bid, share0_ref2.i, share0_ref2.c3
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=2.43..2.47 rows=0 width=20)
+                                 Hash Key: share0_ref2.bid, share0_ref2.i, share0_ref2.c3
+                                 ->  GroupAggregate  (cost=2.43..2.47 rows=0 width=20)
+                                       Group By: share0_ref2.bid, share0_ref2.i, share0_ref2.c3
+                                       ->  Sort  (cost=2.43..2.44 rows=2 width=24)
+                                             Sort Key: share0_ref2.bid, share0_ref2.i, share0_ref2.c3
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=2.20..2.40 rows=2 width=24)
+               ->  GroupAggregate  (cost=2.48..2.48 rows=0 width=41)
+                     Group By: share0_ref3.bid, share0_ref3.i, share0_ref3.c2
+                     ->  Sort  (cost=2.48..2.48 rows=0 width=20)
+                           Sort Key: share0_ref3.bid, share0_ref3.i, share0_ref3.c2
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=2.43..2.47 rows=0 width=20)
+                                 Hash Key: share0_ref3.bid, share0_ref3.i, share0_ref3.c2
+                                 ->  GroupAggregate  (cost=2.43..2.47 rows=0 width=20)
+                                       Group By: share0_ref3.bid, share0_ref3.i, share0_ref3.c2
+                                       ->  Sort  (cost=2.43..2.44 rows=2 width=24)
+                                             Sort Key: share0_ref3.bid, share0_ref3.i, share0_ref3.c2
+                                             ->  Shared Scan (share slice:id 4:0)  (cost=2.20..2.40 rows=2 width=24)
+ Optimizer status: legacy query optimizer
+(46 rows)
+
+SELECT
+	bid, i, c2, c3, c4,
+	(i=c4::oid), COUNT(DISTINCT c5)    -- the type cast here will force RelabelType in expression
+FROM tbla a
+INNER JOIN tblb b
+    ON a.i=ANY(b.c1)
+GROUP BY GROUPING SETS(
+    (bid,i,c2),
+    (bid,i,c3),
+    (bid,i,c4)
+)
+ORDER BY 1,2,3,4;
+ bid | i | c2 | c3 | c4 | ?column? | count 
+-----+---+----+----+----+----------+-------
+   1 | 1 |  1 |    |    |          |     1
+   1 | 1 |    |  1 |    |          |     1
+   1 | 1 |    |    |  1 | t        |     1
+   1 | 2 |  1 |    |    |          |     1
+   1 | 2 |    |  1 |    |          |     1
+   1 | 2 |    |    |  1 | f        |     1
+   1 | 3 |  1 |    |    |          |     1
+   1 | 3 |    |  1 |    |          |     1
+   1 | 3 |    |    |  1 | f        |     1
+   2 | 1 |  2 |    |    |          |     1
+   2 | 1 |    |  2 |    |          |     1
+   2 | 1 |    |    |  2 | f        |     1
+   2 | 2 |  2 |    |    |          |     1
+   2 | 2 |    |  2 |    |          |     1
+   2 | 2 |    |    |  2 | t        |     1
+   2 | 3 |  2 |    |    |          |     1
+   2 | 3 |    |  2 |    |          |     1
+   2 | 3 |    |    |  2 | f        |     1
+   3 | 1 |  3 |    |    |          |     1
+   3 | 1 |    |  3 |    |          |     1
+   3 | 1 |    |    |  3 | f        |     1
+   3 | 2 |  3 |    |    |          |     1
+   3 | 2 |    |  3 |    |          |     1
+   3 | 2 |    |    |  3 | f        |     1
+   3 | 3 |  3 |    |    |          |     1
+   3 | 3 |    |  3 |    |          |     1
+   3 | 3 |    |    |  3 | t        |     1
+(27 rows)
+
+reset optimizer;
+drop table tbla;
+drop table tblb;


### PR DESCRIPTION
In commit 5eaaa5800e9f492683c3ce313e54d3db5afbce79, it didn't
consider the grouping columns that need to be replaced with NULL
may appear in expression with RelabelType wrap. We should consider
this case too. For example:
CREATE TABLE w_time_d (
    row_wid bigint,
    per_name_qtr character varying(150)
) DISTRIBUTED BY (row_wid);

CREATE TABLE iqm_unified_assets_contract_qtr_base_asset_test (
    apid character varying,
    qtrs character varying[],
    start_qtr character varying(150),
    end_qtr character varying(150),
    nxt_qtr_exp_join character varying,
    quota_block character varying,
    cust_cntrct_nbr numeric(18,0),
    svc_rtl_rev numeric
) DISTRIBUTED BY (cust_cntrct_nbr);

explain SELECT
    (per_name_qtr=nxt_qtr_exp_join),
     COUNT(DISTINCT cust_cntrct_nbr) AS warranties_count
FROM w_time_d a
INNER JOIN iqm_unified_assets_contract_qtr_base_asset_test b
ON a.per_name_qtr=ANY(b.qtrs)
GROUP BY GROUPING SETS(
    (apid,per_name_qtr,start_qtr),
    (apid,per_name_qtr,end_qtr),
    (apid,per_name_qtr,nxt_qtr_exp_join)
);

The grouping column `nxt_qtr_exp_join` appears in an expression.
Otherwise when calling `make_two_stage_agg_plan`, it'll crash in
`generate_multi_stage_tlists` when `reconstruct_agg_info` tring to
reconstruct final target list.
This is because when doing `deconstruct_expr` for the target list,
the unreplaced var can not find match in grouping attrs and it's
also not a const. But `finalize_split_expr` in `reconstruct_agg_info`
expect flat target list containing only the grouping key and the results
of individual aggregate functions. `nxt_qtr_exp_join` is belong to
neither for grouping set (apid,per_name_qtr,start_qtr) and
(apid,per_name_qtr,end_qtr).
0  0x00007f339727503f in __GI___select (nfds=0, readfds=0x0, writefds=0x0, exceptfds=0x0, timeout=0x7ffd97940c10)
   at ../sysdeps/unix/sysv/linux/select.c:41
1  0x000055a43cde9c65 in pg_usleep (microsec=30000000) at pgsleep.c:43
2  0x000055a43cc4a0fd in elog_debug_linger (edata=0x55a43d3c7bc0 <errordata>) at elog.c:4342
3  0x000055a43cc412ea in errfinish (dummy=0) at elog.c:616
4  0x000055a43cc3f94f in ExceptionalCondition (conditionName=0x55a43cf5d34c "!(n < list->length)",
   errorType=0x55a43cf5d0a7 "FailedAssertion", fileName=0x55a43cf5d0a0 "list.c", lineNumber=392) at assert.c:49
5  0x000055a43c981a05 in list_nth_cell (list=0x55a43eb109e0, n=7) at list.c:392
6  0x000055a43c981b32 in list_nth (list=0x55a43eb109e0, n=7) at list.c:428
7  0x000055a43cd4f9d7 in finalize_split_expr_mutator (node=0x55a43eb0f6b0, ctx=0x7ffd979424a0) at cdbgroup.c:3865
8  0x000055a43ca4dcab in expression_tree_mutator (node=0x55a43eb0f658,
    mutator=0x55a43cd4f85b <finalize_split_expr_mutator>, context=0x7ffd979424a0) at clauses.c:4330
......
17 0x000055a43cd4f9fc in finalize_split_expr_mutator (node=0x55a43eb0f878, ctx=0x7ffd979424a0) at cdbgroup.c:3870
18 0x000055a43cd4f859 in finalize_split_expr (expr=0x55a43eb0f878, ctx=0x7ffd979424a0) at cdbgroup.c:3816
19 0x000055a43cd4e9ce in reconstruct_agg_info (ctx=0x7ffd979424a0, p_prelim_tlist=0x7ffd979421b8,
   p_inter_tlist=0x0, p_final_tlist=0x7ffd979421c0, p_final_qual=0x7ffd979421c8) at cdbgroup.c:3388
20 0x000055a43cd4e135 in generate_multi_stage_tlists (ctx=0x7ffd979424a0, p_prelim_tlist=0x7ffd979421b8,
   p_inter_tlist=0x0, p_final_tlist=0x7ffd979421c0, p_final_qual=0x7ffd979421c8) at cdbgroup.c:3113
21 0x000055a43cd49e61 in make_two_stage_agg_plan (root=0x55a43ea0fc38, ctx=0x7ffd979424a0) at cdbgroup.c:1317
22 0x000055a43cd48fd2 in cdb_grouping_planner (root=0x55a43ea0fc38, agg_counts=0x7ffd97942ef0,
   group_context=0x7ffd979426e0) at cdbgroup.c:936
23 0x000055a43ca2f34f in generate_dqa_plan (root=0x55a43ea0fc38, context=0x7ffd97942bd0, rollup_level=2,
   grouping=5, subplans=0x55a43eb02728, subplan_no=0) at plangroupext.c:1195
24 0x000055a43ca3034f in plan_append_aggs_with_rewrite (root=0x55a43ea0fc38, context=0x7ffd97942bd0,
   lefttree=0x55a43eace868) at plangroupext.c:1599
25 0x000055a43ca2eb49 in make_append_aggs_for_rollup (root=0x55a43ea0fc38, context=0x7ffd97942bd0,
   lefttree=0x55a43eace868) at plangroupext.c:1022
26 0x000055a43ca2d059 in make_aggs_for_rollup (root=0x55a43ea0fc38, context=0x7ffd97942bd0,
   lefttree=0x55a43eace868) at plangroupext.c:472
27 0x000055a43ca31e39 in plan_list_rollup_plans (root=0x55a43ea0fc38, context=0x7ffd97942bd0,
   lefttree=0x55a43eac6910) at plangroupext.c:2240
28 0x000055a43ca2cc8e in plan_grouping_extension

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
