### PR TITLE
Make gp_toolkit bloat computation more lenient

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -966,11 +966,20 @@ AS
         SELECT
             oid as btdrelid,
             pgc.relpages as btdrelpages,
-            CEIL((pgc.reltuples * (25 + width))::numeric / current_setting('block_size')::numeric) AS btdexppages,
+            -- The width value is approximate, particularly when
+            -- variable length attributes are involved (see
+            -- WIDTH_THRESHOLD in analyze.c).  Often times, it was
+            -- found to be wrong, leading to "moderate" or
+            -- "significant" bloat being reported when there is
+            -- actually no bloat (e.g. right after vacuum full).
+            -- Therefore, a compensating factor is added that is
+            -- proportional to the number of variable length
+            -- attributes in a table.
+            CEIL((pgc.reltuples * (25 + width + width * (pga.varlen_cnt::numeric / pgc.relnatts::numeric)))::numeric / current_setting('block_size')::numeric) AS btdexppages,
             (select numsegments from gp_toolkit.__gp_number_of_segments) as numsegments
         FROM
             (
-                SELECT pgc.oid, pgc.reltuples, pgc.relpages
+                SELECT pgc.oid, pgc.reltuples, pgc.relpages, pgc.relnatts
                 FROM pg_class pgc
                 WHERE NOT EXISTS
                 (
@@ -994,6 +1003,14 @@ AS
             )
             AS btwcols
         ON pgc.oid = btwcols.starelid
+        LEFT OUTER JOIN
+            (
+                SELECT  attrelid, sum(CASE WHEN attlen = -1 THEN 1 ELSE 0 END) AS varlen_cnt
+                FROM pg_attribute
+                GROUP BY 1
+            )
+            AS pga
+        ON pgc.oid = pga.attrelid
         WHERE starelid IS NOT NULL
     ) AS subq;
 
@@ -1039,8 +1056,8 @@ $$
                 WHEN $1 < 10 AND $2 = 0 THEN -1
                 WHEN $2 = 0 THEN 2
                 WHEN $1 < $2 THEN 0
-                WHEN ($1/$2)::numeric > 10 THEN 2
-                WHEN ($1/$2)::numeric > 3 THEN 1
+                WHEN ($1/$2)::numeric > 12 THEN 2
+                WHEN ($1/$2)::numeric > 5 THEN 1
                 ELSE -1
             END AS bloatidx
     ) AS bloatmapping

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -676,3 +676,22 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
+create database gptoolkit;
+\c gptoolkit
+-- cover "moderate bloat" case
+create table test (a int, b int) distributed by (a);
+insert into test select i, i from generate_series(1,5000)i;
+-- update all rows 4 times, so that relpages is 4 times greater
+-- than expected pages.
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+analyze test;
+select bdinspname, bdirelname, bdirelpages, bdiexppages, bdidiag from gp_toolkit.gp_bloat_diag;
+ bdinspname | bdirelname | bdirelpages | bdiexppages | bdidiag 
+------------+------------+-------------+-------------+---------
+(0 rows)
+
+\c regression
+drop database gptoolkit

--- a/src/test/regress/sql/gp_toolkit.sql
+++ b/src/test/regress/sql/gp_toolkit.sql
@@ -389,3 +389,20 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
+
+create database gptoolkit;
+\c gptoolkit
+-- cover "moderate bloat" case
+create table test (a int, b int) distributed by (a);
+insert into test select i, i from generate_series(1,5000)i;
+-- update all rows 4 times, so that relpages is 4 times greater
+-- than expected pages.
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+analyze test;
+select bdinspname, bdirelname, bdirelpages, bdiexppages, bdidiag from gp_toolkit.gp_bloat_diag;
+
+\c regression
+drop database gptoolkit


### PR DESCRIPTION
The gp_toolkit.gp_bloat_diag view uses average width of a row as
computed from a sample of a relation's blocks (by analyze) and
multiplies it with reltuples to compute expected size of the relation.
The width itself is approximate and using it as a multiplying factor
further increases the error.  Consequently, we have seen confusion in
production deployments where the gp_bloat_diag reported "moderate
bloat" for a relation right after it was vacuumed using "vacuum full".

To fix this confusion, a factor is added to the approximate width
computed from pg_statistic.  The added amount is proportional to the
number of variable length attributes in the relation.  The thresholds
used to report moderate and severe bloat are changed too, so that the
bloat compulation now errors on the side of "not vacuuming".

Co-authored-by: Jinbao Chen <cjinbao@vmware.com>
Reviewed by: Ashwin Agrawal <aashwin@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
