### PR TITLE
Docs: resource group cpu ceiling enforcement

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -382,7 +382,7 @@
             20.</p>
         </section>
         <section>
-          <title>Ceiling performance mode</title>
+          <title>Ceiling Enforcement mode</title>
           <p>This mode is active when <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph> is
             set to <codeph>true</codeph>. The resource group is enforced to not use more CPU
             resources than the defined value <codeph>CPU_RATE_LIMIT</codeph>, avoiding the use of

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -363,8 +363,11 @@
               multiplied by 100, and</li>
             <li>The <codeph>gp_resource_group_cpu_limit</codeph> value.</li>
           </ul></p>
-        <p>There are two different ways of assigning CPU resources, determined by the value of the
-          configuration parameter <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph>.</p>
+        <p>When you configure <codeph>CPU_RATE_LIMIT</codeph> for a resource group, Greenplum
+          Database disables <codeph>CPUSET</codeph> for the group and sets the value to -1.</p>
+        <p>There are two different ways of assigning CPU resources by percentage, determined by the
+          value of the configuration parameter
+            <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph>:</p>
         <section>
           <title>Elastic mode</title>
           <p>This mode is active when <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph> is
@@ -385,8 +388,6 @@
             resources than the defined value <codeph>CPU_RATE_LIMIT</codeph>, avoiding the use of
             the CPU burst feature.</p>
         </section>
-        <p>When you configure <codeph>CPU_RATE_LIMIT</codeph> for a resource group, Greenplum
-          Database disables <codeph>CPUSET</codeph> for the group and sets the value to -1.</p>
       </body>
     </topic>
   </topic>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -363,15 +363,28 @@
               multiplied by 100, and</li>
             <li>The <codeph>gp_resource_group_cpu_limit</codeph> value.</li>
           </ul></p>
-        <p>CPU resource assignment for resource groups configured with a
-            <codeph>CPU_RATE_LIMIT</codeph> is elastic in that Greenplum Database may allocate the
-          CPU resources of an idle resource group to a busier one(s). In such situations, CPU
-          resources are re-allocated to the previously idle resource group when that resource group
-          next becomes active. If multiple resource groups are busy, they are allocated the CPU
-          resources of any idle resource groups based on the ratio of their
-            <codeph>CPU_RATE_LIMIT</codeph>s. For example, a resource group created with a
-            <codeph>CPU_RATE_LIMIT</codeph> of 40 will be allocated twice as much extra CPU resource
-          as a resource group that you create with a <codeph>CPU_RATE_LIMIT</codeph> of 20.</p>
+        <p>There are two different ways of assigning CPU resources, determined by the value of the
+          configuration parameter <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph>.</p>
+        <section>
+          <title>Elastic mode</title>
+          <p>This mode is active when <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph> is
+            set to <codeph>false</codeph> (default). It is elastic in that Greenplum Database may
+            allocate the CPU resources of an idle resource group to a busier one(s). In such
+            situations, CPU resources are re-allocated to the previously idle resource group when
+            that resource group next becomes active. If multiple resource groups are busy, they are
+            allocated the CPU resources of any idle resource groups based on the ratio of their
+              <codeph>CPU_RATE_LIMIT</codeph>s. For example, a resource group created with a
+              <codeph>CPU_RATE_LIMIT</codeph> of 40 will be allocated twice as much extra CPU
+            resource as a resource group that you create with a <codeph>CPU_RATE_LIMIT</codeph> of
+            20.</p>
+        </section>
+        <section>
+          <title>Ceiling performance mode</title>
+          <p>This mode is active when <codeph>gp_resource_group_cpu_ceiling_enforcement</codeph> is
+            set to <codeph>true</codeph>. The resource group is enforced to not use more CPU
+            resources than the defined value <codeph>CPU_RATE_LIMIT</codeph>, avoiding the use of
+            the CPU burst feature.</p>
+        </section>
         <p>When you configure <codeph>CPU_RATE_LIMIT</codeph> for a resource group, Greenplum
           Database disables <codeph>CPUSET</codeph> for the group and sets the value to -1.</p>
       </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4268,8 +4268,8 @@
   <topic id="gp_resource_group_cpu_ceiling_enforcement">
     <title>gp_resource_group_cpu_ceiling_enforcement</title>
     <body>
-      <p>Enables the Ceiling Performance mode when assigning CPU resources. When disabled, the
-        Elastic mode will be used. </p>
+      <p>Enables the Ceiling Performance mode when assigning CPU resources by Percentage. When
+        disabled, the Elastic mode will be used. </p>
       <table id="table_wtb_y2g_fpb">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -264,6 +264,12 @@
             <li>
               <xref href="#gp_hashjoin_tuples_per_bucket"/>
             </li>
+            <li><xref href="#gp_resgroup_memory_policy"/></li>
+            <li><xref href="#gp_resource_group_bypass"/></li>
+            <li><xref href="#gp_resource_group_cpu_ceiling_enforcement"/></li>
+            <li><xref href="#gp_resource_group_cpu_limit"/></li>
+            <li><xref href="#gp_resource_group_memory_limit"/></li>
+            <li><xref href="#gp_resource_group_queuing_timeout"/></li>
             <li>
               <xref href="#gp_resource_manager"/>
             </li>
@@ -4253,6 +4259,34 @@
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">false</entry>
               <entry colname="col3">session</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_resource_group_cpu_ceiling_enforcement">
+    <title>gp_resource_group_cpu_ceiling_enforcement</title>
+    <body>
+      <p>Enables the Ceiling Performance mode when assigning CPU resources. When disabled, the
+        Elastic mode will be used. </p>
+      <table id="table_wtb_y2g_fpb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">false</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4268,7 +4268,7 @@
   <topic id="gp_resource_group_cpu_ceiling_enforcement">
     <title>gp_resource_group_cpu_ceiling_enforcement</title>
     <body>
-      <p>Enables the Ceiling Performance mode when assigning CPU resources by Percentage. When
+      <p>Enables the Ceiling Enforcement mode when assigning CPU resources by Percentage. When
         disabled, the Elastic mode will be used. </p>
       <table id="table_wtb_y2g_fpb">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1140,6 +1140,9 @@
             <xref href="guc-list.xml#gp_resource_group_bypass" type="section"
               >gp_resource_group_bypass</xref>
             <p>
+              <xref href="guc-list.xml#gp_resource_group_cpu_ceiling_enforcement" type="section"
+                >gp_resource_group_cpu_ceiling_enforcement</xref>
+            </p><p>
               <xref href="guc-list.xml#gp_resource_group_cpu_limit" type="section"
                 >gp_resource_group_cpu_limit</xref>
             </p><p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -141,6 +141,7 @@
             <topicref href="guc-list.xml#gp_resqueue_priority_sweeper_interval"/>
             <topicref href="guc-list.xml#gp_resgroup_memory_policy"/>
             <topicref href="guc-list.xml#gp_resource_group_bypass"/>
+            <topicref href="guc-list.xml#gp_resource_group_cpu_ceiling_enforcement"/>
             <topicref href="guc-list.xml#gp_resource_group_cpu_limit"/>
             <topicref href="guc-list.xml#gp_resource_group_memory_limit"/>
             <topicref href="guc-list.xml#gp_resource_group_queuing_timeout"/>


### PR DESCRIPTION
Documenting PR: https://github.com/greenplum-db/gpdb/pull/11678 
Added reference under Assigning CPU Resources by Percentage and new GUC in the utility reference.
Preview link (needs VPN):
https://mireia-cpu-resources.sc2-04-pcf1-apps.oc.vmware.com/7-0/admin_guide/workload_mgmt_resgroups.html
https://mireia-cpu-resources.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/config_params/guc-list.html#gp_resource_group_cpu_ceiling_enforcement