### PR TITLE
Fix the bug that the global transacation is not aborted when the session is reset.

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -751,7 +751,7 @@ cdbcomponent_destroyCdbComponents(void)
 /*
  * Allocated a segdb
  *
- * If thers is idle segdb in the freelist, return it, otherwise, initialize
+ * If there is idle segdb in the freelist, return it, otherwise, initialize
  * a new segdb.
  *
  * idle segdbs has an established connection with segment, but new segdb is

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -25,6 +25,7 @@
 #include <sys/poll.h>
 #endif
 
+#include "access/xact.h"
 #include "storage/ipc.h"		/* For proc_exit_inprogress  */
 #include "tcop/tcopprot.h"
 #include "libpq-fe.h"
@@ -77,6 +78,23 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	/* allocate and initialize a gang structure */
 	newGangDefinition = buildGangDefinition(segments, segmentType);
 	CurrentGangCreating = newGangDefinition;
+	/*
+	 * If we're in a global transaction, and there is some primary segment down,
+	 * we have to error out so that the current global transaction can be aborted.
+	 * Before error out, we need to clean up QEs, destroy the gang, and reset
+	 * the session.
+	 */
+	if (IsTransactionState())
+	{
+		for (i = 0; i < size; i++)
+		{
+			if (FtsIsSegmentDown(newGangDefinition->db_descriptors[i]->segment_database_info))
+			{
+				DisconnectAndDestroyAllGangs(true);
+				elog(ERROR, "gang was lost due to cluster reconfiguration");
+			}
+		}
+	}
 	totalSegs = getgpsegmentCount();
 	Assert(totalSegs > 0);
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -83,6 +83,9 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	 * we have to error out so that the current global transaction can be aborted.
 	 * Before error out, we need to clean up QEs, destroy the gang, and reset
 	 * the session.
+	 * We shouldn't error out in transaction abort state to avoid recursive abort.
+	 * In such case, the dispatcher would catch the error and then dtm does (retry)
+	 * abort.
 	 */
 	if (IsTransactionState())
 	{

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -134,7 +134,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
@@ -142,12 +142,12 @@ ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
 ----+----
 (0 rows)
 3:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 4:select * from tmp4;
 ERROR:  relation "tmp4" does not exist
 LINE 1: select * from tmp4;
@@ -155,7 +155,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 5:ROLLBACK TO SAVEPOINT s1;
 ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 5:END;

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -142,7 +142,9 @@ ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
 ----+----
 (0 rows)
 3:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session
 --            is reset

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -134,7 +134,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
@@ -149,7 +149,7 @@ ERROR: server closed the connection unexpectedly
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 4:select * from tmp4;
 ERROR:  relation "tmp4" does not exist
 LINE 1: select * from tmp4;
@@ -157,7 +157,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 5:ROLLBACK TO SAVEPOINT s1;
 ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 5:END;

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -1,0 +1,116 @@
+-- This test performs segment reconfiguration when a distributed
+-- transaction is in progress. The expectation is that the first
+-- command in the transaction after reconfiguration should fail. It
+-- verifies a bug where a stale gang was reused in such a case, if the
+-- failed primary happened to be up and listening.
+
+-- set these values purely to cut down test time, as default ts trigger is
+-- every min and 5 retries
+alter system set gp_fts_probe_interval to 10;
+ALTER
+alter system set gp_fts_probe_retries to 0;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+create table test_fts_session_reset(c1 int);
+CREATE
+
+CREATE or REPLACE FUNCTION wait_until_primary_down() RETURNS VOID AS $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select status = 'd' from gp_segment_configuration where content = 0 and role = 'm') then /* in func */ return; /* in func */ end if; /* in func */ perform pg_sleep(1); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+1:BEGIN;
+BEGIN
+-- let the dispatcher create a gang
+1:insert into test_fts_session_reset select * from generate_series(1,20);
+INSERT 20
+1:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1:select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+1:select wait_until_primary_down();
+ wait_until_primary_down 
+-------------------------
+                         
+(1 row)
+-- At this point, content 0 mirror is promoted and the primary is marked down.
+-- the gang used by the previous insert is no longer valid. It must be destroyed
+-- and the transaction must be aborted.
+1:insert into test_fts_session_reset select * from generate_series(21,40);
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+1:select count(*) from test_fts_session_reset;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+1:END;
+END
+1:select count(*) from test_fts_session_reset;
+ count 
+-------
+ 0     
+(1 row)
+2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- expect one primary is down and mirror is promoted to primary
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0 order by role;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | m    | d      | n    
+ 0       | m              | p    | u      | n    
+(2 rows)
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+alter system reset gp_fts_probe_interval;
+ALTER
+alter system reset gp_fts_probe_retries;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -44,7 +44,7 @@ INSERT 20
 -- the gang used by the previous insert is no longer valid. It must be destroyed
 -- and the transaction must be aborted.
 1:insert into test_fts_session_reset select * from generate_series(21,40);
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 1:select count(*) from test_fts_session_reset;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 1:END;

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -19,28 +19,26 @@ select pg_reload_conf();
 create table test_fts_session_reset(c1 int);
 CREATE
 
-CREATE or REPLACE FUNCTION wait_until_primary_down() RETURNS VOID AS $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select status = 'd' from gp_segment_configuration where content = 0 and role = 'm') then /* in func */ return; /* in func */ end if; /* in func */ perform pg_sleep(1); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE
-
 1:BEGIN;
 BEGIN
 -- let the dispatcher create a gang
 1:insert into test_fts_session_reset select * from generate_series(1,20);
 INSERT 20
-1:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
+-- this injected fault can make dispatcher think the primary is down
+2:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1:select gp_request_fts_probe_scan();
+2:select gp_request_fts_probe_scan();
  gp_request_fts_probe_scan 
 ---------------------------
  t                         
 (1 row)
-1:select wait_until_primary_down();
- wait_until_primary_down 
--------------------------
-                         
+2:select status = 'd' from gp_segment_configuration where content = 0 and role = 'm';
+ ?column? 
+----------
+ t        
 (1 row)
 -- At this point, content 0 mirror is promoted and the primary is marked down.
 -- the gang used by the previous insert is no longer valid. It must be destroyed

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -208,6 +208,7 @@ test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
 test: segwalrep/dtx_recovery_wait_lsn
 test: fts_manual_probe
+test: fts_session_reset
 
 # Reindex tests
 test: reindex/abort_reindex

--- a/src/test/isolation2/sql/fts_session_reset.sql
+++ b/src/test/isolation2/sql/fts_session_reset.sql
@@ -12,25 +12,13 @@ select pg_reload_conf();
 
 create table test_fts_session_reset(c1 int);
 
-CREATE or REPLACE FUNCTION wait_until_primary_down()
-RETURNS VOID AS
-$$
-begin /* in func */
-  for i in 1..120 loop /* in func */
-    if (select status = 'd' from gp_segment_configuration where content = 0 and role = 'm') then /* in func */
-      return; /* in func */
-    end if; /* in func */
-    perform pg_sleep(1); /* in func */
-  end loop; /* in func */
-end; /* in func */
-$$ language plpgsql;
-
 1:BEGIN;
 -- let the dispatcher create a gang
 1:insert into test_fts_session_reset select * from generate_series(1,20);
-1:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
-1:select gp_request_fts_probe_scan();
-1:select wait_until_primary_down();
+-- this injected fault can make dispatcher think the primary is down
+2:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
+2:select gp_request_fts_probe_scan();
+2:select status = 'd' from gp_segment_configuration where content = 0 and role = 'm';
 -- At this point, content 0 mirror is promoted and the primary is marked down. 
 -- the gang used by the previous insert is no longer valid. It must be destroyed 
 -- and the transaction must be aborted.

--- a/src/test/isolation2/sql/fts_session_reset.sql
+++ b/src/test/isolation2/sql/fts_session_reset.sql
@@ -1,0 +1,66 @@
+-- This test performs segment reconfiguration when a distributed 
+-- transaction is in progress. The expectation is that the first 
+-- command in the transaction after reconfiguration should fail. It 
+-- verifies a bug where a stale gang was reused in such a case, if the 
+-- failed primary happened to be up and listening.
+
+-- set these values purely to cut down test time, as default ts trigger is
+-- every min and 5 retries
+alter system set gp_fts_probe_interval to 10;
+alter system set gp_fts_probe_retries to 0;
+select pg_reload_conf();
+
+create table test_fts_session_reset(c1 int);
+
+CREATE or REPLACE FUNCTION wait_until_primary_down()
+RETURNS VOID AS
+$$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select status = 'd' from gp_segment_configuration where content = 0 and role = 'm') then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform pg_sleep(1); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+1:BEGIN;
+-- let the dispatcher create a gang
+1:insert into test_fts_session_reset select * from generate_series(1,20);
+1:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
+1:select gp_request_fts_probe_scan();
+1:select wait_until_primary_down();
+-- At this point, content 0 mirror is promoted and the primary is marked down. 
+-- the gang used by the previous insert is no longer valid. It must be destroyed 
+-- and the transaction must be aborted.
+1:insert into test_fts_session_reset select * from generate_series(21,40);
+1:select count(*) from test_fts_session_reset;
+1:END;
+1:select count(*) from test_fts_session_reset;
+2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
+1q:
+2q:
+
+-- expect one primary is down and mirror is promoted to primary
+select content, preferred_role, role, status, mode
+from gp_segment_configuration
+where content = 0 order by role;
+
+!\retcode gprecoverseg -aF --no-progress;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+
+alter system reset gp_fts_probe_interval;
+alter system reset gp_fts_probe_retries;
+select pg_reload_conf();
+


### PR DESCRIPTION
If FTS changed cluster configuration in between two commands within a
transaction, the session is reset and the global transaction should be aborted.

fts_session_reset.sql is the test case for the this fix.
An new expected file fts_errors_1.out is added for fts_errors.sql. That is because,
with gp_interconnect_type "tcp" or "udpifc", the outputs of "END" statement in session#3 are different.

For interconnect type "tcp", when "END" statement is executed, function CommitTransaction
is called, then function mppExecutorFinishup throws QE error. The error is catched and the function
AbortTransaction is called to abort the transaction, a new gang is created to dispach command:
DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED, at this point, the transaction is not in progress,
so the check for FTS is down from line:87 in function cdbgang_createGang_async won't be exected.

For interconnect type "udpifc", when "END" statement is executed, function CommitTransaction
is called, then function mppExecutorFinishup can't detect connection error and won't throw QE error.
The function CommitTransaction will create a new gang and dispach command:DTX_PROTOCOL_COMMAND_PREPARE,
at this point, the transaction is still in progress, then the check for FTS is down will be exectued.
That's why with gp_interconnect_type "tcp" or "udpifc", the outputs are different.

Co-authored-by: Asim R P <pasim@vmware.com>
