### PR TITLE
Allow fuzzing of gpdb

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -72,7 +72,11 @@ ifneq ($(PORTNAME), win32)
 ifneq ($(PORTNAME), aix)
 
 postgres: $(OBJS)
-	$(CXX) $(CXXFLAGS) $(call expand_subsys,$^) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(LIBS) -o $@
+ifeq ($(OSS_FUZZ),ON)
+	$(CXX) $(CXXFLAGS) $(LIB_FUZZING_ENGINE) $(filter-out main/main.o,$(call expand_subsys,$^)) $(LDFLAGS) $(LDFLAGS_EX) -o /out/fuzzer -lpthread
+else
+	$(CXX) $(CXXFLAGS) $(filter-out parser/fuzzer.o,$(call expand_subsys,$^)) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(LIBS) -o $@
+endif
 
 endif
 endif

--- a/src/backend/parser/Makefile
+++ b/src/backend/parser/Makefile
@@ -12,7 +12,7 @@ include $(top_builddir)/src/Makefile.global
 
 override CPPFLAGS := -I. -I$(srcdir) $(CPPFLAGS)
 
-OBJS= analyze.o gram.o scan.o parser.o \
+OBJS= analyze.o gram.o scan.o parser.o fuzzer.o \
       parse_agg.o parse_clause.o parse_coerce.o parse_collate.o parse_cte.o \
       parse_enr.o parse_expr.o parse_func.o parse_node.o parse_oper.o \
       parse_param.o parse_relation.o parse_target.o parse_type.o \

--- a/src/backend/parser/fuzzer.c
+++ b/src/backend/parser/fuzzer.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "postgres.h"
+#include "common/unicode_norm.h"
+#include "utils/memutils.h"
+
+const char *progname;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+	if(size<5) {
+		return 1;
+	}
+
+	// Null-terminate input test case
+	char *new_str = (char *)malloc(size+1);
+	if (new_str == NULL){
+		return 0;
+	}
+	memcpy(new_str, data, size);
+	new_str[size] = '\0';
+
+	MemoryContextInit();
+	pg_wchar   *pg_data, *result;
+	int			data_len;
+
+	pg_data = (pg_wchar *) palloc(((int)size + 2) * sizeof(pg_wchar));
+	data_len = pg_mb2wchar(new_str, pg_data);
+	result = unicode_normalize_kc(pg_data);
+	
+	free(new_str);
+	pfree(pg_data);
+	pfree(result);
+	return 0;
+}


### PR DESCRIPTION
Hi all!

This is [Adam](https://twitter.com/AdamKorcz4) from [Ada Logics](https://adalogics.com/). I secure critical open source software and have worked on the initial setup for fuzzing gpdb continuously.

For those unaware: Fuzzing is a method of testing software whereby pseudo-random data is passed to a target entrypoint with the goal of finding bugs and vulnerabilities. A number of database projects use this kind of testing which has revealed a bunch of bugs. 

In this PR I submit upstream changes to gpdb that will allow it to be fuzzed continuously by Googles [OSS-fuzz](https://github.com/google/oss-fuzz) project.

I have set up a draft integration application on the OSS-fuzz side to demonstrate that the current changes pass all tests: https://github.com/google/oss-fuzz/pull/5594 

**A few notes about this PR:**
A few changes have been added to two makefiles. These allow the added fuzzer to be built by GPDB’s existing build system. This allows for easy addition of future fuzzers. 
The place that these changes are made is wrong. The fuzzer in this PR should not be placed in the parser directory, and at the same time I do not know where it should be placed. Currently the PR demonstrates a working prototype of _which_ changes need to be made, and I leave it to the maintainers to comment on _where_ they should be made. For example, is a dedicated “Fuzz” directory preferred or would you like to place the fuzzers in the folders of the code that they target?

The fuzzer is a working prototype to allow future fuzzers to be built upon. Please note that Postgres is already being fuzzed by OSS-fuzz (https://github.com/google/oss-fuzz/tree/master/projects/postgresql). I would be happy to improve the fuzzing efforts in the future, and my strong recommendation hereof is to start with the initial integration and then in separate iterations add more complex fuzzers. Again, I will be happy to add more fuzzers, and I will appreciate any feedback about productive targets including code that is specific to gpdb and that will not be reached by the existing Postgres fuzzers.

To finalize this initial integration into OSS-fuzz, the following steps have to be taken:

1. The fuzzer has to be moved to a relevant directory. This is optional as fuzzers _can_ be placed on the OSS-fuzz repository, however it allows for much more flexibility to have the fuzzers upstream.
2. A maintainers email address has to be added to the project.yaml file on the OSS-fuzz side. This is for bug reports.
