### PR TITLE
[5X Only]Fix the bug that it can not re-order the expansion segments into thei…

### DIFF
--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -59,13 +59,19 @@ Datum		create_empty_extension(PG_FUNCTION_ARGS);
 
 Datum		view_has_anyarray_casts(PG_FUNCTION_ARGS);
 
+Datum		view_has_unknown_casts(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(add_pg_enum_label);
 
 PG_FUNCTION_INFO_V1(create_empty_extension);
 
 PG_FUNCTION_INFO_V1(view_has_anyarray_casts);
 
+PG_FUNCTION_INFO_V1(view_has_unknown_casts);
+
 static bool check_node_anyarray_walker(Node *node, void *context);
+
+static bool check_node_unknown_walker(Node *node, void *context);
 
 Datum
 add_pg_enum_label(PG_FUNCTION_ARGS)
@@ -720,4 +726,68 @@ check_node_anyarray_walker(Node *node, void *context)
 
 	return expression_tree_walker(node, check_node_anyarray_walker,
 								  context);
+}
+
+Datum
+view_has_unknown_casts(PG_FUNCTION_ARGS)
+{
+	Oid			view_oid = PG_GETARG_OID(0);
+	Relation 	rel = try_relation_open(view_oid, AccessShareLock, false);
+	Query		*viewquery;
+	bool		found;
+
+	if (rel == NULL)
+		elog(ERROR, "Could not open relation file for relation oid %u", view_oid);
+
+	if(rel->rd_rel->relkind == RELKIND_VIEW)
+	{
+		viewquery = get_view_query(rel);
+		found = query_tree_walker(viewquery, check_node_unknown_walker, NULL, 0);
+	}
+	else
+		found = false;
+
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_BOOL(found);
+}
+
+static bool
+check_node_unknown_walker(Node *node, void *context)
+{
+	Assert(context == NULL);
+
+	if (node == NULL)
+		return false;
+
+	/*
+	 * Look only at FuncExpr since the GPDB special handling hack for unknown
+	 * types is only applied to FuncExpr. See parse_coerce.c: coerce_type()
+	 */
+	if (IsA(node, FuncExpr))
+	{
+		FuncExpr *fe = (FuncExpr *) node;
+		/*
+		 * Check to see if the FuncExpr has an unknown::cstring cast.
+		 *
+		 * If it has no such cast yet, check its arguments.
+		 */
+		if ((fe->funcresulttype != CSTRINGOID) || !fe->args || (list_length(fe->args) != 1))
+			return expression_tree_walker(node, check_node_unknown_walker, context);
+
+		Node *head = lfirst(((List *)fe->args)->head);
+
+		if (IsA(head, Var) && ((Var *)head)->vartype == UNKNOWNOID)
+			return true;
+		else
+			return expression_tree_walker(node, check_node_unknown_walker, context);
+	}
+	else if (IsA(node, Query))
+	{
+		/* recurse into subselects and ctes */
+		Query *query = (Query *) node;
+		return query_tree_walker(query, check_node_unknown_walker, context, 0);
+	}
+
+	return expression_tree_walker(node, check_node_unknown_walker, context);
 }

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -453,6 +453,8 @@ class GpDB:
             cmd.run(validateAfter = True)
             MakeDirectory.local("gpexpand make directory to hold file spaces", fullPathFsDir)
             for oid in self.__filespaces:
+                if oid == SYSTEM_FILESPACE:
+                    continue
                 MakeDirectory.local("gpexpand make directory to hold file space oid: " + str(oid), fullPathFsDir)
                 dir = self.__filespaces[oid]
                 destDir = fullPathFsDir + "/" + str(oid)

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -387,7 +387,7 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(infunc));
 
 			/* do unknownout(Var) */
-			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node), cformat);
+			fe = makeFuncExpr(outfunc, TEXTOID, list_make1(node), cformat);
 			fe->location = location;
 
 			if (location >= 0 &&

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -123,4 +123,26 @@ SELECT pg_get_viewdef('view_with_array_op_expr');
 -----------------------------------------------
  SELECT ('{1}'::integer[] = '{2}'::integer[]);
 (1 row)
- 
+
+-- Coerce unknown-type literals to type text
+CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
+WARNING:  column "field_unknown" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
+\d+ unknown_v2
+                 View "public.unknown_v2"
+    Column     | Type | Modifiers | Storage | Description 
+---------------+------+-----------+---------+-------------
+ field_unknown | date |           | plain   | 
+View definition:
+ SELECT unknown_v1.field_unknown::text::date AS field_unknown
+   FROM unknown_v1;
+
+SELECT * FROM unknown_v2;
+ field_unknown 
+---------------
+ 12-13-2020
+(1 row)
+
+DROP VIEW unknown_v2;
+DROP VIEW unknown_v1;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -68,3 +68,11 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 -- correct internal representation
 CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
 SELECT pg_get_viewdef('view_with_array_op_expr');
+
+-- Coerce unknown-type literals to type text
+CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
+CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
+\d+ unknown_v2
+SELECT * FROM unknown_v2;
+DROP VIEW unknown_v2;
+DROP VIEW unknown_v1;


### PR DESCRIPTION
When running gpexpand utility, it can not re-order the segments into their proper positions in the method of reOrderExpansionSegs. Since there is a bug that the newExpansionSegments variable is assigned to the last element of the gparray.expansionSegments list. However, it should be assigned to the gparray.expansionSegments list.

Please see the log below:
(Pdb) p dir(self.gparray.expansionSegments[0])
['__doc__', '__init__', '__module__', '__str__', 'addMirror', 'addPrimary', 'get_dbs', 'get_hosts', 'is_segment_pair_valid', 'mirrorDBs', 'primaryDB']
(Pdb) p dir(self.gparray.expansionSegments[1])
['__doc__', '__init__', '__module__', '__str__', 'addMirror', 'addPrimary', **'expansionSegments'**, 'get_dbs', 'get_hosts', 'is_segment_pair_valid', 'mirrorDBs', 'primaryDB']


