### PR TITLE
FIXME: retrieve append only table entry atts in one call

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2082,28 +2082,14 @@ appendonly_fetch_init(Relation relation,
 					  Snapshot snapshot,
 					  Snapshot appendOnlyMetaDataSnapshot)
 {
-	AppendOnlyFetchDesc aoFetchDesc;
+	AppendOnlyFetchDesc				aoFetchDesc;
+	AppendOnlyStorageAttributes	   *attr;
+	PGFunction					   *fns;
+	StringInfoData					titleBuf;
+	FormData_pg_appendonly			aoFormData;
+	int								segno;
 
-	AppendOnlyStorageAttributes *attr;
-
-	PGFunction *fns;
-
-	StringInfoData titleBuf;
-	int32 blocksize;
-	int32 safefswritesize;
-	int16 compresslevel;
-	bool checksum;
-	NameData compresstype;
-	Oid			segrelid;
-	Oid			visimaprelid;
-	Oid			visimapidxid;
-
-	/* GPDB_12_MERGE_FIXME: Consolidate these calls together. */
-	GetAppendOnlyEntryAttributes(relation->rd_id, &blocksize, &safefswritesize, &compresslevel, &checksum, &compresstype);
-
-	GetAppendOnlyEntryAuxOids(relation->rd_id, NULL, &segrelid, NULL, NULL, &visimaprelid, &visimapidxid);
-
-	int segno;
+	GetAppendOnlyEntry(relation->rd_id, &aoFormData);
 
 	/*
 	 * increment relation ref count while scanning relation
@@ -2143,8 +2129,8 @@ appendonly_fetch_init(Relation relation,
 	/*
 	 * These attributes describe the AppendOnly format to be scanned.
 	 */
-	if (strcmp(NameStr(compresstype), "") == 0 ||
-		pg_strcasecmp(NameStr(compresstype), "none") == 0)
+	if (strcmp(NameStr(aoFormData.compresstype), "") == 0 ||
+		pg_strcasecmp(NameStr(aoFormData.compresstype), "none") == 0)
 	{
 		attr->compress = false;
 		attr->compressType = "none";
@@ -2152,12 +2138,12 @@ appendonly_fetch_init(Relation relation,
 	else
 	{
 		attr->compress = true;
-		attr->compressType = NameStr(compresstype);
+		attr->compressType = NameStr(aoFormData.compresstype);
 	}
-	attr->compressLevel = compresslevel;
-	attr->checksum = checksum;
-	attr->safeFSWriteSize = safefswritesize;
-	aoFetchDesc->usableBlockSize = blocksize;
+	attr->compressLevel = aoFormData.compresslevel;
+	attr->checksum = aoFormData.checksum;
+	attr->safeFSWriteSize = aoFormData.safefswritesize;
+	aoFetchDesc->usableBlockSize = aoFormData.blocksize;
 
 	/*
 	 * Get information about all the file segments we need to scan
@@ -2169,7 +2155,7 @@ appendonly_fetch_init(Relation relation,
 						  &aoFetchDesc->totalSegfiles);
 	for (segno = 0; segno < AOTupleId_MultiplierSegmentFileNum; ++segno)
 	{
-		aoFetchDesc->lastSequence[segno] = ReadLastSequence(segrelid, segno);
+		aoFetchDesc->lastSequence[segno] = ReadLastSequence(aoFormData.segrelid, segno);
 	}
 
 	AppendOnlyStorageRead_Init(
@@ -2181,7 +2167,7 @@ appendonly_fetch_init(Relation relation,
 							   &aoFetchDesc->storageAttributes);
 
 
-	fns = get_funcs_for_compression(NameStr(compresstype));
+	fns = get_funcs_for_compression(NameStr(aoFormData.compresstype));
 	aoFetchDesc->storageRead.compression_functions = fns;
 
 	if (fns)
@@ -2190,9 +2176,9 @@ appendonly_fetch_init(Relation relation,
 		CompressionState *cs;
 		StorageAttributes sa;
 
-		sa.comptype = NameStr(compresstype);
-		sa.complevel = compresslevel;
-		sa.blocksize = blocksize;
+		sa.comptype = NameStr(aoFormData.compresstype);
+		sa.complevel = aoFormData.compresslevel;
+		sa.blocksize = aoFormData.blocksize;
 
 
 		cs = callCompressionConstructor(cons, RelationGetDescr(relation),
@@ -2219,8 +2205,8 @@ appendonly_fetch_init(Relation relation,
 											NULL);
 
 	AppendOnlyVisimap_Init(&aoFetchDesc->visibilityMap,
-						   visimaprelid,
-						   visimapidxid,
+						   aoFormData.visimaprelid,
+						   aoFormData.visimapidxid,
 						   AccessShareLock,
 						   appendOnlyMetaDataSnapshot);
 
@@ -2368,10 +2354,9 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 	{
 #ifdef USE_ASSERT_CHECKING
 		/*
-		 * GPDB_12_MERGE_FIXME: we are getting this warning after building a
-		 * btree index.  May be, something changed in the way the index access
-		 * method returns the TIDs?  Does that warning make sense if scan
-		 * direction is backwards?
+		 * Currently, we only support Index Scan on bitmap index and Bitmap Index Scan
+		 * on AO tables, so normally the below warning should not happen.
+		 * See get_index_paths in indxpath.c.
 		 */
 		if (segmentFileNum < aoFetchDesc->currentSegmentFile.num)
 			ereport(WARNING,

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -122,11 +122,10 @@ GetAppendOnlyEntryAttributes(Oid relid,
 {
 	Relation	pg_appendonly;
 	TupleDesc	tupDesc;
-	ScanKeyData key[1];
-	SysScanDesc scan;
+	ScanKeyData	key[1];
+	SysScanDesc	scan;
 	HeapTuple	tuple;
-	bool isNull;
-	Datum dat;
+	Form_pg_appendonly	aoForm;
 
 	pg_appendonly = table_open(AppendOnlyRelationId, AccessShareLock);
 	tupDesc = RelationGetDescr(pg_appendonly);
@@ -145,80 +144,21 @@ GetAppendOnlyEntryAttributes(Oid relid,
 				 errmsg("missing pg_appendonly entry for relation \"%s\"",
 						get_rel_name(relid))));
 
+	aoForm = (Form_pg_appendonly) GETSTRUCT(tuple);
 	if (blocksize != NULL)
-	{
-		dat = heap_getattr(tuple,
-							  Anum_pg_appendonly_blocksize,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid segrelid value: NULL")));
-
-		*blocksize = DatumGetInt32(dat);
-	}
+		*blocksize = aoForm->blocksize;
 
 	if (safefswritesize != NULL)
-	{
-		dat = heap_getattr(tuple,
-							  Anum_pg_appendonly_safefswritesize,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid segrelid value: NULL")));
-
-		*safefswritesize = DatumGetInt32(dat);
-	}
+		*safefswritesize = aoForm->safefswritesize;
 
 	if (compresslevel != NULL)
-	{
-		dat = heap_getattr(tuple,
-							  Anum_pg_appendonly_compresslevel,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid segrelid value: NULL")));
-
-		*compresslevel = DatumGetInt16(dat);
-	}
+		*compresslevel = aoForm->compresslevel;
 
 	if (checksum != NULL)
-	{
-		dat = heap_getattr(tuple,
-							  Anum_pg_appendonly_checksum,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid segrelid value: NULL")));
-
-		*checksum = DatumGetBool(dat);
-	}
+		*checksum = aoForm->checksum;
 
 	if (compresstype != NULL)
-	{
-		dat = heap_getattr(tuple,
-							  Anum_pg_appendonly_compresstype,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid segrelid value: NULL")));
-
-		*compresstype = *DatumGetName(dat);
-	}
+		namestrcpy(compresstype, NameStr(aoForm->compresstype));
 
 	/* Finish up scan and close pg_appendonly catalog. */
 	systable_endscan(scan);
@@ -249,12 +189,11 @@ GetAppendOnlyEntryAuxOids(Oid relid,
 	ScanKeyData key[1];
 	SysScanDesc scan;
 	HeapTuple	tuple;
-	Datum auxOid;
-	bool isNull;
-	
+	Form_pg_appendonly	aoForm;
+
 	/*
-	 * Check the pg_appendonly relation to be certain the ao table 
-	 * is there. 
+	 * Check the pg_appendonly relation to be certain the ao table
+	 * is there.
 	 */
 	pg_appendonly = table_open(AppendOnlyRelationId, AccessShareLock);
 	tupDesc = RelationGetDescr(pg_appendonly);
@@ -273,80 +212,62 @@ GetAppendOnlyEntryAuxOids(Oid relid,
 				 errmsg("missing pg_appendonly entry for relation \"%s\"",
 						get_rel_name(relid))));
 
+	aoForm = (Form_pg_appendonly) GETSTRUCT(tuple);
+
 	if (segrelid != NULL)
-	{
-		auxOid = heap_getattr(tuple,
-							  Anum_pg_appendonly_segrelid,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid segrelid value: NULL")));	
-		
-		*segrelid = DatumGetObjectId(auxOid);
-	}
+		*segrelid = aoForm->segrelid;
 
 	if (blkdirrelid != NULL)
-	{
-		auxOid = heap_getattr(tuple,
-							  Anum_pg_appendonly_blkdirrelid,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid blkdirrelid value: NULL")));	
-		
-		*blkdirrelid = DatumGetObjectId(auxOid);
-	}
+		*blkdirrelid = aoForm->blkdirrelid;
 
 	if (blkdiridxid != NULL)
-	{
-		auxOid = heap_getattr(tuple,
-							  Anum_pg_appendonly_blkdiridxid,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid blkdiridxid value: NULL")));	
-		
-		*blkdiridxid = DatumGetObjectId(auxOid);
-	}
+		*blkdiridxid = aoForm->blkdiridxid;
 
 	if (visimaprelid != NULL)
-	{
-		auxOid = heap_getattr(tuple,
-							  Anum_pg_appendonly_visimaprelid,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid visimaprelid value: NULL")));	
-		
-		*visimaprelid = DatumGetObjectId(auxOid);
-	}
+		*visimaprelid = aoForm->visimaprelid;
 
 	if (visimapidxid != NULL)
-	{
-		auxOid = heap_getattr(tuple,
-							  Anum_pg_appendonly_visimapidxid,
-							  tupDesc,
-							  &isNull);
-		Assert(!isNull);
-		if(isNull)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid visimapidxid value: NULL")));	
-		
-		*visimapidxid = DatumGetObjectId(auxOid);
-	}
+		*visimapidxid = aoForm->visimapidxid;
+
+	/* Finish up scan and close pg_appendonly catalog. */
+	systable_endscan(scan);
+	table_close(pg_appendonly, AccessShareLock);
+}
+
+void
+GetAppendOnlyEntry(Oid relid, Form_pg_appendonly aoEntry)
+{
+	Relation	pg_appendonly;
+	TupleDesc	tupDesc;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	Form_pg_appendonly	aoForm;
+
+	/*
+	 * Check the pg_appendonly relation to be certain the ao table
+	 * is there.
+	 */
+	pg_appendonly = table_open(AppendOnlyRelationId, AccessShareLock);
+	tupDesc = RelationGetDescr(pg_appendonly);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_appendonly_relid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(pg_appendonly, AppendOnlyRelidIndexId, true,
+							  NULL, 1, key);
+	tuple = systable_getnext(scan);
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("missing pg_appendonly entry for relation \"%s\"",
+						get_rel_name(relid))));
+
+	aoForm = (Form_pg_appendonly) GETSTRUCT(tuple);
+	memcpy(aoEntry, aoForm, APPENDONLY_TUPLE_SIZE);
+
 	/* Finish up scan and close pg_appendonly catalog. */
 	systable_endscan(scan);
 	table_close(pg_appendonly, AccessShareLock);

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -146,6 +146,9 @@ GetAppendOnlyEntryAuxOids(Oid relid,
 						  Oid *visimaprelid,
 						  Oid *visimapidxid);
 
+
+void
+GetAppendOnlyEntry(Oid relid, Form_pg_appendonly aoEntry);
 /*
  * Update the segrelid and/or blkdirrelid if the input new values
  * are valid OIDs.


### PR DESCRIPTION
Retrieve append only table entry atts in one function call
in appendonly_fetch_init.

Also refactor GetAppendOnlyEntryAttributes and GetAppendOnlyEntryAuxOids.
There is no need to check NULL for pg_appendonly catalog entries since
InsertAppendOnlyEntry never insert NULL values.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
