### PR TITLE
Use 64 bits vertex ID for GDD

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4874,7 +4874,9 @@ ListAllGxid(void)
 		gxid = tmGxact->gxid;
 		if (gxid == InvalidDistributedTransactionId)
 			continue;
-		gxids = lappend_int(gxids, gxid);
+		DistributedTransactionId *pgxid = palloc(sizeof(DistributedTransactionId));
+		*pgxid = gxid;
+		gxids = lappend(gxids, pgxid);
 	}
 
 	LWLockRelease(ProcArrayLock);

--- a/src/backend/utils/gdd/gdddetector.h
+++ b/src/backend/utils/gdd/gdddetector.h
@@ -27,7 +27,7 @@ typedef struct GddGraph		GddGraph;
 typedef struct GddStat		GddStat;
 
 extern GddCtx *GddCtxNew(void);
-extern GddEdge *GddCtxAddEdge(GddCtx *ctx, int segid, int from, int to, bool solid);
+extern GddEdge *GddCtxAddEdge(GddCtx *ctx, int segid, DistributedTransactionId from, DistributedTransactionId to, bool solid);
 extern void GddCtxReduce(GddCtx *ctx);
 extern List *GddCtxBreakDeadLock(GddCtx *ctx);
 extern bool GddCtxEmpty(GddCtx *ctx);

--- a/src/backend/utils/gdd/gdddetectorpriv.h
+++ b/src/backend/utils/gdd/gdddetectorpriv.h
@@ -140,7 +140,7 @@
  */
 struct GddPair
 {
-	int			key;
+	DistributedTransactionId key;
 	void		*ptr;
 };
 
@@ -192,7 +192,7 @@ struct GddEdge
  */
 struct GddVert
 {
-	int			id;				/* vert id */
+	DistributedTransactionId id; /* vert id */
 
 	/*
 	 * Pointer to ctx->topstat, all the verts on all the globals maintain
@@ -231,7 +231,7 @@ struct GddGraph
  */
 struct GddStat
 {
-	int			id;				/* vert id */
+	DistributedTransactionId id; /* vert id */
 
 	int			indeg;			/* in degree */
 	int			outdeg;			/* out degree */

--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -106,9 +106,9 @@ gp_dist_wait_status(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segid",
 						   INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "waiter_dxid",
-						   XIDOID, -1, 0);
+						   INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "holder_dxid",
-						   XIDOID, -1, 0);
+						   INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "holdTillEndXact",
 						   BOOLOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "waiter_lpid",
@@ -266,8 +266,8 @@ gp_dist_wait_status(PG_FUNCTION_ARGS)
 			h_dxid = h_lock->distribXid;
 
 			values[0] = Int32GetDatum(GpIdentity.segindex);
-			values[1] = TransactionIdGetDatum(w_dxid);
-			values[2] = TransactionIdGetDatum(h_dxid);
+			values[1] = Int64GetDatum(w_dxid);
+			values[2] = Int64GetDatum(h_dxid);
 			values[3] = BoolGetDatum(lockIsHoldTillEndXact(w_lock));
 			values[4] = Int32GetDatum(w_lock->pid);
 			values[5] = Int32GetDatum(h_lock->pid);
@@ -307,8 +307,8 @@ gp_dist_wait_status(PG_FUNCTION_ARGS)
 				int row = ctx->row++;
 
 				values[0] = Int32GetDatum(atoi(PQgetvalue(pg_result, row, 0)));
-				values[1] = TransactionIdGetDatum(atoi(PQgetvalue(pg_result, row, 1)));
-				values[2] = TransactionIdGetDatum(atoi(PQgetvalue(pg_result, row, 2)));
+				values[1] = Int64GetDatum(atol(PQgetvalue(pg_result, row, 1)));
+				values[2] = Int64GetDatum(atol(PQgetvalue(pg_result, row, 2)));
 				values[3] = BoolGetDatum(strncmp(PQgetvalue(pg_result, row, 3), "t", 1) == 0);
 				values[4] = Int32GetDatum(atoi(PQgetvalue(pg_result, row, 4)));
 				values[5] = Int32GetDatum(atoi(PQgetvalue(pg_result, row, 5)));

--- a/src/backend/utils/gdd/test/gdddetector_test.c
+++ b/src/backend/utils/gdd/test/gdddetector_test.c
@@ -48,8 +48,8 @@
 typedef struct TestWaitRelation
 {
 	int 		seg_id;
-	TransactionId	waiter_xid;
-	TransactionId	holder_xid;
+	DistributedTransactionId	waiter_xid;
+	DistributedTransactionId	holder_xid;
 	bool		solid_edge;
 	int 		waiter_pid;
 	int 		holder_pid;
@@ -95,8 +95,8 @@ loadTestWaitRelations(GddCtx *ctx, TestWaitRelation *wait_relations, int num)
 	 */
 	for (i = 0; i < num; i++)
 	{
-		TransactionId  waiter_xid;
-		TransactionId  holder_xid;
+		DistributedTransactionId  waiter_xid;
+		DistributedTransactionId  holder_xid;
 		bool		   solidedge;
 		int			   segid;
 		GddEdge       *edge;
@@ -246,8 +246,8 @@ test_reduce_large_graph_pair_deadlocks(void **state)
 		TestWaitRelation *r1 = &wait_relations[i*2];
 		TestWaitRelation *r2 = &wait_relations[i*2+1];
 
-		TransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
-		TransactionId gxid2 = gxid1 + 100;
+		DistributedTransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
+		DistributedTransactionId gxid2 = gxid1 + 100;
 		int segment1 = i; /* segment id starts with 0. */
 		int segment2 = i+1;
 
@@ -341,8 +341,8 @@ test_reduce_large_graph_no_deadlock1(void **state)
 		TestWaitRelation *r1 = &wait_relations[i*2];
 		TestWaitRelation *r2 = &wait_relations[i*2+1];
 
-		TransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
-		TransactionId gxid2 = gxid1 + 100;
+		DistributedTransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
+		DistributedTransactionId gxid2 = gxid1 + 100;
 		int segment1 = i; /* segment id starts with 0. */
 		int segment2 = i+1;
 
@@ -433,8 +433,8 @@ test_reduce_large_graph_single_deadlock(void **state)
 	{
 		TestWaitRelation *r = &wait_relations[i];
 
-		TransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
-		TransactionId gxid2 = (gxid1 < num_transactions) ? gxid1 + 1 : 1;
+		DistributedTransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
+		DistributedTransactionId gxid2 = (gxid1 < num_transactions) ? gxid1 + 1 : 1;
 		int segment = i; /* segment id starts with 0. */
 
 		/* Make up pids and session ids. */
@@ -513,8 +513,8 @@ test_reduce_large_graph_no_deadlock2(void **state)
 	{
 		TestWaitRelation *r = &wait_relations[i];
 
-		TransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
-		TransactionId gxid2 = (gxid1 < num_transactions) ? gxid1 + 1 : 1;
+		DistributedTransactionId gxid1 = i + 1; /* Valid gxids start with 1. */
+		DistributedTransactionId gxid2 = (gxid1 < num_transactions) ? gxid1 + 1 : 1;
 		int segment = i; /* segment id starts with 0. */
 
 		/* Make up pids and session ids. */

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302104021
+#define CATALOG_VERSION_NO	302104151
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10848,7 +10848,7 @@
    proname => 'gp_dist_wait_status', prorows => '1000', proisstrict => 'f',
    proretset => 't', provolatile => 'v', proparallel => 'r',
    prorettype => 'record', proargtypes => '',
-   proallargtypes => '{int4,xid,xid,bool,int4,int4,text,text,int4,int4}',
+   proallargtypes => '{int4,int8,int8,bool,int4,int4,text,text,int4,int4}',
    proargmodes => '{o,o,o,o,o,o,o,o,o,o}',
    proargnames => '{segid,waiter_dxid,holder_dxid,holdTillEndXact,waiter_lpid,holder_lpid,waiter_lockmode,waiter_locktype,waiter_sessionid,holder_sessionid}',
    prosrc => 'gp_dist_wait_status' },


### PR DESCRIPTION
Note that commit 24e274093461727b305fda4bae8ea41e2de6507b introduce
64 bits gxid for distribtued transaction. But GDD didn't modified
accordingly, and there is a slim chance that vertex ID in GDD's wait-for
graph can overflow and result in deadlock can't be resolved properly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
