### PR TITLE
Fix exception handling in the very initial stages of ORCA optimization

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -114,7 +114,7 @@ protected:
 		GPOS_CATCH_EX(ex)
 		{
 			gpos::clib::Free(alloc_internal);
-			CException::Reraise(ex, false /*propagate*/);
+			GPOS_RETHROW(ex);
 		}
 		GPOS_CATCH_END;
 		return GPOS_OK;

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -113,12 +113,8 @@ protected:
 		}
 		GPOS_CATCH_EX(ex)
 		{
-			if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-			{
-				gpos::clib::Free(alloc_internal);
-
-				return GPOS_OOM;
-			}
+			gpos::clib::Free(alloc_internal);
+			CException::Reraise(ex, false /*propagate*/);
 		}
 		GPOS_CATCH_END;
 		return GPOS_OK;

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -60,8 +60,6 @@ InitDXL()
 	GPOS_ASSERT(nullptr != pmpXerces);
 	GPOS_ASSERT(nullptr != pmpDXL);
 
-	m_ulpInitDXL++;
-
 	// setup own memory manager
 	dxl_memory_manager = GPOS_NEW(pmpXerces) CDXLMemoryManager(pmpXerces);
 
@@ -78,6 +76,8 @@ InitDXL()
 
 	// initialize parse handler mappings
 	CParseHandlerFactory::Init(pmpDXL);
+
+	m_ulpInitDXL++;
 }
 
 


### PR DESCRIPTION
When ORCA runs out of memory while setting up its memory pool manager, in
CMemoryPoolManager::SetupGlobalMemoryPoolManager<>, it used to ignore
exceptions other than those of minor type ExmiOOM. When we use the
default GPDB memory allocators (optimizer_use_gpdb_allocators = true),
then an OOM condition will generate a different type of exception
(minor type of ExmiGPDBError). Ignoring that exception leads to a
crash with a segment violation.

The fix is to re-throw either of these OOM exceptions, so that they
are caught in the try/catch block in global method InitGPOPT(). Since
this is called before we set up a longjump buffer, that still causes a
FATAL error and an abort, but that's an improvement over the crash.

The reason for changing the behavior for exception of type ExmiOOM is
that the calling methods currently continue for any type of exception
seen in CMemoryPoolManager::SetupGlobalMemoryPoolManager<>, which
will cause a crash.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
