### PR TITLE
(6x backport from master) Avoid dispatching OIDs for InitPlan.

### DIFF
--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -176,3 +176,38 @@ SELECT * FROM ctas_aocs;
 
 DROP TABLE ctas_base;
 DROP TABLE ctas_aocs;
+-- Github Issue 10760
+-- Previously CTAS with Initplan will dispatch oids twice
+create table t1_github_issue_10760(a int, b int) distributed randomly;
+-- Because there is no Initplan in ORCA of this test case, there is no
+-- 10760 problem in ORCA. So here manually set the optimizer to
+-- ensure that there is Initplan in the execution plan.
+set optimizer=off;
+explain select * from t1_github_issue_10760 where b > (select count(*) from t1_github_issue_10760);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1176.32..2352.57 rows=28700 width=8)
+   ->  Seq Scan on t1_github_issue_10760  (cost=1176.32..2352.57 rows=9567 width=8)
+         Filter: (b > $0)
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Aggregate  (cost=1176.31..1176.32 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1176.25..1176.30 rows=1 width=8)
+                       ->  Aggregate  (cost=1176.25..1176.26 rows=1 width=8)
+                             ->  Seq Scan on t1_github_issue_10760 t1_github_issue_10760_1  (cost=0.00..961.00 rows=28700 width=0)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+begin;
+        create table t2_github_issue_10760 as select * from t1_github_issue_10760 where b > (select count(*) from t1_github_issue_10760) distributed randomly;
+        drop table t2_github_issue_10760;
+        create table t2_github_issue_10760 as select * from t1_github_issue_10760 where b > (select count(*) from t1_github_issue_10760) distributed randomly;
+end;
+select count (distinct oid) from  (select oid from pg_class where relname = 't2_github_issue_10760' union all select oid from gp_dist_random('pg_class') where relname = 't2_github_issue_10760')x;
+ count 
+-------
+     1
+(1 row)
+
+drop table t1_github_issue_10760;
+drop table t2_github_issue_10760;
+reset optimizer;

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -98,3 +98,26 @@ CREATE TABLE ctas_aocs WITH (appendonly=true, orientation=column) AS SELECT * FR
 SELECT * FROM ctas_aocs;
 DROP TABLE ctas_base;
 DROP TABLE ctas_aocs;
+
+-- Github Issue 10760
+-- Previously CTAS with Initplan will dispatch oids twice
+create table t1_github_issue_10760(a int, b int) distributed randomly;
+
+-- Because there is no Initplan in ORCA of this test case, there is no
+-- 10760 problem in ORCA. So here manually set the optimizer to
+-- ensure that there is Initplan in the execution plan.
+set optimizer=off;
+explain select * from t1_github_issue_10760 where b > (select count(*) from t1_github_issue_10760);
+
+begin;
+        create table t2_github_issue_10760 as select * from t1_github_issue_10760 where b > (select count(*) from t1_github_issue_10760) distributed randomly;
+        drop table t2_github_issue_10760;
+        create table t2_github_issue_10760 as select * from t1_github_issue_10760 where b > (select count(*) from t1_github_issue_10760) distributed randomly;
+end;
+
+select count (distinct oid) from  (select oid from pg_class where relname = 't2_github_issue_10760' union all select oid from gp_dist_random('pg_class') where relname = 't2_github_issue_10760')x;
+
+drop table t1_github_issue_10760;
+drop table t2_github_issue_10760;
+
+reset optimizer;


### PR DESCRIPTION
CTAS will first define relation in QD, and generate the OIDs,
and then dispatch with these OIDs to QEs.
QEs store these OIDs in a static variable and delete the one
used to create table.

If CTAS's query contains initplan, when we invoke
preprocess_initplan to dispatch initplans, if with
queryDesc->ddesc->oidAssignments be set, these OIDs are
also dispatched to QEs.

This commit avoid dispatching OIDs for InitPlan to fixes
github issue https://github.com/greenplum-db/gpdb/issues/10760


--------

Backport https://github.com/greenplum-db/gpdb/commit/6c424a9fb20febfb69d1a6891157975b84efa8ef
to 6X.
