### PR TITLE
[WIP] Optimize the selection of segment to when executing replicated table scan

### DIFF
--- a/src/test/regress/expected/dispatch_replicated_table.out
+++ b/src/test/regress/expected/dispatch_replicated_table.out
@@ -1,0 +1,66 @@
+-- This test is used to test the dispatch of the can on replicated table
+CREATE TABLE test_rep_dispatch_rep (c1 int, c2 int) DISTRIBUTED REPLICATED;
+CREATE TABLE test_rep_dispatch_normal (c1 int, c2 int) DISTRIBUTED BY (c1);
+INSERT INTO test_rep_dispatch_rep values (1,1),(2,2),(3,3);
+INSERT INTO test_rep_dispatch_normal values (1,2),(2,3),(5,6);
+SELECT gp_segment_id, * FROM test_rep_dispatch_normal;
+ gp_segment_id | c1 | c2 
+---------------+----+----
+             2 |  5 |  6
+             1 |  1 |  2
+             0 |  2 |  3
+(3 rows)
+
+-- Test 3 times to make sure with the same gp_session_id, but update the tuples of
+-- different segmets, all the 3 DTX will use 1PC.
+SET Test_print_direct_dispatch_info = ON;
+SET optimizer = OFF;
+BEGIN;
+UPDATE test_rep_dispatch_normal set c2 = 1 where c1 = 1;
+INFO:  (slice 0) Dispatch command to SINGLE content
+SELECT * FROM test_rep_dispatch_rep;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+(3 rows)
+
+COMMIT;
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+BEGIN;
+UPDATE test_rep_dispatch_normal set c2 = 2 where c1 = 2;
+INFO:  (slice 0) Dispatch command to SINGLE content
+SELECT * FROM test_rep_dispatch_rep;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+(3 rows)
+
+COMMIT;
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+BEGIN;
+UPDATE test_rep_dispatch_normal set c2 = 5 where c1 = 5;
+INFO:  (slice 0) Dispatch command to SINGLE content
+SELECT * FROM test_rep_dispatch_rep;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+(3 rows)
+
+COMMIT;
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+-- Clean up
+DROP TABLE test_rep_dispatch_rep;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+DROP TABLE test_rep_dispatch_normal;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -282,4 +282,7 @@ test: run_utility_gpexpand_phase1
 # check correct error message when create extension error on segment
 test: create_extension_gp_debug_segments
 
+# check the segment selection of replicated table scan
+test: dispatch_replicated_table
+
 # end of tests

--- a/src/test/regress/sql/dispatch_replicated_table.sql
+++ b/src/test/regress/sql/dispatch_replicated_table.sql
@@ -1,0 +1,33 @@
+-- This test is used to test the dispatch of the can on replicated table
+
+CREATE TABLE test_rep_dispatch_rep (c1 int, c2 int) DISTRIBUTED REPLICATED;
+CREATE TABLE test_rep_dispatch_normal (c1 int, c2 int) DISTRIBUTED BY (c1);
+
+INSERT INTO test_rep_dispatch_rep values (1,1),(2,2),(3,3);
+INSERT INTO test_rep_dispatch_normal values (1,2),(2,3),(5,6);
+
+
+SELECT gp_segment_id, * FROM test_rep_dispatch_normal;
+
+-- Test 3 times to make sure with the same gp_session_id, but update the tuples of
+-- different segmets, all the 3 DTX will use 1PC.
+SET Test_print_direct_dispatch_info = ON;
+SET optimizer = OFF;
+BEGIN;
+UPDATE test_rep_dispatch_normal set c2 = 1 where c1 = 1;
+SELECT * FROM test_rep_dispatch_rep;
+COMMIT;
+
+BEGIN;
+UPDATE test_rep_dispatch_normal set c2 = 2 where c1 = 2;
+SELECT * FROM test_rep_dispatch_rep;
+COMMIT;
+
+BEGIN;
+UPDATE test_rep_dispatch_normal set c2 = 5 where c1 = 5;
+SELECT * FROM test_rep_dispatch_rep;
+COMMIT;
+
+-- Clean up
+DROP TABLE test_rep_dispatch_rep;
+DROP TABLE test_rep_dispatch_normal;


### PR DESCRIPTION
Before this PR, the selection of segment to execute scan on a replicated
table is based on the gp_session_id, which is randommized among sessions.
However, for the case in a explicit begin transaction, this is not a
optimal choice, when this transaction already has selected segments,
since the replicated table scan can choose the segment in these segments,
in this way, we can reduce the segments involved in a DTX. In some certain
cases, a 2PC dtx can even be turned into 1PC.

A typical case is TPC-C benchmark workloads, as we know, item table is
unchanable during the whole test, and almost 90% transactions of
new_order will access the data of one given warehouse ID. So we can
make item as a replicated table, and with this PR, 90% transactions of
new_order can be turned from 2PC into 1PC, henceforth, the performce of
TPC-C can be improved.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
