### PR TITLE
FIXME: Remove toast table for AO table

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -286,7 +286,11 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 		else
 		{
 			/* Tuple is invisible and needs to be dropped */
-			AppendOnlyThrowAwayTuple(aorel, slot);
+			if (Debug_appendonly_print_compaction)
+				ereport(DEBUG5,
+						(errmsg("Compaction: Throw away tuple (%d," INT64_FORMAT ")",
+								AOTupleIdGet_segmentFileNum(aoTupleId),
+								AOTupleIdGet_rowNum(aoTupleId))));
 		}
 
 		/*

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1689,54 +1689,16 @@ appendonly_relation_size(Relation rel, ForkNumber forkNumber)
 }
 
 /*
- * Check to see whether the table needs a TOAST table.  It does only if
- * (1) there are any toastable attributes, and (2) the maximum length
- * of a tuple could exceed TOAST_TUPLE_THRESHOLD.  (We don't want to
- * create a toast table for something like "f1 varchar(20)".)
+ * Check to see whether the table needs a TOAST table.
  */
 static bool
 appendonly_relation_needs_toast_table(Relation rel)
 {
-	int32		data_length = 0;
-	bool		maxlength_unknown = false;
-	bool		has_toastable_attrs = false;
-	TupleDesc	tupdesc = rel->rd_att;
-	int32		tuple_length;
-	int			i;
-
-	for (i = 0; i < tupdesc->natts; i++)
-	{
-		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
-
-		if (att->attisdropped)
-			continue;
-		data_length = att_align_nominal(data_length, att->attalign);
-		if (att->attlen > 0)
-		{
-			/* Fixed-length types are never toastable */
-			data_length += att->attlen;
-		}
-		else
-		{
-			int32		maxlen = type_maximum_size(att->atttypid,
-												   att->atttypmod);
-
-			if (maxlen < 0)
-				maxlength_unknown = true;
-			else
-				data_length += maxlen;
-			if (att->attstorage != 'p')
-				has_toastable_attrs = true;
-		}
-	}
-	if (!has_toastable_attrs)
-		return false;			/* nothing to toast? */
-	if (maxlength_unknown)
-		return true;			/* any unlimited-length attrs? */
-	tuple_length = MAXALIGN(SizeofHeapTupleHeader +
-							BITMAPLEN(tupdesc->natts)) +
-		MAXALIGN(data_length);
-	return (tuple_length > TOAST_TUPLE_THRESHOLD);
+	/*
+	 * AO never used the toasting, don't create the toast table from
+	 * Greenplum 7
+	 */
+	return false;
 }
 
 /* ------------------------------------------------------------------------

--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -947,29 +947,6 @@ memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind,
 	memtuple_get_values(mtup, pbind, datum, isnull, false /* aligned */);
 }
 
-bool MemTupleHasExternal(MemTuple mtup, MemTupleBinding *pbind)
-{
-	MemTupleBindingCols *colbind = memtuple_get_islarge(mtup) ? &pbind->large_bind : &pbind->bind;
-	int i;
-
-	for(i=0; i<pbind->tupdesc->natts; ++i)
-	{
-		MemTupleAttrBinding *attrbind = &(colbind->bindings[i]);
-		if(attrbind->flag == MTB_ByRef)
-		{
-			bool isnull;
-			Datum d = memtuple_getattr(mtup, pbind, i+1, &isnull);
-			if(!isnull)
-			{
-				if(VARATT_IS_EXTERNAL(DatumGetPointer(d)))
-					return true;
-			}
-		}
-	}
-
-	return false;
-}
-
 /*
  * Check if a memtuple has null attributes with bindings that can possibly be misaligned.
  *

--- a/src/include/access/appendonly_compaction.h
+++ b/src/include/access/appendonly_compaction.h
@@ -33,7 +33,6 @@ extern bool AppendOnlyCompaction_ShouldCompact(
 								   int64 segmentTotalTupcount,
 								   bool isFull,
 								   Snapshot appendOnlyMetaDataSnapshot);
-extern void AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot);
 extern void AppendOnlyTruncateToEOF(Relation aorel);
 
 #endif

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -168,8 +168,6 @@ MemTupleClearMatch(MemTuple mtup)
 	mtup->PRIVATE_mt_len &= ~MEMTUP_HAS_MATCH;
 }
 
-extern bool MemTupleHasExternal(MemTuple mtup, MemTupleBinding *pbind);
-
 extern bool memtuple_has_misaligned_attribute(MemTuple mtup, MemTupleBinding *pbind);
 
 #endif /* MEMTUP_H */

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -78,7 +78,6 @@ typedef struct AppendOnlyInsertDescData
 	int64			bufferCount;
 	int64			blockFirstRowNum;
 	bool			usingChecksum;
-	bool			useNoToast;
 	bool			skipModCountIncrement;
 	int32			completeHeaderLen;
 	uint8			*tempSpace;
@@ -87,19 +86,9 @@ typedef struct AppendOnlyInsertDescData
 	int32			maxDataLen;
 	int32			tempSpaceLen;
 
-	char						*title;
-				/*
-				 * A phrase that better describes the purpose of the this open.
-				 *
-				 * We manage the storage for this.
-				 */
+	char		   *title;	/* A phrase that better describes the purpose of this open.
+							 * We manage the storage for this. */
 
-	/*
-	 * These serve the equivalent purpose of the uppercase constants of the same
-	 * name in tuptoaster.h but here we make these values dynamic.
-	 */	
-	int32			toast_tuple_threshold;
-	int32			toast_tuple_target;
 	AppendOnlyStorageAttributes storageAttributes;
 	AppendOnlyStorageWrite		storageWrite;
 

--- a/src/test/regress/expected/freeze_aux_tables.out
+++ b/src/test/regress/expected/freeze_aux_tables.out
@@ -71,16 +71,12 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table test_table_ao (id int, col1 int) with (appendonly=true, orientation=row);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table test_table_ao_with_toast (id int, col1 int, col2 text) with (appendonly=true, orientation=row);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table test_table_co (id int, col1 int) with (appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create index test_heap_idx on test_table_heap using btree(id);
 create index test_heap_wt_idx on test_table_heap_with_toast using btree(id);
 create index test_heap_ao_idx on test_table_ao using btree(id);
-create index test_heap_ao_wt_idx on test_table_ao_with_toast using btree(id);
 create index test_heap_co_idx on test_table_co using btree(id);
 -- Advance XID counter, vacuum, and check that relfrozenxid was advanced for
 -- all the tables, including auxiliary tables, even though there were no
@@ -122,20 +118,6 @@ group by segid = -1, relname, classify_age(age);
  t         | pg_aoblkdir_<oid>  | very young
 (6 rows)
 
-select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
-group by segid = -1, relname, classify_age(age);
- is_master |      relname       | classify_age 
------------+--------------------+--------------
- f         | pg_toast_<oid>     | old
- t         | pg_toast_<oid>     | very young
- t         | pg_aovisimap_<oid> | very young
- f         | pg_aovisimap_<oid> | old
- f         | pg_aoblkdir_<oid>  | old
- f         | pg_aoseg_<oid>     | old
- t         | pg_aoseg_<oid>     | very young
- t         | pg_aoblkdir_<oid>  | very young
-(8 rows)
-
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
@@ -152,7 +134,6 @@ group by segid = -1, relname, classify_age(age);
 vacuum test_table_heap;
 vacuum test_table_heap_with_toast;
 vacuum test_table_ao;
-vacuum test_table_ao_with_toast;
 vacuum test_table_co;
 -- Check table ages.
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_heap')
@@ -185,20 +166,6 @@ group by segid = -1, relname, classify_age(age);
  t         | pg_aoblkdir_<oid>  | very young
 (6 rows)
 
-select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
-group by segid = -1, relname, classify_age(age);
- is_master |      relname       | classify_age 
------------+--------------------+--------------
- f         | pg_aoblkdir_<oid>  | young
- f         | pg_toast_<oid>     | young
- t         | pg_toast_<oid>     | very young
- f         | pg_aovisimap_<oid> | young
- t         | pg_aovisimap_<oid> | very young
- t         | pg_aoseg_<oid>     | very young
- f         | pg_aoseg_<oid>     | young
- t         | pg_aoblkdir_<oid>  | very young
-(8 rows)
-
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
  is_master |      relname       | classify_age 
@@ -216,12 +183,10 @@ group by segid = -1, relname, classify_age(age);
 INSERT INTO test_table_heap select i, i*2 from generate_series(1, 20)i;
 INSERT INTO test_table_heap_with_toast select i, i*2, i*5 from generate_series(1, 20)i;
 INSERT INTO test_table_ao select i, i*2 from generate_series(1, 20)i;
-INSERT INTO test_table_ao_with_toast select i, i*2, i*5 from generate_series(1, 20)i;
 INSERT INTO test_table_co select i, i*2 from generate_series(1, 20)i;
 delete from test_table_heap;
 delete from test_table_heap_with_toast;
 delete from test_table_ao;
-delete from test_table_ao_with_toast;
 delete from test_table_co;
 select count(*) from test_table_heap;
  count 
@@ -236,12 +201,6 @@ select count(*) from test_table_heap_with_toast;
 (1 row)
 
 select count(*) from test_table_ao;
- count 
--------
-     0
-(1 row)
-
-select count(*) from test_table_ao_with_toast;
  count 
 -------
      0
@@ -262,7 +221,6 @@ select advance_xid_counter(500);
 vacuum freeze test_table_heap;
 vacuum freeze test_table_heap_with_toast;
 vacuum freeze test_table_ao;
-vacuum freeze test_table_ao_with_toast;
 vacuum freeze test_table_co;
 -- Check table ages again. Because we used VACUUM FREEZE, they should be
 -- very young now.
@@ -295,20 +253,6 @@ group by segid = -1, relname, classify_age(age);
  t         | pg_aoblkdir_<oid>  | very young
  f         | pg_aovisimap_<oid> | very young
 (6 rows)
-
-select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
-group by segid = -1, relname, classify_age(age);
- is_master |      relname       | classify_age 
------------+--------------------+--------------
- f         | pg_toast_<oid>     | very young
- f         | pg_aoblkdir_<oid>  | very young
- f         | pg_aoseg_<oid>     | very young
- t         | pg_toast_<oid>     | very young
- t         | pg_aovisimap_<oid> | very young
- t         | pg_aoseg_<oid>     | very young
- t         | pg_aoblkdir_<oid>  | very young
- f         | pg_aovisimap_<oid> | very young
-(8 rows)
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -227,13 +227,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
- toast index       | AccessExclusiveLock | relation | master
- toast index       | AccessExclusiveLock | relation | master
- toast index       | AccessExclusiveLock | relation | master
- toast table       | ShareLock           | relation | master
- toast table       | ShareLock           | relation | master
- toast table       | ShareLock           | relation | master
-(10 rows)
+(4 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
@@ -242,13 +236,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
- toast table       | ShareLock           | relation | n segments
- toast index       | AccessExclusiveLock | relation | n segments
- toast table       | ShareLock           | relation | n segments
- toast index       | AccessExclusiveLock | relation | n segments
- toast table       | ShareLock           | relation | n segments
- toast index       | AccessExclusiveLock | relation | n segments
-(10 rows)
+(4 rows)
 
 commit;
 begin;
@@ -296,13 +284,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
-(19 rows)
+(13 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -320,13 +302,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
-(19 rows)
+(13 rows)
 
 commit;
 -- Indexing

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -227,13 +227,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
- toast index       | AccessExclusiveLock | relation | master
- toast index       | AccessExclusiveLock | relation | master
- toast index       | AccessExclusiveLock | relation | master
- toast table       | ShareLock           | relation | master
- toast table       | ShareLock           | relation | master
- toast table       | ShareLock           | relation | master
-(10 rows)
+(4 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
@@ -242,13 +236,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
- toast table       | ShareLock           | relation | n segments
- toast index       | AccessExclusiveLock | relation | n segments
- toast table       | ShareLock           | relation | n segments
- toast index       | AccessExclusiveLock | relation | n segments
- toast table       | ShareLock           | relation | n segments
- toast index       | AccessExclusiveLock | relation | n segments
-(10 rows)
+(4 rows)
 
 commit;
 begin;
@@ -296,13 +284,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
- dropped table | AccessExclusiveLock | relation | master
-(19 rows)
+(13 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -320,13 +302,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
- dropped table | AccessExclusiveLock | relation | n segments
-(19 rows)
+(13 rows)
 
 commit;
 -- Indexing

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -196,17 +196,6 @@ where c.oid = a.segrelid and
  t            | t
 (2 rows)
 
--- Verify that age of toast table is updated by vacuum.
--- AOCS doesn't have a valid reltoastrelid from Greenplum 7.
-select 0 < age(relfrozenxid) as age_positive,
-       age(relfrozenxid) < 100 as age_within_limit
-from pg_class where oid in (select reltoastrelid from pg_class
-       where relname = 'ao_empty' or relname = 'aocs_empty');
- age_positive | age_within_limit 
---------------+------------------
- t            | t
-(1 row)
-
 -- Verify that index is displayed by \d after vacuum.
 \d ao_empty;
                    Table "public.ao_empty"

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -578,7 +578,7 @@ DROP TABLE aosizetest_2;
 -- to indexes etc.)
 CREATE TABLE aosizetest_3(a text) WITH (appendonly=true);
 insert into aosizetest_3 select repeat('x', 100) from generate_series(1, 10000);
-SELECT pg_total_relation_size('aosizetest_3') between 1400000 and 1500000;
+SELECT pg_total_relation_size('aosizetest_3') between 1300000 and 1400000;
 
 
 -- These tests validate current segfile selection algorithm

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1189,7 +1189,7 @@ DROP TABLE aosizetest_2;
 -- to indexes etc.)
 CREATE TABLE aosizetest_3(a text) WITH (appendonly=true);
 insert into aosizetest_3 select repeat('x', 100) from generate_series(1, 10000);
-SELECT pg_total_relation_size('aosizetest_3') between 1400000 and 1500000;
+SELECT pg_total_relation_size('aosizetest_3') between 1300000 and 1400000;
  ?column? 
 ----------
  t

--- a/src/test/regress/sql/freeze_aux_tables.sql
+++ b/src/test/regress/sql/freeze_aux_tables.sql
@@ -74,13 +74,11 @@ set vacuum_freeze_min_age = 50;
 create table test_table_heap (id int, col1 int) with (appendonly=false);
 create table test_table_heap_with_toast (id int, col1 int, col2 text) with (appendonly=false);
 create table test_table_ao (id int, col1 int) with (appendonly=true, orientation=row);
-create table test_table_ao_with_toast (id int, col1 int, col2 text) with (appendonly=true, orientation=row);
 create table test_table_co (id int, col1 int) with (appendonly=true, orientation=column);
 
 create index test_heap_idx on test_table_heap using btree(id);
 create index test_heap_wt_idx on test_table_heap_with_toast using btree(id);
 create index test_heap_ao_idx on test_table_ao using btree(id);
-create index test_heap_ao_wt_idx on test_table_ao_with_toast using btree(id);
 create index test_heap_co_idx on test_table_co using btree(id);
 
 -- Advance XID counter, vacuum, and check that relfrozenxid was advanced for
@@ -98,9 +96,6 @@ group by segid = -1, relname, classify_age(age);
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao')
 group by segid = -1, relname, classify_age(age);
 
-select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
-group by segid = -1, relname, classify_age(age);
-
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
 
@@ -108,7 +103,6 @@ group by segid = -1, relname, classify_age(age);
 vacuum test_table_heap;
 vacuum test_table_heap_with_toast;
 vacuum test_table_ao;
-vacuum test_table_ao_with_toast;
 vacuum test_table_co;
 
 -- Check table ages.
@@ -121,9 +115,6 @@ group by segid = -1, relname, classify_age(age);
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao')
 group by segid = -1, relname, classify_age(age);
 
-select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
-group by segid = -1, relname, classify_age(age);
-
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')
 group by segid = -1, relname, classify_age(age);
 
@@ -132,19 +123,16 @@ group by segid = -1, relname, classify_age(age);
 INSERT INTO test_table_heap select i, i*2 from generate_series(1, 20)i;
 INSERT INTO test_table_heap_with_toast select i, i*2, i*5 from generate_series(1, 20)i;
 INSERT INTO test_table_ao select i, i*2 from generate_series(1, 20)i;
-INSERT INTO test_table_ao_with_toast select i, i*2, i*5 from generate_series(1, 20)i;
 INSERT INTO test_table_co select i, i*2 from generate_series(1, 20)i;
 
 delete from test_table_heap;
 delete from test_table_heap_with_toast;
 delete from test_table_ao;
-delete from test_table_ao_with_toast;
 delete from test_table_co;
 
 select count(*) from test_table_heap;
 select count(*) from test_table_heap_with_toast;
 select count(*) from test_table_ao;
-select count(*) from test_table_ao_with_toast;
 select count(*) from test_table_co;
 
 select advance_xid_counter(500);
@@ -152,7 +140,6 @@ select advance_xid_counter(500);
 vacuum freeze test_table_heap;
 vacuum freeze test_table_heap_with_toast;
 vacuum freeze test_table_ao;
-vacuum freeze test_table_ao_with_toast;
 vacuum freeze test_table_co;
 
 -- Check table ages again. Because we used VACUUM FREEZE, they should be
@@ -164,9 +151,6 @@ select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('te
 group by segid = -1, relname, classify_age(age);
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao')
-group by segid = -1, relname, classify_age(age);
-
-select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_ao_with_toast')
 group by segid = -1, relname, classify_age(age);
 
 select segid = -1 as is_master, relname, classify_age(age) from aux_rel_ages('test_table_co')

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -140,12 +140,6 @@ from pg_class c, pg_appendonly a
 where c.oid = a.segrelid and
 	   (a.relid = 'ao_empty'::regclass or
 	    a.relid = 'aocs_empty'::regclass);
--- Verify that age of toast table is updated by vacuum.
--- AOCS doesn't have a valid reltoastrelid from Greenplum 7.
-select 0 < age(relfrozenxid) as age_positive,
-       age(relfrozenxid) < 100 as age_within_limit
-from pg_class where oid in (select reltoastrelid from pg_class
-       where relname = 'ao_empty' or relname = 'aocs_empty');
 
 -- Verify that index is displayed by \d after vacuum.
 \d ao_empty;


### PR DESCRIPTION
1. Never use toast table for AO table and remove related useless codes.
AOCS already removed the toast table.
2. Remove the FIXME for appendonly_rescan, the newly add args is useless
for AO tables which same with AOCS tables.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
