### PR TITLE
Fix use after free in GetSnapshotData()

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2168,7 +2168,7 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 						MemoryContextSwitchTo(oldCtx);
 					}
 					else
-						repalloc(comboCids, SharedLocalSnapshotSlot->combocidcnt * sizeof(ComboCidKeyData));
+						comboCids = repalloc(comboCids, SharedLocalSnapshotSlot->combocidcnt * sizeof(ComboCidKeyData));
 				}
 				memcpy(comboCids, (char *)SharedLocalSnapshotSlot->combocids, SharedLocalSnapshotSlot->combocidcnt * sizeof(ComboCidKeyData));
 				usedComboCids = ((SharedLocalSnapshotSlot->combocidcnt < MaxComboCids) ? SharedLocalSnapshotSlot->combocidcnt : MaxComboCids);

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -801,7 +801,7 @@ readSharedLocalSnapshot_forCursor(Snapshot snapshot, DtxContext distributedTrans
 			MemoryContextSwitchTo(oldCtx);
 		}
 		else
-			repalloc(comboCids, combocidcnt * sizeof(ComboCidKeyData));
+			comboCids = repalloc(comboCids, combocidcnt * sizeof(ComboCidKeyData));
 	}
 	memcpy(comboCids, tmp_combocids, combocidcnt * sizeof(ComboCidKeyData));
 	usedComboCids = ((combocidcnt < MaxComboCids) ? combocidcnt : MaxComboCids);

--- a/src/test/regress/expected/gp_combocid.out
+++ b/src/test/regress/expected/gp_combocid.out
@@ -1,0 +1,17 @@
+--
+-- test use after free in GetSnapshotData()
+-- needs a CTAS query with two slices a SQL call in both slices
+--
+BEGIN;
+CREATE TABLE cmbt (a text, b int) DISTRIBUTED BY (a);
+INSERT INTO cmbt select 1, 1 from generate_series(1, 3000)i;
+CREATE OR REPLACE FUNCTION yolo (tm TEXT, s TEXT) RETURNS TEXT LANGUAGE sql VOLATILE STRICT
+AS $$
+	SELECT '10'::text;
+$$
+EXECUTE ON ANY;
+-- EXPLAIN VERBOSE
+CREATE TABLE ytbl AS SELECT a, yolo(a, 'writer')
+	FROM (SELECT a FROM cmbt WHERE '10' = yolo('1', 'reader')) u;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+ROLLBACK;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -41,7 +41,7 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format misc_jiras direct_dispatch_explain_analyze
+test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format misc_jiras direct_dispatch_explain_analyze
 test: guc_gp
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.

--- a/src/test/regress/sql/gp_combocid.sql
+++ b/src/test/regress/sql/gp_combocid.sql
@@ -1,0 +1,19 @@
+--
+-- test use after free in GetSnapshotData()
+-- needs a CTAS query with two slices a SQL call in both slices
+--
+BEGIN;
+CREATE TABLE cmbt (a text, b int) DISTRIBUTED BY (a);
+INSERT INTO cmbt select 1, 1 from generate_series(1, 3000)i;
+
+CREATE OR REPLACE FUNCTION yolo (tm TEXT, s TEXT) RETURNS TEXT LANGUAGE sql VOLATILE STRICT
+AS $$
+	SELECT '10'::text;
+$$
+EXECUTE ON ANY;
+
+-- EXPLAIN VERBOSE
+CREATE TABLE ytbl AS SELECT a, yolo(a, 'writer')
+	FROM (SELECT a FROM cmbt WHERE '10' = yolo('1', 'reader')) u;
+
+ROLLBACK;


### PR DESCRIPTION
After a call to repalloc the address of the newly allocated memory must
be saved back in the pointer, otherwise the pointer is left to point to
the old (now free’d) memory.
In GetSnapshotData(), GPDB repalloc()'s comboCids and then memcpy()'s
into it contents larger than than its previously allocated size.
This overflows to other allocations in the block and corrupts the chunk
header of other allocations.
In the attached test, this corrupt the chunk header of ActiveSnapshot
and subsequently crashes the backend later during PopSnapshot().

The affected allocation happens to be that of the ActiveSnapshot, but
that is coincidental. This could affect any allocation in the same block
of the TopTransactionContext.

To reproduce this, we first need to execute the query within a
transaction which activates the whole comboCids mechanism. Then, we need
a plan with at least two slices that execute on the segment with the
following sequence of events in this order:
1. Writer slice takes a snapshot & updates shared memory.
2. Reader slice takes a snapshot & updates its usedComboCids to a
   non-zero value
3. Writer slice takes an additional snapshot and updates the shared
   memory.
4. Reader slice takes another snapshot & updates usedComboCids. This
   will hit the faulty case.

The repro in the attached test achieves with a CREATE TABLE AS with:
1. A toast-able column (e.g text, which creates a toast table that
   increments command counter before execution of the SELECT)
2. Calls to SQL UDFs (which in turn call GetSnapshotData())
3. Generating a plan with 2 slices that will execute this SQL UDF on
   both the writer & reader slice (resulting in the sequence of events
   described above).

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
