### PR TITLE
[5X]Fix the bug of copying pg_system filespace data twice during expansion

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -453,6 +453,8 @@ class GpDB:
             cmd.run(validateAfter = True)
             MakeDirectory.local("gpexpand make directory to hold file spaces", fullPathFsDir)
             for oid in self.__filespaces:
+                if oid == SYSTEM_FILESPACE:
+                    continue
                 MakeDirectory.local("gpexpand make directory to hold file space oid: " + str(oid), fullPathFsDir)
                 dir = self.__filespaces[oid]
                 destDir = fullPathFsDir + "/" + str(oid)


### PR DESCRIPTION
Creates a filespace using a configuration file that defines per-segment file system locations. 
When running gpexpand utility,  it will create a segment template given the information in the GPDB. However, the segment template will contain not only the filespaces, but also pg_system data which already exists in the template. And some data of the pg_system is also in the template, such as pg_log. These data do not need to exist in the template, since it will affect the efficiency of distributing the template between expansion hosts. 
In fact, the pg_system filespace of the directory fs_directory is not used. such as the following log in expansion：
```
gpconfigurenewsegment:sdw1:gpadmin-[INFO]:-Starting gpconfigurenewsegment with args: -c /gpdata/primarydata3/gpseg4:6002:true:false:10:16457:/gpdata/fstest/pri/gpseg4:24717:/gpdata/gpfs2/pri/gpseg4 -n -t /tmp/gpexpand_schema.tar -v -B 4
gpconfigurenewsegment:sdw1:gpadmin-[INFO]:-###### init,self.tarfile: /tmp/gpexpand_schema.tar,self.filespaceOids: ['16457', '24717']
```
