### PR TITLE
Add check for appendonly materialized view to pg_upgrade

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -28,7 +28,7 @@ static void check_for_reg_data_type_usage(ClusterInfo *cluster);
 static void check_for_jsonb_9_4_usage(ClusterInfo *cluster);
 static void check_for_pg_role_prefix(ClusterInfo *cluster);
 static char *get_canonical_locale_name(int category, const char *locale);
-
+static void check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster);
 
 /*
  * fix_path_separator
@@ -193,6 +193,12 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 		old_GPDB4_check_for_money_data_type_usage();
 		old_GPDB4_check_no_free_aoseg();
 		check_hash_partition_usage();
+	}
+
+	/* For now, the issue exists only for Greenplum 6.x/PostgreSQL 9.4 */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) == 904)
+	{
+		check_for_appendonly_materialized_view_with_relfrozenxid(&old_cluster);
 	}
 
 	/*
@@ -1361,4 +1367,108 @@ get_canonical_locale_name(int category, const char *locale)
 	pg_free(save);
 
 	return res;
+}
+
+/* Check for any materialized view of append only mode with relfrozenxid != 0
+ *
+ * A materialized view of append only mode must have invalid relfrozenxid (0).
+ * However, some views might have valid relfrozenxid due to a known code issue.
+ * We need to check the problematical view before upgrading.
+ * The problem can be fixed by issuing "REFRESH MATERIALIZED VIEW <viewname>"
+ * with latest code.
+ * See the PR for details:
+ *
+ * https://github.com/greenplum-db/gpdb/pull/11662/
+ */
+static void
+check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster)
+{
+	FILE	   *script = NULL;
+	char		output_path[MAXPGPATH];
+	bool		found = false;
+
+	prep_status("Checking for appendonly materialized view with relfrozenxid\n");
+
+	snprintf(output_path,
+				sizeof(output_path),
+				"appendonly_materialized_view_with_relfrozenxid.txt");
+	if (script == NULL && (script = fopen_priv(output_path, "w")) == NULL)
+	{
+		pg_fatal("could not open file \"%s\": %s\n",
+					output_path,
+					strerror(errno));
+	}
+
+	for (int dbnum = 0; dbnum < cluster->dbarr.ndbs; dbnum++)
+	{
+		DbInfo	   *active_db = &cluster->dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(cluster, active_db->db_name);
+		PGresult   *res;
+		int			ntups = 0, i_relname = 0, i_relfxid = 0;
+
+		fprintf(script, "Checking database: %s\n", active_db->db_name);
+		if (conn == NULL)
+		{
+			pg_fatal("Failed to connect to database %s\n", active_db->db_name);
+		}
+
+        // Detect any materialized view of append only mode with relfrozenxid != 0
+		res = executeQueryOrDie(conn,
+						        "SELECT relname, relfrozenxid "
+                                " FROM pg_catalog.pg_class "
+            	           		" WHERE relkind = 'm' AND reloptions = '{appendonly=true}' "
+								" AND relfrozenxid::text <> '0'");
+		if (res == 0)
+		{
+			pg_fatal("Failed to query pg_catalog.pg_class on database \"%s\"\n",
+					 active_db->db_name);
+		}
+
+		ntups = PQntuples(res);
+		if (ntups == 0)
+		{
+			fprintf(script, "No problematical view detected.\n\n");
+		}
+		else
+		{
+			found = true;
+			i_relname = PQfnumber(res, "relname");
+			i_relfxid = PQfnumber(res, "relfrozenxid");
+			for (int rowno = 0; rowno < ntups; rowno++)
+			{
+				fprintf(script,
+						"Detected view: %s, relfrozenxid: %s\n",
+						PQgetvalue(res, rowno, i_relname),
+						PQgetvalue(res, rowno, i_relfxid));
+			}
+			fprintf(script, "%d problematical view(s) detected.\n\n", ntups);
+		}
+		PQclear(res);
+
+		PQfinish(conn);
+	}
+
+	if(found)
+	{
+		fprintf(script,
+				"Note: A materialized view of append only mode must have invalid\n"
+				"relfrozenxid (0). However, view(s) with valid relfrozenxid was\n"
+				"detected.\n"
+				"Try to fix it by issuing \"REFRESH MATERIALIZED VIEW <viewname>\"\n"
+				"with latest code and run the upgrading again.\n");
+	}
+
+	if (script)
+		fclose(script);
+
+	if(found)
+	{
+		pg_fatal("Detected appendonly materialized view with valid relfrozenxid.\n"
+					"See %s for details.\n",
+					output_path);
+	}
+	else
+	{
+		check_ok();
+	}
 }

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -1412,14 +1412,15 @@ check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster)
 			pg_fatal("Failed to connect to database %s\n", active_db->db_name);
 		}
 
-		// Detect any materialized view of append only mode with relfrozenxid != 0
+		// Detect any materialized view of append only mode (relstorage is
+		// RELSTORAGE_AOROWS or RELSTORAGE_AOCOLS) with relfrozenxid != 0
 		res = executeQueryOrDie(conn,
 								"select tb.relname, tb.relfrozenxid, tbsp.nspname "
 								" from pg_catalog.pg_class tb "
 								" left join pg_catalog.pg_namespace tbsp "
 								" on tb.relnamespace = tbsp.oid "
 								" where tb.relkind = 'm' "
-								" and tb.reloptions::text like '%%appendonly=true%%' "
+								" and (tb.relstorage = 'a' or tb.relstorage = 'c') "
 								" and tb.relfrozenxid::text <> '0';");
 		if (res == 0)
 		{
@@ -1463,7 +1464,7 @@ check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster)
 				"detected.\n"
 				"Try to fix it by issuing \"REFRESH MATERIALIZED VIEW "
 				"<schemaname>.<viewname>\"\n"
-				"with latest code and run the upgrading again.\n");
+				"with latest GPDB 6 release and run the upgrading again.\n");
 	}
 
 	if (script)

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -1383,7 +1383,7 @@ get_canonical_locale_name(int category, const char *locale)
 static void
 check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster)
 {
-	FILE	   *script = NULL;
+	FILE		*script = NULL;
 	char		output_path[MAXPGPATH];
 	bool		found = false;
 
@@ -1412,11 +1412,12 @@ check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster)
 			pg_fatal("Failed to connect to database %s\n", active_db->db_name);
 		}
 
-        // Detect any materialized view of append only mode with relfrozenxid != 0
+		// Detect any materialized view of append only mode with relfrozenxid != 0
 		res = executeQueryOrDie(conn,
-						        "SELECT relname, relfrozenxid "
-                                " FROM pg_catalog.pg_class "
-            	           		" WHERE relkind = 'm' AND reloptions = '{appendonly=true}' "
+								"SELECT relname, relfrozenxid "
+								" FROM pg_catalog.pg_class "
+								" WHERE relkind = 'm' "
+								" AND reloptions::text like '%%appendonly=true%%' "
 								" AND relfrozenxid::text <> '0'");
 		if (res == 0)
 		{


### PR DESCRIPTION
A materialized view of append only mode must have invalid relfrozenxid (0).
However, some views might have valid relfrozenxid due to a known code issue.
We need to check the problematical view before upgrading.
The problem can be fixed by issuing "REFRESH MATERIALIZED VIEW <viewname>"
with latest code.
See the PR for details:

https://github.com/greenplum-db/gpdb/pull/11662/

About to test:

I didn't add unit test because it's difficult to do. The scenario is hit only when we apply pg_upgrade of GPDB7 to a GPDB6 instance, i.e. we cannot simply test with GPDB6 or GPDB7, and the scenario is not covered by existing test framework. Instead, I did some tests manually:

Create table/view in a GPDB6 instance:

```
create table foo(a int);
CREATE MATERIALIZED VIEW m_view WITH ("appendonly"='true', compresslevel=5) AS SELECT * FROM foo WITH NO DATA DISTRIBUTED BY (a);
select relname, reloptions, relminmxid from pg_catalog.pg_class where relkind = 'm' and reloptions::text like '%appendonly=true%' and relfrozenxid::text <> '0';
 relname |            reloptions             | relminmxid 
---------+-----------------------------------+------------
 m_view  | {appendonly=true,compresslevel=5} |          1
(1 row)
```

In GPDB7, apply pg_upgrade with specifying the GPDB6 instance directory:

```
pg_upgrade -d /home/wayao/gpdb6/gpAux/gpdemo/datadirs/qddir/demoDataDir-1 -D /home/wayao/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1 -b /home/wayao/gpbin6/bin -B /home/wayao/gpbin/bin -c
Performing Consistency Checks on Old Live Server
------------------------------------------------
Checking cluster versions                                   ok
Checking database user is the install user                  ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for reg* data types in user tables                 ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking for external tables used in partitioning           ok
Checking for non-covering indexes on partitioned AO tables  ok
Checking for indexes on partitioned tables                  ok
Checking for orphaned TOAST relations                       ok
Checking array types derived from partitions                ok
Checking for SHA-256 hashed passwords                       ok
Checking for tables WITH OIDS                               ok
Checking for invalid "unknown" user columns                 ok
Checking for hash indexes                                   ok
Checking for roles starting with "pg_"                      ok
Checking for appendonly materialized view with relfrozenxid

Detected appendonly materialized view with valid relfrozenxid.
See appendonly_materialized_view_with_relfrozenxid.txt for details.
Failure, exiting
```

Drop the view in GPDB6:

`DROP MATERIALIZED VIEW m_view;`

Run pg_upgrade again:

```
pg_upgrade -d /home/wayao/gpdb6/gpAux/gpdemo/datadirs/qddir/demoDataDir-1 -D /home/wayao/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1 -b /home/wayao/gpbin6/bin -B /home/wayao/gpbin/bin -c
Performing Consistency Checks on Old Live Server
------------------------------------------------
Checking cluster versions                                   ok
Checking database user is the install user                  ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for reg* data types in user tables                 ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking for external tables used in partitioning           ok
Checking for non-covering indexes on partitioned AO tables  ok
Checking for indexes on partitioned tables                  ok
Checking for orphaned TOAST relations                       ok
Checking array types derived from partitions                ok
Checking for SHA-256 hashed passwords                       ok
Checking for tables WITH OIDS                               ok
Checking for invalid "unknown" user columns                 ok
Checking for hash indexes                                   ok
Checking for roles starting with "pg_"                      ok
Checking for appendonly materialized view with relfrozenxid
ok
Checking for presence of required libraries                 ok
Checking database user is the install user                  ok
Checking for prepared transactions                          ok

*Clusters are compatible*
```

