### PR TITLE
Fix exception handling in initial stages of ORCA optimization (#11806)

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -119,12 +119,8 @@ protected:
 		}
 		GPOS_CATCH_EX(ex)
 		{
-			if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-			{
-				gpos::clib::Free(alloc_internal);
-
-				return GPOS_OOM;
-			}
+			gpos::clib::Free(alloc_internal);
+			GPOS_RETHROW(ex);
 		}
 		GPOS_CATCH_END;
 		return GPOS_OK;

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -60,8 +60,6 @@ InitDXL()
 	GPOS_ASSERT(NULL != pmpXerces);
 	GPOS_ASSERT(NULL != pmpDXL);
 
-	m_ulpInitDXL++;
-
 	// setup own memory manager
 	dxl_memory_manager = GPOS_NEW(pmpXerces) CDXLMemoryManager(pmpXerces);
 
@@ -77,6 +75,8 @@ InitDXL()
 
 	// initialize parse handler mappings
 	CParseHandlerFactory::Init(pmpDXL);
+
+	m_ulpInitDXL++;
 }
 
 


### PR DESCRIPTION
This is a backport of #11806.

* Fix exception handling in the very initial stages of ORCA optimization

When ORCA runs out of memory while setting up its memory pool manager, in
CMemoryPoolManager::SetupGlobalMemoryPoolManager<>, it used to ignore
exceptions other than those of minor type ExmiOOM. When we use the
default GPDB memory allocators (optimizer_use_gpdb_allocators = true),
then an OOM condition will generate a different type of exception
(minor type of ExmiGPDBError). Ignoring that exception leads to a
crash with a segment violation.

The fix is to re-throw either of these OOM exceptions, so that they
are caught in the try/catch block in global method InitGPOPT(). Since
this is called before we set up a longjump buffer, that still causes a
FATAL error and an abort, but that's an improvement over the crash.

The reason for changing the behavior for exception of type ExmiOOM is
that the calling methods currently continue for any type of exception
seen in CMemoryPoolManager::SetupGlobalMemoryPoolManager<>, which
will cause a crash.

* Improve handling of failures in the InitDXL method

This method has a variable that prevents initializing the DXL context
more than once. Set this variable only upon exit from the method, so
that we re-attempt the code on the next query when we fail (at least
some failures will cause a longjmp to a higher stack frame and won't
take the regular exit path). Note that there is no guarantee that it
will work the second time, expecially when the failure was inside the
xerces initialization code (detected or undetected).  For simple
memory allocation failures in GPDB code it should work, though. Note
also that failures could cause small memory leaks, which is probably
acceptable and common in most of our code.

Here is the situation the InitDXL fix tries to address:

- On executing a first query, we fail in InitDXL(). We increment m_ulpInitDXL,
   but we fail to reach the call to CParseHandlerFactory::Init(), due to a
  memory allocation failure that throws an exception. The query fails with
  an error.
- On executing a second query, we call InitDXL() again, but since
  m_ulpInitDXL is set to 1, we do nothing and continue.
- Once we try to use the CParseHanderFactory, which is still uninitialized,
  we crash.

(cherry picked from commit fad3b42ea55b5e52b6363d49d808636556dbd978)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
