### PR TITLE
Remove compress dead code for AO table

### DIFF
--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -77,13 +77,11 @@ typedef struct AppendOnlyInsertDescData
 	VarBlockMaker	varBlockMaker;
 	int64			bufferCount;
 	int64			blockFirstRowNum;
-	bool			shouldCompress;
 	bool			usingChecksum;
 	bool			useNoToast;
 	bool			skipModCountIncrement;
 	int32			completeHeaderLen;
 	uint8			*tempSpace;
-	uint8			*uncompressedBuffer; /* used for compression */
 
 	int32			usableBlockSize;
 	int32			maxDataLen;


### PR DESCRIPTION
Currently, whether to compress data in AO table is stored in
`AppendOnlyStorageWrite`'s `storageAttributes`.

`aoInsertDesc->shouldCompress` is never set to ture, so just remove
the related logic.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
