### PR TITLE
gpcheckcat permits readable external partitions

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -560,7 +560,8 @@ def checkPartitionIntegrity():
            pg_get_table_distributedby(inhrelid) as dby_child
     from pg_inherits inner join pg_partitioned_table on (pg_inherits.inhparent = pg_partitioned_table.partrelid)
     where pg_get_table_distributedby(inhrelid) is distinct from pg_get_table_distributedby(inhparent)
-          and not (pg_get_table_distributedby(inhparent) = 'DISTRIBUTED RANDOMLY' and pg_get_table_distributedby(inhrelid) = '');
+          and not (pg_get_table_distributedby(inhparent) = 'DISTRIBUTED RANDOMLY' and pg_get_table_distributedby(inhrelid) = '')
+          and not (inhrelid in (select ftrelid from pg_catalog.pg_foreign_table) and pg_get_table_distributedby(inhrelid) = '');
     '''
     try:
         curs = db.query(qry)

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3576,8 +3576,10 @@ DROP EXTERNAL TABLE ext_subplan_t1;
 DROP EXTERNAL TABLE ext_subplan_t2;
 
 -- Test external tables as partitions, and gpcheckcat
-CREATE TABLE test_part_integrity(a int, b int) PARTITION BY LIST(a) DISTRIBUTED BY (a);
+CREATE TABLE test_part_integrity(a int, b int) PARTITION BY LIST (a) DISTRIBUTED BY (a);
 CREATE TABLE test_part_integrity_p1(a int, b int) DISTRIBUTED BY (a);
-CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'cat /dev/null' FORMAT 'TEXT';
+INSERT INTO test_part_integrity_p1 VALUES (1,2),(1,3);
+CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'echo 2,2;echo 2,3' ON MASTER FORMAT 'CSV';
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);
+SELECT * FROM test_part_integrity;

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3574,3 +3574,10 @@ FROM ext_subplan_t1;
 
 DROP EXTERNAL TABLE ext_subplan_t1;
 DROP EXTERNAL TABLE ext_subplan_t2;
+
+-- Test external tables as partitions, and gpcheckcat
+CREATE TABLE test_part_integrity(a int, b int) PARTITION BY LIST(a) DISTRIBUTED BY (a);
+CREATE TABLE test_part_integrity_p1(a int, b int) DISTRIBUTED BY (a);
+CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'cat /dev/null' FORMAT 'TEXT';
+ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
+ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4860,3 +4860,9 @@ FROM ext_subplan_t1;
 
 DROP EXTERNAL TABLE ext_subplan_t1;
 DROP EXTERNAL TABLE ext_subplan_t2;
+-- Test external tables as partitions, and gpcheckcat
+CREATE TABLE test_part_integrity(a int, b int) PARTITION BY LIST(a) DISTRIBUTED BY (a);
+CREATE TABLE test_part_integrity_p1(a int, b int) DISTRIBUTED BY (a);
+CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'cat /dev/null' FORMAT 'TEXT';
+ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
+ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4861,8 +4861,18 @@ FROM ext_subplan_t1;
 DROP EXTERNAL TABLE ext_subplan_t1;
 DROP EXTERNAL TABLE ext_subplan_t2;
 -- Test external tables as partitions, and gpcheckcat
-CREATE TABLE test_part_integrity(a int, b int) PARTITION BY LIST(a) DISTRIBUTED BY (a);
+CREATE TABLE test_part_integrity(a int, b int) PARTITION BY LIST (a) DISTRIBUTED BY (a);
 CREATE TABLE test_part_integrity_p1(a int, b int) DISTRIBUTED BY (a);
-CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'cat /dev/null' FORMAT 'TEXT';
+INSERT INTO test_part_integrity_p1 VALUES (1,2),(1,3);
+CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'echo 2,2;echo 2,3' ON MASTER FORMAT 'CSV';
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);
+SELECT * FROM test_part_integrity;
+ a | b 
+---+---
+ 1 | 2
+ 1 | 3
+ 2 | 2
+ 2 | 3
+(4 rows)
+


### PR DESCRIPTION
gpcheckcat check partitions with different distributing policies from
the parent table. Readable external partitions are fine, this commit
skips them.
