### PR TITLE
Upstreaming fixes from refcount 3

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
@@ -24,7 +24,7 @@ public:
 	explicit CPhysicalFullMergeJoin(CMemoryPool *mp,
 									CExpressionArray *outer_merge_clauses,
 									CExpressionArray *inner_merge_clauses,
-									IMdIdArray *hash_opfamilies = nullptr);
+									IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalFullMergeJoin() override;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -115,7 +115,7 @@ public:
 	// ctor
 	CPhysicalHashJoin(CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 					  CExpressionArray *pdrgpexprInnerKeys,
-					  IMdIdArray *hash_opfamilies = nullptr);
+					  IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalHashJoin() override;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
@@ -55,7 +55,7 @@ public:
 	CPhysicalInnerHashJoin(CMemoryPool *mp,
 						   CExpressionArray *pdrgpexprOuterKeys,
 						   CExpressionArray *pdrgpexprInnerKeys,
-						   IMdIdArray *hash_opfamilies = nullptr);
+						   IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalInnerHashJoin() override;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
@@ -36,7 +36,7 @@ public:
 	CPhysicalLeftAntiSemiHashJoin(CMemoryPool *mp,
 								  CExpressionArray *pdrgpexprOuterKeys,
 								  CExpressionArray *pdrgpexprInnerKeys,
-								  IMdIdArray *hash_opfamilies = nullptr);
+								  IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalLeftAntiSemiHashJoin() override;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
@@ -36,7 +36,7 @@ public:
 	CPhysicalLeftAntiSemiHashJoinNotIn(CMemoryPool *mp,
 									   CExpressionArray *pdrgpexprOuterKeys,
 									   CExpressionArray *pdrgpexprInnerKeys,
-									   IMdIdArray *hash_opfamilies = nullptr);
+									   IMdIdArray *hash_opfamilies);
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
@@ -35,7 +35,7 @@ public:
 	CPhysicalLeftOuterHashJoin(CMemoryPool *mp,
 							   CExpressionArray *pdrgpexprOuterKeys,
 							   CExpressionArray *pdrgpexprInnerKeys,
-							   IMdIdArray *hash_opfamilies = nullptr);
+							   IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalLeftOuterHashJoin() override;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
@@ -35,7 +35,7 @@ public:
 	CPhysicalLeftSemiHashJoin(CMemoryPool *mp,
 							  CExpressionArray *pdrgpexprOuterKeys,
 							  CExpressionArray *pdrgpexprInnerKeys,
-							  IMdIdArray *hash_opfamilies = nullptr);
+							  IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalLeftSemiHashJoin() override;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
@@ -39,7 +39,7 @@ public:
 	CPhysicalRightOuterHashJoin(CMemoryPool *mp,
 								CExpressionArray *pdrgpexprOuterKeys,
 								CExpressionArray *pdrgpexprInnerKeys,
-								IMdIdArray *hash_opfamilies = nullptr);
+								IMdIdArray *hash_opfamilies);
 
 	// dtor
 	~CPhysicalRightOuterHashJoin() override;

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecStrictSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecStrictSingleton.cpp
@@ -61,7 +61,7 @@ CDistributionSpecStrictSingleton::FSatisfies(
 
 	return (
 		(EdtSingleton == pdss->Edt() || EdtStrictSingleton == pdss->Edt()) &&
-		m_est == ((CDistributionSpecStrictSingleton *) pdss)->Est());
+		m_est == static_cast<const CDistributionSpecSingleton *>(pdss)->Est());
 }
 
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5656,7 +5656,6 @@ CTranslatorExprToDXL::PdxlnScCmpPartKey(CExpression *pexprScCmp,
 		{
 			pexprNewPartKey =
 				CUtils::PexprCast(m_mp, m_pmda, pexprPartKey, pmdidTypeOther);
-			pexprPartKey->Release();
 		}
 
 		//Extract cast/func details


### PR DESCRIPTION
Stumbled upon these while working on my reference count refactoring, see eacg commit for details

1. Fix an incorrect cast (In case you wonder why it didn't trigger a warning: It was a C-style cast, so "no questions asked")
2. Remove an incorrectly placed call to `Release()`
3. This is the most interesting one: remove a default argument to various physical hash join constructors, it's never used.