### PR TITLE
Fix  Release_Candidate job

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -46,7 +46,7 @@ function generate_build_number() {
 	# Only if its git repo, add commit SHA as build number
 	# BUILD_NUMBER file is used by getversion file in GPDB to append to version
 	if [ -d .git ]; then
-		echo "commit: $(git rev-parse HEAD)" >BUILD_NUMBER
+		echo "commit:$(git rev-parse HEAD)" >BUILD_NUMBER
 	fi
 	popd
 }


### PR DESCRIPTION
    Fix postgre --gp-version
    
    Previous commit:
    https://github.com/greenplum-db/gpdb/commit/444bcb99caf7cc3b337a02cfd7e5324739a6fbe8#diff-75a3e145e34ecdcbddb795d0c26cadfdd0c29de469d4519b84ca249bc5acefccR49
    accidentally changed postgres --gp-version output, which add an extra
    space in `commit: XXXX`, which should be `commit:XXXX`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
