### PR TITLE
Fix Release_Candidate job

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -38,7 +38,7 @@ function generate_build_number() {
     # Only if its git repo, add commit SHA as build number
     # BUILD_NUMBER file is used by getversion file in GPDB to append to version
     if [ -d .git ]; then
-        echo "commit: $(git rev-parse HEAD)" >BUILD_NUMBER
+        echo "commit:$(git rev-parse HEAD)" >BUILD_NUMBER
     fi
     popd
 }


### PR DESCRIPTION
Fix postgres --gp-version

Previous commit: ee4961fc349aad16ae64e4fa10154d7996ce0401 accidentally
changed postgres --gp-version output, which add an extra
space in `commit: XXXX`, which should be `commit:XXXX`

Co-authored-by: Ning Wu <ningw@vmware.com>
Co-authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
