### PR TITLE
Fix treating COPY FROM dtx as a read only dtx

### DIFF
--- a/src/test/regress/expected/gp_copy_dtx.out
+++ b/src/test/regress/expected/gp_copy_dtx.out
@@ -1,0 +1,26 @@
+-- Test if COPY FROM dtx will use correct distribued transaction command protocol
+CREATE TABLE test_copy (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET Test_print_direct_dispatch_info = ON;
+COPY test_copy (c1, c2) FROM stdin;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+SELECT * FROM test_copy;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ c1 | c2 
+----+----
+  5 |  6
+  6 |  7
+  9 | 10
+  1 |  2
+  2 |  3
+  3 |  4
+  4 |  5
+  7 |  8
+  8 |  9
+(9 rows)
+
+SET Test_print_direct_dispatch_info = OFF;
+-- Clean up
+DROP TABLE test_copy;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -40,6 +40,9 @@ test: temp_tablespaces
 test: default_tablespace
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views replication_slots create_table_like_gp gp_constraints matview_ao gpcopy_dispatch
+# the above test group has reached the maximum size (20), put the newly
+# added test to an another group
+test: gp_copy_dtx
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 

--- a/src/test/regress/sql/gp_copy_dtx.sql
+++ b/src/test/regress/sql/gp_copy_dtx.sql
@@ -1,0 +1,24 @@
+-- Test if COPY FROM dtx will use correct distribued transaction command protocol
+
+CREATE TABLE test_copy (c1 int, c2 int);
+
+SET Test_print_direct_dispatch_info = ON;
+
+COPY test_copy (c1, c2) FROM stdin;
+1	2
+2	3
+3	4
+4	5
+5	6
+6	7
+7	8
+8	9
+9	10
+\.
+
+SELECT * FROM test_copy;
+
+SET Test_print_direct_dispatch_info = OFF;
+
+-- Clean up
+DROP TABLE test_copy;


### PR DESCRIPTION
When execute COPY FROM statement, QD will wait in cdbCopyEndInternal
to get the executing results from QE, but before this fix, flag
TopXactexecutorDidWriteXLog is not set as processResults does, which
results in the incorrect use of dtx protocol command. So we need check
if segments have written XLOG, and set the flag properly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
