### PR TITLE
Use the same code for generating two-stage DISTINCT plans as GROUP BY

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4325,6 +4325,8 @@ create_sort_path(PlannerInfo *root,
 {
 	SortPath   *pathnode = makeNode(SortPath);
 
+	Assert(pathkeys != NIL);
+
 	pathnode->path.pathtype = T_Sort;
 	pathnode->path.parent = rel;
 	/* Sort doesn't project, so use source path's pathtarget */

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1404,28 +1404,10 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	else if (linitial(stmt->distinctClause) == NULL)
 	{
 		/* We had SELECT DISTINCT */
-		if (!pstate->p_hasAggs && !pstate->p_hasWindowFuncs &&
-			qry->groupClause == NIL && qry->groupingSets == NIL &&
-			qry->targetList != NIL)
-		{
-			/*
-			 * GPDB: We convert the DISTINCT to an equivalent GROUP BY, when
-			 * possible, because the planner can generate smarter plans for
-			 * GROUP BY. In particular, the "pre-unique" optimization has not
-			 * been implemented for DISTINCT.
-			 */
-			qry->distinctClause = transformDistinctToGroupBy(pstate,
-															 &qry->targetList,
-															 &qry->sortClause,
-															 &qry->groupClause);
-		}
-		else
-		{
-			qry->distinctClause = transformDistinctClause(pstate,
-														  &qry->targetList,
-														  qry->sortClause,
-														  false);
-		}
+		qry->distinctClause = transformDistinctClause(pstate,
+													  &qry->targetList,
+													  qry->sortClause,
+													  false);
 		qry->hasDistinctOn = false;
 	}
 	else

--- a/src/include/cdb/cdbgroupingpaths.h
+++ b/src/include/cdb/cdbgroupingpaths.h
@@ -16,21 +16,26 @@
 
 #include "nodes/pathnodes.h"
 
-extern void cdb_create_twostage_grouping_paths(PlannerInfo *root,
+extern void cdb_create_multistage_grouping_paths(PlannerInfo *root,
+												 RelOptInfo *input_rel,
+												 RelOptInfo *output_rel,
+												 PathTarget *target,
+												 PathTarget *partial_grouping_target,
+												 List *havingQual,
+												 double dNumGroupsTotal,
+												 const AggClauseCosts *agg_costs,
+												 const AggClauseCosts *agg_partial_costs,
+												 const AggClauseCosts *agg_final_costs,
+												 List *rollups,
+												 List *new_rollups,
+												 AggStrategy strat);
+
+
+extern void cdb_create_twostage_distinct_paths(PlannerInfo *root,
 											   RelOptInfo *input_rel,
 											   RelOptInfo *output_rel,
 											   PathTarget *target,
-											   PathTarget *partial_grouping_target,
-											   List *havingQual,
-											   bool can_sort,
-											   bool can_hash,
-											   double dNumGroupsTotal,
-											   const AggClauseCosts *agg_costs,
-											   const AggClauseCosts *agg_partial_costs,
-											   const AggClauseCosts *agg_final_costs,
-											   List *rollups,
-											   List *new_rollups,
-											   AggStrategy strat);
+											   double dNumGroupsTotal);
 
 extern Path *cdb_prepare_path_for_sorted_agg(PlannerInfo *root,
 											 bool is_sorted,

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -94,6 +94,7 @@ typedef enum UpperRelationKind
 	UPPERREL_CDB_FIRST_STAGE_GROUP_AGG,
 	UPPERREL_WINDOW,			/* result of window functions, if any */
 	UPPERREL_DISTINCT,			/* result of "SELECT DISTINCT", if any */
+	UPPERREL_CDB_FIRST_STAGE_DISTINCT,
 	UPPERREL_ORDERED,			/* result of ORDER BY, if any */
 	UPPERREL_FINAL				/* result of any remaining top-level actions */
 	/* NB: UPPERREL_FINAL must be last enum entry; it's used to size arrays */

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -36,8 +36,6 @@ extern List *transformWindowDefinitions(ParseState *pstate,
 										List *windowdefs,
 										List **targetlist);
 
-extern List *transformDistinctToGroupBy(ParseState *pstate, List **targetlist,
-						   List **sortClause, List **groupClause);
 extern List *transformDistinctClause(ParseState *pstate,
 									 List **targetlist, List *sortClause, bool is_agg);
 extern List *transformDistinctOnClause(ParseState *pstate, List *distinctlist,

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1153,15 +1153,15 @@ explain (costs off) select a,c from t1 group by a,c,d;
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: a, c, d
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: a, c, d
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: a, c, d
                      ->  Seq Scan on t1
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 -- Test removal across multiple relations
 explain (costs off) select *

--- a/src/test/regress/expected/gp_distinct_plans.out
+++ b/src/test/regress/expected/gp_distinct_plans.out
@@ -1,0 +1,271 @@
+--
+-- Test all the different plan shapes that the planner can generate for
+-- DISTINCT queries
+--
+create table distinct_test (a int, b int, c int) distributed by (a);
+insert into distinct_test select g / 1000, g / 2000, g from generate_series(1, 10000) g;
+analyze distinct_test;
+--
+-- With the default cost settings, you get hashed plans
+--
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=55.00..56.10 rows=66 width=8)
+   ->  HashAggregate  (cost=55.00..55.22 rows=22 width=8)
+         Group Key: a, b
+         ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=8)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  1 | 0
+  0 | 0
+  6 | 3
+  9 | 4
+ 10 | 5
+  5 | 2
+  3 | 1
+  4 | 2
+  2 | 1
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=46.86..46.96 rows=6 width=4)
+   ->  Finalize HashAggregate  (cost=46.86..46.88 rows=2 width=4)
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=46.67..46.85 rows=6 width=4)
+               Hash Key: b
+               ->  Partial HashAggregate  (cost=46.67..46.73 rows=6 width=4)
+                     Group Key: b
+                     ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 5
+ 2
+ 4
+ 3
+ 1
+ 0
+(6 rows)
+
+-- The two-stage aggregation can be disabled with GUC
+set gp_enable_preunique = off;
+explain select distinct b from distinct_test;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=113.33..113.43 rows=6 width=4)
+   ->  HashAggregate  (cost=113.33..113.35 rows=2 width=4)
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..105.00 rows=3333 width=4)
+               Hash Key: b
+               ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+reset gp_enable_preunique;
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=113.33..280.00 rows=10000 width=4)
+   ->  HashAggregate  (cost=113.33..146.67 rows=3333 width=4)
+         Group Key: c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..105.00 rows=3333 width=4)
+               Hash Key: c
+               ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Repeat the same tests with sorted Unique plans
+--
+set enable_hashagg=off;
+set optimizer_enable_hashagg=off;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=233.38..259.26 rows=66 width=8)
+   Merge Key: a, b
+   ->  Unique  (cost=233.38..258.38 rows=22 width=8)
+         Group Key: a, b
+         ->  Sort  (cost=233.38..241.71 rows=3333 width=8)
+               Sort Key: a, b
+               ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  2 | 1
+  3 | 1
+  4 | 2
+  5 | 2
+  6 | 3
+  7 | 3
+  8 | 4
+  9 | 4
+ 10 | 5
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize GroupAggregate  (cost=233.38..250.45 rows=6 width=4)
+   Group Key: b
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=233.38..250.35 rows=18 width=4)
+         Merge Key: b
+         ->  Partial GroupAggregate  (cost=233.38..250.11 rows=6 width=4)
+               Group Key: b
+               ->  Sort  (cost=233.38..241.71 rows=3333 width=4)
+                     Sort Key: b
+                     ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+ 5
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=300.05..450.05 rows=10000 width=4)
+   Merge Key: c
+   ->  Unique  (cost=300.05..316.71 rows=3333 width=4)
+         Group Key: c
+         ->  Sort  (cost=300.05..308.38 rows=3333 width=4)
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..105.00 rows=3333 width=4)
+                     Hash Key: c
+                     ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Also test paths where the explicit Sort is not needed
+--
+create index on distinct_test (a, b);
+create index on distinct_test (b);
+create index on distinct_test (c);
+set random_page_cost=1;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..206.04 rows=66 width=8)
+   Merge Key: a, b
+   ->  Unique  (cost=0.16..205.16 rows=22 width=8)
+         Group Key: a, b
+         ->  Index Only Scan using distinct_test_a_b_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=8)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  2 | 1
+  3 | 1
+  4 | 2
+  5 | 2
+  6 | 3
+  7 | 3
+  8 | 4
+  9 | 4
+ 10 | 5
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate  (cost=0.16..197.23 rows=6 width=4)
+   Group Key: b
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..197.13 rows=18 width=4)
+         Merge Key: b
+         ->  Partial GroupAggregate  (cost=0.16..196.89 rows=6 width=4)
+               Group Key: b
+               ->  Index Only Scan using distinct_test_b_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+ 5
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Unique  (cost=0.16..346.83 rows=10000 width=4)
+   Group Key: c
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..321.83 rows=10000 width=4)
+         Merge Key: c
+         ->  Index Only Scan using distinct_test_c_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+

--- a/src/test/regress/expected/gp_distinct_plans_optimizer.out
+++ b/src/test/regress/expected/gp_distinct_plans_optimizer.out
@@ -1,0 +1,287 @@
+--
+-- Test all the different plan shapes that the planner can generate for
+-- DISTINCT queries
+--
+create table distinct_test (a int, b int, c int) distributed by (a);
+insert into distinct_test select g / 1000, g / 2000, g from generate_series(1, 10000) g;
+analyze distinct_test;
+--
+-- With the default cost settings, you get hashed plans
+--
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.93 rows=38 width=8)
+   ->  HashAggregate  (cost=0.00..431.93 rows=13 width=8)
+         Group Key: a, b
+         ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  1 | 0
+  0 | 0
+  6 | 3
+  9 | 4
+ 10 | 5
+  5 | 2
+  3 | 1
+  4 | 2
+  2 | 1
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..431.51 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.51 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=2 width=4)
+                     Hash Key: b
+                     ->  Streaming HashAggregate  (cost=0.00..431.51 rows=2 width=4)
+                           Group Key: b
+                           ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 5
+ 2
+ 4
+ 3
+ 1
+ 0
+(6 rows)
+
+-- The two-stage aggregation can be disabled with GUC
+set gp_enable_preunique = off;
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..431.51 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.51 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=2 width=4)
+                     Hash Key: b
+                     ->  Streaming HashAggregate  (cost=0.00..431.51 rows=2 width=4)
+                           Group Key: b
+                           ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+reset gp_enable_preunique;
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.70 rows=10000 width=4)
+   ->  HashAggregate  (cost=0.00..431.55 rows=3334 width=4)
+         Group Key: c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+               Hash Key: c
+               ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Repeat the same tests with sorted Unique plans
+--
+set enable_hashagg=off;
+set optimizer_enable_hashagg=off;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.92 rows=38 width=8)
+   ->  GroupAggregate  (cost=0.00..432.92 rows=13 width=8)
+         Group Key: a, b
+         ->  Sort  (cost=0.00..432.90 rows=3334 width=8)
+               Sort Key: a, b
+               ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  5 | 2
+  6 | 3
+  9 | 4
+ 10 | 5
+  2 | 1
+  3 | 1
+  4 | 2
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.00 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..432.00 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.00 rows=2 width=4)
+                     Hash Key: b
+                     ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+                           Group Key: b
+                           ->  Sort  (cost=0.00..431.99 rows=3334 width=4)
+                                 Sort Key: b
+                                 ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 2
+ 3
+ 4
+ 0
+ 1
+ 5
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.20 rows=10000 width=4)
+   ->  GroupAggregate  (cost=0.00..432.05 rows=3334 width=4)
+         Group Key: c
+         ->  Sort  (cost=0.00..432.03 rows=3334 width=4)
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                     Hash Key: c
+                     ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Also test paths where the explicit Sort is not needed
+--
+create index on distinct_test (a, b);
+create index on distinct_test (b);
+create index on distinct_test (c);
+set random_page_cost=1;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.92 rows=38 width=8)
+   ->  GroupAggregate  (cost=0.00..432.92 rows=13 width=8)
+         Group Key: a, b
+         ->  Sort  (cost=0.00..432.90 rows=3334 width=8)
+               Sort Key: a, b
+               ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  5 | 2
+  6 | 3
+  9 | 4
+ 10 | 5
+  2 | 1
+  3 | 1
+  4 | 2
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.00 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..432.00 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.00 rows=2 width=4)
+                     Hash Key: b
+                     ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+                           Group Key: b
+                           ->  Sort  (cost=0.00..431.99 rows=3334 width=4)
+                                 Sort Key: b
+                                 ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 0
+ 1
+ 5
+ 2
+ 3
+ 4
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.20 rows=10000 width=4)
+   ->  GroupAggregate  (cost=0.00..432.05 rows=3334 width=4)
+         Group Key: c
+         ->  Sort  (cost=0.00..432.03 rows=3334 width=4)
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                     Hash Key: c
+                     ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -421,16 +421,19 @@ analyze try_distinct_array;
 insert into try_distinct_array select 'n',string_to_array('1~1','~')::int[];
 -- Aggregate with grouping column that does not have legacy hashop
 explain (costs off) select distinct test_array from try_distinct_array;
-                    QUERY PLAN                    
---------------------------------------------------
- Finalize HashAggregate
-   Group Key: test_array
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
-               Group Key: test_array
-               ->  Seq Scan on try_distinct_array
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: test_array
+   ->  Unique
+         Group Key: test_array
+         ->  Sort
+               Sort Key: test_array
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: test_array
+                     ->  Seq Scan on try_distinct_array
  Optimizer: Postgres query optimizer
-(7 rows)
+(10 rows)
 
 select distinct test_array from try_distinct_array;
  test_array 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12051,7 +12051,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- GroupAggregate  (cost=5.25..5.31 rows=3 width=8)
+ Unique  (cost=5.25..5.28 rows=3 width=8)
    Output: l1.c, l1.lid
    Group Key: l1.c, l1.lid
    ->  Sort  (cost=5.25..5.26 rows=3 width=8)

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -4568,19 +4568,21 @@ select d.* from d left join (select * from b group by b.id, b.c_id) s
 explain (costs off)
 select d.* from d left join (select distinct * from b) s
   on d.a = s.id;
-                 QUERY PLAN                  
----------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
          Hash Cond: (d.a = s.id)
          ->  Seq Scan on d
          ->  Hash
                ->  Subquery Scan on s
-                     ->  HashAggregate
-                           Group Key: b.id
-                           ->  Seq Scan on b
+                     ->  Unique
+                           Group Key: b.id, b.c_id
+                           ->  Sort
+                                 Sort Key: b.id, b.c_id
+                                 ->  Seq Scan on b
  Optimizer: Postgres query optimizer
-(10 rows)
+(12 rows)
 
 -- check join removal works when uniqueness of the join condition is enforced
 -- by a UNION

--- a/src/test/regress/expected/olap_plans.out
+++ b/src/test/regress/expected/olap_plans.out
@@ -314,11 +314,11 @@ analyze foo_ctas;
 explain create table bar_ctas as select * from foo_ctas group by a, b distributed by (b);
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
- Finalize HashAggregate  (cost=11.47..11.51 rows=3 width=8)
+ HashAggregate  (cost=11.47..11.51 rows=3 width=8)
    Group Key: a, b
    ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
          Hash Key: b
-         ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
+         ->  HashAggregate  (cost=1.50..1.60 rows=10 width=8)
                Group Key: a, b
                ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
  Optimizer: Postgres query optimizer
@@ -333,11 +333,11 @@ explain insert into bar_ctas select * from foo_ctas group by a, b;
  Insert on bar_ctas  (cost=11.47..14.87 rows=3 width=8)
    ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=11.47..14.87 rows=3 width=8)
          Hash Key: foo_ctas.b
-         ->  Finalize HashAggregate  (cost=11.47..11.51 rows=3 width=8)
+         ->  HashAggregate  (cost=11.47..11.51 rows=3 width=8)
                Group Key: foo_ctas.a, foo_ctas.b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
                      Hash Key: foo_ctas.a, foo_ctas.b
-                     ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
+                     ->  HashAggregate  (cost=1.50..1.60 rows=10 width=8)
                            Group Key: foo_ctas.a, foo_ctas.b
                            ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/partition_aggregate.out
+++ b/src/test/regress/expected/partition_aggregate.out
@@ -304,29 +304,29 @@ SELECT c FROM pagg_tab GROUP BY c ORDER BY 1;
 -------------------------------------------------------
  Merge Append
    Sort Key: pagg_tab_p1.c
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p1.c
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: pagg_tab_p1.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p1.c
                      ->  Sort
                            Sort Key: pagg_tab_p1.c
                            ->  Seq Scan on pagg_tab_p1
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p2.c
          ->  Gather Motion 3:1  (slice2; segments: 3)
                Merge Key: pagg_tab_p2.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p2.c
                      ->  Sort
                            Sort Key: pagg_tab_p2.c
                            ->  Seq Scan on pagg_tab_p2
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p3.c
          ->  Gather Motion 3:1  (slice3; segments: 3)
                Merge Key: pagg_tab_p3.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p3.c
                      ->  Sort
                            Sort Key: pagg_tab_p3.c

--- a/src/test/regress/expected/pg_lsn.out
+++ b/src/test/regress/expected/pg_lsn.out
@@ -74,7 +74,7 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
   ORDER BY f;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- GroupAggregate
+ Unique
    Group Key: (((((i.i)::text || '/'::text) || (j.j)::text))::pg_lsn)
    ->  Sort
          Sort Key: (((((i.i)::text || '/'::text) || (j.j)::text))::pg_lsn)

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3527,21 +3527,24 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.15..3.18 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..10001.04 rows=1 width=4)
+   Merge Key: qp_tab1.a
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.14 rows=4 width=1)
-           ->  Hash Semi Join  (cost=1.02..2.07 rows=2 width=1)
+     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.09 rows=3 width=1)
+           ->  Hash Semi Join  (cost=1.02..2.05 rows=1 width=1)
                  Hash Cond: (qp_tab2.c = qp_tab3.e)
                  ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
                  ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                        ->  Seq Scan on qp_tab3  (cost=0.00..1.01 rows=1 width=4)
-   ->  HashAggregate  (cost=3.15..3.16 rows=1 width=4)
+   ->  Unique  (cost=1.02..10001.03 rows=0 width=4)
          Group Key: qp_tab1.a
-         ->  Result  (cost=0.00..1.01 rows=1 width=4)
-               One-Time Filter: (NOT $0)
-               ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+               Sort Key: qp_tab1.a
+               ->  Result  (cost=0.00..1.01 rows=1 width=4)
+                     One-Time Filter: (NOT $0)
+                     ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(14 rows)
+(17 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
  a 

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3646,21 +3646,24 @@ GPDB_12_MERGE_FIXME: Fallsback due to unsupported exec location.
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.15..3.18 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..10001.04 rows=1 width=4)
+   Merge Key: qp_tab1.a
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.14 rows=4 width=1)
-           ->  Hash Semi Join  (cost=1.02..2.07 rows=2 width=1)
+     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.09 rows=3 width=1)
+           ->  Hash Semi Join  (cost=1.02..2.05 rows=1 width=1)
                  Hash Cond: (qp_tab2.c = qp_tab3.e)
                  ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
                  ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                        ->  Seq Scan on qp_tab3  (cost=0.00..1.01 rows=1 width=4)
-   ->  HashAggregate  (cost=3.15..3.16 rows=1 width=4)
+   ->  Unique  (cost=1.02..10001.03 rows=0 width=4)
          Group Key: qp_tab1.a
-         ->  Result  (cost=0.00..1.01 rows=1 width=4)
-               One-Time Filter: (NOT $0)
-               ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+               Sort Key: qp_tab1.a
+               ->  Result  (cost=0.00..1.01 rows=1 width=4)
+                     One-Time Filter: (NOT $0)
+                     ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(14 rows)
+(17 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
  a 

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4727,14 +4727,14 @@ then 'MO' else 'foo' end
 case when ir_call_type_group_code in ('H', 'VH', 'PCB') then 'Thailland'
 else 'Unidentify' end
 ;
-                                                                                                                                QUERY PLAN                                                                                                                                 
+                                                                                                                                QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=184.79..258.96 rows=1000 width=96)
-   ->  Finalize HashAggregate  (cost=184.79..192.29 rows=333 width=96)
+   ->  HashAggregate  (cost=184.79..192.29 rows=333 width=96)
          Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=75.08..180.27 rows=905 width=102)
                Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-               ->  Partial HashAggregate  (cost=75.08..89.79 rows=905 width=102)
+               ->  HashAggregate  (cost=75.08..89.79 rows=905 width=102)
                      Group Key: CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END, CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END
                      ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..65.42 rows=1933 width=102)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/regex_gp.out
+++ b/src/test/regress/expected/regex_gp.out
@@ -5072,7 +5072,7 @@ select DISTINCT lname, regexp_matches(lname, '(dad)') from phone_book_substr ;
 --(0 rows)
 --Changed to First Name from Last Name.
 select DISTINCT fname, regexp_matches(fname, '(dad)') from phone_book_substr order by lname;
-ERROR:  column "phone_book_substr.lname" must appear in the GROUP BY clause or be used in an aggregate function
+ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
 LINE 1: ...tches(fname, '(dad)') from phone_book_substr order by lname;
                                                                  ^
 --  fname  | regexp_matches 

--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -138,13 +138,13 @@ SELECT count(*) FROM
          Output: (PARTIAL count(*))
          ->  Partial Aggregate
                Output: PARTIAL count(*)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Output: tenk1.two, tenk1.four, tenk1.two
                      Group Key: tenk1.two, tenk1.four, tenk1.two
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Output: tenk1.two, tenk1.four, tenk1.two
                            Hash Key: tenk1.two, tenk1.four, tenk1.two
-                           ->  Partial HashAggregate
+                           ->  HashAggregate
                                  Output: tenk1.two, tenk1.four, tenk1.two
                                  Group Key: tenk1.two, tenk1.four, tenk1.two
                                  ->  Seq Scan on public.tenk1
@@ -174,7 +174,7 @@ EXPLAIN (costs off)
 SELECT DISTINCT g%1000 FROM generate_series(0,9999) g;
                    QUERY PLAN                   
 ------------------------------------------------
- GroupAggregate
+ Unique
    Group Key: ((g % 1000))
    ->  Sort
          Sort Key: ((g % 1000))

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -258,18 +258,18 @@ select sp_parallel_restricted(unique1) from tenk1
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
-                         QUERY PLAN                         
+                         QUERY PLAN
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: (length((stringu1)::text))
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: length((stringu1)::text)
                      ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 select length(stringu1) from tenk1 group by length(stringu1);
  length 

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -261,18 +261,18 @@ select sp_parallel_restricted(unique1) from tenk1
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
-                         QUERY PLAN                         
+                         QUERY PLAN
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: (length((stringu1)::text))
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: length((stringu1)::text)
                      ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 select length(stringu1) from tenk1 group by length(stringu1);
  length 

--- a/src/test/regress/expected/tsrf.out
+++ b/src/test/regress/expected/tsrf.out
@@ -597,17 +597,13 @@ ORDER BY a, b DESC, g DESC;
 (18 rows)
 
 -- only SRF mentioned in DISTINCT ON
--- GPDB: the result is not well-defined, because for rows with same 'g',
--- any row can legally be returned. GPDB chooses a different plan than
--- upstream, one that redistributes the data. (That's probably not a
--- good plan in this simple case, but it's not incorrect.)
 SELECT DISTINCT ON (g) a, b, generate_series(1,3) g
 FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b);
  a | b | g 
 ---+---+---
  3 | 2 | 1
- 3 | 2 | 2
- 5 | 3 | 3
+ 5 | 1 | 2
+ 3 | 1 | 3
 (3 rows)
 
 -- LIMIT / OFFSET is evaluated after SRF evaluation

--- a/src/test/regress/expected/tsrf_optimizer.out
+++ b/src/test/regress/expected/tsrf_optimizer.out
@@ -614,17 +614,13 @@ ORDER BY a, b DESC, g DESC;
 (18 rows)
 
 -- only SRF mentioned in DISTINCT ON
--- GPDB: the result is not well-defined, because for rows with same 'g',
--- any row can legally be returned. GPDB chooses a different plan than
--- upstream, one that redistributes the data. (That's probably not a
--- good plan in this simple case, but it's not incorrect.)
 SELECT DISTINCT ON (g) a, b, generate_series(1,3) g
 FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b);
  a | b | g 
 ---+---+---
  3 | 2 | 1
- 3 | 2 | 2
- 5 | 3 | 3
+ 5 | 1 | 2
+ 3 | 1 | 3
 (3 rows)
 
 -- LIMIT / OFFSET is evaluated after SRF evaluation

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -975,24 +975,30 @@ select distinct q1 from
    union all
    select distinct * from int8_tbl i82) ss
 where q2 = q2;
-                        QUERY PLAN                        
-----------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   Merge Key: "*SELECT* 1".q1
+   ->  Unique
          Group Key: "*SELECT* 1".q1
-         ->  Append
+         ->  Merge Append
+               Sort Key: "*SELECT* 1".q1
                ->  Subquery Scan on "*SELECT* 1"
-                     ->  HashAggregate
+                     ->  Unique
                            Group Key: i81.q1, i81.q2
-                           ->  Seq Scan on int8_tbl i81
-                                 Filter: (q2 IS NOT NULL)
+                           ->  Sort
+                                 Sort Key: i81.q1, i81.q2
+                                 ->  Seq Scan on int8_tbl i81
+                                       Filter: (q2 IS NOT NULL)
                ->  Subquery Scan on "*SELECT* 2"
-                     ->  HashAggregate
+                     ->  Unique
                            Group Key: i82.q1, i82.q2
-                           ->  Seq Scan on int8_tbl i82
-                                 Filter: (q2 IS NOT NULL)
+                           ->  Sort
+                                 Sort Key: i82.q1, i82.q2
+                                 ->  Seq Scan on int8_tbl i82
+                                       Filter: (q2 IS NOT NULL)
  Optimizer: Postgres query optimizer
-(15 rows)
+(21 rows)
 
 select distinct q1 from
   (select distinct * from int8_tbl i81
@@ -1014,23 +1020,27 @@ where -q1 = q2;
                           QUERY PLAN                          
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   Merge Key: "*SELECT* 1".q1
+   ->  Unique
          Group Key: "*SELECT* 1".q1
-         ->  Sort
+         ->  Merge Append
                Sort Key: "*SELECT* 1".q1
-               ->  Append
-                     ->  Subquery Scan on "*SELECT* 1"
-                           ->  HashAggregate
-                                 Group Key: i81.q1, i81.q2
+               ->  Subquery Scan on "*SELECT* 1"
+                     ->  Unique
+                           Group Key: i81.q1, i81.q2
+                           ->  Sort
+                                 Sort Key: i81.q1, i81.q2
                                  ->  Seq Scan on int8_tbl i81
                                        Filter: ((- q1) = q2)
-                     ->  Subquery Scan on "*SELECT* 2"
-                           ->  HashAggregate
-                                 Group Key: i82.q1, i82.q2
+               ->  Subquery Scan on "*SELECT* 2"
+                     ->  Unique
+                           Group Key: i82.q1, i82.q2
+                           ->  Sort
+                                 Sort Key: i82.q1, i82.q2
                                  ->  Seq Scan on int8_tbl i82
                                        Filter: ((- q1) = q2)
  Optimizer: Postgres query optimizer
-(17 rows)
+(21 rows)
 
 select distinct q1 from
   (select distinct * from int8_tbl i81

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -138,7 +138,7 @@ SELECT table_name, column_name, is_updatable
 -- Read-only views
 DELETE FROM ro_view1;
 ERROR:  cannot delete from view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable deleting from the view, provide an INSTEAD OF DELETE trigger or an unconditional ON DELETE DO INSTEAD rule.
 DELETE FROM ro_view2;
 ERROR:  cannot delete from view "ro_view2"
@@ -320,7 +320,7 @@ DELETE FROM rw_view16 WHERE a=-3; -- should be OK
 -- Read-only views
 INSERT INTO ro_view17 VALUES (3, 'ROW 3');
 ERROR:  cannot insert into view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.
 DELETE FROM ro_view18;
 ERROR:  cannot delete from view "ro_view18"

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -138,7 +138,7 @@ SELECT table_name, column_name, is_updatable
 -- Read-only views
 DELETE FROM ro_view1;
 ERROR:  cannot delete from view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable deleting from the view, provide an INSTEAD OF DELETE trigger or an unconditional ON DELETE DO INSTEAD rule.
 DELETE FROM ro_view2;
 ERROR:  cannot delete from view "ro_view2"
@@ -320,7 +320,7 @@ DELETE FROM rw_view16 WHERE a=-3; -- should be OK
 -- Read-only views
 INSERT INTO ro_view17 VALUES (3, 'ROW 3');
 ERROR:  cannot insert into view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.
 DELETE FROM ro_view18;
 ERROR:  cannot delete from view "ro_view18"

--- a/src/test/regress/expected/write_parallel.out
+++ b/src/test/regress/expected/write_parallel.out
@@ -21,11 +21,11 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'le
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                       QUERY PLAN                      
 ------------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: (length((stringu1)::text))
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Hash Key: (length((stringu1)::text))
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: length((stringu1)::text)
                ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
@@ -40,11 +40,11 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'le
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                       QUERY PLAN                      
 ------------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: (length((stringu1)::text))
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Hash Key: (length((stringu1)::text))
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: length((stringu1)::text)
                ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
@@ -59,11 +59,11 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'le
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                       QUERY PLAN                      
 ------------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: (length((stringu1)::text))
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Hash Key: (length((stringu1)::text))
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: length((stringu1)::text)
                ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
@@ -78,11 +78,11 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'le
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                       QUERY PLAN                      
 ------------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: (length((stringu1)::text))
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Hash Key: (length((stringu1)::text))
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: length((stringu1)::text)
                ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -1925,13 +1925,13 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY a, b SCATTER BY a) );
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.54 rows=10 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.54 rows=4 width=36)
-         ->  GroupAggregate  (cost=2.27..2.44 rows=4 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.06..1.59 rows=30 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.06..1.19 rows=10 width=36)
+         ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                Group Key: example.a, example.b
-               ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+               ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                      Sort Key: example.a, example.b
-                     ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                     ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -1953,18 +1953,18 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY b, a LIMIT 2 SCATTER RANDOMLY) );
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.33 rows=2 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.33 rows=1 width=36)
-         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.31 rows=2 width=36)
-               ->  Limit  (cost=2.27..2.31 rows=2 width=36)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.31 rows=2 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..1.28 rows=9 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.07..1.16 rows=3 width=36)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.07..1.13 rows=1 width=16)
+               ->  Limit  (cost=1.07..1.10 rows=2 width=16)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.07..1.16 rows=6 width=16)
                            Merge Key: example.b, example.a
-                           ->  Limit  (cost=2.27..2.27 rows=1 width=36)
-                                 ->  GroupAggregate  (cost=2.27..2.44 rows=27 width=36)
+                           ->  Limit  (cost=1.07..1.08 rows=2 width=16)
+                                 ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                                        Group Key: example.b, example.a
-                                       ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+                                       ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                                              Sort Key: example.b, example.a
-                                             ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                                             ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -1925,13 +1925,13 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY a, b SCATTER BY a) );
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.54 rows=10 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.54 rows=4 width=36)
-         ->  GroupAggregate  (cost=2.27..2.44 rows=4 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.06..1.59 rows=30 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.06..1.19 rows=10 width=36)
+         ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                Group Key: example.a, example.b
-               ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+               ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                      Sort Key: example.a, example.b
-                     ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                     ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -1953,18 +1953,18 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY b, a LIMIT 2 SCATTER RANDOMLY) );
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.33 rows=2 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.33 rows=1 width=36)
-         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.31 rows=2 width=36)
-               ->  Limit  (cost=2.27..2.31 rows=2 width=36)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.31 rows=2 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..1.28 rows=9 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.07..1.16 rows=3 width=36)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.07..1.13 rows=1 width=16)
+               ->  Limit  (cost=1.07..1.10 rows=2 width=16)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.07..1.16 rows=6 width=16)
                            Merge Key: example.b, example.a
-                           ->  Limit  (cost=2.27..2.27 rows=1 width=36)
-                                 ->  GroupAggregate  (cost=2.27..2.44 rows=27 width=36)
+                           ->  Limit  (cost=1.07..1.08 rows=2 width=16)
+                                 ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                                        Group Key: example.b, example.a
-                                       ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+                                       ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                                              Sort Key: example.b, example.a
-                                             ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                                             ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/sql/gp_distinct_plans.sql
+++ b/src/test/regress/sql/gp_distinct_plans.sql
@@ -1,0 +1,79 @@
+--
+-- Test all the different plan shapes that the planner can generate for
+-- DISTINCT queries
+--
+create table distinct_test (a int, b int, c int) distributed by (a);
+insert into distinct_test select g / 1000, g / 2000, g from generate_series(1, 10000) g;
+analyze distinct_test;
+
+--
+-- With the default cost settings, you get hashed plans
+--
+
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+select distinct a, b from distinct_test;
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+select distinct b from distinct_test;
+
+-- The two-stage aggregation can be disabled with GUC
+set gp_enable_preunique = off;
+explain select distinct b from distinct_test;
+reset gp_enable_preunique;
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+
+--
+-- Repeat the same tests with sorted Unique plans
+--
+set enable_hashagg=off;
+set optimizer_enable_hashagg=off;
+
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+select distinct a, b from distinct_test;
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+select distinct b from distinct_test;
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+
+--
+-- Also test paths where the explicit Sort is not needed
+--
+create index on distinct_test (a, b);
+create index on distinct_test (b);
+create index on distinct_test (c);
+set random_page_cost=1;
+
+
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+select distinct a, b from distinct_test;
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+select distinct b from distinct_test;
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;

--- a/src/test/regress/sql/tsrf.sql
+++ b/src/test/regress/sql/tsrf.sql
@@ -151,10 +151,6 @@ FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b)
 ORDER BY a, b DESC, g DESC;
 
 -- only SRF mentioned in DISTINCT ON
--- GPDB: the result is not well-defined, because for rows with same 'g',
--- any row can legally be returned. GPDB chooses a different plan than
--- upstream, one that redistributes the data. (That's probably not a
--- good plan in this simple case, but it's not incorrect.)
 SELECT DISTINCT ON (g) a, b, generate_series(1,3) g
 FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b);
 


### PR DESCRIPTION
Previously, we had a parse analysis step to convert DISTINCT into a
corresponding GROUP BY query, because the planner was smarter about GROUP
BY than DISTINCT. The DISTINCT planning code was still needed for more
complicated cases, though, where you had both DISTINCT and GROUP BY or
aggregates in the same query. The DISTINCT planning code was badly
dilapidated, there was broken commented-out remnants of "pre-unique"
optimization in the DISTINCT planner code, for example, that got broken
in the 8.4 and 9.6 merges, but we hadn't bothered to fix.

Clean that up. Instead of transforming DISTINCT into GROUP BY in the
parse analysis stage, re-use the GROUP BY planning code for DISTINCT
queries in the planner.

This removes the gp_eager_preunique GUC, that was previously used to
force two-stage DISTINCT plans. It was undocumented, only had an effect
in the limited cases that we didn't transform the DISTINCT to GROUP BY,
so we probably don't want it in that form. It would make some sense to
have a GUC to force multi-stage DISTINCT and aggregation, perhaps by
adding a penalty cost to one-stage plans, but that should be a separate
PR.

Co-authored-by: Jinbao Chen <cjinbao@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
