### PR TITLE
docs: pxf upgrade landing page

### DIFF
--- a/gpdb-doc/dita/install_guide/install_guide.ditamap
+++ b/gpdb-doc/dita/install_guide/install_guide.ditamap
@@ -37,13 +37,9 @@
         <topicref href="localization.xml" navtitle="Configuring Localization Settings"/>
         <topicref href="upgrade_intro.xml" navtitle="Upgrading to Greenplum 6.x">
           <topicref href="upgrading.xml"/>
-          <topicref href="../pxf/upgrade_pxf_6x.html"
-                format="html" scope="peer" navtitle="Upgrading PXF When You Upgrade Greenplum 6"/>
+          <topicref href="../pxf/pxf_upgrade_migration.html"
+                format="html" scope="peer" navtitle="PXF Upgrade and Migration"/>
           <topicref href="migrate.xml"/>
-          <topicref href="../pxf/gphdfs-pxf-migrate.html"
-                format="html" otherprops="pivotal" scope="peer" navtitle="Migrating gphdfs External Tables to PXF"/>
-          <topicref href="../pxf/migrate_5to6.html"
-                format="html" scope="peer" navtitle="Migrating PXF from Greenplum 5"/>
         </topicref>
         <topicref href="enable_iptables.xml" navtitle="Enabling iptables"/>
         <topicref href="apx_mgmt_utils.xml" navtitle="Installation Management Utilities"/>

--- a/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
@@ -5,7 +5,6 @@ When you upgrade your Greenplum Database system, you must perform some additiona
 
 There are three possible scenarios:
 
-1. Upgrading PXF after [migrating from Greenplum Database 5.x](migrate_5to6.html).
-    - If you were previously using the `gphdfs` external table protocol to access data stored in Hadoop, you must [migrate your gphdfs external tables](gphdfs-pxf-migrate.html) to use PXF instead, since Greenplum Database version 6 removes support for the `gphdfs` protocol.
+1. Upgrading PXF after [migrating from Greenplum Database 5.x](migrate_5to6.html). If you were previously using the `gphdfs` external table protocol to access data stored in Hadoop, you must [migrate your gphdfs external tables](gphdfs-pxf-migrate.html) to use PXF instead, since Greenplum Database version 6 removes support for the `gphdfs` protocol.
 1. Upgrading PXF after [upgrading Greenplum Database from a previous 6.x version](upgrade_pxf_6x.html). Note that different steps are outlined based on your PXF installation source: a manually installed `rpm` or `deb` package downloaded from Tanzu Network, or the version included with Greenplum Database installer. 
 1. If you are upgrading a PXF `rpm` or `deb` installation outside of a Greenplum Database upgrade, refer to the [PXF Documentation](../../pxf/6-0/upgrade_pxf_rpm.html).

--- a/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
@@ -3,9 +3,9 @@ title: PXF Upgrade and Migration
 ---
 When you upgrade your Greenplum Database system, you must perform some additional steps in order to bring your PXF configuration up to date.
 
-There are different possible scenarios:
+There are three possible scenarios:
 
 1. Upgrading PXF after [migrating from Greenplum Database 5.x](migrate_5to6.html).
     - If you were previously using the `gphdfs` external table protocol to access data stored in Hadoop, you must [migrate your gphdfs external tables](gphdfs-pxf-migrate.html) to use PXF instead, since Greenplum Database version 6 removes support for the `gphdfs` protocol.
-1. Upgrading PXF after [upgrading Greenplum Database from a previous 6.x version](upgrade_pxf_6x.html). Note that different steps are outlined based on your PXF installation source: a manually installed `rpm` or `deb` package downloaded from TanzuNet, or the version included with Greenplum Database installer. 
-1. If you are planning to upgrade a PXF `rpm` or `deb` installation outside of a Greenplum Database upgrade, you must refer to the [PXF Documentation](../../pxf/6-0/upgrade_pxf_rpm.html).
+1. Upgrading PXF after [upgrading Greenplum Database from a previous 6.x version](upgrade_pxf_6x.html). Note that different steps are outlined based on your PXF installation source: a manually installed `rpm` or `deb` package downloaded from Tanzu Network, or the version included with Greenplum Database installer. 
+1. If you are upgrading a PXF `rpm` or `deb` installation outside of a Greenplum Database upgrade, refer to the [PXF Documentation](../../pxf/6-0/upgrade_pxf_rpm.html).

--- a/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: PXF Upgrade and Migration
+---
+When you upgrade your Greenplum Database system, you must perform some additional steps in order to bring your PXF configuration up to date.
+
+There are different possible scenarios:
+
+1. Upgrading PXF after [migrating from Greenplum Database 5.x](migrate_5to6.html).
+    - If you were previously using the `gphdfs` external table protocol to access data stored in Hadoop, you must [migrate](gphdfs-pxf-migrate.html) your `gphdfs` external tables to use PXF instead, since Greenplum Database version 6 removes support for the `gphdfs` protocol.
+1. Upgrading PXF after [upgrading Greenplum Database from a previous 6.x version](upgrade_pxf_6x.html). Note that different steps are outlined based on your PXF installation type: it can be a manually installed `rpm` or the version shipped with Greenplum Database binaries. 
+1. If you are planning a PXF upgrade, but not as part of a Greenplum Database upgrade, you must refer to the [PXF Documentation](../../pxf/5-15/upgrade_pxf_rpm.html).
+
+

--- a/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_upgrade_migration.html.md.erb
@@ -6,8 +6,6 @@ When you upgrade your Greenplum Database system, you must perform some additiona
 There are different possible scenarios:
 
 1. Upgrading PXF after [migrating from Greenplum Database 5.x](migrate_5to6.html).
-    - If you were previously using the `gphdfs` external table protocol to access data stored in Hadoop, you must [migrate](gphdfs-pxf-migrate.html) your `gphdfs` external tables to use PXF instead, since Greenplum Database version 6 removes support for the `gphdfs` protocol.
-1. Upgrading PXF after [upgrading Greenplum Database from a previous 6.x version](upgrade_pxf_6x.html). Note that different steps are outlined based on your PXF installation type: it can be a manually installed `rpm` or the version shipped with Greenplum Database binaries. 
-1. If you are planning a PXF upgrade, but not as part of a Greenplum Database upgrade, you must refer to the [PXF Documentation](../../pxf/5-15/upgrade_pxf_rpm.html).
-
-
+    - If you were previously using the `gphdfs` external table protocol to access data stored in Hadoop, you must [migrate your gphdfs external tables](gphdfs-pxf-migrate.html) to use PXF instead, since Greenplum Database version 6 removes support for the `gphdfs` protocol.
+1. Upgrading PXF after [upgrading Greenplum Database from a previous 6.x version](upgrade_pxf_6x.html). Note that different steps are outlined based on your PXF installation source: a manually installed `rpm` or `deb` package downloaded from TanzuNet, or the version included with Greenplum Database installer. 
+1. If you are planning to upgrade a PXF `rpm` or `deb` installation outside of a Greenplum Database upgrade, you must refer to the [PXF Documentation](../../pxf/6-0/upgrade_pxf_rpm.html).


### PR DESCRIPTION
Added a "PXF Upgrade and Migration" landing page for Greenplum upgrade documentation. 
When upgrading to Greenplum 6 (https://mireia-pxf-upgrade-landing.sc2-04-pcf1-apps.oc.vmware.com/7-0/install_guide/upgrade_intro.html), all PXF options are grouped into one into the landing page: 
https://mireia-pxf-upgrade-landing.sc2-04-pcf1-apps.oc.vmware.com/7-0/pxf/pxf_upgrade_migration.html
This provides a breakdown of different scenarios and directs user to the specific steps to follow in every case.
