### PR TITLE
Remove unnecessary sort nodes for grouping sets with DQA

### DIFF
--- a/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg.out
+++ b/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg.out
@@ -1208,22 +1208,18 @@ explain select median(a) from perct group by grouping sets((), (b));
  Append  (cost=13.69..29.54 rows=12 width=24)
    ->  GroupAggregate  (cost=13.69..14.83 rows=11 width=24)
          Group Key: share0_ref1.b
-         ->  Sort  (cost=13.69..13.94 rows=100 width=8)
-               Sort Key: share0_ref1.b
-               ->  Shared Scan (share slice:id 0:0)  (cost=10.07..10.37 rows=100 width=8)
-                     ->  Materialize  (cost=7.32..10.07 rows=100 width=8)
-                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=7.32..9.57 rows=100 width=8)
-                                 Merge Key: perct.b
-                                 ->  Sort  (cost=7.32..7.57 rows=34 width=8)
-                                       Sort Key: perct.b
-                                       ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
-   ->  GroupAggregate  (cost=13.69..14.71 rows=1 width=24)
+         ->  Shared Scan (share slice:id 0:0)  (cost=10.07..10.37 rows=100 width=8)
+               ->  Materialize  (cost=7.32..10.07 rows=100 width=8)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=7.32..9.57 rows=100 width=8)
+                           Merge Key: perct.b
+                           ->  Sort  (cost=7.32..7.57 rows=34 width=8)
+                                 Sort Key: perct.b
+                                 ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+   ->  GroupAggregate  (cost=10.07..11.13 rows=1 width=24)
          Group Key: share0_ref2.b
-         ->  Sort  (cost=13.69..13.94 rows=100 width=8)
-               Sort Key: share0_ref2.b
-               ->  Shared Scan (share slice:id 0:0)  (cost=10.07..10.37 rows=100 width=8)
+         ->  Shared Scan (share slice:id 0:0)  (cost=10.07..10.37 rows=100 width=8)
  Optimizer: Postgres query optimizer
-(18 rows)
+(14 rows)
 
 select median(a) from perct group by grouping sets((), (b));
  median 

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -1867,12 +1867,13 @@ generate_list_subplans(PlannerInfo *root, int num_subplans,
 
 	for(group_no = 0; group_no < num_subplans; ++group_no)
 	{
-		/* GPDB_93_MERGE_FIXME: Check whether we could just use
-		 * context->current_pathkeys for the function's caller
-		 * since the list includes duplicates.
+		/*
+		 * compare_pathkeys() assumes the pathkeys are canonical, and
+		 * checks them for equality by simple pointer comparison. So we
+		 * use context->current_pathkeys for the function's caller.
 		 */
 		context->pathkeys = lappend(context->pathkeys,
-									copyObject(context->current_pathkeys));
+									context->current_pathkeys);
 	}
 
 	return subplans;

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -221,31 +221,27 @@ select 1, a from foo_gset_const group by grouping sets(1,2);
 
 explain (costs off)
 select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Append
    ->  GroupAggregate
          Group Key: share0_ref1.a, share0_ref1.col_2
-         ->  Sort
-               Sort Key: share0_ref1.a
-               ->  Gather Motion 3:1  (slice1; segments: 3)
-                     Merge Key: share0_ref1.a
-                     ->  Sort
-                           Sort Key: share0_ref1.a
-                           ->  Shared Scan (share slice:id 1:0)
-                                 ->  Materialize
-                                       ->  Seq Scan on foo_gset_const
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: share0_ref1.a
+               ->  Sort
+                     Sort Key: share0_ref1.a
+                     ->  Shared Scan (share slice:id 1:0)
+                           ->  Materialize
+                                 ->  Seq Scan on foo_gset_const
    ->  GroupAggregate
          Group Key: share0_ref2.col_2, share0_ref2.a
-         ->  Sort
-               Sort Key: share0_ref2.a
-               ->  Gather Motion 3:1  (slice2; segments: 3)
-                     Merge Key: share0_ref2.a
-                     ->  Sort
-                           Sort Key: share0_ref2.a
-                           ->  Shared Scan (share slice:id 2:0)
+         ->  Gather Motion 3:1  (slice2; segments: 3)
+               Merge Key: share0_ref2.a
+               ->  Sort
+                     Sort Key: share0_ref2.a
+                     ->  Shared Scan (share slice:id 2:0)
  Optimizer: Postgres query optimizer
-(22 rows)
+(18 rows)
 
 select 1, a, count(distinct(a)) from foo_gset_const group by grouping sets(1,2);
  ?column? | a | count 
@@ -356,6 +352,47 @@ select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
 (3 rows)
 
 drop table foo_gset_const;
+--
+-- GROUPING SETS with DQA should not have unnecessary sort nodes
+--
+create table foo_gset_dqa(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo_gset_dqa values(1,1);
+insert into foo_gset_dqa values(2,1);
+explain (costs off)
+select i, j, count(distinct j) from foo_gset_dqa GROUP BY grouping sets((i), (j));
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Append
+   ->  GroupAggregate
+         Group Key: share0_ref1.j, share0_ref1.i
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: share0_ref1.j, share0_ref1.i
+               ->  Sort
+                     Sort Key: share0_ref1.j, share0_ref1.i
+                     ->  Shared Scan (share slice:id 1:0)
+                           ->  Materialize
+                                 ->  Seq Scan on foo_gset_dqa
+   ->  GroupAggregate
+         Group Key: share0_ref2.i, share0_ref2.j
+         ->  Gather Motion 3:1  (slice2; segments: 3)
+               Merge Key: share0_ref2.i, share0_ref2.j
+               ->  Sort
+                     Sort Key: share0_ref2.i, share0_ref2.j
+                     ->  Shared Scan (share slice:id 2:0)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+select i, j, count(distinct j) from foo_gset_dqa GROUP BY grouping sets((i), (j));
+ i | j | count 
+---+---+-------
+   | 1 |     1
+ 1 |   |     1
+ 2 |   |     1
+(3 rows)
+
+drop table foo_gset_dqa;
 --
 -- Reset settings
 --

--- a/src/test/regress/sql/aggregate_with_groupingsets.sql
+++ b/src/test/regress/sql/aggregate_with_groupingsets.sql
@@ -133,6 +133,20 @@ select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
 select '' ,'' ,count(distinct(a)) from foo_gset_const group by rollup(1,2) ;
 drop table foo_gset_const;
 
+
+--
+-- GROUPING SETS with DQA should not have unnecessary sort nodes
+--
+create table foo_gset_dqa(i int, j int);
+insert into foo_gset_dqa values(1,1);
+insert into foo_gset_dqa values(2,1);
+
+explain (costs off)
+select i, j, count(distinct j) from foo_gset_dqa GROUP BY grouping sets((i), (j));
+select i, j, count(distinct j) from foo_gset_dqa GROUP BY grouping sets((i), (j));
+
+drop table foo_gset_dqa;
+
 --
 -- Reset settings
 --


### PR DESCRIPTION
compare_pathkeys() assumes the pathkeys are canonical, and checks them
for equality by simple pointer comparison. So we should not use the copy
of pathkeys when generating subplans for rollups. Otherwise we would
have unnecessary sort nodes in the final plan.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
