### PR TITLE
gprecoverseg: handle mismatched tablespace locations during full recovery

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -894,7 +894,7 @@ class ConfigureNewSegment(Command):
 
     def __init__(self, name, confinfo, logdir, newSegments=False, tarFile=None,
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
-                 forceoverwrite=False):
+                 forceoverwrite=False, tablespaceMapFile=None):
 
         cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
 
@@ -912,6 +912,8 @@ class ConfigureNewSegment(Command):
             cmdStr += " --write-gpid-file-only"
         if forceoverwrite:
             cmdStr += " --force-overwrite"
+        if tablespaceMapFile:
+            cmdStr += " --tablespace-map-file %s" % tablespaceMapFile
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -894,7 +894,7 @@ class ConfigureNewSegment(Command):
 
     def __init__(self, name, confinfo, logdir, newSegments=False, tarFile=None,
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
-                 forceoverwrite=False, tablespaceMappingFile=None):
+                 forceoverwrite=False, tablespaceMappingList=None):
 
         cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
 
@@ -912,8 +912,8 @@ class ConfigureNewSegment(Command):
             cmdStr += " --write-gpid-file-only"
         if forceoverwrite:
             cmdStr += " --force-overwrite"
-        if tablespaceMappingFile:
-            cmdStr += " --tablespace-mapping-file %s" % tablespaceMappingFile
+        if tablespaceMappingList:
+            cmdStr += " --tablespace-mapping " + " --tablespace-mapping ".join(tablespaceMappingList)
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -894,7 +894,7 @@ class ConfigureNewSegment(Command):
 
     def __init__(self, name, confinfo, logdir, newSegments=False, tarFile=None,
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
-                 forceoverwrite=False, tablespaceMapFile=None):
+                 forceoverwrite=False, tablespaceMappingFile=None):
 
         cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
 
@@ -912,8 +912,8 @@ class ConfigureNewSegment(Command):
             cmdStr += " --write-gpid-file-only"
         if forceoverwrite:
             cmdStr += " --force-overwrite"
-        if tablespaceMapFile:
-            cmdStr += " --tablespace-map-file %s" % tablespaceMapFile
+        if tablespaceMappingFile:
+            cmdStr += " --tablespace-mapping-file %s" % tablespaceMappingFile
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -176,7 +176,7 @@ class PgControlData(Command):
 
 class PgBaseBackup(Command):
     def __init__(self, pgdata, host, port, replication_slot_name=None, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False, target_gp_dbid=0, logfile=None,
-                 recovery_mode=True):
+                 recovery_mode=True, tablespace_mappings=[]):
         cmd_tokens = ['pg_basebackup', '-c', 'fast']
         cmd_tokens.append('-D')
         cmd_tokens.append(pgdata)
@@ -191,6 +191,10 @@ class PgBaseBackup(Command):
 
         if recovery_mode:
             cmd_tokens.append('--write-recovery-conf')
+
+        if tablespace_mappings and len(tablespace_mappings) > 0:
+            for mapping in tablespace_mappings:
+                cmd_tokens.append('--tablespace-mapping=%s' % mapping)
 
         # This is needed to handle Greenplum tablespaces
         cmd_tokens.append('--target-gp-dbid')

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -176,7 +176,7 @@ class PgControlData(Command):
 
 class PgBaseBackup(Command):
     def __init__(self, pgdata, host, port, replication_slot_name=None, excludePaths=[], ctxt=LOCAL, remoteHost=None, forceoverwrite=False, target_gp_dbid=0, logfile=None,
-                 recovery_mode=True, tablespace_mappings=[]):
+                 recovery_mode=True, tablespace_mappings_list=None):
         cmd_tokens = ['pg_basebackup', '-c', 'fast']
         cmd_tokens.append('-D')
         cmd_tokens.append(pgdata)
@@ -192,8 +192,8 @@ class PgBaseBackup(Command):
         if recovery_mode:
             cmd_tokens.append('--write-recovery-conf')
 
-        if tablespace_mappings and len(tablespace_mappings) > 0:
-            for mapping in tablespace_mappings:
+        if tablespace_mappings_list:
+            for mapping in tablespace_mappings_list:
                 cmd_tokens.append('--tablespace-mapping=%s' % mapping)
 
         # This is needed to handle Greenplum tablespaces

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -205,7 +205,7 @@ class GpMirrorListToBuild:
                                                                 timeStamp,
                                                                 targetSegment.getSegmentDbId())
 
-    def buildMirrors(self, actionName, gpEnv, gpArray, tablespaceMapFile=None):
+    def buildMirrors(self, actionName, gpEnv, gpArray, tablespaceMappingFile=None):
         """
         Build the mirrors.
 
@@ -261,7 +261,7 @@ class GpMirrorListToBuild:
         self.__ensureMarkedDown(gpEnv, toEnsureMarkedDown)
         if not self.__forceoverwrite:
             self.__cleanUpSegmentDirectories(cleanupDirectives)
-        self.__copySegmentDirectories(gpEnv, gpArray, copyDirectives, tablespaceMapFile)
+        self.__copySegmentDirectories(gpEnv, gpArray, copyDirectives, tablespaceMappingFile)
 
         # update and save metadata in memory
         for toRecover in self.__mirrorsToBuild:
@@ -555,7 +555,7 @@ class GpMirrorListToBuild:
             unix.MakeDirectory("create blank directory for segment", subDir).run(validateAfter=True)
             unix.Chmod.local('set permissions on blank dir', subDir, '0700')
 
-    def __copySegmentDirectories(self, gpEnv, gpArray, directives, tablespaceMapFile=None):
+    def __copySegmentDirectories(self, gpEnv, gpArray, directives, tablespaceMappingFile=None):
         """
         directives should be composed of GpCopySegmentDirectoryDirective values
         """
@@ -581,7 +581,7 @@ class GpMirrorListToBuild:
         destSegmentByHost = GpArray.getSegmentsByHostName(destSegments)
         newSegmentInfo = gp.ConfigureNewSegment.buildSegmentInfoForNewSegment(destSegments, isTargetReusedLocation)
 
-        def createConfigureNewSegmentCommand(hostName, cmdLabel, validationOnly, tablespaceMapFile=None):
+        def createConfigureNewSegmentCommand(hostName, cmdLabel, validationOnly, tablespaceMappingFile=None):
             segmentInfo = newSegmentInfo[hostName]
             checkNotNone("segmentInfo for %s" % hostName, segmentInfo)
 
@@ -595,7 +595,7 @@ class GpMirrorListToBuild:
                                           remoteHost=hostName,
                                           validationOnly=validationOnly,
                                           forceoverwrite=self.__forceoverwrite,
-                                          tablespaceMapFile=tablespaceMapFile)
+                                          tablespaceMappingFile=tablespaceMappingFile)
         #
         # validate directories for target segments
         #
@@ -649,7 +649,7 @@ class GpMirrorListToBuild:
                     progressCmds.append(progressCmd)
 
             cmds.append(
-                createConfigureNewSegmentCommand(hostName, 'configure blank segments', False, tablespaceMapFile))
+                createConfigureNewSegmentCommand(hostName, 'configure blank segments', False, tablespaceMappingFile))
 
         self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, "unpacking basic segment directory",
                                                           suppressErrorCheck=False,

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -673,11 +673,11 @@ class GpRecoverSegmentProgram:
                 self.syncPackages(new_hosts)
 
             # sync tablespace map file, if it exists
-            if self.__options.tablespaceMapFile:
-                self.copy_tablespace_map_file_to_segments(gpArray, mirrorBuilder, self.__options.tablespaceMapFile)
+            if self.__options.tablespaceMappingFile:
+                self.copy_tablespace_map_file_to_segments(gpArray, mirrorBuilder, self.__options.tablespaceMappingFile)
 
             config_primaries_for_replication(gpArray, self.__options.hba_hostnames)
-            if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray, self.__options.tablespaceMapFile):
+            if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray, self.__options.tablespaceMappingFile):
                 sys.exit(1)
 
             confProvider.sendPgElogFromMaster("Recovery of %d segment(s) has been started." % \
@@ -798,8 +798,8 @@ class GpRecoverSegmentProgram:
         addTo.add_option('', '--hba-hostnames', action='store_true', dest='hba_hostnames',
                          help='use hostnames instead of CIDR in pg_hba.conf')
         addTo.add_option("", "--tablespace-map-file", type="string",
-                         dest="tablespaceMapFile",
-                         metavar="<tablespaceMapFile>",
+                         dest="tablespaceMappingFile",
+                         metavar="<tablespaceMappingFile>",
                          help="File giving primary-mirror tablespace mapping if differing tablespace locations are used")
 
         parser.set_defaults()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -108,7 +108,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.spareDataDirectoryFile = self.config_file_path
         options.showProgress = True
         options.showProgressInplace = True
-        options.tablespaceMapFile = None
+        options.tablespaceMappingFile = None
 
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
@@ -224,7 +224,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.spareDataDirectoryFile = None
         options.showProgress = True
         options.showProgressInplace = True
-        options.tablespaceMapFile = None
+        options.tablespaceMappingFile = None
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
@@ -249,7 +249,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.spareDataDirectoryFile = None
         options.showProgress = True
         options.showProgressInplace = True
-        options.tablespaceMapFile = None
+        options.tablespaceMappingFile = None
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -108,6 +108,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.spareDataDirectoryFile = self.config_file_path
         options.showProgress = True
         options.showProgressInplace = True
+        options.tablespaceMapFile = None
 
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
@@ -223,6 +224,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.spareDataDirectoryFile = None
         options.showProgress = True
         options.showProgressInplace = True
+        options.tablespaceMapFile = None
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)
@@ -247,6 +249,7 @@ class GpRecoversegTestCase(GpTestCase):
         options.spareDataDirectoryFile = None
         options.showProgress = True
         options.showProgressInplace = True
+        options.tablespaceMapFile = None
         # import HERE so that patches are already in place!
         from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
         self.subject = GpRecoverSegmentProgram(options)

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -43,7 +43,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, contentid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile, tablespaceMappingFile):
+                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile, tablespaceMappingList):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -62,7 +62,7 @@ class ConfExpSegCmd(Command):
         self.replicationSlotName = replicationSlotName
         self.logfileDirectory = logfileDirectory
         self.progressFile = progressFile
-        self.tablespaceMappings = self.parseTablespaceMappingFile(tablespaceMappingFile)
+        self.tablespaceMappingList = tablespaceMappingList
 
         #
         # validationOnly if True then we validate directories and other simple things only; we don't
@@ -107,40 +107,6 @@ class ConfExpSegCmd(Command):
         else:
             os.makedirs(path, 0700)
 
-    # The map file should consist of one line per tablespace per mismatched segment pair, where each line
-    # has the following format:
-    #
-    #     [content]:[location on recovery segment]=[location on failed segment]
-    #
-    # See gprecoverseg_help for more details.
-    #
-    # The function returns a dictionary mapping each content all of the mappings for that content, to make it
-    # easy to pass down to gpconfigurenewsegment on a per-content basis.
-    def parseTablespaceMappingFile(self, filename):
-        if filename is None:
-            return None
-
-        lines = []
-        mappings = {}
-        with open(filename, 'r') as fd:
-            lines = fd.read().splitlines()
-
-        for line in lines:
-            tokens = line.split(':')
-            if len(tokens) != 2:
-                raise Exception("Invalid line format in tablespace map file: %s" % line)
-            content, mapping = tokens[0], tokens[1]
-            tokens = mapping.split('=')
-            if len(tokens) != 2:
-                raise Exception("Invalid line format in tablespace map file: %s" % line)
-            # Don't do anything with tokens; we're leaving mapping in 'foo=bar' format, just checking the syntax
-            content = int(content)
-            if content not in mappings:
-                mappings[content] = []
-            mappings[content].append(mapping)
-
-        return mappings
-
     def run(self):
         try:
             if self.newseg:
@@ -172,11 +138,6 @@ class ConfExpSegCmd(Command):
                                                                                 datetime.datetime.today().strftime('%Y%m%d_%H%M%S'),
                                                                                 self.dbid)
 
-                    # Extract the tablespace mappings used for this particular segment pair
-                    tablespace_mappings = None
-                    if self.tablespaceMappings and self.contentid in self.tablespaceMappings:
-                        tablespace_mappings = self.tablespaceMappings[self.contentid]
-
                     # Create a mirror based on the primary
                     cmd = PgBaseBackup(pgdata=self.datadir,
                                        host=self.syncWithSegmentHostname,
@@ -185,7 +146,7 @@ class ConfExpSegCmd(Command):
                                        forceoverwrite=self.forceoverwrite,
                                        target_gp_dbid=self.dbid,
                                        logfile=self.progressFile,
-                                       tablespace_mappings=tablespace_mappings)
+                                       tablespace_mappings_list=self.tablespaceMappingList)
                     try:
                         logger.info("Running pg_basebackup with progress output temporarily in %s" % self.progressFile)
                         cmd.run(validateAfter=True)
@@ -334,7 +295,7 @@ def parseargs():
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
     parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)
     parser.add_option('-l', '--log-dir', dest="logfileDirectory", type="string")
-    parser.add_option('-T', '--tablespace-mapping-file', dest="tablespaceMappingFile", type="string")
+    parser.add_option('-T', '--tablespace-mapping', dest="tablespaceMappingList", action='append', type="string")
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
 
@@ -427,7 +388,7 @@ try:
                            , replicationSlotName = options.replicationSlotName
                            , logfileDirectory = options.logfileDirectory
                            , progressFile= progressFile
-                           , tablespaceMappingFile = options.tablespaceMappingFile
+                           , tablespaceMappingList= options.tablespaceMappingList
                            )
         pool.addCommand(cmd)
 

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -43,7 +43,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, contentid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile):
+                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile, tablespaceMapFile):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -62,6 +62,8 @@ class ConfExpSegCmd(Command):
         self.replicationSlotName = replicationSlotName
         self.logfileDirectory = logfileDirectory
         self.progressFile = progressFile
+        self.tablespaceMappings = self.parseTablespaceMapFile(tablespaceMapFile)
+
         #
         # validationOnly if True then we validate directories and other simple things only; we don't
         #                actually configure the segment
@@ -105,6 +107,45 @@ class ConfExpSegCmd(Command):
         else:
             os.makedirs(path, 0700)
 
+    # The map file should consist of one line per tablespace per mismatched segment pair, where each line
+    # has the following format:
+    #
+    #     [content]:[location on recovery segment]=[location on failed segment]
+    #
+    # For example, the following file contents:
+    #     2:/tmp/newspace/primary=/tmp/newspace/mirror
+    #     4:/tmp/newspace/primary=/tmp/newspace/mirror
+    #     2:/tmp/otherspace/primary=/tmp/otherspace/mirror
+    # indicate that the segment pair for content 2 has mismatches for two tablespaces (newspace and otherspace)
+    # and the segment pair for content 4 has a mismatch for one tablespace (newspace), and in all three cases
+    # the mirrors have failed and will be rebuilt from the corresponding primaries.
+    # The function returns a dictionary mapping each content all of the mappings for that content, to make it
+    # easy to pass down to gpconfigurenewsegment on a per-content basis.
+    def parseTablespaceMapFile(self, filename):
+        if filename is None:
+            return None
+
+        lines = []
+        mappings = {}
+        with open(filename, 'r') as fd:
+            lines = fd.read().splitlines()
+
+        for line in lines:
+            tokens = line.split(':')
+            if len(tokens) != 2:
+                raise Exception("Invalid line format in tablespace map file: %s" % line)
+            content, mapping = tokens[0], tokens[1]
+            tokens = mapping.split('=')
+            if len(tokens) != 2:
+                raise Exception("Invalid line format in tablespace map file: %s" % line)
+            # Don't do anything with tokens; we're leaving mapping in 'foo=bar' format, just checking the syntax
+            content = int(content)
+            if content not in mappings:
+                mappings[content] = []
+            mappings[content].append(mapping)
+
+        return mappings
+
     def run(self):
         try:
             if self.newseg:
@@ -135,6 +176,12 @@ class ConfExpSegCmd(Command):
                         self.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
                                                                                 datetime.datetime.today().strftime('%Y%m%d_%H%M%S'),
                                                                                 self.dbid)
+
+                    # Extract the tablespace mappings used for this particular segment pair
+                    tablespace_mappings = None
+                    if self.tablespaceMappings and self.contentid in self.tablespaceMappings:
+                        tablespace_mappings = self.tablespaceMappings[self.contentid]
+
                     # Create a mirror based on the primary
                     cmd = PgBaseBackup(pgdata=self.datadir,
                                        host=self.syncWithSegmentHostname,
@@ -142,7 +189,8 @@ class ConfExpSegCmd(Command):
                                        replication_slot_name=self.replicationSlotName,
                                        forceoverwrite=self.forceoverwrite,
                                        target_gp_dbid=self.dbid,
-                                       logfile=self.progressFile)
+                                       logfile=self.progressFile,
+                                       tablespace_mappings=tablespace_mappings)
                     try:
                         logger.info("Running pg_basebackup with progress output temporarily in %s" % self.progressFile)
                         cmd.run(validateAfter=True)
@@ -291,6 +339,7 @@ def parseargs():
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
     parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)
     parser.add_option('-l', '--log-dir', dest="logfileDirectory", type="string")
+    parser.add_option('-T', '--tablespace-map-file', dest="tablespaceMapFile", type="string")
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
 
@@ -383,6 +432,7 @@ try:
                            , replicationSlotName = options.replicationSlotName
                            , logfileDirectory = options.logfileDirectory
                            , progressFile= progressFile
+                           , tablespaceMapFile = options.tablespaceMapFile
                            )
         pool.addCommand(cmd)
 

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -43,7 +43,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, contentid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile, tablespaceMapFile):
+                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile, tablespaceMappingFile):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -62,7 +62,7 @@ class ConfExpSegCmd(Command):
         self.replicationSlotName = replicationSlotName
         self.logfileDirectory = logfileDirectory
         self.progressFile = progressFile
-        self.tablespaceMappings = self.parseTablespaceMapFile(tablespaceMapFile)
+        self.tablespaceMappings = self.parseTablespaceMappingFile(tablespaceMappingFile)
 
         #
         # validationOnly if True then we validate directories and other simple things only; we don't
@@ -112,16 +112,11 @@ class ConfExpSegCmd(Command):
     #
     #     [content]:[location on recovery segment]=[location on failed segment]
     #
-    # For example, the following file contents:
-    #     2:/tmp/newspace/primary=/tmp/newspace/mirror
-    #     4:/tmp/newspace/primary=/tmp/newspace/mirror
-    #     2:/tmp/otherspace/primary=/tmp/otherspace/mirror
-    # indicate that the segment pair for content 2 has mismatches for two tablespaces (newspace and otherspace)
-    # and the segment pair for content 4 has a mismatch for one tablespace (newspace), and in all three cases
-    # the mirrors have failed and will be rebuilt from the corresponding primaries.
+    # See gprecoverseg_help for more details.
+    #
     # The function returns a dictionary mapping each content all of the mappings for that content, to make it
     # easy to pass down to gpconfigurenewsegment on a per-content basis.
-    def parseTablespaceMapFile(self, filename):
+    def parseTablespaceMappingFile(self, filename):
         if filename is None:
             return None
 
@@ -339,7 +334,7 @@ def parseargs():
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
     parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)
     parser.add_option('-l', '--log-dir', dest="logfileDirectory", type="string")
-    parser.add_option('-T', '--tablespace-map-file', dest="tablespaceMapFile", type="string")
+    parser.add_option('-T', '--tablespace-mapping-file', dest="tablespaceMappingFile", type="string")
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
 
@@ -432,7 +427,7 @@ try:
                            , replicationSlotName = options.replicationSlotName
                            , logfileDirectory = options.logfileDirectory
                            , progressFile= progressFile
-                           , tablespaceMapFile = options.tablespaceMapFile
+                           , tablespaceMappingFile = options.tablespaceMappingFile
                            )
         pool.addCommand(cmd)
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -9,6 +9,7 @@ Synopsis
 
 gprecoverseg [-p <new_recover_host>[,...]]
              |-i <recover_config_file> 
+             |--tablespace-mapping-file <tablespace_mapping_file>
              [-d <master_data_directory>] [-B <parallel_processes>] 
              [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
 
@@ -170,6 +171,35 @@ Obtaining a Sample File
 
 You can use the -o option to output a sample recovery configuration file 
 to use as a starting point.
+
+
+--tablespace-mapping-file <tablespace_mapping_file>
+
+Specifies the name of a file with the details about tablespaces that exist
+at different locations on the primary and mirror of a given segment pair.
+If a single segment has multiple mismatched tablespaces, a separate line
+is required for each.  Each line in the file is in the following format.
+
+<content id>:<location on recovery segment>=<location on failed segment>
+
+Locations should be absolute paths to tablespace directories, excluding the
+dbid directory added automatically by CREATE TABLESPACE, if applicable. For
+example, if the full path for segment 5 is /data/tablespace/5, only the path
+/data/tablespace should be used.
+
+Examples
+
+One mirror with one mismatched tablespace
+
+1:/data/tablespaces/primary=/data/tablespaces/mirror
+
+Two mirrors with one tablespace each and one primary with two tablespaces
+
+1:/data/nfs1/primary=/data/nfs2/mirror
+3:/data/nfs1/primary=/data/nfs2/mirror
+2:/data/mirror/ts1=/data/primary/ts1
+2:/data/mirror/ts2=/data/primary/ts2
+
 
 -l <logfile_directory>
 


### PR DESCRIPTION
When creating a tablespace, the specified location is normally the same
for both the primary and the mirror of a given segment pair.  If the
location is manually changed by the user so they no longer match, a full
recovery with gprecoverseg -F will change the location of the tablespace
on the recovered segment to that on the other segment, which can cause
problems with disk usage and such.

This commit adds an argument to gprecoverseg to address that case.  The
user passes in a file specifying a mapping between tablespace locations
on the two segments for each affected tablespace, which is then passed
to pg_basebackup to be handled with that utility's existing tablespace
mapping functionality.

---

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_gprecoverseg_mismatched_tablespaces)