### PR TITLE
6X: Fix treat COPY FROM dtx as a read-only dtx

### DIFF
--- a/src/test/regress/expected/gp_copy_dtx.out
+++ b/src/test/regress/expected/gp_copy_dtx.out
@@ -1,0 +1,26 @@
+-- Test if COPY FROM uses correct distribued transaction command protocol
+CREATE TABLE test_copy_from_dtx (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET Test_print_direct_dispatch_info = ON;
+COPY test_copy_from_dtx (c1, c2) FROM stdin;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+SELECT * FROM test_copy_from_dtx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ c1 | c2 
+----+----
+  5 |  6
+  6 |  7
+  9 | 10
+  1 |  2
+  2 |  3
+  3 |  4
+  4 |  5
+  7 |  8
+  8 |  9
+(9 rows)
+
+SET Test_print_direct_dispatch_info = OFF;
+-- Clean up
+DROP TABLE test_copy_from_dtx;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,11 +37,13 @@ test: gp_tablespace
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao prepare_lockmode gpcopy_dispatch
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp
+test: gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao prepare_lockmode gpcopy_dispatch gp_copy_dtx
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
 test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format misc_jiras direct_dispatch_explain_analyze
+# below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.

--- a/src/test/regress/sql/gp_copy_dtx.sql
+++ b/src/test/regress/sql/gp_copy_dtx.sql
@@ -1,0 +1,24 @@
+-- Test if COPY FROM uses correct distribued transaction command protocol
+
+CREATE TABLE test_copy_from_dtx (c1 int, c2 int);
+
+SET Test_print_direct_dispatch_info = ON;
+
+COPY test_copy_from_dtx (c1, c2) FROM stdin;
+1	2
+2	3
+3	4
+4	5
+5	6
+6	7
+7	8
+8	9
+9	10
+\.
+
+SELECT * FROM test_copy_from_dtx;
+
+SET Test_print_direct_dispatch_info = OFF;
+
+-- Clean up
+DROP TABLE test_copy_from_dtx;


### PR DESCRIPTION
When executing COPY FROM statement, QD will wait in cdbCopyEndInternal
to get the execution results from QE, but before this fix, flag
TopXactexecutorDidWriteXLog is not set as processResults does, which
results in the incorrect use of dtx protocol command. So we need to
check if segments have written XLOG, and set the flag properly.

COPY FROM will have 2PC after this commit.

Signed-off-by: Adam Lee <adlee@vmware.com>
(cherry picked from commit 2a224dbc1e718e9fd45d75bf091bdfa1c828fe14)