### PR TITLE
Prefetch NonJoinQual to avoid motion hazard.

### DIFF
--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -170,14 +170,20 @@ ExecNestLoop_guts(PlanState *pstate)
 	}
 
 	/*
-	 * Prefetch JoinQual to prevent motion hazard.
+	 * Prefetch JoinQual or NonJoinQual to prevent motion hazard.
 	 *
-	 * See ExecPrefetchJoinQual() for details.
+	 * See ExecPrefetchQual() for details.
 	 */
 	if (node->prefetch_joinqual)
 	{
-		ExecPrefetchJoinQual(&node->js);
+		ExecPrefetchQual(&node->js, true);
 		node->prefetch_joinqual = false;
+	}
+
+	if (node->prefetch_qual)
+	{
+		ExecPrefetchQual(&node->js, false);
+		node->prefetch_qual = false;
 	}
 
 	/*
@@ -420,10 +426,20 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 
 	nlstate->prefetch_inner = node->join.prefetch_inner;
 	nlstate->prefetch_joinqual = node->join.prefetch_joinqual;
+	nlstate->prefetch_qual = node->join.prefetch_qual;
 
 	if (Test_print_prefetch_joinqual && nlstate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
+	/*
+	 * reuse GUC Test_print_prefetch_joinqual to output debug information for
+	 * prefetching non join qual
+	 */
+	if (Test_print_prefetch_joinqual && nlstate->prefetch_qual)
+		elog(NOTICE,
+			 "prefetch non join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/*CDB-OLAP*/

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -996,6 +996,7 @@ CopyJoinFields(const Join *from, Join *newnode)
 
     COPY_SCALAR_FIELD(prefetch_inner);
 	COPY_SCALAR_FIELD(prefetch_joinqual);
+	COPY_SCALAR_FIELD(prefetch_qual);
 
 	COPY_SCALAR_FIELD(jointype);
 	COPY_SCALAR_FIELD(inner_unique);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -517,6 +517,7 @@ _outJoinPlanInfo(StringInfo str, const Join *node)
 
 	WRITE_BOOL_FIELD(prefetch_inner);
 	WRITE_BOOL_FIELD(prefetch_joinqual);
+	WRITE_BOOL_FIELD(prefetch_qual);
 
 	WRITE_ENUM_FIELD(jointype, JoinType);
 	WRITE_BOOL_FIELD(inner_unique);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3030,6 +3030,7 @@ ReadCommonJoin(Join *local_node)
 
 	READ_BOOL_FIELD(prefetch_inner);
 	READ_BOOL_FIELD(prefetch_joinqual);
+	READ_BOOL_FIELD(prefetch_qual);
 
 	READ_ENUM_FIELD(jointype, JoinType);
 	READ_BOOL_FIELD(inner_unique);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -647,7 +647,7 @@ extern void CheckSubscriptionRelkind(char relkind, const char *nspname,
 									 const char *relname);
 
 extern void fake_outer_params(JoinState *node);
-extern void ExecPrefetchJoinQual(JoinState *node);
+extern void ExecPrefetchQual(JoinState *node, bool isJoinQual);
 
 /* Additions for MPP Slice table utilities defined in execUtils.c */
 extern GpExecIdentity getGpExecIdentity(QueryDesc *queryDesc,

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2031,6 +2031,7 @@ typedef struct NestLoopState
 	bool		shared_outer;
 	bool		prefetch_inner;
 	bool		prefetch_joinqual;
+	bool		prefetch_qual;
 	bool		reset_inner; /*CDB-OLAP*/
 	bool		require_inner_reset; /*CDB-OLAP*/
 
@@ -2089,6 +2090,7 @@ typedef struct MergeJoinState
 	ExprContext *mj_InnerEContext;
 	bool		prefetch_inner; /* MPP-3300 */
 	bool		prefetch_joinqual;
+	bool		prefetch_qual;
 } MergeJoinState;
 
 /* ----------------
@@ -2148,6 +2150,7 @@ typedef struct HashJoinState
 	bool		hj_InnerEmpty;  /* set to true if inner side is empty */
 	bool		prefetch_inner;
 	bool		prefetch_joinqual;
+	bool		prefetch_qual;
 	bool		hj_nonequijoin;
 
 	/* set if the operator created workfiles */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -927,6 +927,7 @@ typedef struct Join
 
 	bool		prefetch_inner; /* to avoid deadlock in MPP */
 	bool		prefetch_joinqual; /* to avoid deadlock in MPP */
+	bool		prefetch_qual; /* to avoid deadlock in MPP */
 } Join;
 
 /* ----------------

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -36,19 +36,25 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table t_subplan (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_subplan2 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- First load enough data on all the relations to generate redistribute-both
 -- motion instead of broadcast-one motion.
 insert into t_inner select i, i from generate_series(1,:scale) i;
 insert into t_outer select i, i from generate_series(1,:scale) i;
 insert into t_subplan select i, i from generate_series(1,:scale) i;
+insert into t_subplan2 select i, i from generate_series(1,:scale) i;
 analyze t_inner;
 analyze t_outer;
 analyze t_subplan;
+analyze t_subplan2;
 -- Then delete all of them and load the real data, do not use TRUNCATE as it
 -- will clear the analyze information.
 delete from t_inner;
 delete from t_outer;
 delete from t_subplan;
+delete from t_subplan2;
 -- t_inner is the inner relation, it does not need much data as long as it is
 -- not empty.
 insert into t_inner values (:x0, :x0);
@@ -63,6 +69,8 @@ insert into t_outer select :x0, :x0 from generate_series(1,:scale) i;
 -- to hashjoin@slice4@seg1 it has to wait for ACK from it, this can happen
 -- before hashjoin@slice4@seg1 reading from outer@slice1.
 insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
+-- t_subplan2 is same as t_subplan, used for case of multiple quals
+insert into t_subplan2 select :x0, :x0 from generate_series(1,:scale) i;
 -- In the past hash join do the job like this:
 --
 -- 10. read all the inner tuples and build the hash table;
@@ -129,5 +137,31 @@ NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:700
  count 
 -------
  10000
+(1 row)
+
+-- Except JoinQual, NonJoinQual has the similar deadlock issue.
+-- Test NonJoinQual which should also be prefetched.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch non join qual in slice 0 of plannode 3
+NOTICE:  prefetch non join qual in slice 1 of plannode 3  (seg0 slice1 10.146.0.4:7002 pid=13096)
+NOTICE:  prefetch non join qual in slice 1 of plannode 3  (seg1 slice1 10.146.0.4:7003 pid=13097)
+NOTICE:  prefetch non join qual in slice 1 of plannode 3  (seg2 slice1 10.146.0.4:7004 pid=13098)
+ count 
+-------
+     0
+(1 row)
+
+-- Test NonJoinQual includes multiple motion nodes
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+	or not exists (select 0 from t_subplan2 where t_subplan2.c2=t_outer.c1));
+NOTICE:  prefetch non join qual in slice 0 of plannode 3
+NOTICE:  prefetch non join qual in slice 1 of plannode 3  (seg0 slice1 10.146.0.4:7002 pid=13096)
+NOTICE:  prefetch non join qual in slice 1 of plannode 3  (seg1 slice1 10.146.0.4:7003 pid=13097)
+NOTICE:  prefetch non join qual in slice 1 of plannode 3  (seg2 slice1 10.146.0.4:7004 pid=13098)
+ count 
+-------
+     0
 (1 row)
 

--- a/src/test/regress/expected/deadlock2_optimizer.out
+++ b/src/test/regress/expected/deadlock2_optimizer.out
@@ -19,21 +19,26 @@
 --                  ->  Materialize
 --                        ->  Broadcast Motion 3:3  (slice3; segments: 3)
 --                              ->  Seq Scan on t_subplan
-
 -- Suppose :x0 is distributed on seg0, it does not matter if it is not.
 -- This assumption is only to simplify the explanation.
 \set x0 1
 \set scale 10000
-
 drop schema if exists deadlock2 cascade;
+NOTICE:  schema "deadlock2" does not exist, skipping
 create schema deadlock2;
 set search_path = deadlock2;
-
 create table t_inner (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t_outer (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t_subplan (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t_subplan2 (c1 int, c2 int);
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- First load enough data on all the relations to generate redistribute-both
 -- motion instead of broadcast-one motion.
 insert into t_inner select i, i from generate_series(1,:scale) i;
@@ -44,34 +49,28 @@ analyze t_inner;
 analyze t_outer;
 analyze t_subplan;
 analyze t_subplan2;
-
 -- Then delete all of them and load the real data, do not use TRUNCATE as it
 -- will clear the analyze information.
 delete from t_inner;
 delete from t_outer;
 delete from t_subplan;
 delete from t_subplan2;
-
 -- t_inner is the inner relation, it does not need much data as long as it is
 -- not empty.
 insert into t_inner values (:x0, :x0);
-
 -- t_outer is the outer relation of the hash join, all its data are on seg0,
 -- and redistributes to seg0, so outer@slice1@seg0 sends data to
 -- hashjoin@slice4@seg0 and waits for ACK from it.  After all the data are sent
 -- it will send EOS to all the segments of hashjoin@slice4.  So once
 -- hashjoin@slice4@seg1 reads from outer@slice1 it has to wait for EOS.
 insert into t_outer select :x0, :x0 from generate_series(1,:scale) i;
-
 -- t_subplan is the subplan relation of the hash join, all its data are on
 -- seg0, and broadcasts to seg0 and seg1.  When subplan@slice3@seg0 sends data
 -- to hashjoin@slice4@seg1 it has to wait for ACK from it, this can happen
 -- before hashjoin@slice4@seg1 reading from outer@slice1.
 insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
-
 -- t_subplan2 is same as t_subplan, used for case of multiple quals
 insert into t_subplan2 select :x0, :x0 from generate_series(1,:scale) i;
-
 -- In the past hash join do the job like this:
 --
 -- 10. read all the inner tuples and build the hash table;
@@ -93,16 +92,22 @@ insert into t_subplan2 select :x0, :x0 from generate_series(1,:scale) i;
 --     hashjoin@slice4@seg1  <-[wait for ACK]--  subplan@slice3@seg0
 --
 -- This deadlock is prevented by prefetching the subplan.
-
 -- In theory this deadlock exists in all of hash join, merge join and nestloop
 -- join, but so far we have only constructed a reproducer for hash join.
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
 set Test_print_prefetch_joinqual = on;
-
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 3
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=25303)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=25304)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=25305)
+ count 
+-------
+ 10000
+(1 row)
 
 -- The logic of ExecPrefetchJoinQual is to use two null
 -- tuples to fake inner and outertuple and then to ExecQual.
@@ -113,17 +118,42 @@ select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 -- for details.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch join qual in slice 0 of plannode 3
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)
+ count 
+-------
+ 10000
+(1 row)
 
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
    and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 3
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)
+ count 
+-------
+ 10000
+(1 row)
 
 -- Except JoinQual, NonJoinQual has the similar deadlock issue.
 -- Test NonJoinQual which should also be prefetched.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+ count 
+-------
+     0
+(1 row)
 
 -- Test NonJoinQual includes multiple motion nodes
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
 	or not exists (select 0 from t_subplan2 where t_subplan2.c2=t_outer.c1));
+ count 
+-------
+     0
+(1 row)
+


### PR DESCRIPTION
In commit fa762b, we introduce prefetch joinqual logic to avoid motion
hazard. For non join qual in a join node, if it contains a motion and
the outer relation also contains a motion, then motion deadlock could
happen as well. Prefetch NonJoinQual if required.

Motion Hazard details please refer to commit fa762b

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
