### PR TITLE
[6X]: vendor libquicklz.so during Photon compile

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -103,7 +103,7 @@ function include_zstd() {
 function include_quicklz() {
 	local libdir
 	case "${OS}" in
-	centos | sles) libdir=/usr/lib64 ;;
+	centos | sles | photon) libdir=/usr/lib64 ;;
 	ubuntu) libdir=/usr/local/lib ;;
 	*) return ;;
 	esac


### PR DESCRIPTION
Authored-by: Brent Doil <bdoil@vmware.com>
