### PR TITLE
[BackPort 6X] Prefetch NonJoinQual to avoid motion hazard.

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1773,46 +1773,53 @@ fake_outer_params(JoinState *node)
 }
 
 /*
- * Prefetch JoinQual to prevent motion hazard.
+ * Prefetch JoinQual or NonJoinQual to prevent motion hazard.
  *
  * A motion hazard is a deadlock between motions, a classic motion hazard in a
  * join executor is formed by its inner and outer motions, it can be prevented
  * by prefetching the inner plan, refer to motion_sanity_check() for details.
  *
  * A similar motion hazard can be formed by the outer motion and the join qual
- * motion.  A join executor fetches a outer tuple, filters it with the join
- * qual, then repeat the process on all the outer tuples.  When there are
- * motions in both outer plan and the join qual then below state is possible:
+ * motion(or non join qual motion).  A join executor fetches a outer tuple,
+ * filters it with the qual, then repeat the process on all the outer tuples.
+ * When there are motions in both outer plan and the join qual then below state
+ * is possible:
  *
  * 0. processes A and B belong to the join slice, process C belongs to the
- *    outer slice, process D belongs to the JoinQual slice;
+ *    outer slice, process D belongs to the JoinQual(NonJoinQual) slice;
  * 1. A has read the first outer tuple and is fetching tuples from D;
  * 2. D is waiting for ACK from B;
  * 3. B is fetching the first outer tuple from C;
  * 4. C is waiting for ACK from A;
  *
  * So a deadlock is formed A->D->B->C->A.  We can prevent it also by
- * prefetching the join qual.
+ * prefetching the join qual or non join qual
  *
  * An example is demonstrated and explained in test case
  * src/test/regress/sql/deadlock2.sql.
  *
- * Return true if the JoinQual is prefetched.
+ * Return true if the JoinQual or NonJoinQual is prefetched.
  */
 void
-ExecPrefetchJoinQual(JoinState *node)
+ExecPrefetchQual(JoinState *node, bool isJoinQual)
 {
 	EState	   *estate = node->ps.state;
 	ExprContext *econtext = node->ps.ps_ExprContext;
 	PlanState  *inner = innerPlanState(node);
 	PlanState  *outer = outerPlanState(node);
-	List	   *joinqual = node->joinqual;
 	TupleTableSlot *innertuple = econtext->ecxt_innertuple;
 
 	ListCell   *lc = NULL;
 	List       *quals = NIL;
 
-	Assert(joinqual);
+	List   *qual;
+
+	if (isJoinQual)
+		qual = node->joinqual;
+	else
+		qual = node->ps.qual;
+
+	Assert(qual);
 
 	/* Outer tuples should not be fetched before us */
 	Assert(econtext->ecxt_outertuple == NULL);
@@ -1830,13 +1837,13 @@ ExecPrefetchJoinQual(JoinState *node)
 			fake_outer_params(node);
 	}
 
-	quals = flatten_logic_exprs((Node *) joinqual);
+	quals = flatten_logic_exprs((Node *) qual);
 
 	/* Fetch subplan with the fake inner & outer tuples */
 	foreach(lc, quals)
 	{
 		/*
-		 * Force every joinqual is prefech because
+		 * Force every qual is prefech because
 		 * our target is to materialize motion node.
 		 */
 		ExprState  *clause = (ExprState *) lfirst(lc);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -237,14 +237,20 @@ ExecHashJoin_guts(HashJoinState *node)
 					return NULL;
 
 				/*
-				 * Prefetch JoinQual to prevent motion hazard.
+				 * Prefetch JoinQual or NonJoinQual to prevent motion hazard.
 				 *
-				 * See ExecPrefetchJoinQual() for details.
+				 * See ExecPrefetchQual() for details.
 				 */
 				if (node->prefetch_joinqual)
 				{
-					ExecPrefetchJoinQual(&node->js);
+					ExecPrefetchQual(&node->js, true);
 					node->prefetch_joinqual = false;
+				}
+
+				if (node->prefetch_qual)
+				{
+					ExecPrefetchQual(&node->js, false);
+					node->prefetch_qual = false;
 				}
 
 				/*
@@ -606,10 +612,20 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	 */
 	hjstate->prefetch_inner = node->join.prefetch_inner;
 	hjstate->prefetch_joinqual = node->join.prefetch_joinqual;
+	hjstate->prefetch_qual = node->join.prefetch_qual;
 
 	if (Test_print_prefetch_joinqual && hjstate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
+	/*
+	 * reuse GUC Test_print_prefetch_joinqual to output debug information for
+	 * prefetching non join qual
+	 */
+	if (Test_print_prefetch_joinqual && hjstate->prefetch_qual)
+		elog(NOTICE,
+			 "prefetch non join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/*

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -682,14 +682,20 @@ ExecMergeJoin_guts(MergeJoinState *node)
 	}
 
 	/*
-	 * Prefetch JoinQual to prevent motion hazard.
+	 * Prefetch JoinQual or NonJoinQual to prevent motion hazard.
 	 *
-	 * See ExecPrefetchJoinQual() for details.
+	 * See ExecPrefetchQual() for details.
 	 */
 	if (node->prefetch_joinqual)
 	{
-		ExecPrefetchJoinQual(&node->js);
+		ExecPrefetchQual(&node->js, true);
 		node->prefetch_joinqual = false;
+	}
+
+	if (node->prefetch_qual)
+	{
+		ExecPrefetchQual(&node->js, false);
+		node->prefetch_qual = false;
 	}
 
 	/*
@@ -1577,10 +1583,20 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 
 	mergestate->prefetch_inner = node->join.prefetch_inner;
 	mergestate->prefetch_joinqual = node->join.prefetch_joinqual;
+	mergestate->prefetch_qual = node->join.prefetch_qual;
 
 	if (Test_print_prefetch_joinqual && mergestate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
+	/*
+	 * reuse GUC Test_print_prefetch_joinqual to output debug information for
+	 * prefetching non join qual
+	 */
+	if (Test_print_prefetch_joinqual && mergestate->prefetch_qual)
+		elog(NOTICE,
+			 "prefetch non join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/* Prepare inner operators for rewind after the prefetch */

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -166,14 +166,20 @@ ExecNestLoop_guts(NestLoopState *node)
 	}
 
 	/*
-	 * Prefetch JoinQual to prevent motion hazard.
+	 * Prefetch JoinQual or NonJoinQual to prevent motion hazard.
 	 *
-	 * See ExecPrefetchJoinQual() for details.
+	 * See ExecPrefetchQual() for details.
 	 */
 	if (node->prefetch_joinqual)
 	{
-		ExecPrefetchJoinQual(&node->js);
+		ExecPrefetchQual(&node->js, true);
 		node->prefetch_joinqual = false;
+	}
+
+	if (node->prefetch_qual)
+	{
+		ExecPrefetchQual(&node->js, false);
+		node->prefetch_qual = false;
 	}
 
 	/*
@@ -417,10 +423,20 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 
 	nlstate->prefetch_inner = node->join.prefetch_inner;
 	nlstate->prefetch_joinqual = node->join.prefetch_joinqual;
+	nlstate->prefetch_qual = node->join.prefetch_qual;
 
 	if (Test_print_prefetch_joinqual && nlstate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
+	/*
+	 * reuse GUC Test_print_prefetch_joinqual to output debug information for
+	 * prefetching non join qual
+	 */
+	if (Test_print_prefetch_joinqual && nlstate->prefetch_qual)
+		elog(NOTICE,
+			 "prefetch non join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/*CDB-OLAP*/

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -876,6 +876,7 @@ CopyJoinFields(const Join *from, Join *newnode)
 
     COPY_SCALAR_FIELD(prefetch_inner);
 	COPY_SCALAR_FIELD(prefetch_joinqual);
+	COPY_SCALAR_FIELD(prefetch_qual);
 
 	COPY_SCALAR_FIELD(jointype);
 	COPY_NODE_FIELD(joinqual);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -409,6 +409,7 @@ _outJoinPlanInfo(StringInfo str, const Join *node)
 
 	WRITE_BOOL_FIELD(prefetch_inner);
 	WRITE_BOOL_FIELD(prefetch_joinqual);
+	WRITE_BOOL_FIELD(prefetch_qual);
 
 	WRITE_ENUM_FIELD(jointype, JoinType);
 	WRITE_NODE_FIELD(joinqual);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2380,6 +2380,7 @@ void readJoinInfo(Join *local_node)
 
 	READ_BOOL_FIELD(prefetch_inner);
 	READ_BOOL_FIELD(prefetch_joinqual);
+	READ_BOOL_FIELD(prefetch_qual);
 
 	READ_ENUM_FIELD(jointype, JoinType);
 	READ_NODE_FIELD(joinqual);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -808,6 +808,7 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 	{
 		((Join *) plan)->prefetch_inner = false;
 		((Join *) plan)->prefetch_joinqual = false;
+		((Join *) plan)->prefetch_qual = false;
 	}
 
 	plan->flow = cdbpathtoplan_create_flow(root,
@@ -837,6 +838,18 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 
 		((Join *) plan)->prefetch_joinqual = contain_motion(root,
 															(Node *) joinqual);
+	}
+
+	/*
+	 * Similar for non join qual. If it contains a motion and outer relation
+	 * also contains a motion, then we should set prefetch_qual to true.
+	 */
+	if (((Join *) plan)->prefetch_qual)
+	{
+		List *qual = ((Join *) plan)->plan.qual;
+
+		((Join *) plan)->prefetch_qual = contain_motion(root,
+															(Node *) qual);
 	}
 
 	/*
@@ -3347,6 +3360,14 @@ create_nestloop_plan(PlannerInfo *root,
 		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
+	/*
+	 * Similar for non join qual.
+	 */
+	if (best_path->outerjoinpath &&
+		best_path->outerjoinpath->motionHazard &&
+		join_plan->join.plan.qual != NIL)
+		join_plan->join.prefetch_qual = true;
+
 	return join_plan;
 }
 
@@ -3693,6 +3714,14 @@ create_mergejoin_plan(PlannerInfo *root,
 		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
+	/*
+	 * Similar for non join qual.
+	 */
+	if (best_path->jpath.innerjoinpath &&
+		best_path->jpath.innerjoinpath->motionHazard &&
+		join_plan->join.plan.qual != NIL)
+		join_plan->join.prefetch_qual = true;
+
 	/* Costs of sort and material steps are included in path cost already */
 	copy_path_costsize(root, &join_plan->join.plan, &best_path->jpath.path);
 
@@ -3859,6 +3888,14 @@ create_hashjoin_plan(PlannerInfo *root,
 		best_path->jpath.outerjoinpath->motionHazard &&
 		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
+
+	/*
+	 * Similar for non join qual.
+	 */
+	if (best_path->jpath.outerjoinpath &&
+		best_path->jpath.outerjoinpath->motionHazard &&
+		join_plan->join.plan.qual != NIL)
+		join_plan->join.prefetch_qual = true;
 
 	copy_path_costsize(root, &join_plan->join.plan, &best_path->jpath.path);
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -471,7 +471,7 @@ extern void UnregisterExprContextCallback(ExprContext *econtext,
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
 extern void fake_outer_params(JoinState *node);
-extern void ExecPrefetchJoinQual(JoinState *node);
+extern void ExecPrefetchQual(JoinState *node, bool isJoinQual);
 
 /* ResultRelInfo and Append Only segment assignment */
 void ResultRelInfoSetSegno(ResultRelInfo *resultRelInfo, List *mapping);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2290,6 +2290,7 @@ typedef struct NestLoopState
 	bool		shared_outer;
 	bool		prefetch_inner;
 	bool		prefetch_joinqual;
+	bool		prefetch_qual;
 	bool		reset_inner; /*CDB-OLAP*/
 	bool		require_inner_reset; /*CDB-OLAP*/
 
@@ -2346,6 +2347,7 @@ typedef struct MergeJoinState
 	ExprContext *mj_InnerEContext;
 	bool		prefetch_inner; /* MPP-3300 */
 	bool		prefetch_joinqual;
+	bool		prefetch_qual;
 } MergeJoinState;
 
 /* ----------------
@@ -2404,6 +2406,7 @@ typedef struct HashJoinState
 	bool		hj_InnerEmpty;  /* set to true if inner side is empty */
 	bool		prefetch_inner;
 	bool		prefetch_joinqual;
+	bool		prefetch_qual;
 	bool		hj_nonequijoin;
 
 	/* set if the operator created workfiles */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -873,6 +873,7 @@ typedef struct Join
 
 	bool		prefetch_inner; /* to avoid deadlock in MPP */
 	bool		prefetch_joinqual; /* to avoid deadlock in MPP */
+	bool		prefetch_qual; /* to avoid deadlock in MPP */
 } Join;
 
 /* ----------------

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -36,19 +36,25 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table t_subplan (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_subplan2 (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- First load enough data on all the relations to generate redistribute-both
 -- motion instead of broadcast-one motion.
 insert into t_inner select i, i from generate_series(1,:scale) i;
 insert into t_outer select i, i from generate_series(1,:scale) i;
 insert into t_subplan select i, i from generate_series(1,:scale) i;
+insert into t_subplan2 select i, i from generate_series(1,:scale) i;
 analyze t_inner;
 analyze t_outer;
 analyze t_subplan;
+analyze t_subplan2;
 -- Then delete all of them and load the real data, do not use TRUNCATE as it
 -- will clear the analyze information.
 delete from t_inner;
 delete from t_outer;
 delete from t_subplan;
+delete from t_subplan2;
 -- t_inner is the inner relation, it does not need much data as long as it is
 -- not empty.
 insert into t_inner values (:x0, :x0);
@@ -63,6 +69,8 @@ insert into t_outer select :x0, :x0 from generate_series(1,:scale) i;
 -- to hashjoin@slice4@seg1 it has to wait for ACK from it, this can happen
 -- before hashjoin@slice4@seg1 reading from outer@slice1.
 insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
+-- t_subplan2 is same as t_subplan, used for case of multiple quals
+insert into t_subplan2 select :x0, :x0 from generate_series(1,:scale) i;
 -- In the past hash join do the job like this:
 --
 -- 10. read all the inner tuples and build the hash table;
@@ -129,5 +137,31 @@ NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg2 slice7 127.0.1.1:600
  count 
 -------
  10000
+(1 row)
+
+-- Except JoinQual, NonJoinQual has the similar deadlock issue.
+-- Test NonJoinQual which should also be prefetched.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch non join qual in slice 0 of plannode 4
+NOTICE:  prefetch non join qual in slice 5 of plannode 4  (seg0 slice5 10.146.0.4:6002 pid=27463)
+NOTICE:  prefetch non join qual in slice 5 of plannode 4  (seg1 slice5 10.146.0.4:6003 pid=27464)
+NOTICE:  prefetch non join qual in slice 5 of plannode 4  (seg2 slice5 10.146.0.4:6004 pid=27465)
+ count 
+-------
+     0
+(1 row)
+
+-- Test NonJoinQual includes multiple motion nodes
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+	or not exists (select 0 from t_subplan2 where t_subplan2.c2=t_outer.c1));
+NOTICE:  prefetch non join qual in slice 0 of plannode 4
+NOTICE:  prefetch non join qual in slice 7 of plannode 4  (seg0 slice7 10.146.0.4:6002 pid=27463)
+NOTICE:  prefetch non join qual in slice 7 of plannode 4  (seg1 slice7 10.146.0.4:6003 pid=27464)
+NOTICE:  prefetch non join qual in slice 7 of plannode 4  (seg2 slice7 10.146.0.4:6004 pid=27465)
+ count 
+-------
+     0
 (1 row)
 

--- a/src/test/regress/expected/deadlock2_optimizer.out
+++ b/src/test/regress/expected/deadlock2_optimizer.out
@@ -19,21 +19,26 @@
 --                  ->  Materialize
 --                        ->  Broadcast Motion 3:3  (slice3; segments: 3)
 --                              ->  Seq Scan on t_subplan
-
 -- Suppose :x0 is distributed on seg0, it does not matter if it is not.
 -- This assumption is only to simplify the explanation.
 \set x0 1
 \set scale 10000
-
 drop schema if exists deadlock2 cascade;
+NOTICE:  schema "deadlock2" does not exist, skipping
 create schema deadlock2;
 set search_path = deadlock2;
-
 create table t_inner (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t_outer (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t_subplan (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t_subplan2 (c1 int, c2 int);
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- First load enough data on all the relations to generate redistribute-both
 -- motion instead of broadcast-one motion.
 insert into t_inner select i, i from generate_series(1,:scale) i;
@@ -44,34 +49,28 @@ analyze t_inner;
 analyze t_outer;
 analyze t_subplan;
 analyze t_subplan2;
-
 -- Then delete all of them and load the real data, do not use TRUNCATE as it
 -- will clear the analyze information.
 delete from t_inner;
 delete from t_outer;
 delete from t_subplan;
 delete from t_subplan2;
-
 -- t_inner is the inner relation, it does not need much data as long as it is
 -- not empty.
 insert into t_inner values (:x0, :x0);
-
 -- t_outer is the outer relation of the hash join, all its data are on seg0,
 -- and redistributes to seg0, so outer@slice1@seg0 sends data to
 -- hashjoin@slice4@seg0 and waits for ACK from it.  After all the data are sent
 -- it will send EOS to all the segments of hashjoin@slice4.  So once
 -- hashjoin@slice4@seg1 reads from outer@slice1 it has to wait for EOS.
 insert into t_outer select :x0, :x0 from generate_series(1,:scale) i;
-
 -- t_subplan is the subplan relation of the hash join, all its data are on
 -- seg0, and broadcasts to seg0 and seg1.  When subplan@slice3@seg0 sends data
 -- to hashjoin@slice4@seg1 it has to wait for ACK from it, this can happen
 -- before hashjoin@slice4@seg1 reading from outer@slice1.
 insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
-
 -- t_subplan2 is same as t_subplan, used for case of multiple quals
 insert into t_subplan2 select :x0, :x0 from generate_series(1,:scale) i;
-
 -- In the past hash join do the job like this:
 --
 -- 10. read all the inner tuples and build the hash table;
@@ -93,16 +92,22 @@ insert into t_subplan2 select :x0, :x0 from generate_series(1,:scale) i;
 --     hashjoin@slice4@seg1  <-[wait for ACK]--  subplan@slice3@seg0
 --
 -- This deadlock is prevented by prefetching the subplan.
-
 -- In theory this deadlock exists in all of hash join, merge join and nestloop
 -- join, but so far we have only constructed a reproducer for hash join.
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
 set Test_print_prefetch_joinqual = on;
-
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg0 slice5 127.0.1.1:6002 pid=27794)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg1 slice5 127.0.1.1:6003 pid=27795)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg2 slice5 127.0.1.1:6004 pid=27796)
+ count 
+-------
+ 10000
+(1 row)
 
 -- The logic of ExecPrefetchJoinQual is to use two null
 -- tuples to fake inner and outertuple and then to ExecQual.
@@ -113,17 +118,42 @@ select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 -- for details.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg0 slice5 127.0.1.1:6002 pid=27794)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg1 slice5 127.0.1.1:6003 pid=27795)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg2 slice5 127.0.1.1:6004 pid=27796)
+ count 
+-------
+ 10000
+(1 row)
 
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
    and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg0 slice7 127.0.1.1:6002 pid=27794)
+NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg1 slice7 127.0.1.1:6003 pid=27795)
+NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg2 slice7 127.0.1.1:6004 pid=27796)
+ count 
+-------
+ 10000
+(1 row)
 
 -- Except JoinQual, NonJoinQual has the similar deadlock issue.
 -- Test NonJoinQual which should also be prefetched.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+ count 
+-------
+     0
+(1 row)
 
 -- Test NonJoinQual includes multiple motion nodes
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 	where (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
 	or not exists (select 0 from t_subplan2 where t_subplan2.c2=t_outer.c1));
+ count 
+-------
+     0
+(1 row)
+

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -125,4 +125,7 @@ s/ERROR:  infinite recursion detected.*/ERROR:  infinite recursion detected/
 m/ERROR:  could not find hash function for hash operator.*/
 s/ERROR:  could not find hash function for hash operator.*/ERROR:  could not find hash function for hash operator/
 
+m/ERROR:  could not devise a plan.*/
+s/ERROR:  could not devise a plan.*/ERROR:  could not devise a plan/
+
 -- end_matchsubs


### PR DESCRIPTION
In commit fa762b, we introduce prefetch joinqual logic to avoid motion
hazard. For non join qual in a join node, if it contains a motion and
the outer relation also contains a motion, then motion deadlock could
happen as well. Prefetch NonJoinQual if required.

Motion Hazard details please refer to commit fa762b

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
