### PR TITLE
Move bytea_output guc to be a sync'd guc

### DIFF
--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -1,3 +1,4 @@
+		"bytea_output",
 		"client_min_messages",
 		"commit_delay",
 		"commit_siblings",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -29,7 +29,6 @@
 		"block_size",
 		"bonjour",
 		"bonjour_name",
-		"bytea_output",
 		"check_function_bodies",
 		"checkpoint_completion_target",
 		"checkpoint_flush_after",


### PR DESCRIPTION
The guc bytea_output sets the output format for the binary type bytea to
be either escape (octal notation) or hex. This guc should be synced
across all segments so that the output from different segments is using
a consistent format.

See https://github.com/greenplum-db/gpdb/issues/11870 for more details.

Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Bradford Boyle <bradfordb@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
