### PR TITLE
fix behave tests 'escaped' keyword

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1393,8 +1393,12 @@ def impl(context, filename, output):
     print contents
     check_stdout_msg(context, output)
 
+@then('verify that the last line of the file "{filename}" in the master data directory {contain} the string "{output}"')
+def impl(context, filename, contain, output):
+    return verify_master_file_last_line(context, filename, contain, output, "")
+
 @then('verify that the last line of the file "{filename}" in the master data directory {contain} the string "{output}"{escape}')
-def impl(context, filename, contain, output, escape):
+def verify_master_file_last_line(context, filename, contain, output, escape):
     if contain == 'should contain':
         valuesShouldExist = True
     elif contain == 'should not contain':


### PR DESCRIPTION
Fix broken behave tests that check files on master data directory. 
Behave sub-step wasn't named correctly, and hence wasn't found.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/fix_behave_tests_6x