### PR TITLE
Fix segfault in elog.c

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3723,9 +3723,9 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 			}
 		}
 
-		if (fd_ok && strlen(cmdresult[0]) > 1)
+		if (!fd_ok || strlen(cmdresult[0]) <= 1)
 		{
-			addr2line_ok = true;
+			addr2line_ok = false;
 		}
 
 		if (fd != NULL)
@@ -3794,7 +3794,9 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 				{
 					lineInfo = parenth + 1;
 					parenth = strrchr(lineInfo, ')');
-					*parenth = '\0';
+					if (parenth != NULL) {
+						*parenth = '\0';
+					}
 				}
 
 				/* line info added, print file and line info */


### PR DESCRIPTION
I had noticed over the past few years that gpdb occasionally crashes with a SIGSEGV while trying to write an error message to the log.  But usually the error I cared about investigating became clear after opening the core file, and went away after fixing it, so I never took the time to go back and reproduce this crash.

It happened a couple days ago, and I took a look at it this time.  It's a null pointer dereference in `append_stacktrace()` that can happen while parsing the output of `addr2line/atos` when they output lines longer than 512 bytes (SYMBOL_SIZE).  This may not happen often in C, but the symbols are often longer than that in C++ so the output lines gets truncated.  If there are open parenthesis in the string and the truncation happens before the first close paren, then it dereferences a null pointer when `strrchar()` returns NULL:
```
3768                 char *parenth = strrchr(lineInfo, '(');
3769                 if (parenth != NULL)
3770                 {
3771                     lineInfo = parenth + 1;
3772                     parenth = strrchr(lineInfo, ')');
3773                     *parenth = '\0';
3774                 }
```
Here is the specific command it was calling to look up the symbols which caused this crash (our team does all of our dev work on OSX, I assume addr2line can also output more than 512 characters per line, but haven't tested it) along with the output it gets back:
```
atos -o /usr/local/gpdb6/bin/postgres 0x10136efab 0x109030778 0x10903271c 0x109035e74 0x100f08175 0x100f067b5 0x100f0659d 0x100f3b8c9 0x100ef6b27 0x100f449ac 0x100f097d5 0x100f09531 0x100f44989 0x100ef6c62 0x100eed5de 0x100eed24f 0x100eecd3a 0x1011ac9b7 0x1011ab4af 0x1011aaac9 0x1011a50b8 0x1011a2ad7 0x1010f1385 0x1010f0438 0x1010ef2c0 0x1010ec8ea 0x100fac447 0x7fff203e5621

dataSplitPageInternal.allitems (in postgres) + 31515
0x109030778
0x10903271c
0x109035e74
0x0000000100f08175 (in postgres)
0x0000000100f067b5 (in postgres)
0x0000000100f0659d (in postgres)
0x0000000100f3b8c9 (in postgres)
0x0000000100ef6b27 (in postgres)
0x0000000100f449ac (in postgres)
0x0000000100f097d5 (in postgres)
0x0000000100f09531 (in postgres)
0x0000000100f44989 (in postgres)
0x0000000100ef6c62 (in postgres)
0x0000000100eed5de (in postgres)
0x0000000100eed24f (in postgres)
0x0000000100eecd3a (in postgres)
typeinfo name for gpos::CDynamicPtrArray<gpos::CHashMap<gpopt::CColRef, gpdxl::CDXLNode, &(unsigned int gpos::HashValue<gpopt::CColRef>(gpopt::CColRef const*)), &(bool gpos::Equals<gpopt::CColRef>(gpopt::CColRef const*, gpopt::CColRef const*)), &(void gpos::CleanupNULL<gpopt::CColRef>(gpopt::CColRef*)), &(void gpos::CleanupRelease<gpdxl::CDXLNode>(gpopt::CColRef*))>::CHashMapElem, &(void gpos::CleanupDelete<gpos::CHashMap<gpopt::CColRef, gpdxl::CDXLNode, &(unsigned int gpos::HashValue<gpopt::CColRef>(gpopt::CColRef const*)), &(bool gpos::Equals<gpopt::CColRef>(gpopt::CColRef const*, gpopt::CColRef const*)), &(void gpos::CleanupNULL<gpopt::CColRef>(gpopt::CColRef*)), &(void gpos::CleanupRelease<gpdxl::CDXLNode>(gpopt::CColRef*))>::CHashMapElem>(gpopt::CColRef*))> (in postgres) + 17575
typeinfo name for gpos::CDynamicPtrArray<gpos::CHashMap<gpopt::CColRef, gpdxl::CDXLNode, &(unsigned int gpos::HashValue<gpopt::CColRef>(gpopt::CColRef const*)), &(bool gpos::Equals<gpopt::CColRef>(gpopt::CColRef const*, gpopt::CColRef const*)), &(void gpos::CleanupNULL<gpopt::CColRef>(gpopt::CColRef*)), &(void gpos::CleanupRelease<gpdxl::CDXLNode>(gpopt::CColRef*))>::CHashMapElem, &(void gpos::CleanupDelete<gpos::CHashMap<gpopt::CColRef, gpdxl::CDXLNode, &(unsigned int gpos::HashValue<gpopt::CColRef>(gpopt::CColRef const*)), &(bool gpos::Equals<gpopt::CColRef>(gpopt::CColRef const*, gpopt::CColRef const*)), &(void gpos::CleanupNULL<gpopt::CColRef>(gpopt::CColRef*)), &(void gpos::CleanupRelease<gpdxl::CDXLNode>(gpopt::CColRef*))>::CHashMapElem>(gpopt::CColRef*))> (in postgres) + 12191
typeinfo name for gpos::CDynamicPtrArray<gpos::CHashMap<gpopt::CColRef, gpdxl::CDXLNode, &(unsigned int gpos::HashValue<gpopt::CColRef>(gpopt::CColRef const*)), &(bool gpos::Equals<gpopt::CColRef>(gpopt::CColRef const*, gpopt::CColRef const*)), &(void gpos::CleanupNULL<gpopt::CColRef>(gpopt::CColRef*)), &(void gpos::CleanupRelease<gpdxl::CDXLNode>(gpopt::CColRef*))>::CHashMapElem, &(void gpos::CleanupDelete<gpos::CHashMap<gpopt::CColRef, gpdxl::CDXLNode, &(unsigned int gpos::HashValue<gpopt::CColRef>(gpopt::CColRef const*)), &(bool gpos::Equals<gpopt::CColRef>(gpopt::CColRef const*, gpopt::CColRef const*)), &(void gpos::CleanupNULL<gpopt::CColRef>(gpopt::CColRef*)), &(void gpos::CleanupRelease<gpdxl::CDXLNode>(gpopt::CColRef*))>::CHashMapElem>(gpopt::CColRef*))> (in postgres) + 9657
gpopt::CTranslatorExprToDXL::GetWindowFrame(gpopt::CWindowFrame*)::rgulExclusionStrategyMapping (in postgres) + 3608
typeinfo name for gpmd::IMDType (in postgres) + 24935
typeinfo name for xercesc_3_1::MemoryManager (in postgres) + 28101
typeinfo name for xercesc_3_1::MemoryManager (in postgres) + 24184
typeinfo name for xercesc_3_1::MemoryManager (in postgres) + 19712
typeinfo name for xercesc_3_1::MemoryManager (in postgres) + 9002
yycheck (in postgres) + 116871
0x7fff203e5621
```
I added a check for the NULL pointer, and increased the buffer size (SYMBOL_SIZE) from 512 to 2048; seems to be working on my branch.

While fixing this, I noticed a minor issue with the logic in setting the `addr2line_ok` flag.
It starts out set to true, and then was conditionally set to true again if the call to `addr2line/atos`
succeeds, but not set to false if an error is returned by `addr2line` or `atos`.