### PR TITLE
[6X backport] Move bytea_output guc to be a sync'd guc

### DIFF
--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -1,3 +1,4 @@
+		"bytea_output",
 		"check_function_bodies",
 		"client_min_messages",
 		"commit_delay",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -27,7 +27,6 @@
 		"block_size",
 		"bonjour",
 		"bonjour_name",
-		"bytea_output",
 		"checkpoint_completion_target",
 		"checkpoint_segments",
 		"checkpoint_timeout",


### PR DESCRIPTION
The guc bytea_output sets the output format for the binary type bytea to
be either escape (octal notation) or hex. This guc should be synced
across all segments so that the output from different segments is using
a consistent format.

See https://github.com/greenplum-db/gpdb/issues/11870 for more details.

This commit is a backport of master commit 227b05f78a401b4a46977bb20c829ab4fdede7c2

Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Bradford Boyle <bradfordb@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
