### PR TITLE
[6X FIX] Fix incremental recovery failure because the checkpoint redo wal file…

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -813,6 +813,12 @@ static bool bgwriterLaunched = false;
 static int	MyLockNo = 0;
 static bool holdingAllLocks = false;
 
+/*
+ * gpdb: backup of ControlFile->checkPointCopy.redo.  This is used by
+ * KeepLogSeg() to avoid pg_rewind failure due to missing xlog file.
+ */
+static XLogRecPtr ControlFileOldCheckpointCopyRedo = InvalidXLogRecPtr;
+
 static void readRecoveryCommandFile(void);
 static void exitArchiveRecovery(TimeLineID endTLI, XLogSegNo endLogSegNo);
 static bool recoveryStopsBefore(XLogRecord *record);
@@ -8989,6 +8995,12 @@ CreateCheckPoint(int flags)
 				(errmsg("concurrent transaction log activity while database system is shutting down")));
 
 	/*
+	 * ControlFile->checkPointCopy.redo will be updated soon so let's store it
+	 * for later use in KeepLogSeg().
+	 */
+	ControlFileOldCheckpointCopyRedo = ControlFile->checkPointCopy.redo;
+
+	/*
 	 * Select point at which we can truncate the log, which we base on the
 	 * prior checkpoint's earliest info or the oldest prepared transaction xlog record's info.
 	 */
@@ -9544,6 +9556,7 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo)
 	XLogSegNo	segno;
 	XLogRecPtr	keep;
 	bool setvalue = false;
+	static XLogRecPtr CkptRedoBeforeMinLSN = InvalidXLogRecPtr;
 
 	XLByteToSeg(recptr, currSegNo);
 	segno = currSegNo;
@@ -9555,16 +9568,34 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo)
 	keep = XLogGetReplicationSlotMinimumLSN();
 #ifdef FAULT_INJECTOR
 	/*
-	 * Ignore the replication slot's LSN and let the WAL still needed by the
-	 * replication slot to be removed.  This is used to test if WAL sender can
-	 * recognize that an incremental recovery has failed when the WAL
+	 * Let the WAL still needed be removed.  This is used to test if WAL sender
+	 * can recognize that an incremental recovery has failed when the WAL
 	 * requested by a mirror no longer exists.
 	 */
 	if (SIMPLE_FAULT_INJECTOR("keep_log_seg") == FaultInjectorTypeSkip)
+	{
 		keep = GetXLogWriteRecPtr();
+		XLByteToSeg(keep, *logSegNo);
+	}
 #endif
 	if (keep != InvalidXLogRecPtr)
 	{
+		if (!XLogRecPtrIsInvalid(ControlFileOldCheckpointCopyRedo))
+		{
+			/*
+			 * basically with this logic, GPDB never uses restart_lsn as
+			 * lowest cut-off point. Instead always will use Checkpoint redo
+			 * location prior to restart_lsn as cut-off point.
+			 */
+			if (ControlFileOldCheckpointCopyRedo < keep)
+			{
+				keep = ControlFileOldCheckpointCopyRedo;
+				CkptRedoBeforeMinLSN = ControlFileOldCheckpointCopyRedo;
+			}
+			else if (!XLogRecPtrIsInvalid(CkptRedoBeforeMinLSN))
+				keep = CkptRedoBeforeMinLSN;
+		}
+
 		XLByteToSeg(keep, segno);
 		setvalue = true;
 

--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -1,0 +1,247 @@
+-- Test the bug that if checkpoint.redo before the oldest replication slot LSN
+-- is removed/recylced in checkpointer, gprecoverseg (based on pg_rewind) would
+-- would fail.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+include: helpers/server_helpers.sql;
+CREATE
+
+SHOW gp_keep_all_xlog;
+ gp_keep_all_xlog 
+------------------
+ off              
+(1 row)
+CREATE TABLE tst_missing_tbl (a int);
+CREATE
+INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+
+-- make the test faster.
+!\retcode gpconfig -c wal_keep_segments -v 2;
+(exited with code 0)
+!\retcode gpstop -ari;
+(exited with code 0)
+
+-- Test 1: primary was marked down by the master but acetually it keeps running
+-- and previously, checkpoints could recycle/remove the checkpoint.redo wal
+-- file before the oldest replication slot LSN and thus make pg_rewind fail due
+-- to missing xlog file.
+
+-- Run a checkpoint so that the below sqls won't cause a checkpoint
+-- until an explicit checkpoint command is issued by the test.
+-- checkpoint_timeout is by default 300 but the below test should be able to
+-- finish in 300 seconds.
+1: CHECKPOINT;
+CHECKPOINT
+
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+-- Should be not needed mostly but let's 100% ensure since pg_switch_xlog()
+-- won't switch if it has been on the boundary (seldom though).
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+
+-- Mark down the primary with content 0 via fts fault injection.
+1: SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Trigger failover and double check.
+1: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+1: SELECT role, preferred_role from gp_segment_configuration where content = 0;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
+
+-- Run two more checkpoints. Previously this causes the checkpoint.redo wal
+-- file before the oldest replication slot LSN is recycled/removed.
+0M: CHECKPOINT;
+CHECKPOINT
+0M: CHECKPOINT;
+CHECKPOINT
+
+-- Write something (promote adds a 'End Of Recovery' xlog that causes the
+-- divergence between primary and mirror, but I add a write here so that we
+-- know that a wal divergence is explicitly triggered and 100% completed.  Also
+-- sanity check the tuple distribution (assumption of the test).
+2: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+2: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 6     
+ 1             | 6     
+ 2             | 6     
+(3 rows)
+
+-- Ensure that pg_rewind succeeds. Previously it could fail since the divergence
+-- LSN wal file is missing.
+!\retcode gprecoverseg -av;
+-- start_ignore
+20210429:15:31:23:021451 gprecoverseg:host67:pguo-[DEBUG]:-pg_rewind results: cmd had rc=1 completed=True halted=False
+  stdout=''
+  stderr=''
+20210429:15:31:23:021451 gprecoverseg:host67:pguo-[DEBUG]:-rewind dbid: 2 failed
+20210429:15:31:23:021451 gprecoverseg:host67:pguo-[WARNING]:-
+20210429:15:31:23:021451 gprecoverseg:host67:pguo-[WARNING]:-Incremental recovery failed for dbid 2. You must use gprecoverseg -F to recover the segment.
+-- end_ignore
+(exited with code 0)
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+(exited with code 0)
+2: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Test 2
+-- primary is abnormally shutdown, but pg_rewind would call single mode
+-- postgres to ensure it clean shutdown and that causes two checkpoints.
+
+-- See previous comment for why.
+3: CHECKPOINT;
+CHECKPOINT
+
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+-- Should be not needed mostly but let's 100% ensure since pg_switch_xlog()
+-- won't switch if it is on the boundary already (seldom though).
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+ ?column? 
+----------
+ t        
+(1 row)
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+
+-- Hang at checkpointer before writing checkpoint xlog.
+3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1U&: CHECKPOINT;  <waiting ...>
+3: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Stop the primary immediately and promote the mirror.
+3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+3: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
+
+4: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+4: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 1             | 11    
+ 0             | 11    
+ 2             | 11    
+(3 rows)
+
+-- CHECKPOINT should fail now.
+1U<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1Uq: ... <quitting>
+
+-- Ensure that pg_rewind succeeds. For unclean shutdown, there are two
+-- checkpoints are introduced in pg_rewind when running single-mode postgres
+-- (one is the checkpoint after crash recovery and another is the shutdown
+-- checkpoint) and previously the checkpoints clean up the wal files that
+-- include the previous checkpoint (before divergence LSN) for pg_rewind and
+-- thus makes gprecoverseg (pg_rewind) fail.
+!\retcode gprecoverseg -av;
+(exited with code 0)
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+(exited with code 0)
+4: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Cleanup
+5: DROP TABLE tst_missing_tbl;
+DROP
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+5: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+!\retcode gpconfig -r wal_keep_segments;
+(exited with code 0)
+!\retcode gpstop -ari;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -4,6 +4,7 @@ test: lockmodes
 # Put test prepare_limit near to test lockmodes since both of them reboot the
 # cluster during testing. Usually the 2nd reboot should be faster.
 test: prepare_limit
+test: pg_rewind_fail_missing_xlog
 test: prepared_xact_deadlock_pg_rewind
 test: ao_partition_lock query_gp_partitions_view
 test: dml_on_root_locks_all_parts

--- a/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
+++ b/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
@@ -1,0 +1,114 @@
+-- Test the bug that if checkpoint.redo before the oldest replication slot LSN
+-- is removed/recylced in checkpointer, gprecoverseg (based on pg_rewind) would
+-- would fail.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+include: helpers/server_helpers.sql;
+
+SHOW gp_keep_all_xlog;
+CREATE TABLE tst_missing_tbl (a int);
+INSERT INTO tst_missing_tbl values(2),(1),(5);
+
+-- make the test faster.
+!\retcode gpconfig -c wal_keep_segments -v 2;
+!\retcode gpstop -ari;
+
+-- Test 1: primary was marked down by the master but acetually it keeps running
+-- and previously, checkpoints could recycle/remove the checkpoint.redo wal
+-- file before the oldest replication slot LSN and thus make pg_rewind fail due
+-- to missing xlog file.
+
+-- Run a checkpoint so that the below sqls won't cause a checkpoint
+-- until an explicit checkpoint command is issued by the test.
+-- checkpoint_timeout is by default 300 but the below test should be able to
+-- finish in 300 seconds.
+1: CHECKPOINT;
+
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+-- Should be not needed mostly but let's 100% ensure since pg_switch_xlog()
+-- won't switch if it has been on the boundary (seldom though).
+0U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+
+-- Mark down the primary with content 0 via fts fault injection.
+1: SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+-- Trigger failover and double check.
+1: SELECT gp_request_fts_probe_scan();
+1: SELECT role, preferred_role from gp_segment_configuration where content = 0;
+
+-- Run two more checkpoints. Previously this causes the checkpoint.redo wal
+-- file before the oldest replication slot LSN is recycled/removed.
+0M: CHECKPOINT;
+0M: CHECKPOINT;
+
+-- Write something (promote adds a 'End Of Recovery' xlog that causes the
+-- divergence between primary and mirror, but I add a write here so that we
+-- know that a wal divergence is explicitly triggered and 100% completed.  Also
+-- sanity check the tuple distribution (assumption of the test).
+2: INSERT INTO tst_missing_tbl values(2),(1),(5);
+2: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+
+-- Ensure that pg_rewind succeeds. Previously it could fail since the divergence
+-- LSN wal file is missing.
+!\retcode gprecoverseg -av;
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+2: SELECT wait_until_all_segments_synchronized();
+
+-- Test 2
+-- primary is abnormally shutdown, but pg_rewind would call single mode
+-- postgres to ensure it clean shutdown and that causes two checkpoints.
+
+-- See previous comment for why.
+3: CHECKPOINT;
+
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+-- Should be not needed mostly but let's 100% ensure since pg_switch_xlog()
+-- won't switch if it is on the boundary already (seldom though).
+1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+
+-- Hang at checkpointer before writing checkpoint xlog.
+3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+1U&: CHECKPOINT;
+3: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+
+-- Stop the primary immediately and promote the mirror.
+3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
+3: SELECT gp_request_fts_probe_scan();
+3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
+
+4: INSERT INTO tst_missing_tbl values(2),(1),(5);
+4: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+
+-- CHECKPOINT should fail now.
+1U<:
+1Uq:
+
+-- Ensure that pg_rewind succeeds. For unclean shutdown, there are two
+-- checkpoints are introduced in pg_rewind when running single-mode postgres
+-- (one is the checkpoint after crash recovery and another is the shutdown
+-- checkpoint) and previously the checkpoints clean up the wal files that
+-- include the previous checkpoint (before divergence LSN) for pg_rewind and
+-- thus makes gprecoverseg (pg_rewind) fail.
+!\retcode gprecoverseg -av;
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+4: SELECT wait_until_all_segments_synchronized();
+
+-- Cleanup
+5: DROP TABLE tst_missing_tbl;
+!\retcode gprecoverseg -ar;
+5: SELECT wait_until_all_segments_synchronized();
+!\retcode gpconfig -r wal_keep_segments;
+!\retcode gpstop -ari;

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -58,7 +58,7 @@ class SQLIsolationExecutor(object):
         # The re.S flag makes the "." in the regex match newlines.
         # When matched against a command in process_command(), all
         # lines in the command are matched and sent as SQL query.
-        self.command_pattern = re.compile(r"^(-?\d+|[*])([&\\<\\>USIq]*?)\:(.*)", re.S)
+        self.command_pattern = re.compile(r"^(-?\d+|[*])([&\\<\\>USIMq]*?)\:(.*)", re.S)
         if dbname:
             self.dbname = dbname
         else:
@@ -161,6 +161,16 @@ class SQLIsolationExecutor(object):
                 self.con = self.connectdb(given_dbname=self.dbname,
                                           given_host=hostname,
                                           given_port=port)
+            elif self.mode == "mirror":
+                # Connect to mirror even when it's role is recorded
+                # as mirror.  This is useful for scenarios where a
+                # primary is marked down but could actually accept
+                # connection. This implies utility connection.
+                (hostname, port) = self.get_hostname_port(name, 'm')
+                self.con = self.connectdb(given_dbname=self.dbname,
+                                          given_host=hostname,
+                                          given_port=port,
+                                          given_opt="-c gp_session_role=utility")
             else:
                 self.con = self.connectdb(self.dbname)
 
@@ -368,6 +378,8 @@ class SQLIsolationExecutor(object):
                 if len(flag) > 1:
                     flag = flag[1:]
                 con_mode = "standby"
+            elif flag and flag[0] == "M":
+                con_mode = "mirror"
             sql = m.groups()[2]
             sql = sql.lstrip()
             # If db_name is specifed , it should be of the following syntax:
@@ -452,6 +464,8 @@ class SQLIsolationExecutor(object):
                 raise Exception("No query should be given on quit")
             self.quit_process(output_file, process_name, con_mode, dbname=dbname)
         elif flag == "S":
+            self.get_process(output_file, process_name, con_mode, dbname=dbname).query(sql.strip())
+        elif flag == "M":
             self.get_process(output_file, process_name, con_mode, dbname=dbname).query(sql.strip())
         else:
             raise Exception("Invalid isolation flag")


### PR DESCRIPTION
… before divergence LSN is gone.

gprecoverseg calls pg_rewind to do incremental recovery. For unclean shutdown,
pg_rewind calls single mode postgres to ensure the clean shutdown, however the
single mode postgres would introduce two additional checkpoints, one is after
crash recovery, and another is for shutdown. Current gp6 xlog removing/recyling
logic ensures that the previous checkpoint.redo is kept when doing checkpoint, now
that two additional checkpoints are added the checkpoint wal file before the
divergence LSN might be recycled/removed and thus pg_rewind fails sometimes due
to missing wal files. This issue happens also when the primary is not actually
running but just was marked down by fts. The coordinator promotes the mirror,
and the continuing checkpoint on the primary could remove the needed wal files
for pg_rewind.

In real scenario this could be reproduced by the below script,

  psql -c 'create table t(a int);'
  psql -c 'insert into t select * from generate_series(1,10000000);'
  psql -c 'insert into t select * from generate_series(1,10000000);'
  psql -c 'insert into t select * from generate_series(1,10000000);'

  kill -9 `ps -ef |grep 6002|grep gpAux|awk '{print $2}'`
  psql -c "select gp_request_fts_probe_scan()" postgres

  gprecoverseg -av
  echo $?

For this case, the key point to reproduce this issue is there is an ongoing
checkpoint after bulk inserting, then if the primary postmaster is kill-9-ed,
the checkpointer flushes the replication slots in CheckPointReplicationSlots()
already but waits in CheckPointBuffers() for some time since bgwriter is gone.
The checkpoint might finish or not (checkpoint xlog write and xlog file
recycling/removal) before gprecoverseg, but either scenario could lead to the
issue (since this checkpoint xlog is after divergence LSN so it is uselss -
pg_rewind needs to find the common ancestor).

This issue happens on master and upstream also. Fixing this in 6X by trying to
keep the checkpoint.redo before the oldest replication slot LSN.  For master &
upstream, let's discuss on upstream at first.

Co-authored-by: Gang Xiong <gxiong@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
