### PR TITLE
gpmovemirrors: add disk space check

### DIFF
--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -25,6 +25,7 @@ try:
     from gppylib.operations.startSegments import *
     from pgdb import DatabaseError
     from gppylib import gparray, gplog, pgconf, userinput, utils
+    from gppylib.operations.validate_disk_space import RelocateSegmentPair, RelocateDiskUsage, InsufficientDiskSpaceError
     from gppylib.parseutils import line_reader, check_values, canonicalize_address
 
 except ImportError as e:
@@ -339,6 +340,7 @@ try:
     newConfig.read_input_file(options.input_filename)
 
     PgHbaEntriesToUpdate = []
+    pairs = []
     """ Do some sanity checks on the input. """
     for oldMirror, newMirror in zip(newConfig.oldMirrorList, newConfig.newMirrorList):
         seg = lookupGpdb(oldMirror.address, oldMirror.port, oldMirror.dataDirectory)
@@ -362,6 +364,12 @@ try:
                 if segment.getSegmentContentId() == seg.getSegmentContentId() and segment.getSegmentRole() != seg.getSegmentRole():
                     PgHbaEntriesToUpdate.append((segment.getSegmentDataDirectory(), segment.getSegmentHostName(), newMirror.address))
 
+        pair = RelocateSegmentPair(oldMirror.address, oldMirror.dataDirectory, newMirror.address, newMirror.dataDirectory)
+        pairs.append(pair)
+
+    disk_usage = RelocateDiskUsage(pairs, options.batch_size)
+    if not disk_usage.validate_disk_space():
+        raise InsufficientDiskSpaceError("Insufficient disk space on target mirror hosts.")
 
     """ Prepare common execution steps for running commands on segments """
     mirrorsToDelete = [mirror for mirror in newConfig.oldMirrorList if not mirror.inPlace]

--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -7,7 +7,7 @@ PROGRAMS= initstandby.py test_utils_helper.py
 
 DATA= __init__.py buildMirrorSegments.py deletesystem.py detect_unreachable_hosts.py \
 	package.py rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
-	unix.py update_pg_hba_conf.py utils.py
+	unix.py update_pg_hba_conf.py validate_disk_space.py utils.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(libdir)/python/gppylib/operations'

--- a/gpMgmt/bin/gppylib/operations/validate_disk_space.py
+++ b/gpMgmt/bin/gppylib/operations/validate_disk_space.py
@@ -1,0 +1,181 @@
+import base64
+import pickle
+
+from gppylib.commands.base import REMOTE, WorkerPool, Command
+from gppylib.commands.unix import DiskFree, DiskUsage, MakeDirectory
+from gppylib.db import dbconn
+from gppylib.gplog import get_default_logger
+
+logger = get_default_logger()
+
+
+class RelocateSegmentPair:
+    """
+    RelocateSegmentPair maps source and target information for ease of use in
+    other functions. For example, it encapsulates the information needed to
+    calculate disk usage on the source host to ensure enough free space on
+    the target host.
+
+    The parameter hostaddr is the hostname or ip address of the segment.
+    """
+    def __init__(self, source_hostaddr, source_data_dir, target_hostaddr, target_data_dir):
+        self.source_hostaddr = source_hostaddr
+        self.source_data_dir = source_data_dir
+        self.target_hostaddr = target_hostaddr
+        self.target_data_dir = target_data_dir
+
+
+class RelocateDiskUsage:
+    """
+    RelocateDiskUsage validates if there is enough disk space on the target host
+    for the source data directories and tablespaces.
+
+    The parameter pairs is a list of RelocateSegmentPair().
+    """
+    def __init__(self, pairs, batch_size):
+        self.pairs = pairs  # list of RelocateSegmentPair()
+        self.batch_size = batch_size
+        for pair in self.pairs:
+            pair.source_tablespace_usage = {}  # map of tablespace_location to disk usage
+            pair.source_data_dir_usage = None
+            pair.dirs_created = None
+
+    # Calculates total disk usage for source directories, and checks free disk
+    # space on target host filesystems.
+    def validate_disk_space(self):
+        self._determine_source_disk_usage()
+
+        for hostaddr, filesystems in self._target_host_filesystems().items():
+            for fs in filesystems:
+                if fs.disk_free <= fs.disk_required:
+                    logger.error("Not enough space on host %s for directories %s." % (hostaddr, ', '.join(map(str, fs.directories))))
+                    logger.error("Filesystem %s has %d kB available, but requires %d kB." % (fs.name, fs.disk_free, fs.disk_required))
+                    return False
+        return True
+
+    # Calculates disk usage for the data directory, and all user defined
+    # tablespaces for the source host.
+    # NOTE: The user can specify a different target data directory from
+    # the source. However, we do not allow them to specify different tablespace
+    # locations from the source to target since the primary and mirror tablespace
+    # locations must match.
+    def _determine_source_disk_usage(self):
+        for pair in self.pairs:
+            pair.source_data_dir_usage = self._disk_usage(pair.source_hostaddr, [pair.source_data_dir])[pair.source_data_dir]
+            pair.source_tablespace_usage = self._disk_usage(pair.source_hostaddr, get_segment_tablespace_dirs(pair.source_data_dir))
+
+    def _disk_usage(self, hostaddr, dirs):
+        dirs_disk_usage = {}  # map of directories to disk usage
+
+        pool = WorkerPool(numWorkers=min(len(dirs), self.batch_size))
+        try:
+            for directory in dirs:
+                cmd = DiskUsage('check source segments disk space used', directory, ctxt=REMOTE, remoteHostAddr=hostaddr)
+                pool.addCommand(cmd)
+            pool.join()
+        finally:
+            pool.haltWork()
+            pool.joinWorkers()
+
+        for cmd in pool.getCompletedItems():
+            if not cmd.was_successful():
+                raise Exception("Unable to check disk usage on source segment: " + cmd.get_results().stderr_value())
+
+            dirs_disk_usage[cmd.directory] = cmd.kbytes_used()
+
+        return dirs_disk_usage
+
+    # Returns a map of hostaddr to list of target filesystems containing the
+    # disk space required and disk space available.
+    def _target_host_filesystems(self):
+        hostaddr_to_filesystems = {}  # map of hostaddr to list of FileSystem()
+
+        for pair in self.pairs:
+            target_filesystems = self._target_filesystems(pair)
+            host_filesystems = hostaddr_to_filesystems[pair.target_hostaddr]
+
+            if not host_filesystems:
+                host_filesystems.extend(target_filesystems)
+                continue
+
+            # Consolidate the same target filesystems across other pairs
+            for target_fs in target_filesystems:
+                for host_fs in host_filesystems:
+                    if target_fs.name == host_fs.name:
+                        host_fs.disk_required += target_fs.disk_required
+                        host_fs.directories += set(target_fs.directories)
+
+            # add any target filesystems not already in host_filesystems
+            to_add = set(target_filesystems).difference(set(host_filesystems))
+            host_filesystems.extend(to_add)
+
+        return hostaddr_to_filesystems
+
+    # For each source/target pair find the "target" filesystems and associated
+    # free disk space. Returns a list of target filesystems
+    def _target_filesystems(self, pair):
+        filesystems = []  # list of FileSystem()
+
+        directories = [pair.target_data_dir] + list(pair.source_tablespace_usage.keys())
+        pool = WorkerPool(numWorkers=min(len(directories), self.batch_size))
+        try:
+            cmd = DiskFree(pair.target_hostaddr, directories)
+            pool.addCommand(cmd)
+            pool.join()
+        finally:
+            pool.haltWork()
+            pool.joinWorkers()
+
+        for cmd in pool.getCompletedItems():
+            if not cmd.was_successful():
+                raise Exception("Failed to check disk free on target segment: " + cmd.get_results().stderr_value())
+
+            filesystems = pickle.loads(base64.urlsafe_b64decode(cmd.get_results().stdout_value()))
+            for fs in filesystems:
+                fs.add_disk_usage(pair)
+
+        return filesystems
+
+
+class FileSystem:
+    def __init__(self, name, disk_free=None):
+        self.name = name
+        self.disk_free = disk_free  # in kB
+        self.disk_required = None  # in kB
+        self.directories = None  # set of directories
+
+    def add_disk_usage(self, pair):
+        for dir in self.directories:
+            if dir == pair.target_data_dir:
+                self.disk_required += pair.source_data_dir_usage
+            else:
+                self.disk_required += pair.source_tablespace_usage[dir]
+
+
+class InsufficientDiskSpaceError(Exception):
+    pass
+
+
+# temporary picked from https://github.com/greenplum-db/gpdb/pull/11831
+# FIXME: don't filter on dataDirectory, but rather something else such as contentID or host/port, etc.
+def get_segment_tablespace_dirs(dataDirectory):
+    """ Create list of user-created tablespace locations for a segment data directory """
+
+    tblspclocs = []
+    tblspcoids = []
+    gettblspcoids_sql = "select oid from pg_tablespace where spcname not in ('pg_default', 'pg_global')"
+    gettblspclocs_sql = "select t.tblspc_loc||'/'||dbid from gp_tablespace_location(%s) t, gp_segment_configuration c where t.gp_segment_id = c.content and c.datadir ='%s'"
+
+    with dbconn.connect(dbconn.DbURL()) as conn:
+        result = dbconn.execSQL(conn, gettblspcoids_sql)
+        if result:
+            tblspcoids = dbconn.execSQL(conn, gettblspcoids_sql).fetchall()
+
+        # Use the tablespace oids to get the tablespace locations
+    for row in tblspcoids:
+        tblspcoid = row[0]
+        with dbconn.connect(dbconn.DbURL()) as conn:
+            something = dbconn.execSQL(conn, gettblspclocs_sql % (tblspcoid, dataDirectory)).fetchall()
+            tblspclocs.append(something)
+
+    return tblspclocs

--- a/gpMgmt/bin/lib/Makefile
+++ b/gpMgmt/bin/lib/Makefile
@@ -10,6 +10,7 @@ $(recurse)
 PROGRAMS= __init__.py \
 	gp_bash_functions.sh \
 	gp_bash_version.sh \
+	calculate_disk_free.py \
 	gpconfigurenewsegment \
 	gpcreateseg.sh \
 	gppinggpfdist.py \

--- a/gpMgmt/bin/lib/calculate_disk_free.py
+++ b/gpMgmt/bin/lib/calculate_disk_free.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import pickle
+import subprocess
+import sys
+
+from gppylib.operations.validate_disk_space import FileSystem
+from gppylib.gpparseopts import OptParser, OptChecker
+from gppylib.mainUtils import addStandardLoggingAndHelpOptions
+
+
+# For each directory determine the filesystem and calculate the free disk space.
+# Returns a list of FileSystem() objects.
+def calculate_disk_free(directories):
+    filesystem_to_dirs = {}  # map of FileSystem() to list of directories
+    for dir in directories:
+        cmd = _disk_free(dir)
+        if cmd.returncode < 0:
+            sys.stderr.write("Failed to calculate free disk space: %s" % cmd.stderr)
+            return []
+
+        # skip the first line which is the header
+        for line in cmd.stdout.split('\n')[1:]:
+            parts = line.split()
+            fs = FileSystem(parts[0], disk_free=parts[3])
+            filesystem_to_dirs.setdefault(fs, []).append(dir)
+
+    filesystems = []  # list of FileSystem()
+    for fs, directories in filesystem_to_dirs.items():
+        fs.directories = set(directories)
+        filesystems.append(fs)
+
+    return filesystems
+
+
+# Since the input directory may not have been created df will fail. Thus, take
+# each path element starting at the end and execute df until it succeeds in
+# order to find the filesystem and free space.
+def _disk_free(directory):
+    # The -P flag is for POSIX formatting to prevent errors on lines that
+    # would wrap.
+    cmd = subprocess.run(["df", "-Pk", directory],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         universal_newlines=True)
+
+    if directory == os.sep:
+        return cmd
+
+    if cmd.returncode < 0:
+        path, last_element = os.path.split(directory)
+        return _disk_free(path)
+
+    return cmd
+
+
+def create_parser():
+    parser = OptParser(option_class=OptChecker,
+                       description='Calculates the disk free for the filesystem given the input directory. '
+                                   'Returns a list of base64 encoded pickled FileSystem objects.')
+
+    addStandardLoggingAndHelpOptions(parser, includeNonInteractiveOption=True)
+
+    parser.add_option('-d', '--directories',
+                      help='list of directories to calculate the disk usage for the filesystem',
+                      type='string',
+                      action='callback',
+                      callback=lambda option, opt, value, parser: setattr(parser.values, option.dest, value.split(',')),
+                      dest='directories')
+
+    return parser
+
+
+# NOTE: The caller uses the Command framework such as CommandResult
+# which assumes that the **only** thing written to stdout is the result. Thus,
+# do not use a logger to print to stdout as that would affect the deserialization
+# of the actual result.
+def main():
+    parser = create_parser()
+    (options, args) = parser.parse_args()
+
+    filesystems = calculate_disk_free(options.directories)
+    sys.stdout.write(base64.urlsafe_b64encode(pickle.dumps(filesystems)).decode('UTF-8'))
+    return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
gpmovemirrors fails late while creating mirrors (after running for several hours), if we find that there isn't enough disk space on the host.
This change is to have a disk space check before we start creating mirrors/copying data.

This is a draft PR to gather input on the high level approach, and more importantly gather specific input on testing.

Unit testing will be tricky and cumbersome. Ideas and suggestions appreciated.

One idea for end-to-end behave testing is the following:
- Create a small partition on the disk
- Create a new filesystem on that partition
- Mount it
- Use dd command or other to fill the partition.
- Try to move a mirror data directory to that partition, and assert that it fails.

**Open questions?**
How do we test tablespaces?