### PR TITLE
ORCA falls with segfault when trying to select from view:

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3793,6 +3793,9 @@ CTranslatorQueryToDXL::TranslateJoinExprInFromToDXL(JoinExpr *join_expr)
 	ForBoth(lc_node, rte->joinaliasvars, lc_col_name, alias->colnames)
 	{
 		Node *join_alias_node = (Node *) lfirst(lc_node);
+		// rte->joinaliasvars may contain NULL ptrs which indicates dropped columns
+		if (!join_alias_node)
+			continue;
 		GPOS_ASSERT(IsA(join_alias_node, Var) ||
 					IsA(join_alias_node, CoalesceExpr));
 		Value *value = (Value *) lfirst(lc_col_name);

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -271,3 +271,13 @@ ALTER TABLE test_part_col ADD COLUMN f int;
 ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
 ALTER TABLE test_part_col DROP COLUMN f;
 DROP TABLE test_part_col;
+-- Create view with JOIN clause, drop column, check select to view not causing segfault
+CREATE TABLE dropped_col_t1(i1 int, i2 int);
+CREATE TABLE dropped_col_t2(i1 int, i2 int);
+CREATE VIEW dropped_col_v AS SELECT dropped_col_t1.i1 FROM dropped_col_t1 JOIN dropped_col_t2 ON dropped_col_t1.i1=dropped_col_t2.i1;
+ALTER TABLE dropped_col_t1 DROP COLUMN i2;
+SELECT * FROM dropped_col_v;
+ i1 
+----
+(0 rows)
+

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -223,3 +223,10 @@ ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
 ALTER TABLE test_part_col DROP COLUMN f;
 
 DROP TABLE test_part_col;
+
+-- Create view with JOIN clause, drop column, check select to view not causing segfault
+CREATE TABLE dropped_col_t1(i1 int, i2 int);
+CREATE TABLE dropped_col_t2(i1 int, i2 int);
+CREATE VIEW dropped_col_v AS SELECT dropped_col_t1.i1 FROM dropped_col_t1 JOIN dropped_col_t2 ON dropped_col_t1.i1=dropped_col_t2.i1;
+ALTER TABLE dropped_col_t1 DROP COLUMN i2;
+SELECT * FROM dropped_col_v;


### PR DESCRIPTION
 - With JOIN clause
 - With table which column was dropped after view creation
RangeTblEntry::joinaliasvars alias list can contain pointers to NULL
node if corresponding column was dropped

ORCA doesn't respect NULL pointers when loop over them
which cause segfault

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
