### PR TITLE
Panic on AO tables fsync() failure

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -426,7 +426,7 @@ copy_file(char *srcsegpath, char *dstsegpath,
 	}
 
 	if (FileSync(dstFile, WAIT_EVENT_DATA_FILE_IMMEDIATE_SYNC) != 0)
-		ereport(ERROR,
+		ereport(data_sync_elevel(ERROR),
 				(errcode_for_file_access(),
 				 errmsg("could not fsync file \"%s\": %m",
 						dstsegpath)));

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -478,7 +478,7 @@ AppendOnlyStorageWrite_FlushAndCloseFile(
 	 */
 	if (!RelFileNodeBackendIsTemp(storageWrite->relFileNode) &&
 		FileSync(storageWrite->file, WAIT_EVENT_DATA_FILE_SYNC) != 0)
-		ereport(ERROR,
+		ereport(data_sync_elevel(ERROR),
 				(errcode_for_file_access(),
 				 errmsg("Could not flush (fsync) Append-Only segment file '%s' to disk for relation '%s': %m",
 						storageWrite->segmentFileName,


### PR DESCRIPTION
As we know since fsyncgate, there is no sense to retry `fsync()` because dirty data cached by the kernel may have been dropped on write-back failure. This problem was fixed in vanilla PG by a new GUC `data_sync_retry`, that controls a fallback to PANIC on `fsync()` error, and backported to GPDB. But we forgot about AO/AOC tables that use their own storage manager to bypass shared buffers. Current commit makes them panic on `fsync()` failure as well.

This PR should be backported to 6X branch (5X doesn't have `fsync()` PANIC support at all).