### PR TITLE
[6X FIX]Fix a bug of concurrently executing UPDATE/DELETE with VACUUM on a partition ao table

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -698,7 +698,7 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 		CommitTransactionCommand();
 		return;
 	}
-
+	SIMPLE_FAULT_INJECTOR("vacuum_hold_lock");
 	/*
 	 * Check permissions.
 	 *

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1739,18 +1739,6 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			resultRelationOid = getrelid(resultRelationIndex, rangeTable);
 			if (operation == CMD_UPDATE || operation == CMD_DELETE)
 			{
-				/*
-				 * On QD, the lock on the table has already been taken during parsing, so if it's a child
-				 * partition, we don't need to take a lock. If there a deadlock GDD will come in place
-				 * and resolve the deadlock. ORCA Update / Delete plans only contains the root relation, so
-				 * no locks on leaf partition are taken here. The below changes makes planner as well to not
-				 * take locks on leaf partitions with GDD on.
-				 * Note: With GDD off, ORCA and planner both will acquire locks on the leaf partitions.
-				 */
-				if (Gp_role == GP_ROLE_DISPATCH && rel_is_child_partition(resultRelationOid) && gp_enable_global_deadlock_detector)
-				{
-					lockmode = NoLock;
-				}
 				resultRelation = CdbOpenRelation(resultRelationOid, lockmode, NULL);
 			}
 			else
@@ -1812,50 +1800,10 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			if (containRoot)
 			{
 				/*
-				 * For partition tables, if GDD is off, any DML statement on root
-				 * partition, must acquire locks on the leaf partitions to avoid
-				 * deadlocks.
-				 *
-				 * Without locking the partition relations on QD when INSERT
-				 * with Planner the following dead lock scenario may happen
-				 * between INSERT and AppendOnly VACUUM drop phase on the
-				 * partition table:
-				 *
-				 * 1. AO VACUUM drop on QD: acquired AccessExclusiveLock
-				 * 2. INSERT on QE: acquired RowExclusiveLock
-				 * 3. AO VACUUM drop on QE: waiting for AccessExclusiveLock
-				 * 4. INSERT on QD: waiting for AccessShareLock at ExecutorEnd()
-				 *
-				 * 2 blocks 3, 1 blocks 4, 1 and 2 will not release their locks
-				 * until 3 and 4 proceed. Hence INSERT needs to Lock the partition
-				 * tables on QD here (before 2) to prevent this dead lock.
-				 *
-				 * Deadlock can also occur in case of DELETE as below
-				 * Session1: BEGIN; delete from foo_1_prt_1 WHERE c = 999999; => Holds
-				 * Exclusive lock on foo_1_prt_1 on QD and marks the tuple c updated by the
-				 * current transaction;
-				 * Session2: BEGIN; delete from foo WHERE c = 1; => Holds Exclusive lock
-				 * on foo on QD and marks the tuple c = 1 updated by current transaction
-				 * Session1: DELETE FROM foo_1_prt_1 WHERE c = 1; => This wait, as Session
-				 * 2 has already taken the lock, Session1 will wait to acquire the
-				 * transaction lock.
-				 * Session2: DELETE FROM foo WHERE c = 999999; => This waits, as Session 1
-				 * has already taken the lock, Session 2 will wait to acquire the
-				 * transaction lock.
-				 * This will cause a deadlock.
-				 * Similar scenario apply for UPDATE as well.
+				 * We already get all the locks in the parse-analyze stage.
+				 * So we don't need to acquire any locks here.
 				 */
-				lockmode = NoLock;
-				if ((operation == CMD_DELETE || operation == CMD_INSERT || operation == CMD_UPDATE) &&
-					!gp_enable_global_deadlock_detector &&
-					rel_is_partitioned(relid))
-				{
-					if (operation == CMD_INSERT)
-						lockmode = RowExclusiveLock;
-					else
-						lockmode = ExclusiveLock;
-				}
-				all_relids = find_all_inheritors(relid, lockmode, NULL);
+				all_relids = find_all_inheritors(relid, NoLock, NULL);
 			}
 			else
 			{

--- a/src/backend/storage/lmgr/README-partition
+++ b/src/backend/storage/lmgr/README-partition
@@ -1,0 +1,61 @@
+src/backend/storage/lmgr/README-partition
+
+The behavior about locking on partition table
+===========================================================
+
+If the relation is partitioned, we should acquire corresponding locks on
+each leaf partition before entering InitPlan. The snapshot will acquire before
+the InitPlan, so if we wait the locks for a while in the InitPlan. When we
+get all locks, the snapshot maybe become invalid. So we must acquire lock
+before entering InitPlan to keep the snapshot valid.
+
+If the sql statement is not cached, we will acquire locks on partition in the 
+function setTargetTable. In the past, we will only acquire locks on the parent table.
+But now, if the table is partitioned, we will acquire all the locks on all the children
+tables. 
+
+If the sql statement is cached, we will acquire locks on partition in the function
+ScanQueryForLocks.
+
+We need to keep lock type consistent with upstreaming. If the lockUpgraded 
+happens, we need to upgrade lock on the partition table. 
+
+About the lock type, only one situation is special, when the command is to insert,
+and gdd don't open, the dead lock will happen.
+for example:
+Without locking the partition relations on QD when INSERT with Planner the 
+following dead lock scenario may happen between INSERT and AppendOnly VACUUM 
+drop phase on the partition table:
+
+1. AO VACUUM drop on QD: acquired AccessExclusiveLock
+2. INSERT on QE: acquired RowExclusiveLock
+3. AO VACUUM drop on QE: waiting for AccessExclusiveLock
+4. INSERT on QD: waiting for AccessShareLock at ExecutorEnd()
+
+2 blocks 3, 1 blocks 4, 1 and 2 will not release their locks until 3 and 4 proceed. 
+Hence INSERT needs to Lock the partition tables on QD here (before 2) to prevent 
+this dead lock.
+
+This will cause a deadlock. But if gdd have already opened, gdd will solve the 
+dead lock. So it is safe to not get locks for partitions.
+
+But for the update and delete, we must acquire locks whether the gdd opens or not.
+
+More detail about the lock behavior
+-----------------------------------------------------------
+
+We can start with that. It is important to focus on partitioned tables. Regular, 
+non-partitioned tables have simpler locking strategy. And whether we use orca or not,
+the lock behavior is the same. Suppose we have a root partition table named root. The root
+table have three child tables named child_1、child_2 and child_3. We want to delete a tuple from
+table when the gdd is off, we need to acquire RowExclusiveLock on root and all child tables. 
+Although we know the tuple is in the child_1, we still want to acquire RowExclusiveLock on the
+all child tables for security.
+
+ -----------------------------------------------------------------------------------------------------------------
+|    DML        |       gdd on                                    |      gdd off                                  |
+|    Insert     | RowExclusiveLock on root table                  | RowExclusiveLock on root and all child tables |
+|    Delete     | ExclusiveLock on root and all child tables      | ExclusiveLock on root and all child tables    |
+|    Update     | ExclusiveLock on root and all child tables      | ExclusiveLock on root and all child tables    |
+ -----------------------------------------------------------------------------------------------------------------
+

--- a/src/test/isolation2/expected/concurrent_vacuum_with_delete.out
+++ b/src/test/isolation2/expected/concurrent_vacuum_with_delete.out
@@ -1,0 +1,164 @@
+-- The test has two parts, first part is when I use normal sql command(no cached), I don't have problem with vacuum.
+-- Second part is when I use cached plan sql command, I don't have problem with vacuum.
+-- for example:
+-- session 1: vacuum sales_row_1_prt_1
+-- session 2: delete from sales_row;
+-- The old lock behavior(If we acquires leaf locks in the InitPlan):
+-- session 2 get locks for the sales_row
+-- session 1 get locks for the sales_row_1_prt_1
+-- session 2 will get snapshot and enter InitPlan, wait session 1 to release the locks for the sales_row_1_prt_1
+-- session 1 complete
+-- session 2 get locks but the snapshot is invalid.
+--
+-- Now the lock behavior is:(If we acquires all the locks in the parse and analyze):
+-- session 2 get locks for the sales_row
+-- session 1 get locks for the sales_row_1_prt_1
+-- session 2 will wait session 1 to release the locks for the sales_row_1_prt_1 in the function setTargetTable or AcquirePlannerLocks
+-- session 1 complete
+-- session 2 get locks and get snapshot, then it will complete correctly
+--
+-- So the problem is solved
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+create table sales_row (id int, date date, amt decimal(10,2)) with (appendonly=true) distributed by (id) partition by range (date) ( start (date '2008-01-01') inclusive end (date '2009-01-01') exclusive every (interval '1 month') );
+CREATE
+
+insert into sales_row values (generate_series(1,1000),'2008-01-01',10);
+INSERT 1000
+update sales_row set amt = amt + 1;
+UPDATE 1000
+
+select gp_inject_fault('vacuum_hold_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- session 1 will block after getting locks on leaf partition.
+1&: vacuum sales_row_1_prt_1;  <waiting ...>
+
+select gp_wait_until_triggered_fault('vacuum_hold_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+select gp_inject_fault('parse_wait_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- session 2 will get locks on the sales_row, but still wait locks on the leaf partition in the function setTargetTable.
+2&: delete from sales_row;  <waiting ...>
+
+-- session 2 will wait locks on leaf partition.
+select gp_wait_until_triggered_fault('parse_wait_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+select gp_inject_fault('parse_wait_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- session 1 will complete, so session 2 get locks and complete.
+select gp_inject_fault('vacuum_hold_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+VACUUM
+2<:  <... completed>
+DELETE 1000
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- cached plan
+
+drop table sales_row;
+DROP
+create table sales_row (id int, date date, amt decimal(10,2)) with (appendonly=true) distributed by (id) partition by range (date) ( start (date '2008-01-01') inclusive end (date '2009-01-01') exclusive every (interval '1 month') );
+CREATE
+
+insert into sales_row values (generate_series(1,1000),'2008-01-01',10);
+INSERT 1000
+update sales_row set amt = amt + 1;
+UPDATE 1000
+
+2: prepare test as delete from sales_row;
+PREPARE
+
+select gp_inject_fault('vacuum_hold_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- session 1 will block after getting locks on leaf partition.
+1&: vacuum sales_row_1_prt_1;  <waiting ...>
+
+select gp_wait_until_triggered_fault('vacuum_hold_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+select gp_inject_fault('cache_wait_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- session 2 will get locks on the sales_row, but still wait locks on the leaf partition in the function AcquirePlannerLocks.
+2&: execute test;  <waiting ...>
+
+select gp_wait_until_triggered_fault('cache_wait_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- session 2 will wait locks on leaf partition.
+select gp_inject_fault('cache_wait_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- session 1 will complete, so session 2 get locks and complete.
+select gp_inject_fault('vacuum_hold_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+VACUUM
+2<:  <... completed>
+EXECUTE 1000
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop table sales_row;

--- a/src/test/isolation2/expected/gdd/dml_locks_only_targeted_table_in_query.out
+++ b/src/test/isolation2/expected/gdd/dml_locks_only_targeted_table_in_query.out
@@ -17,11 +17,12 @@ INSERT 10
 BEGIN
 1: DELETE FROM part_tbl_upd_del;
 DELETE 10
--- since the delete operation is on root part and gdd is on, there will be no lock on leaf partition on QD
+-- since the delete operation is on root part and gdd is on, there will be a lock on leaf partition on QD
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
  ?column? 
 ----------
-(0 rows)
+ 1        
+(1 row)
 -- lock on qd will be there for root partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
  ?column? 
@@ -36,11 +37,12 @@ ROLLBACK
 BEGIN
 1: UPDATE part_tbl_upd_del SET c = 1 WHERE c = 1;
 UPDATE 1
--- since the update operation is on root part and gdd is on, there will be no lock on leaf partition on QD
+-- since the update operation is on root part and gdd is on, there will be a lock on leaf partition on QD
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
  ?column? 
 ----------
-(0 rows)
+ 1        
+(1 row)
 -- lock on qd will be there for root partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
  ?column? 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -267,3 +267,6 @@ test: distributed_transactions
 
 # Test for distributed commit array overflow during replay on standby
 test: standby_replay_dtx_info
+
+# Test for concurrent vacuum with delete
+test: concurrent_vacuum_with_delete

--- a/src/test/isolation2/sql/concurrent_vacuum_with_delete.sql
+++ b/src/test/isolation2/sql/concurrent_vacuum_with_delete.sql
@@ -1,0 +1,105 @@
+-- The test has two parts, first part is when I use normal sql command(no cached), I don't have problem with vacuum.
+-- Second part is when I use cached plan sql command, I don't have problem with vacuum.
+-- for example:
+-- session 1: vacuum sales_row_1_prt_1
+-- session 2: delete from sales_row;
+-- The old lock behavior(If we acquires leaf locks in the InitPlan):
+-- session 2 get locks for the sales_row
+-- session 1 get locks for the sales_row_1_prt_1
+-- session 2 will get snapshot and enter InitPlan, wait session 1 to release the locks for the sales_row_1_prt_1
+-- session 1 complete
+-- session 2 get locks but the snapshot is invalid.
+--
+-- Now the lock behavior is:(If we acquires all the locks in the parse and analyze):
+-- session 2 get locks for the sales_row
+-- session 1 get locks for the sales_row_1_prt_1
+-- session 2 will wait session 1 to release the locks for the sales_row_1_prt_1 in the function setTargetTable or AcquirePlannerLocks
+-- session 1 complete
+-- session 2 get locks and get snapshot, then it will complete correctly
+-- 
+-- So the problem is solved
+
+create extension if not exists gp_inject_fault;
+
+create table sales_row (id int, date date, amt decimal(10,2))
+with (appendonly=true) distributed by (id)
+partition by range (date)
+( start (date '2008-01-01') inclusive
+end (date '2009-01-01') exclusive
+every (interval '1 month') );
+
+insert into sales_row values (generate_series(1,1000),'2008-01-01',10);
+update sales_row set amt = amt + 1;
+
+select gp_inject_fault('vacuum_hold_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- session 1 will block after getting locks on leaf partition. 
+1&: vacuum sales_row_1_prt_1;
+
+select gp_wait_until_triggered_fault('vacuum_hold_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select gp_inject_fault('parse_wait_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- session 2 will get locks on the sales_row, but still wait locks on the leaf partition in the function setTargetTable.
+2&: delete from sales_row;
+
+-- session 2 will wait locks on leaf partition.
+select gp_wait_until_triggered_fault('parse_wait_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select gp_inject_fault('parse_wait_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select pg_sleep(1);
+
+-- session 1 will complete, so session 2 get locks and complete.
+select gp_inject_fault('vacuum_hold_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+1<:
+2<:
+
+1q:
+2q:
+
+-- cached plan
+
+drop table sales_row;
+create table sales_row (id int, date date, amt decimal(10,2))
+with (appendonly=true) distributed by (id)
+partition by range (date)
+( start (date '2008-01-01') inclusive
+end (date '2009-01-01') exclusive
+every (interval '1 month') );
+
+insert into sales_row values (generate_series(1,1000),'2008-01-01',10);
+update sales_row set amt = amt + 1;
+
+2: prepare test as delete from sales_row;
+
+select gp_inject_fault('vacuum_hold_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- session 1 will block after getting locks on leaf partition. 
+1&: vacuum sales_row_1_prt_1;
+
+select gp_wait_until_triggered_fault('vacuum_hold_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select gp_inject_fault('cache_wait_lock', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- session 2 will get locks on the sales_row, but still wait locks on the leaf partition in the function AcquirePlannerLocks.
+2&: execute test;
+
+select gp_wait_until_triggered_fault('cache_wait_lock', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- session 2 will wait locks on leaf partition.
+select gp_inject_fault('cache_wait_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select pg_sleep(1);
+
+-- session 1 will complete, so session 2 get locks and complete.
+select gp_inject_fault('vacuum_hold_lock', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+1<:
+2<:
+
+1q:
+2q:
+
+drop table sales_row;

--- a/src/test/isolation2/sql/gdd/dml_locks_only_targeted_table_in_query.sql
+++ b/src/test/isolation2/sql/gdd/dml_locks_only_targeted_table_in_query.sql
@@ -8,7 +8,7 @@ INSERT INTO part_tbl_upd_del SELECT i, 1, i FROM generate_series(1,10)i;
 
 1: BEGIN;
 1: DELETE FROM part_tbl_upd_del;
--- since the delete operation is on root part and gdd is on, there will be no lock on leaf partition on QD
+-- since the delete operation is on root part and gdd is on, there will be a lock on leaf partition on QD
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
 -- lock on qd will be there for root partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
@@ -17,7 +17,7 @@ INSERT INTO part_tbl_upd_del SELECT i, 1, i FROM generate_series(1,10)i;
 
 1: BEGIN;
 1: UPDATE part_tbl_upd_del SET c = 1 WHERE c = 1;
--- since the update operation is on root part and gdd is on, there will be no lock on leaf partition on QD
+-- since the update operation is on root part and gdd is on, there will be a lock on leaf partition on QD
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
 -- lock on qd will be there for root partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -347,8 +347,16 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |     mode      | locktype |  node  
 -------------------+---------------+----------+--------
  partlockt         | ExclusiveLock | relation | master
+ partlockt_1_prt_1 | ExclusiveLock | relation | master
+ partlockt_1_prt_2 | ExclusiveLock | relation | master
+ partlockt_1_prt_3 | ExclusiveLock | relation | master
  partlockt_1_prt_4 | ExclusiveLock | relation | master
-(2 rows)
+ partlockt_1_prt_5 | ExclusiveLock | relation | master
+ partlockt_1_prt_6 | ExclusiveLock | relation | master
+ partlockt_1_prt_7 | ExclusiveLock | relation | master
+ partlockt_1_prt_8 | ExclusiveLock | relation | master
+ partlockt_1_prt_9 | ExclusiveLock | relation | master
+(10 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    


### PR DESCRIPTION
The problem is ERROR "tuple concurrently updated" occurs when running
delete qeury during ETL as below error. When we concurrently execute an
UPDATE/DELETE statement and a VACUUM statement on a partition ao table.
UPDATE/DELETE statement is likely to get an out-of-date snapshot after

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
