### PR TITLE
Docs: modified gpstop options description

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/startstop.xml
+++ b/gpdb-doc/dita/admin_guide/managing/startstop.xml
@@ -128,8 +128,13 @@
           <codeph>postgres</codeph> processes in the system, including the master and all segment
         instances. The <codeph>gpstop</codeph> utility uses a default of up to 64 parallel worker
         threads to bring down the Postgres instances that make up the Greenplum Database cluster.
-        The system waits for any active transactions to finish before shutting down. To stop
-        Greenplum Database immediately, use fast mode.</context>
+        The system waits for any active transactions to finish before shutting down. If after two
+        minutes there are still active connections, <codeph>gpstop</codeph> will prompt you to
+        either continue waiting in smart mode, stop in fast mode, or stop in immediate mode. To stop
+        Greenplum Database immediately, use fast mode. <note type="important">Immediate shut down
+          mode is not recommended. This mode kills all database processes without allowing the
+          database server to complete transaction processing or clean up any temporary or in-process
+          work files.</note></context>
       <steps-unordered>
         <step>
           <cmd>To stop Greenplum Database:</cmd>
@@ -142,9 +147,10 @@
           <stepxmp>
             <codeblock>$ gpstop -M fast</codeblock>
           </stepxmp>
-          <stepresult>By default, you are not allowed to shut down Greenplum Database if there are any
-      client connections to the database. Use the <codeph>-M fast</codeph> option to roll
-      back all in progress transactions and terminate any connections before shutting down.</stepresult>
+          <stepresult>By default, you are not allowed to shut down Greenplum Database if there are
+            any client connections to the database. Use the <codeph>-M fast</codeph> option to roll
+            back all in progress transactions and terminate any connections before shutting
+            down.</stepresult>
         </step>
       </steps-unordered>
     </taskbody>


### PR DESCRIPTION
I have added a description of the behavior of gpstop: waits for 2 minutes then prompts with 3 different options.
Since immediate mode is dangerous and not recommended to use, I have also added a warning section about it.
Preview: https://mireia-capgemini-gpstop.sc2-04-pcf1-apps.oc.vmware.com/7-0/admin_guide/managing/startstop.html
