### PR TITLE
Fix handling of partitioned tables with no partitions in Orca

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2968,6 +2968,10 @@ CTranslatorRelcacheToDXL::RetrieveStorageTypeForPartitionedTable(Relation rel)
 {
 	IMDRelation::Erelstoragetype rel_storage_type =
 		IMDRelation::ErelstorageSentinel;
+	if (rel->rd_partdesc->nparts == 0)
+	{
+		return IMDRelation::ErelstorageHeap;
+	}
 	for (int i = 0; i < rel->rd_partdesc->nparts; ++i)
 	{
 		Oid oid = rel->rd_partdesc->oids[i];

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13592,4 +13592,11 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
  Optimizer: Postgres query optimizer
 (16 rows)
 
+-- test partioned table with no partitions
+create table no_part (a int, b int) partition by list (a) distributed by (b);
+select * from no_part;
+ a | b 
+---+---
+(0 rows)
+
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13967,4 +13967,11 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
  Optimizer: Pivotal Optimizer (GPORCA)
 (23 rows)
 
+-- test partioned table with no partitions
+create table no_part (a int, b int) partition by list (a) distributed by (b);
+select * from no_part;
+ a | b 
+---+---
+(0 rows)
+
 reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3201,6 +3201,10 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
 ,      item_shipment_status_code
 ;
 
+-- test partioned table with no partitions
+create table no_part (a int, b int) partition by list (a) distributed by (b);
+select * from no_part;
+
 reset optimizer_trace_fallback;
 
 -- start_ignore


### PR DESCRIPTION
Commit b48098eeddc added support for partitioned tables with mixed
storage types by checking the child partitions. However, if a
partitioned table has no child partitions, it did not get a valid
storage type and crashed. We now assign it a heap partition type (though
it really doesn't matter as it will error out during execution since
there isn't a valid partition).
