### PR TITLE
Docs: added function definition to create type example

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -618,9 +618,16 @@
         <b>Adding Compression in a TYPE Command</b>
       </title>
       <body>
-        <p>When you create a new type, you can define default compression attributes for the type. For example,
-          the following <codeph>CREATE TYPE</codeph> command defines a type named <codeph>int33</codeph>
-          that specifies <codeph>quicklz</codeph> compression: </p>
+        <p>When you create a new type, you can define default compression attributes for the type.
+          For example, the following <codeph>CREATE TYPE</codeph> command defines a type named
+            <codeph>int33</codeph> that specifies <codeph>quicklz</codeph> compression.</p>
+        <p>First, you must define the <codeph>int33_in</codeph> and <codeph>int33_out</codeph>
+          functions:</p>
+        <codeblock>CREATE FUNCTION int33_in(cstring) returns int33
+  strict immutable language internal as 'int8in';
+CREATE FUNCTION int33_out(int33) returns cstring
+  strict immutable language internal as 'int8out';</codeblock>
+        <p>Next, you define the type named <codeph>int33</codeph>:</p>
         <codeblock>CREATE TYPE int33 (
    internallength = 4,
    input = int33_in,

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -621,24 +621,24 @@
         <p>When you create a new type, you can define default compression attributes for the type.
           For example, the following <codeph>CREATE TYPE</codeph> command defines a type named
             <codeph>int33</codeph> that specifies <codeph>quicklz</codeph> compression.</p>
-        <p>First, you must define the <codeph>int33_in</codeph> and <codeph>int33_out</codeph>
-          functions:</p>
-        <codeblock>CREATE FUNCTION int33_in(cstring) returns int33
-  strict immutable language internal as 'int8in';
-CREATE FUNCTION int33_out(int33) returns cstring
-  strict immutable language internal as 'int8out';</codeblock>
+        <p>First, you must define the input and output functions for the new type,
+            <codeph>int33_in</codeph> and <codeph>int33_out</codeph>:</p>
+        <codeblock>CREATE FUNCTION int33_in(cstring) RETURNS int33
+  STRICT IMMUTABLE LANGUAGE internal AS 'int4in';
+CREATE FUNCTION int33_out(int33) RETURNS cstring
+  STRICT IMMUTABLE LANGUAGE internal AS 'int4in';</codeblock>
         <p>Next, you define the type named <codeph>int33</codeph>:</p>
         <codeblock>CREATE TYPE int33 (
-   internallength = 4,
-   input = int33_in,
-   output = int33_out,
-   alignment = int4,
-   default = 123,
-   passedbyvalue,
-   compresstype="quicklz",
-   blocksize=65536,
-   compresslevel=1
-   );</codeblock>
+   internallength = 4,
+   input = int33_in,
+   output = int33_out,
+   alignment = int4,
+   default = 123,
+   passedbyvalue,
+   compresstype="zlib",
+   blocksize=65536,
+   compresslevel=1
+   );</codeblock>
         <p>When you specify <codeph>int33</codeph> as a column type in a <codeph>CREATE TABLE</codeph>
           command, the column is created with the storage directives you specified for the type:</p>
         <codeblock>CREATE TABLE t2 (c1 int33)

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -626,7 +626,7 @@
         <codeblock>CREATE FUNCTION int33_in(cstring) RETURNS int33
   STRICT IMMUTABLE LANGUAGE internal AS 'int4in';
 CREATE FUNCTION int33_out(int33) RETURNS cstring
-  STRICT IMMUTABLE LANGUAGE internal AS 'int4in';</codeblock>
+  STRICT IMMUTABLE LANGUAGE internal AS 'int4out';</codeblock>
         <p>Next, you define the type named <codeph>int33</codeph>:</p>
         <codeblock>CREATE TYPE int33 (
    internallength = 4,


### PR DESCRIPTION
Since the provided example couldn't be run without defining the functions int33_in and int33_out, added a previous step where the functions are defined.
