### PR TITLE
[6X only] Do not remove WAL that is needed for database operation

### DIFF
--- a/src/backend/access/transam/test/xlog_test.c
+++ b/src/backend/access/transam/test/xlog_test.c
@@ -118,15 +118,15 @@ test_KeepLogSeg(void **state)
 	 ***********************************************/
 	/* Current Delete pointer */
 	wal_keep_segments = 0;
-	_logSegNo = 9 * XLogSegmentsPerXLogId + 45;
+	_logSegNo = recptr / XLogSegSize - 3;
 
 	KeepLogSeg_wrapper(recptr, &_logSegNo);
-	assert_int_equal(_logSegNo, 9*XLogSegmentsPerXLogId + 45);
+	assert_int_equal(_logSegNo, recptr / XLogSegSize - 3);
 
 	wal_keep_segments = -1;
 
 	KeepLogSeg_wrapper(recptr, &_logSegNo);
-	assert_int_equal(_logSegNo, 9*XLogSegmentsPerXLogId + 45);
+	assert_int_equal(_logSegNo, recptr / XLogSegSize - 3);
 	/************************************************/
 }
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9608,10 +9608,7 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo)
 
 			if (slot_keep_segs > wal_keep_segments &&
 				currSegNo - segno > slot_keep_segs)
-			{
-				*logSegNo = currSegNo - slot_keep_segs;
-				return;
-			}
+				segno = currSegNo - slot_keep_segs;
 		}
 	}
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9555,7 +9555,6 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo)
 	XLogSegNo	currSegNo;
 	XLogSegNo	segno;
 	XLogRecPtr	keep;
-	bool setvalue = false;
 	static XLogRecPtr CkptRedoBeforeMinLSN = InvalidXLogRecPtr;
 
 	XLByteToSeg(recptr, currSegNo);
@@ -9597,17 +9596,13 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo)
 		}
 
 		XLByteToSeg(keep, segno);
-		setvalue = true;
 
 		/* Cap by max_slot_wal_keep_size ... */
 		if (max_slot_wal_keep_size_mb >= 0)
 		{
 			XLogRecPtr	slot_keep_segs;
-
 			slot_keep_segs = ConvertToXSegs(max_slot_wal_keep_size_mb);
-
-			if (slot_keep_segs > wal_keep_segments &&
-				currSegNo - segno > slot_keep_segs)
+			if (currSegNo - segno > slot_keep_segs)
 				segno = currSegNo - slot_keep_segs;
 		}
 	}
@@ -9620,11 +9615,10 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo)
 			segno = 1;
 		else
 			segno = currSegNo - wal_keep_segments;
-		setvalue = true;
 	}
 
 	/* don't delete WAL segments newer than the calculated segment */
-	if (setvalue && (XLogRecPtrIsInvalid(*logSegNo) || segno < *logSegNo))
+	if (segno < *logSegNo)
 		*logSegNo = segno;
 }
 

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2357,7 +2357,23 @@ XLogSendPhysical(void)
 #ifdef FAULT_INJECTOR
 		/* the walsender skip send WAL to the mirror . */
 		if (SIMPLE_FAULT_INJECTOR("walsnd_skip_send") == FaultInjectorTypeSkip)
+		{
+			if (!WalSndCaughtUp)
+			{
+				/*
+				 * If we have not caugh up, we must wait here.  Otherwise, the
+				 * walsender process keeps spinning the main loop and the csv
+				 * logs are filled with "fault triggered" messages so much that
+				 * in the CI, the disk filled up to 100% within a short time.
+				 */
+				int			wakeEvents;
+
+				wakeEvents = WL_LATCH_SET | WL_POSTMASTER_DEATH | WL_TIMEOUT;
+				WaitLatchOrSocket(&MyWalSnd->latch, wakeEvents,
+								  MyProcPort->sock, 1000);
+			}
 			return;
+		}
 #endif
 
 	if (streamingDoneSending)

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -283,6 +283,28 @@ END
  walread    
 (1 row)
 
+0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
+ALTER
+0U: ALTER SYSTEM RESET checkpoint_segments;
+ALTER
+0U: ALTER SYSTEM RESET wal_keep_segments;
+ALTER
+0U: ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
+ALTER
+0U: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+0Uq: ... <quitting>
+ALTER SYSTEM RESET gp_fts_probe_retries;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
 -- do full recovery
 !\retcode gprecoverseg -aF;
 -- start_ignore
@@ -305,28 +327,6 @@ select wait_until_segment_synchronized(0);
  state     | sync_error 
 -----------+------------
  streaming | none       
-(1 row)
-
-0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
-ALTER
-0U: ALTER SYSTEM RESET checkpoint_segments;
-ALTER
-0U: ALTER SYSTEM RESET wal_keep_segments;
-ALTER
-0U: ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
-ALTER
-0U: select pg_reload_conf();
- pg_reload_conf 
-----------------
- t              
-(1 row)
-0Uq: ... <quitting>
-ALTER SYSTEM RESET gp_fts_probe_retries;
-ALTER
-select pg_reload_conf();
- pg_reload_conf 
-----------------
- t              
 (1 row)
 
 1q: ... <quitting>

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -41,9 +41,9 @@ CREATE
 ----------
 -- Case 1:
 --
---   Verify that max_slot_wal_keep_size GUC is overridden when the
---   oldest PREPARE record falls behind the replay_lsn.  This behavior
---   is Greenplum-specific.
+--   Verify that max_slot_wal_keep_size GUC is ignored and more WAL is
+--   retained when the oldest active PREPARE record falls behind the
+--   cutoff specified by the GUC.
 ----------
 
 -- Suspend QD after preparing a distributed transaction, it will be
@@ -81,7 +81,7 @@ CREATE
 2: BEGIN;
 BEGIN
 
--- Trigger the fault in walsender.
+-- Trigger the fault in walsender.  Also triggers checkpoint.
 2: SELECT advance_xlog_on_seg0(1);
  advance_xlog_on_seg0 
 ----------------------
@@ -93,15 +93,40 @@ BEGIN
  Success:                      
 (1 row)
 
--- Generate more WAL on seg0 than max_slot_wal_keep_size.  This should
--- trigger checkpoint as checkpoint_segments is set to 1.  The
--- checkpoint is expected to retain WAL even when mirror has lagged
--- behind more than max_slot_wal_keep_size.
+-- Skip checkpoints on seg0.  So that when new WAL is generated in the
+-- next step, checkpoints don't get triggered asynchronously.
+1: SELECT gp_inject_fault_infinite('checkpoint', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+0U: CHECKPOINT;
+CHECKPOINT
+1: SELECT gp_wait_until_triggered_fault('checkpoint', 1, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Generate more WAL on seg0 than max_slot_wal_keep_size.
 2: SELECT advance_xlog_on_seg0(3);
  advance_xlog_on_seg0 
 ----------------------
                       
 (1 row)
+
+-- Resume checkpoints.
+1: SELECT gp_inject_fault('checkpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- At this point:
+--    PREPARE LSN < previous checkpoint < restart_lsn
+-- The checkpoint should retain WAL even when mirror has lagged behind
+-- more than max_slot_wal_keep_size.
+0U: CHECKPOINT;
+CHECKPOINT
 
 -- Replication slot on content 0 primary should report valid LSN
 -- because checkpoint must override max_slot_wal_keep_size GUC in
@@ -171,7 +196,7 @@ INSERT 20
  Success:                 
 (1 row)
 
--- Trigger the fault in walsender.
+-- Trigger the fault in walsender.  Also triggers checkpoint.
 2: SELECT advance_xlog_on_seg0(1);
  advance_xlog_on_seg0 
 ----------------------
@@ -183,13 +208,45 @@ INSERT 20
  Success:                      
 (1 row)
 
--- Generate more WAL on seg0 than max_slot_wal_keep_size.  This should
--- also create at least one checkpoint due to checkpoint_segments.
+-- Replication slot should be valid at this time.
+0U: select restart_lsn is not null as restart_lsn_is_valid from pg_get_replication_slots();
+ restart_lsn_is_valid 
+----------------------
+ t                    
+(1 row)
+
+-- Skip checkpoints on seg0.  So that when new WAL is generated in the
+-- next step, checkpoints don't get triggered asynchronously.
+1: SELECT gp_inject_fault_infinite('checkpoint', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+0U: CHECKPOINT;
+CHECKPOINT
+1: SELECT gp_wait_until_triggered_fault('checkpoint', 1, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Generate more WAL on seg0 than max_slot_wal_keep_size.
 2: SELECT advance_xlog_on_seg0(3);
  advance_xlog_on_seg0 
 ----------------------
                       
 (1 row)
+
+-- Resume checkpoints.
+1: SELECT gp_inject_fault('checkpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- WAL older than max_slot_wal_keep_size should be removed by this
+-- checkpoint.
+0U: CHECKPOINT;
+CHECKPOINT
 
 -- Replication slot on content 0 primary should report invalid LSN
 -- because the WAL files needed by it are removed by previous
@@ -229,7 +286,6 @@ END
 -- do full recovery
 !\retcode gprecoverseg -aF;
 -- start_ignore
-
 -- end_ignore
 (exited with code 0)
 select wait_until_segment_synchronized(0);

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -6,12 +6,16 @@
 include: helpers/server_helpers.sql;
 CREATE
 
-CREATE OR REPLACE FUNCTION advance_xlog(num int) RETURNS void AS $$ DECLARE i int; BEGIN i := 0; CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); LOOP IF i >= num THEN DROP TABLE t_dummy_switch; RETURN; END IF; PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; INSERT INTO t_dummy_switch SELECT generate_series(1,10); i := i + 1; END LOOP; DROP TABLE t_dummy_switch; END; $$ language plpgsql;
+CREATE OR REPLACE FUNCTION advance_xlog_on_seg0(num int) RETURNS void AS $$ DECLARE i int; BEGIN i := 0; CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); LOOP IF i >= num THEN DROP TABLE t_dummy_switch; RETURN; END IF; PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; INSERT INTO t_dummy_switch SELECT generate_series(1,10); i := i + 1; END LOOP; DROP TABLE t_dummy_switch; END; $$ language plpgsql;
 CREATE
 
--- On content 0 primary, retain max 64MB (1 WAL file) for replication
--- slots.  The other GUCs are needed to make the test run faster.
-0U: ALTER SYSTEM SET max_slot_wal_keep_size TO 64;
+-- On content 0 primary, retain max 128MB (2 WAL files) for
+-- replication slots.  That makes it necessary to set
+-- checkpoint_segments to a lower value, that is 1 WAL file.  Other
+-- GUCs are needed to make the test run faster.
+0U: ALTER SYSTEM SET max_slot_wal_keep_size TO 128;
+ALTER
+0U: ALTER SYSTEM SET checkpoint_segments TO 1;
 ALTER
 0U: ALTER SYSTEM SET wal_keep_segments TO 0;
 ALTER
@@ -31,12 +35,43 @@ select pg_reload_conf();
  t              
 (1 row)
 
--- Create a checkpoint now so that another checkpoint doesn't get
--- triggered when the test doesn't expect it to.
-CHECKPOINT;
-CHECKPOINT
+CREATE TABLE t_slot_size_limit(a int, fname text);
+CREATE
 
--- walsender skip sending WAL to the mirror
+----------
+-- Case 1:
+--
+--   Verify that max_slot_wal_keep_size GUC is overridden when the
+--   oldest PREPARE record falls behind the replay_lsn.  This behavior
+--   is Greenplum-specific.
+----------
+
+-- Suspend QD after preparing a distributed transaction, it will be
+-- resumed after checkpoint.
+1: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- This transaction is prepared on segments but not committed yet.  We
+-- advance WAL beyond max_slot_wal_keep_size in the next few steps.
+-- Checkpointer should retain WAL upto this prepare LSN, otherwise we
+-- will never be able to finish this transaction.  Recording two-phase
+-- commit state like this in WAL records in Greenplum specific
+-- behavior.  In newer Greenplum versions and PostgreSQL, two-phase
+-- state file is used to record this state, and checkpointer does not
+-- need to be mindful of prepare WAL records.
+3&: INSERT INTO t_slot_size_limit SELECT generate_series(101,120);  <waiting ...>
+1: SELECT gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Walsender skip sending WAL to the mirror, build replication lag.
+-- Note that this fault causes SyncRepWaitForLSN to get stuck.  We try
+-- to avoid committing transactions in subsequent steps until this
+-- fault is reset.
 1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault_infinite 
 --------------------------
@@ -45,41 +80,125 @@ CHECKPOINT
 
 2: BEGIN;
 BEGIN
-2: DROP TABLE IF EXISTS t_slot_size_limit;
-DROP
-2: CREATE TABLE t_slot_size_limit(a int);
-CREATE
-2: INSERT INTO t_slot_size_limit SELECT generate_series(1,1000);
-INSERT 1000
 
--- generate 2 more WAL files, which exceeds 'max_slot_wal_keep_size'
-2: SELECT advance_xlog(2);
- advance_xlog 
---------------
-              
+-- Trigger the fault in walsender.
+2: SELECT advance_xlog_on_seg0(1);
+ advance_xlog_on_seg0 
+----------------------
+                      
+(1 row)
+1: SELECT gp_wait_until_triggered_fault('walsnd_skip_send', 1, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
 (1 row)
 
--- checkpoint will trigger the check of obsolete replication slot, it will stop the walsender.
-0U: CHECKPOINT;
-CHECKPOINT
+-- Generate more WAL on seg0 than max_slot_wal_keep_size.  This should
+-- trigger checkpoint as checkpoint_segments is set to 1.  The
+-- checkpoint is expected to retain WAL even when mirror has lagged
+-- behind more than max_slot_wal_keep_size.
+2: SELECT advance_xlog_on_seg0(3);
+ advance_xlog_on_seg0 
+----------------------
+                      
+(1 row)
 
--- Count of WAL files in pg_xlog should not exceed XLOGfileslop + 1,
--- where 1 is the max_slot_wal_keep_size set above.
-0U: select count(pg_ls_dir) < current_setting('checkpoint_segments')::int * 2 + 2 from pg_ls_dir('pg_xlog') where pg_ls_dir like '________________________';
- ?column? 
+-- Replication slot on content 0 primary should report valid LSN
+-- because checkpoint must override max_slot_wal_keep_size GUC in
+-- order to retain the PREPARE record created by session 3.
+0U: select restart_lsn is not null as restart_lsn_is_valid from pg_get_replication_slots();
+ restart_lsn_is_valid 
+----------------------
+ t                    
+(1 row)
+-- WAL accumulated should be greater than max_slot_wal_keep_size
+-- (which is set to 128MB above).
+0U: select pg_xlog_location_diff(pg_current_xlog_location(), restart_lsn) / 1024 /1024 > 128 as max_slot_size_overridden from pg_get_replication_slots();
+ max_slot_size_overridden 
+--------------------------
+ t                        
+(1 row)
+
+-- The mirror should remain up in FTS configuration.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
+ role | preferred_role | status 
+------+----------------+--------
+ p    | p              | u      
+ m    | m              | u      
+(2 rows)
+
+-- Unblock walsender, so that the transaction in session 3 can be
+-- finished.
+1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Unblock the session that was suspected after prepare-transaction
+-- step.  It should be able to finish the transaction.
+1: SELECT gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE content=-1 AND role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+3<:  <... completed>
+INSERT 20
+3: select count(*) from t_slot_size_limit;
+ count 
+-------
+ 20    
+(1 row)
+3q: ... <quitting>
+
 ----------
- t        
+-- Case 2:
+--
+--   Verify that max_slot_wal_keep_size GUC is honored by invalidating
+--   replication slot.
+----------
+
+-- Make walsender skip sending WAL to the mirror to build replication
+-- lag again.
+1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Trigger the fault in walsender.
+2: SELECT advance_xlog_on_seg0(1);
+ advance_xlog_on_seg0 
+----------------------
+                      
+(1 row)
+1: SELECT gp_wait_until_triggered_fault('walsnd_skip_send', 1, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Generate more WAL on seg0 than max_slot_wal_keep_size.  This should
+-- also create at least one checkpoint due to checkpoint_segments.
+2: SELECT advance_xlog_on_seg0(3);
+ advance_xlog_on_seg0 
+----------------------
+                      
 (1 row)
 
 -- Replication slot on content 0 primary should report invalid LSN
--- because the WAL file it needs is already removed when checkpoint
--- was created.
-0U: select * from pg_get_replication_slots();
- slot_name                     | plugin | slot_type | datoid | active | xmin | catalog_xmin | restart_lsn 
--------------------------------+--------+-----------+--------+--------+------+--------------+-------------
- internal_wal_replication_slot |        | physical  |        | t      |      |              |             
+-- because the WAL files needed by it are removed by previous
+-- checkpoint.
+0U: select restart_lsn is not null as restart_lsn_is_valid from pg_get_replication_slots();
+ restart_lsn_is_valid 
+----------------------
+ f                    
 (1 row)
-0Uq: ... <quitting>
 
 1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault_infinite 
@@ -110,47 +229,6 @@ END
 -- do full recovery
 !\retcode gprecoverseg -aF;
 -- start_ignore
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting gprecoverseg with args: -aF
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.9.0+dev.60.g75932a9ebe5 build dev'
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.24 (Greenplum Database 6.9.0+dev.60.g75932a9ebe5 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jul 26 2020 15:49:04 (with assert checking)'
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Greenplum instance recovery parameters
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery type              = Standard
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery 1 of 1
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Synchronization mode                 = Full
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance host                 = 09c5497cf854
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance address              = 09c5497cf854
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance port                 = 6005
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance host        = 09c5497cf854
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance address     = 09c5497cf854
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance port        = 6002
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Target                      = in-place
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-1 segment(s) to recover
-20200727:10:49:04:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring 1 failed segment(s) are stopped
-20200727:10:49:05:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-384857: /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
-20200727:10:49:05:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
-20200727:10:49:05:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Validating remote directories
-20200727:10:49:05:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Configuring new segments
-09c5497cf854 (dbid 5): pg_basebackup: base backup completed
-20200727:10:49:06:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating configuration with new mirrors
-20200727:10:49:06:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating mirrors
-20200727:10:49:06:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting mirrors
-20200727:10:49:06:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-era is e4307b9cbf2d16a8_200727100220
-20200727:10:49:06:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Process results...
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Triggering FTS probe
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating segments for streaming is completed.
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-For segments updated successfully, streaming will continue in the background.
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Use  gpstate -s  to check the streaming progress.
-20200727:10:49:07:387723 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
 
 -- end_ignore
 (exited with code 0)
@@ -174,6 +252,8 @@ select wait_until_segment_synchronized(0);
 (1 row)
 
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
+ALTER
+0U: ALTER SYSTEM RESET checkpoint_segments;
 ALTER
 0U: ALTER SYSTEM RESET wal_keep_segments;
 ALTER

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -9,51 +9,32 @@ CREATE
 CREATE OR REPLACE FUNCTION advance_xlog(num int) RETURNS void AS $$ DECLARE i int; BEGIN i := 0; CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); LOOP IF i >= num THEN DROP TABLE t_dummy_switch; RETURN; END IF; PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; INSERT INTO t_dummy_switch SELECT generate_series(1,10); i := i + 1; END LOOP; DROP TABLE t_dummy_switch; END; $$ language plpgsql;
 CREATE
 
-CREATE OR REPLACE FUNCTION check_wal_file_count(content int) RETURNS text AS $$ import subprocess rv = plpy.execute("select datadir from gp_segment_configuration where content = 0 and role = 'p'", 2) datadir = rv[0]['datadir'] cmd = 'ls %s/pg_xlog/ | grep "^[0-9A-F]*$" | wc -l' % datadir remove_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT) return remove_output.strip() $$ LANGUAGE PLPYTHONU;
-CREATE
+-- On content 0 primary, retain max 64MB (1 WAL file) for replication
+-- slots.  The other GUCs are needed to make the test run faster.
+0U: ALTER SYSTEM SET max_slot_wal_keep_size TO 64;
+ALTER
+0U: ALTER SYSTEM SET wal_keep_segments TO 0;
+ALTER
+0U: ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period TO 0;
+ALTER
+0U: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+-- And on coordinator, also to make the test faster.
+ALTER SYSTEM SET gp_fts_probe_retries TO 1;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
 
--- max_slot_wal_keep_size is 64MB * 4
-!\retcode gpconfig -c max_slot_wal_keep_size -v 256;
--- start_ignore
-20200728:18:07:07:087460 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c max_slot_wal_keep_size -v 256'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -c checkpoint_segments -v 1 --skipvalidation;
--- start_ignore
-20200603:13:55:20:376404 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c wal_keep_segments -v 0 --skipvalidation'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -c wal_keep_segments -v 0 --skipvalidation;
--- start_ignore
-20200603:13:55:21:376485 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c max_slot_wal_keep_size -v 65536'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
--- start_ignore
-20200603:13:55:21:376568 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_probe_retries -v 2 --masteronly'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
--- start_ignore
-20200603:13:55:21:376614 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_mark_mirror_down_grace_period -v 0'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpstop -u;
--- start_ignore
-20200603:13:55:21:376696 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -u
-20200603:13:55:21:376696 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
-20200603:13:55:21:376696 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20200603:13:55:21:376696 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200603:13:55:21:376696 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.7.1+dev.83.g8ba3a41176e build dev'
-20200603:13:55:21:376696 gpstop:09c5497cf854:gpadmin-[INFO]:-Signalling all postmaster processes to reload
-
--- end_ignore
-(exited with code 0)
+-- Create a checkpoint now so that another checkpoint doesn't get
+-- triggered when the test doesn't expect it to.
+CHECKPOINT;
+CHECKPOINT
 
 -- walsender skip sending WAL to the mirror
 1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
@@ -72,15 +53,33 @@ CREATE
 INSERT 1000
 
 -- generate 2 more WAL files, which exceeds 'max_slot_wal_keep_size'
-2: SELECT advance_xlog(12);
+2: SELECT advance_xlog(2);
  advance_xlog 
 --------------
               
 (1 row)
 
 -- checkpoint will trigger the check of obsolete replication slot, it will stop the walsender.
-2: CHECKPOINT;
+0U: CHECKPOINT;
 CHECKPOINT
+
+-- Count of WAL files in pg_xlog should not exceed XLOGfileslop + 1,
+-- where 1 is the max_slot_wal_keep_size set above.
+0U: select count(pg_ls_dir) < current_setting('checkpoint_segments')::int * 2 + 2 from pg_ls_dir('pg_xlog') where pg_ls_dir like '________________________';
+ ?column? 
+----------
+ t        
+(1 row)
+
+-- Replication slot on content 0 primary should report invalid LSN
+-- because the WAL file it needs is already removed when checkpoint
+-- was created.
+0U: select * from pg_get_replication_slots();
+ slot_name                     | plugin | slot_type | datoid | active | xmin | catalog_xmin | restart_lsn 
+-------------------------------+--------+-----------+--------+--------+------+--------------+-------------
+ internal_wal_replication_slot |        | physical  |        | t      |      |              |             
+(1 row)
+0Uq: ... <quitting>
 
 1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault_infinite 
@@ -106,12 +105,6 @@ END
  sync_error 
 ------------
  walread    
-(1 row)
--- the number of WAL file is approximate to 1 + XLOGfileslop(checkpoint_segments * 2 + 1) + max_slot_wal_keep_size / 64 / 1024
-1: SELECT check_wal_file_count(0)::int <= 8;
- ?column? 
-----------
- t        
 (1 row)
 
 -- do full recovery
@@ -180,201 +173,25 @@ select wait_until_segment_synchronized(0);
  streaming | none       
 (1 row)
 
--- failover to the mirror and check the data on the primary is replicated to the mirror
-1: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
- pg_ctl 
---------
- OK     
+0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
+ALTER
+0U: ALTER SYSTEM RESET wal_keep_segments;
+ALTER
+0U: ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
+ALTER
+0U: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
 (1 row)
-1: select gp_request_fts_probe_scan();
- gp_request_fts_probe_scan 
----------------------------
- t                         
-(1 row)
-1: select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
- content | preferred_role | role | status | mode 
----------+----------------+------+--------+------
- 0       | p              | m    | d      | n    
- 0       | m              | p    | u      | n    
-(2 rows)
-1: SELECT count(*) FROM t_slot_size_limit;
- count 
--------
- 1000  
+0Uq: ... <quitting>
+ALTER SYSTEM RESET gp_fts_probe_retries;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
 (1 row)
 
-!\retcode gprecoverseg -a;
--- start_ignore
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting gprecoverseg with args: -a
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.9.0+dev.60.g75932a9ebe5 build dev'
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.24 (Greenplum Database 6.9.0+dev.60.g75932a9ebe5 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jul 26 2020 15:49:04 (with assert checking)'
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Greenplum instance recovery parameters
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery type              = Standard
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery 1 of 1
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance host                 = 09c5497cf854
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance address              = 09c5497cf854
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance port                 = 6002
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance host        = 09c5497cf854
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance address     = 09c5497cf854
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance port        = 6005
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Target                      = in-place
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-1 segment(s) to recover
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring 1 failed segment(s) are stopped
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating configuration with new mirrors
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating mirrors
-20200727:06:59:49:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Running pg_rewind on required mirrors
-...
-20200727:06:59:53:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting mirrors
-20200727:06:59:53:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-era is e4307b9cbf2d16a8_200727064945
-20200727:06:59:53:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Process results...
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Triggering FTS probe
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating segments for streaming is completed.
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-For segments updated successfully, streaming will continue in the background.
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Use  gpstate -s  to check the streaming progress.
-20200727:06:59:54:327010 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-
--- end_ignore
-(exited with code 0)
-!\retcode gprecoverseg -ar;
--- start_ignore
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting gprecoverseg with args: -ar
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.9.0+dev.60.g75932a9ebe5 build dev'
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.24 (Greenplum Database 6.9.0+dev.60.g75932a9ebe5 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jul 26 2020 15:49:04 (with assert checking)'
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Greenplum instance recovery parameters
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery type              = Rebalance
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Unbalanced segment 1 of 2
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance host        = 09c5497cf854
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance address     = 09c5497cf854
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance port        = 6005
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Balanced role                   = Mirror
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Current role                    = Primary
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Unbalanced segment 2 of 2
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance host        = 09c5497cf854
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance address     = 09c5497cf854
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Unbalanced instance port        = 6002
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Balanced role                   = Primary
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Current role                    = Mirror
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Getting unbalanced segments
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Stopping unbalanced primary segments...
-20200727:06:59:54:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Triggering segment reconfiguration
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting segment synchronization
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-=============================START ANOTHER RECOVER=========================================
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.9.0+dev.60.g75932a9ebe5 build dev'
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.24 (Greenplum Database 6.9.0+dev.60.g75932a9ebe5 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jul 26 2020 15:49:04 (with assert checking)'
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Greenplum instance recovery parameters
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery type              = Standard
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery 1 of 1
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance host                 = 09c5497cf854
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance address              = 09c5497cf854
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance port                 = 6005
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance host        = 09c5497cf854
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance address     = 09c5497cf854
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance port        = 6002
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Target                      = in-place
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-1 segment(s) to recover
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring 1 failed segment(s) are stopped
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating configuration with new mirrors
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating mirrors
-20200727:06:59:58:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Running pg_rewind on required mirrors
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting mirrors
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-era is e4307b9cbf2d16a8_200727064945
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Process results...
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Triggering FTS probe
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating segments for streaming is completed.
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-For segments updated successfully, streaming will continue in the background.
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Use  gpstate -s  to check the streaming progress.
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-The rebalance operation has completed successfully.
-20200727:06:59:59:327165 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
-
--- end_ignore
-(exited with code 0)
-
-!\retcode gpconfig -r wal_keep_segments --skipvalidation;
--- start_ignore
-20200727:18:51:40:466637 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r wal_keep_segments --skipvalidation'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -r checkpoint_segments --skipvalidation;
--- start_ignore
-20200727:18:51:40:466718 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r checkpoint_segments --skipvalidation'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -r max_slot_wal_keep_size;
--- start_ignore
-20200603:13:55:25:377100 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r max_slot_wal_keep_size'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
--- start_ignore
-20200603:13:55:26:377182 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r gp_fts_probe_retries --masteronly'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
--- start_ignore
-20200603:13:55:26:377228 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r gp_fts_mark_mirror_down_grace_period'
-
--- end_ignore
-(exited with code 0)
-!\retcode gpstop -u;
--- start_ignore
-20200603:13:55:26:377311 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -u
-20200603:13:55:26:377311 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
-20200603:13:55:26:377311 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20200603:13:55:26:377311 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200603:13:55:26:377311 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.7.1+dev.83.g8ba3a41176e build dev'
-20200603:13:55:26:377311 gpstop:09c5497cf854:gpadmin-[INFO]:-Signalling all postmaster processes to reload
-
--- end_ignore
-(exited with code 0)
-
--- no limit on the wal keep size
-1: SELECT advance_xlog(12);
- advance_xlog 
---------------
-              
-(1 row)
-1: SELECT check_wal_file_count(0)::int > 12;
- ?column? 
-----------
- t        
-(1 row)
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
+++ b/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
@@ -174,14 +174,6 @@ SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content 
 1: SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
 1: SELECT sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
 
--- do full recovery
-!\retcode gprecoverseg -aF;
-select wait_until_segment_synchronized(0);
-
--- the mirror is up and the replication is back
-1: SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
-1: SELECT state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
-
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
 0U: ALTER SYSTEM RESET checkpoint_segments;
 0U: ALTER SYSTEM RESET wal_keep_segments;
@@ -190,6 +182,14 @@ select wait_until_segment_synchronized(0);
 0Uq:
 ALTER SYSTEM RESET gp_fts_probe_retries;
 select pg_reload_conf();
+
+-- do full recovery
+!\retcode gprecoverseg -aF;
+select wait_until_segment_synchronized(0);
+
+-- the mirror is up and the replication is back
+1: SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
+1: SELECT state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
 
 1q:
 2q:

--- a/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
+++ b/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
@@ -5,7 +5,7 @@
 
 include: helpers/server_helpers.sql;
 
-CREATE OR REPLACE FUNCTION advance_xlog(num int) RETURNS void AS
+CREATE OR REPLACE FUNCTION advance_xlog_on_seg0(num int) RETURNS void AS
 $$
 DECLARE
 	i int; 
@@ -25,9 +25,12 @@ BEGIN
 END; 
 $$ language plpgsql;
 
--- On content 0 primary, retain max 64MB (1 WAL file) for replication
--- slots.  The other GUCs are needed to make the test run faster.
-0U: ALTER SYSTEM SET max_slot_wal_keep_size TO 64;
+-- On content 0 primary, retain max 128MB (2 WAL files) for
+-- replication slots.  That makes it necessary to set
+-- checkpoint_segments to a lower value, that is 1 WAL file.  Other
+-- GUCs are needed to make the test run faster.
+0U: ALTER SYSTEM SET max_slot_wal_keep_size TO 128;
+0U: ALTER SYSTEM SET checkpoint_segments TO 1;
 0U: ALTER SYSTEM SET wal_keep_segments TO 0;
 0U: ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period TO 0;
 0U: select pg_reload_conf();
@@ -35,34 +38,102 @@ $$ language plpgsql;
 ALTER SYSTEM SET gp_fts_probe_retries TO 1;
 select pg_reload_conf();
 
--- Create a checkpoint now so that another checkpoint doesn't get
--- triggered when the test doesn't expect it to.
-CHECKPOINT;
+CREATE TABLE t_slot_size_limit(a int, fname text);
 
--- walsender skip sending WAL to the mirror
-1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+----------
+-- Case 1:
+--
+--   Verify that max_slot_wal_keep_size GUC is overridden when the
+--   oldest PREPARE record falls behind the replay_lsn.  This behavior
+--   is Greenplum-specific.
+----------
+
+-- Suspend QD after preparing a distributed transaction, it will be
+-- resumed after checkpoint.
+1: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'suspend', dbid)
+   FROM gp_segment_configuration WHERE content=-1 AND role='p';
+-- This transaction is prepared on segments but not committed yet.  We
+-- advance WAL beyond max_slot_wal_keep_size in the next few steps.
+-- Checkpointer should retain WAL upto this prepare LSN, otherwise we
+-- will never be able to finish this transaction.  Recording two-phase
+-- commit state like this in WAL records in Greenplum specific
+-- behavior.  In newer Greenplum versions and PostgreSQL, two-phase
+-- state file is used to record this state, and checkpointer does not
+-- need to be mindful of prepare WAL records.
+3&: INSERT INTO t_slot_size_limit SELECT generate_series(101,120);
+1: SELECT gp_wait_until_triggered_fault('transaction_abort_after_distributed_prepared', 1, dbid)
+   FROM gp_segment_configuration WHERE content=-1 AND role='p';
+
+-- Walsender skip sending WAL to the mirror, build replication lag.
+-- Note that this fault causes SyncRepWaitForLSN to get stuck.  We try
+-- to avoid committing transactions in subsequent steps until this
+-- fault is reset.
+1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'skip', dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
 
 2: BEGIN;
-2: DROP TABLE IF EXISTS t_slot_size_limit;
-2: CREATE TABLE t_slot_size_limit(a int);
-2: INSERT INTO t_slot_size_limit SELECT generate_series(1,1000);
 
--- generate 2 more WAL files, which exceeds 'max_slot_wal_keep_size'
-2: SELECT advance_xlog(2);
+-- Trigger the fault in walsender.
+2: SELECT advance_xlog_on_seg0(1);
+1: SELECT gp_wait_until_triggered_fault('walsnd_skip_send', 1, dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
 
--- checkpoint will trigger the check of obsolete replication slot, it will stop the walsender.
-0U: CHECKPOINT;
+-- Generate more WAL on seg0 than max_slot_wal_keep_size.  This should
+-- trigger checkpoint as checkpoint_segments is set to 1.  The
+-- checkpoint is expected to retain WAL even when mirror has lagged
+-- behind more than max_slot_wal_keep_size.
+2: SELECT advance_xlog_on_seg0(3);
 
--- Count of WAL files in pg_xlog should not exceed XLOGfileslop + 1,
--- where 1 is the max_slot_wal_keep_size set above.
-0U: select count(pg_ls_dir) < current_setting('checkpoint_segments')::int * 2 + 2
-    from pg_ls_dir('pg_xlog') where pg_ls_dir like '________________________';
+-- Replication slot on content 0 primary should report valid LSN
+-- because checkpoint must override max_slot_wal_keep_size GUC in
+-- order to retain the PREPARE record created by session 3.
+0U: select restart_lsn is not null as restart_lsn_is_valid from pg_get_replication_slots();
+-- WAL accumulated should be greater than max_slot_wal_keep_size
+-- (which is set to 128MB above).
+0U: select pg_xlog_location_diff(pg_current_xlog_location(), restart_lsn) / 1024 /1024 > 128
+    as max_slot_size_overridden from pg_get_replication_slots();
+
+-- The mirror should remain up in FTS configuration.
+SELECT gp_request_fts_probe_scan();
+SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
+
+-- Unblock walsender, so that the transaction in session 3 can be
+-- finished.
+1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'reset', dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Unblock the session that was suspected after prepare-transaction
+-- step.  It should be able to finish the transaction.
+1: SELECT gp_inject_fault_infinite('transaction_abort_after_distributed_prepared', 'reset', dbid)
+   FROM gp_segment_configuration WHERE content=-1 AND role='p';
+3<:
+3: select count(*) from t_slot_size_limit;
+3q:
+
+----------
+-- Case 2:
+--
+--   Verify that max_slot_wal_keep_size GUC is honored by invalidating
+--   replication slot.
+----------
+
+-- Make walsender skip sending WAL to the mirror to build replication
+-- lag again.
+1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Trigger the fault in walsender.
+2: SELECT advance_xlog_on_seg0(1);
+1: SELECT gp_wait_until_triggered_fault('walsnd_skip_send', 1, dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Generate more WAL on seg0 than max_slot_wal_keep_size.  This should
+-- also create at least one checkpoint due to checkpoint_segments.
+2: SELECT advance_xlog_on_seg0(3);
 
 -- Replication slot on content 0 primary should report invalid LSN
--- because the WAL file it needs is already removed when checkpoint
--- was created.
-0U: select * from pg_get_replication_slots();
-0Uq:
+-- because the WAL files needed by it are removed by previous
+-- checkpoint.
+0U: select restart_lsn is not null as restart_lsn_is_valid from pg_get_replication_slots();
 
 1: SELECT gp_inject_fault_infinite('walsnd_skip_send', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
 1: SELECT gp_request_fts_probe_scan();
@@ -81,6 +152,7 @@ select wait_until_segment_synchronized(0);
 1: SELECT state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
 
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
+0U: ALTER SYSTEM RESET checkpoint_segments;
 0U: ALTER SYSTEM RESET wal_keep_segments;
 0U: ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
 0U: select pg_reload_conf();


### PR DESCRIPTION
Previously, if the amount of WAL accumulated by a primary segment exceeded max_slot_wal_keep_size due to replication lag, primary would invalidate the replication slot and remove the WAL unconditionally.

This patch fixes the behaviour such that WAL is retained beyond `max_slot_wal_keep_size` if it contains records needed to ensure normal and safe database operations.  Such records include PREPARE state of an active (not yet finished) distributed transaction and redo location of prior checkpoint record.

Note that this change enforces lower limit on `max_slot_wal_keep_size` to (`checkpoint_segments * XLOG_BLCKSZ`).  Setting the GUC to a lower value results in rounding it up to this lower limit.