### PR TITLE
Fix bug: query failed if exists subquery have group by clause

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1727,9 +1727,7 @@ simplify_EXISTS_query(PlannerInfo *root, Query *query)
 	 */
 	if (query->commandType != CMD_SELECT ||
 		query->setOperations ||
-#if 0
 		query->hasAggs ||
-#endif
 		query->groupingSets ||
 #if 0
 		query->hasWindowFuncs ||

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1727,6 +1727,10 @@ simplify_EXISTS_query(PlannerInfo *root, Query *query)
 	 */
 	if (query->commandType != CMD_SELECT ||
 		query->setOperations ||
+		/*
+		 * Greenplum only skip plain Aggs, which are not in a HAVING, since
+		 * Greenplum tries to demote HAVING as above comments say.
+		 */
 		(query->hasAggs && !query->havingQual) ||
 		query->groupingSets ||
 #if 0

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1727,7 +1727,7 @@ simplify_EXISTS_query(PlannerInfo *root, Query *query)
 	 */
 	if (query->commandType != CMD_SELECT ||
 		query->setOperations ||
-		query->hasAggs ||
+		(query->hasAggs && !query->havingQual) ||
 		query->groupingSets ||
 #if 0
 		query->hasWindowFuncs ||

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1813,6 +1813,39 @@ select 1, median(col1) from group_by_const group by 1;
         1 |  500.5
 (1 row)
 
+-- 
+-- Test GROUP BY IN exists subquery
+--
+create temp table group_by_subquery(col1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into group_by_subquery select i from generate_series(1, 5) i;
+explain (costs off)
+select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice3; segments: 3)
+           ->  HashAggregate
+                 Group Key: group_by_subquery_1.col1
+                 ->  Seq Scan on group_by_subquery group_by_subquery_1
+   ->  Result
+         One-Time Filter: $0
+         ->  Seq Scan on group_by_subquery
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
+ col1 
+------
+    1
+    2
+    3
+    4
+    5
+(5 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1813,7 +1813,7 @@ select 1, median(col1) from group_by_const group by 1;
         1 |  500.5
 (1 row)
 
--- 
+--
 -- Test GROUP BY IN exists subquery
 --
 create temp table group_by_subquery(col1 int);

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1823,6 +1823,43 @@ select 1, median(col1) from group_by_const group by 1;
         1 |  500.5
 (1 row)
 
+--
+-- Test GROUP BY IN exists subquery
+--
+create temp table group_by_subquery(col1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into group_by_subquery select i from generate_series(1, 5) i;
+explain (costs off)
+select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on group_by_subquery
+   SubPlan 1
+     ->  Limit
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  GroupAggregate
+                             Group Key: group_by_subquery_1.col1
+                             ->  Sort
+                                   Sort Key: group_by_subquery_1.col1
+                                   ->  Seq Scan on group_by_subquery group_by_subquery_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
+ col1 
+------
+    2
+    3
+    4
+    1
+    5
+(5 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1300,16 +1300,21 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
 (4 rows)
 
 explain select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.20..6.31 rows=4 width=8)
-   ->  Hash Anti Join  (cost=3.20..6.31 rows=2 width=8)
-         Hash Cond: (a.i = c.i)
-         ->  Seq Scan on a  (cost=0.00..3.05 rows=2 width=8)
-         ->  Hash  (cost=3.09..3.09 rows=3 width=4)
-               ->  Seq Scan on c  (cost=0.00..3.09 rows=3 width=4)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.05 rows=2 width=8)
+   ->  Seq Scan on a  (cost=0.00..1.02 rows=1 width=8)
+         Filter: (NOT (SubPlan 1))
+         SubPlan 1
+           ->  GroupAggregate  (cost=0.00..1.34 rows=1 width=12)
+                 Group Key: a.i
+                 ->  Result  (cost=0.00..1.28 rows=9 width=8)
+                       Filter: (c.i = a.i)
+                       ->  Materialize  (cost=0.00..1.19 rows=9 width=4)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.15 rows=9 width=4)
+                                   ->  Seq Scan on c  (cost=0.00..1.03 rows=3 width=4)
  Optimizer: Postgres query optimizer
-(7 rows)
+(12 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i group by a.i);
  i  | j 

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1470,6 +1470,15 @@ explain (costs off)
 select 1, median(col1) from group_by_const group by 1;
 select 1, median(col1) from group_by_const group by 1;
 
+--
+-- Test GROUP BY IN exists subquery
+--
+create temp table group_by_subquery(col1 int);
+insert into group_by_subquery select i from generate_series(1, 5) i;
+explain (costs off)
+select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
+select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;


### PR DESCRIPTION
In upstream, the planner may rid of exists subquery targetlist after
several validations. But for gpdb, it forgets to check if the query
has Aggregation.

For instance,
```sql
create temp table group_by_subquery(col1 int);
insert into group_by_subquery select i from generate_series(1, 5) i;
explain (costs off)
select col1 from group_by_subquery where exists (select avg(col1) from group_by_subquery group by col1);
```

Roll back a piece of code to fix this issue.

https://github.com/greenplum-db/gpdb/issues/11849

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
