### PR TITLE
Don't reuse AO block if the corresponding segment file was closed

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2165,6 +2165,13 @@ scanToFetchTuple(AppendOnlyFetchDesc aoFetchDesc,
 	}
 }
 
+static void
+resetCurrentBlockInfo(CurrentBlock * currentBlock)
+{
+	currentBlock->have = false;
+	currentBlock->firstRowNum = 0;
+	currentBlock->lastRowNum = 0;
+}
 
 AppendOnlyFetchDesc
 appendonly_fetch_init(Relation relation,
@@ -2323,7 +2330,8 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 	 */
 	if (aoFetchDesc->currentBlock.have)
 	{
-		if (segmentFileNum == aoFetchDesc->currentSegmentFile.num &&
+		if (aoFetchDesc->currentSegmentFile.isOpen &&
+			segmentFileNum == aoFetchDesc->currentSegmentFile.num &&
 			segmentFileNum == aoFetchDesc->blockDirectory.currentSegmentFileNum &&
 			segmentFileNum == aoFetchDesc->executorReadBlock.segmentFileNum)
 		{
@@ -2345,7 +2353,7 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 			}
 
 			/*
-			 * Otherwize, if the current Block Directory entry covers the
+			 * Otherwise, if the current Block Directory entry covers the
 			 * request tuples, lets use its information as another performance
 			 * optimization.
 			 */
@@ -2413,8 +2421,6 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 		}
 	}
 
-/* 	resetCurrentBlockInfo(aoFetchDesc); */
-
 	/*
 	 * Open or switch open, if necessary.
 	 */
@@ -2446,6 +2452,9 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 			/* Segment file not in aoseg table.. */
 			/* Must be aborted or deleted and reclaimed. */
 		}
+
+		/* Reset currentBlock info */
+		resetCurrentBlockInfo(&(aoFetchDesc->currentBlock));
 	}
 
 	/*

--- a/src/test/isolation2/input/uao/bitmapindex_rescan.source
+++ b/src/test/isolation2/input/uao/bitmapindex_rescan.source
@@ -1,0 +1,29 @@
+-- start_ignore
+drop table if exists bir;
+drop table if exists yolo cascade;
+-- end_ignore
+create table bir (a int, b int) distributed by (a);
+insert into bir select i, i from generate_series(1, 5) i;
+
+create table yolo (a int, b int) WITH (appendonly=true, orientation=@orientation@) distributed by (a);
+create index yolo_idx on yolo using btree (a);
+
+1: begin;
+2: begin;
+1: insert into yolo select i, i from generate_series(1, 10000) i;
+2: insert into yolo select i, i from generate_series(1, 2) i;
+1: commit;
+2: abort;
+
+analyze yolo;
+
+-- repro needs a plan with bitmap index join with bir on the outer side
+set optimizer_enable_hashjoin = off;
+set enable_nestloop = on;
+set enable_hashjoin = off;
+set enable_seqscan = off;
+
+select *
+from bir left join yolo
+on (bir.a = yolo.a) order by bir.a;
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -71,6 +71,7 @@ test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
 test: uao/insert_should_not_use_awaiting_drop_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop
+test: uao/bitmapindex_rescan_row
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column
@@ -118,6 +119,7 @@ test: uao/vacuum_while_insert_column
 test: uao/vacuum_while_vacuum_column
 test: uao/vacuum_cleanup_column
 test: uao/insert_should_not_use_awaiting_drop_column
+test: uao/bitmapindex_rescan_column
 test: add_column_after_vacuum_skip_drop_column
 test: vacuum_after_vacuum_skip_drop_column
 

--- a/src/test/isolation2/output/uao/bitmapindex_rescan.source
+++ b/src/test/isolation2/output/uao/bitmapindex_rescan.source
@@ -1,0 +1,50 @@
+-- start_ignore
+drop table if exists bir;
+drop table if exists yolo cascade;
+-- end_ignore
+create table bir (a int, b int) distributed by (a);
+CREATE
+insert into bir select i, i from generate_series(1, 5) i;
+INSERT 5
+
+create table yolo (a int, b int) WITH (appendonly=true, orientation=@orientation@) distributed by (a);
+CREATE
+create index yolo_idx on yolo using btree (a);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+1: insert into yolo select i, i from generate_series(1, 10000) i;
+INSERT 10000
+2: insert into yolo select i, i from generate_series(1, 2) i;
+INSERT 2
+1: commit;
+COMMIT
+2: abort;
+ABORT
+
+analyze yolo;
+ANALYZE
+
+-- repro needs a plan with bitmap index join with bir on the outer side
+set optimizer_enable_hashjoin = off;
+SET
+set enable_nestloop = on;
+SET
+set enable_hashjoin = off;
+SET
+set enable_seqscan = off;
+SET
+
+select * from bir left join yolo on (bir.a = yolo.a) order by bir.a;
+a|b|a|b
+-+-+-+-
+1|1|1|1
+2|2|2|2
+3|3|3|3
+4|4|4|4
+5|5|5|5
+(5 rows)
+


### PR DESCRIPTION
ERROR:  append-only table version -1 is invalid

Requires plan containing a Bitmap Index NL join with bir (containing more than
1 tuple) on the outer side and yolo (with 2 aoseg files, the latter of which is
empty) on the inner side:

```
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Nested Loop Left Join
         Join Filter: true
         ->  Seq Scan on bir
         ->  Bitmap Heap Scan on yolo
               Recheck Cond: (a = bir.a)
               ->  Bitmap Index Scan on yolo_idx
                     Index Cond: (a = bir.a)
```

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
