### PR TITLE
Docs: Added missing entry '1' to insert statement

### DIFF
--- a/gpdb-doc/dita/admin_guide/textsearch/features.xml
+++ b/gpdb-doc/dita/admin_guide/textsearch/features.xml
@@ -179,7 +179,7 @@ SELECT numnode('foo &amp; bar'::tsquery);
               value (the substitute) within the current
                 <codeph><i>query</i></codeph> value. For example:</p>
             <codeblock>CREATE TABLE aliases (id int, t tsquery, s tsquery);
-INSERT INTO aliases VALUES('a', 'c');
+INSERT INTO aliases VALUES(1, 'a', 'c');
 
 SELECT ts_rewrite('a &amp; b'::tsquery, 'SELECT t,s FROM aliases');
  ts_rewrite


### PR DESCRIPTION
Insert statement from example was failing because one of the columns input was missing.
