### PR TITLE
Allow DISTRIBUTED BY clause for foreign table

### DIFF
--- a/contrib/file_fdw/init_file
+++ b/contrib/file_fdw/init_file
@@ -19,5 +19,9 @@ m/^ Settings:.*/
 # The following regex is intended to cover all permutations of the above set
 # of messages.
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
-
 -- end_matchignore
+
+-- start_matchsubs
+m/Foreign scan returns tuple for segment ., current segment ./
+s/Foreign scan returns tuple for segment ., current segment ./Foreign scan returns tuple for segment A, current segment B/
+-- end_matchsubs

--- a/contrib/file_fdw/input/file_fdw.source
+++ b/contrib/file_fdw/input/file_fdw.source
@@ -126,16 +126,10 @@ DEALLOCATE st;
 SELECT tableoid::regclass, b FROM agg_csv;
 
 -- updates aren't supported
-INSERT INTO agg_csv VALUES(1,2.0);
 UPDATE agg_csv SET a = 1;
 DELETE FROM agg_csv WHERE a = 100;
 -- but this should be allowed
 SELECT * FROM agg_csv FOR UPDATE;
-
--- copy from isn't supported either
-COPY agg_csv FROM STDIN;
-12	3.4
-\.
 
 -- constraint exclusion tests
 \t on
@@ -172,14 +166,13 @@ CREATE TABLE p2 partition of pt for values in (2);
 SELECT tableoid::regclass, * FROM pt;
 SELECT tableoid::regclass, * FROM p1;
 SELECT tableoid::regclass, * FROM p2;
-COPY pt FROM '@abs_srcdir@/data/list2.bad' with (format 'csv', delimiter ','); -- ERROR
+
 COPY pt FROM '@abs_srcdir@/data/list2.csv' with (format 'csv', delimiter ',');
 SELECT tableoid::regclass, * FROM pt;
 SELECT tableoid::regclass, * FROM p1;
 SELECT tableoid::regclass, * FROM p2;
-INSERT INTO pt VALUES (1, 'xyzzy'); -- ERROR
+
 INSERT INTO pt VALUES (2, 'xyzzy');
-UPDATE pt set a = 1 where a = 2; -- ERROR
 SELECT tableoid::regclass, * FROM pt;
 SELECT tableoid::regclass, * FROM p1;
 SELECT tableoid::regclass, * FROM p2;

--- a/contrib/file_fdw/input/gp_file_fdw.source
+++ b/contrib/file_fdw/input/gp_file_fdw.source
@@ -38,7 +38,41 @@ CREATE FOREIGN TABLE text_csv_any_from_server (
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text.csv');
 SELECT * FROM text_csv_any_from_server;
 
+-- test distributed by feature
+\! rm -f /tmp/ft_*.csv
+CREATE FOREIGN TABLE ft_hash(id int)
+SERVER file_server OPTIONS(format 'csv', filename '/tmp/ft_<SEGID>.csv')
+DISTRIBUTED BY (id);
+
+-- test insert function of file_fdw
+INSERT INTO ft_hash SELECT generate_series(1, 100000);
+SELECT COUNT(*), gp_segment_id FROM ft_hash
+GROUP BY (gp_segment_id);
+
+CREATE TABLE heap_hash(id int) DISTRIBUTED BY(id);
+CREATE TABLE heap_rand(id int) DISTRIBUTED RANDOMLY;
+-- no motion node
+EXPLAIN INSERT INTO heap_hash SELECT * FROM ft_hash;
+-- redistribute motion
+EXPLAIN INSERT INTO ft_hash SELECT * FROM heap_rand;
+
+-- test foreign_distribution_enforce_policy guc 
+-- first exchange data for seg0 and seg1
+\! mv /tmp/ft_0.csv /tmp/ft_tmp.csv
+\! mv /tmp/ft_1.csv /tmp/ft_0.csv
+\! mv /tmp/ft_tmp.csv /tmp/ft_1.csv
+
+-- error immediately
+SET foreign_distribution_enforce_policy TO error_immedately;
+SELECT COUNT(*) FROM ft_hash;
+
+-- notice once
+SET foreign_distribution_enforce_policy TO notice_once;
+SELECT COUNT(*) FROM ft_hash;
+
 -- cleanup
 RESET ROLE;
 DROP EXTENSION file_fdw CASCADE;
+DROP TABLE heap_hash;
+DROP TABLE heap_rand;
 DROP ROLE file_fdw_superuser;

--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -202,8 +202,6 @@ SELECT tableoid::regclass, b FROM agg_csv;
 (3 rows)
 
 -- updates aren't supported
-INSERT INTO agg_csv VALUES(1,2.0);
-ERROR:  cannot insert into foreign table "agg_csv"
 UPDATE agg_csv SET a = 1;
 ERROR:  cannot update foreign table "agg_csv"
 DELETE FROM agg_csv WHERE a = 100;
@@ -217,9 +215,6 @@ SELECT * FROM agg_csv FOR UPDATE;
   42 |  324.78
 (3 rows)
 
--- copy from isn't supported either
-COPY agg_csv FROM STDIN;
-ERROR:  cannot insert into foreign table "agg_csv"
 -- constraint exclusion tests
 \t on
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv WHERE a < 0;
@@ -316,9 +311,6 @@ SELECT tableoid::regclass, * FROM p2;
 ----------+---+---
 (0 rows)
 
-COPY pt FROM '@abs_srcdir@/data/list2.bad' with (format 'csv', delimiter ','); -- ERROR
-ERROR:  cannot insert into foreign table "p1"
-CONTEXT:  COPY pt, line 2: "1,qux"
 COPY pt FROM '@abs_srcdir@/data/list2.csv' with (format 'csv', delimiter ',');
 SELECT tableoid::regclass, * FROM pt;
  tableoid | a |  b  
@@ -343,11 +335,7 @@ SELECT tableoid::regclass, * FROM p2;
  p2       | 2 | qux
 (2 rows)
 
-INSERT INTO pt VALUES (1, 'xyzzy'); -- ERROR
-ERROR:  cannot insert into foreign table "p1"
 INSERT INTO pt VALUES (2, 'xyzzy');
-UPDATE pt set a = 1 where a = 2; -- ERROR
-ERROR:  cannot insert into foreign table "p1"
 SELECT tableoid::regclass, * FROM pt;
  tableoid | a |   b   
 ----------+---+-------

--- a/contrib/file_fdw/output/gp_file_fdw.source
+++ b/contrib/file_fdw/output/gp_file_fdw.source
@@ -42,13 +42,75 @@ CREATE FOREIGN TABLE text_csv_any_from_server (
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text.csv');
 SELECT * FROM text_csv_any_from_server;
 ERROR:  file_fdw does not support mpp_execute option 'any'
+-- test distributed by feature
+\! rm -f /tmp/ft_*.csv
+CREATE FOREIGN TABLE ft_hash(id int)
+SERVER file_server OPTIONS(format 'csv', filename '/tmp/ft_<SEGID>.csv')
+DISTRIBUTED BY (id);
+-- test insert function of file_fdw
+INSERT INTO ft_hash SELECT generate_series(1, 100000);
+SELECT COUNT(*), gp_segment_id FROM ft_hash
+GROUP BY (gp_segment_id);
+ count | gp_segment_id 
+-------+---------------
+ 33211 |             2
+ 33462 |             0
+ 33327 |             1
+(3 rows)
+
+CREATE TABLE heap_hash(id int) DISTRIBUTED BY(id);
+CREATE TABLE heap_rand(id int) DISTRIBUTED RANDOMLY;
+-- no motion node
+EXPLAIN INSERT INTO heap_hash SELECT * FROM ft_hash;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Insert on heap_hash  (cost=0.00..973.00 rows=9630 width=4)
+   ->  Foreign Scan on ft_hash  (cost=0.00..973.00 rows=9630 width=4)
+         Foreign File: /tmp/ft_<SEGID>.csv
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- redistribute motion
+EXPLAIN INSERT INTO ft_hash SELECT * FROM heap_rand;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Insert on ft_hash  (cost=0.00..997.00 rows=32100 width=4)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..997.00 rows=32100 width=4)
+         Hash Key: heap_rand.id
+         ->  Seq Scan on heap_rand  (cost=0.00..355.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- test foreign_distribution_enforce_policy guc 
+-- first exchange data for seg0 and seg1
+\! mv /tmp/ft_0.csv /tmp/ft_tmp.csv
+\! mv /tmp/ft_1.csv /tmp/ft_0.csv
+\! mv /tmp/ft_tmp.csv /tmp/ft_1.csv
+-- error immediately
+SET foreign_distribution_enforce_policy TO error_immedately;
+SELECT COUNT(*) FROM ft_hash;
+ERROR:  Foreign scan returns tuple for segment A, current segment B  (seg0 slice1 127.0.0.1:7002 pid=353964)
+-- notice once
+SET foreign_distribution_enforce_policy TO notice_once;
+SELECT COUNT(*) FROM ft_hash;
+NOTICE:  Foreign scan returns tuple for segment A, current segment B  (seg0 slice1 127.0.0.1:7002 pid=353964)
+NOTICE:  Foreign scan returns tuple for segment A, current segment B  (seg1 slice1 127.0.0.1:7003 pid=353965)
+NOTICE:  Foreign scan returns tuple for segment A, current segment B  (seg2 slice1 127.0.0.1:7004 pid=353966)
+ count 
+-------
+ 33211
+(1 row)
+
 -- cleanup
 RESET ROLE;
 DROP EXTENSION file_fdw CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to server file_server
 drop cascades to user mapping for file_fdw_superuser on server file_server
 drop cascades to foreign table text_csv_any
 drop cascades to foreign table text_csv_all
 drop cascades to foreign table text_csv_any_from_server
+drop cascades to foreign table ft_hash
+DROP TABLE heap_hash;
+DROP TABLE heap_rand;
 DROP ROLE file_fdw_superuser;

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -15,6 +15,8 @@
   [ OPTIONS ( [ mpp_execute { 'master' | 'any' | 'all segments' } [, ] ] <varname>option</varname> '<varname>value</varname>' [, ... ] ) ]</codeblock>
         <p>where <varname>column_constraint</varname> is:</p><codeblock>
 [ CONSTRAINT <varname>constraint_name</varname> ]
+[ DISTRIBUTED BY (<varname>column</varname> [<varname>opclass</varname>], [ ... ] )
+       | DISTRIBUTED RANDOMLY | DISTRIBUTED REPLICATED ]
 { NOT NULL |
   NULL |
   DEFAULT <varname>default_expr</varname> }</codeblock>

--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -638,7 +638,11 @@ heap_getsysattr(HeapTuple tup, int attnum, TupleDesc tupleDesc, bool *isnull)
 {
 	Datum		result;
 
-	Assert(tup);
+	/* GpSegmentIdAttributeNumber doesn't need information in tup.
+	 * Skip the check to allow getting GpSegmentIdAttributeNumber
+	 * from tuples returned by foreign tables. */
+	if (attnum != GpSegmentIdAttributeNumber)
+		Assert(tup);
 
 	/* Currently, no sys attribute ever reads as NULL. */
 	*isnull = false;

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -350,35 +350,6 @@ GpPolicyFetch(Oid tbloid)
 			return createRandomPartitionedPolicy(getgpsegmentCount());
 		}
 	}
-	else if (get_rel_relkind(tbloid) == RELKIND_FOREIGN_TABLE)
-	{
-		/*
-		 * Similar to the external table creation, there is a transient state
-		 * during creation of a foreign table, where the pg_class entry has
-		 * been created, before the pg_foreign_table entry has been created.
-		 */
-		HeapTuple	tp = SearchSysCache1(FOREIGNTABLEREL, ObjectIdGetDatum(tbloid));
-
-		if (HeapTupleIsValid(tp))
-		{
-			ReleaseSysCache(tp);
-
-			ForeignTable *f = GetForeignTable(tbloid);
-
-			if (f->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
-			{
-				/*
-				 * Currently, foreign tables do not support a distribution
-				 * policy, as opposed to writable external tables. For now,
-				 * we will create a random partitioned policy for foreign
-				 * tables that run on all segments. This will allow writing
-				 * to foreign tables from all segments when the mpp_execute
-				 * option is set to 'all segments'
-				 */
-				return createRandomPartitionedPolicy(getgpsegmentCount());
-			}
-		}
-	}
 
 	/*
 	 * Select by value of the localoid field
@@ -468,6 +439,35 @@ GpPolicyFetch(Oid tbloid)
 		}
 
 		ReleaseSysCache(gp_policy_tuple);
+	}
+	else if (get_rel_relkind(tbloid) == RELKIND_FOREIGN_TABLE)
+	{
+		/*
+		 * Similar to the external table creation, there is a transient state
+		 * during creation of a foreign table, where the pg_class entry has
+		 * been created, before the pg_foreign_table entry has been created.
+		 */
+		HeapTuple	tp = SearchSysCache1(FOREIGNTABLEREL, ObjectIdGetDatum(tbloid));
+
+		if (HeapTupleIsValid(tp))
+		{
+			ReleaseSysCache(tp);
+
+			ForeignTable *f = GetForeignTable(tbloid);
+
+			if (f->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
+			{
+				/*
+				 * Currently, foreign tables do not support a distribution
+				 * policy, as opposed to writable external tables. For now,
+				 * we will create a random partitioned policy for foreign
+				 * tables that run on all segments. This will allow writing
+				 * to foreign tables from all segments when the mpp_execute
+				 * option is set to 'all segments'
+				 */
+				return createRandomPartitionedPolicy(getgpsegmentCount());
+			}
+		}
 	}
 
 	/* Interpret absence of a valid policy row as POLICYTYPE_ENTRY */

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -7398,12 +7398,6 @@ CreateForeignTableStmt:
 					n->servername = $10;
 					n->options = $11;
 					n->distributedBy = (DistributedBy *) $12;
-					if (strcmp(n->servername, GP_EXTTABLE_SERVER_NAME) != 0 && n->distributedBy)
-					{
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("DISTRIBUTED BY clause is only supported by FOREIGN SERVER \"%s\"", GP_EXTTABLE_SERVER_NAME)));
-					 }
 					$$ = (Node *) n;
 				}
 		| CREATE FOREIGN TABLE IF_P NOT EXISTS qualified_name

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -52,6 +52,7 @@
 #include "utils/resource_manager.h"
 #include "utils/varlena.h"
 #include "utils/vmem_tracker.h"
+#include "executor/nodeForeignscan.h"
 
 /*
  * These constants are copied from guc.c. They should not bitrot when we
@@ -526,6 +527,12 @@ static const struct config_enum_entry optimizer_join_order_options[] = {
 	{"greedy", JOIN_ORDER_GREEDY_SEARCH},
 	{"exhaustive", JOIN_ORDER_EXHAUSTIVE_SEARCH},
 	{"exhaustive2", JOIN_ORDER_EXHAUSTIVE2_SEARCH},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry distribution_enforce_policy_options[] = {
+	{"error_immedately", FOREIGN_DISTRIBUTION_POLICY_ERROR_IMMEDIATELY},
+	{"notice_once", FOREIGN_DISTRIBUTION_POLICY_NOTICE_ONCE},
 	{NULL, 0}
 };
 
@@ -4521,6 +4528,17 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		},
 		&optimizer_join_order,
 		JOIN_ORDER_EXHAUSTIVE2_SEARCH, optimizer_join_order_options,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"foreign_distribution_enforce_policy", PGC_USERSET, EXTERNAL_TABLES,
+			gettext_noop("Set distribution enforcement policy for foreign table."),
+			gettext_noop("Valid values are error_immedately, notice_once"),
+			GUC_NOT_IN_SAMPLE
+		},
+		&foreign_distribution_enforce_policy,
+		FOREIGN_DISTRIBUTION_POLICY_ERROR_IMMEDIATELY, distribution_enforce_policy_options,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/catalog/pg_foreign_data_wrapper.h
+++ b/src/include/catalog/pg_foreign_data_wrapper.h
@@ -57,4 +57,6 @@ CATALOG(pg_foreign_data_wrapper,2328,ForeignDataWrapperRelationId)
  */
 typedef FormData_pg_foreign_data_wrapper *Form_pg_foreign_data_wrapper;
 
+#define PXF_FDW_NAME "pxf_fdw"
+
 #endif							/* PG_FOREIGN_DATA_WRAPPER_H */

--- a/src/include/executor/nodeForeignscan.h
+++ b/src/include/executor/nodeForeignscan.h
@@ -31,4 +31,12 @@ extern void ExecForeignScanInitializeWorker(ForeignScanState *node,
 											ParallelWorkerContext *pwcxt);
 extern void ExecShutdownForeignScan(ForeignScanState *node);
 
+typedef enum ForeignScanEnforceDistributionPolicy
+{
+	FOREIGN_DISTRIBUTION_POLICY_ERROR_IMMEDIATELY,
+	FOREIGN_DISTRIBUTION_POLICY_NOTICE_ONCE,
+} ForeignScanEnforceDistributionPolicy;
+
+extern int foreign_distribution_enforce_policy;
+
 #endif							/* NODEFOREIGNSCAN_H */

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -125,3 +125,4 @@
 		"wal_debug",
 		"work_mem",
 		"gp_resgroup_debug_wait_queue",
+		"foreign_distribution_enforce_policy",

--- a/src/test/regress/expected/gp_foreign_data.out
+++ b/src/test/regress/expected/gp_foreign_data.out
@@ -26,3 +26,68 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int
 ) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments');
+CREATE FOREIGN TABLE ft5 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments')
+DISTRIBUTED BY (c1);
+\d+ ft5
+                                       Foreign table "public.ft5"
+ Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
+ c1     | integer |           |          |         |             | plain   |              | 
+Server: s0
+FDW options: (delimiter ',', mpp_execute 'all segments')
+Distributed by: (c1)
+
+-- Hash distribution implies mpp_execute 'all segments'
+CREATE FOREIGN TABLE ft6 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',')
+DISTRIBUTED BY (c1);
+\d+ ft6
+                                       Foreign table "public.ft6"
+ Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
+ c1     | integer |           |          |         |             | plain   |              | 
+Server: s0
+FDW options: (delimiter ',', mpp_execute 'all segments')
+Distributed by: (c1)
+
+-- Hash distribution implies mpp_execute 'all segments', override 'any'
+CREATE FOREIGN TABLE ft7 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'any')
+DISTRIBUTED BY (c1);
+NOTICE:  Hash or random distribution implies mpp_execute option "all segments", override existing option
+\d+ ft7
+                                       Foreign table "public.ft7"
+ Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
+ c1     | integer |           |          |         |             | plain   |              | 
+Server: s0
+FDW options: (delimiter ',', mpp_execute 'all segments')
+Distributed by: (c1)
+
+-- Hash distribution implies mpp_execute 'all segments', override 'master'
+CREATE FOREIGN TABLE ft8 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'master')
+DISTRIBUTED BY (c1);
+NOTICE:  Hash or random distribution implies mpp_execute option "all segments", override existing option
+\d+ ft8
+                                       Foreign table "public.ft8"
+ Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
+ c1     | integer |           |          |         |             | plain   |              | 
+Server: s0
+FDW options: (delimiter ',', mpp_execute 'all segments')
+Distributed by: (c1)
+
+-- Distribution policy for pxf_fdw is disabled
+CREATE FOREIGN DATA WRAPPER pxf_fdw;
+CREATE SERVER s1 FOREIGN DATA WRAPPER pxf_fdw;
+CREATE FOREIGN TABLE ft9 (
+	c1 int
+) SERVER s1 OPTIONS (delimiter ',', mpp_execute 'all segments')
+DISTRIBUTED BY (c1);
+ERROR:  pxf_fdw doesn't support DISTRIBUTED BY clause

--- a/src/test/regress/sql/gp_foreign_data.sql
+++ b/src/test/regress/sql/gp_foreign_data.sql
@@ -24,3 +24,43 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int
 ) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments');
+
+CREATE FOREIGN TABLE ft5 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments')
+DISTRIBUTED BY (c1);
+
+\d+ ft5
+
+-- Hash distribution implies mpp_execute 'all segments'
+CREATE FOREIGN TABLE ft6 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',')
+DISTRIBUTED BY (c1);
+\d+ ft6
+
+-- Hash distribution implies mpp_execute 'all segments', override 'any'
+CREATE FOREIGN TABLE ft7 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'any')
+DISTRIBUTED BY (c1);
+\d+ ft7
+
+-- Hash distribution implies mpp_execute 'all segments', override 'master'
+CREATE FOREIGN TABLE ft8 (
+	c1 int
+) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'master')
+DISTRIBUTED BY (c1);
+\d+ ft8
+
+-- Distribution policy for pxf_fdw is disabled
+CREATE FOREIGN DATA WRAPPER pxf_fdw;
+CREATE SERVER s1 FOREIGN DATA WRAPPER pxf_fdw;
+CREATE FOREIGN TABLE ft9 (
+	c1 int
+) SERVER s1 OPTIONS (delimiter ',', mpp_execute 'all segments')
+DISTRIBUTED BY (c1);
+
+-- start_ignore
+DROP FOREIGN DATA WRAPPER pxf_fdw CASCADE;
+-- end_ignore


### PR DESCRIPTION
Currently foreign table has no distribution policy and is by default
master only. When "all segments" mpp_execute option is specified, it
will be treated as randomly distributed. The missing part here is
hash distribution. Allow DISTRIBUTED BY clause for foreign table to
complete this.

Add GUC foreign_distribution_enforce_policy to control whether to
validate data coming from foreign table if it's hash distributed.
Available values are:
- error_immedately: no tolerance for any data belongs to wrong segment.
- notice_once: report if there's bad data, discard and continue.

To keep backward compatibility with existing mpp_execute option, imply
"all segments" if distribution policy is random or hash, except for
external tables.

Implement insert functions of file_fdw as POC of DISTRIBUTED BY clause
for foreign table. Remove previous test case that test for unsupported
insert/update feature.

Because pxf relies on mpp_execute as of now, disable DISTRIBUTED BY
support for pxf to prevent icompatibility.

When projecting tuples, there's an assertion for heap tuple. This
protection is not necessary for the gp_segment_id system column.
Skip it if we are asking GpSegmentIdAttributeNumber.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
