### PR TITLE
Docs: Split Restoring Master Mirroring steps into two processes

### DIFF
--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-restoring-master-mirroring-after-a-recovery.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-restoring-master-mirroring-after-a-recovery.xml
@@ -21,62 +21,76 @@
       operation.</note>
     <p>For information about the Greenplum Database utilities, see the <cite>Greenplum Database
         Utility Guide</cite>.</p>
-    <section>
-      <title>To restore the master mirroring after a recovery</title>
-      <ol id="ol_lxq_dh3_npb">
-        <li>Ensure the original master host is in dependable running condition; ensure the cause of
-          the original failure is fixed.</li>
-        <li>On the original master host, move or remove the data directory,
-          <codeph>gpseg-1</codeph>. This example moves the directory to
-            <codeph>backup_gpseg-1</codeph>:<codeblock>$ mv /data/master/gpseg-1 /data/master/backup_gpseg-1</codeblock><p>You
-            can remove the backup directory once the standby is successfully configured.</p></li>
-        <li>Initialize a standby master on the original master host. For example, run this command
-          from the current master host, smdw:<codeblock>$ gpinitstandby -s mdw</codeblock></li>
-        <li>After the initialization completes, check the status of standby master, mdw. Run
-              <codeph><xref href="../../../utility_guide/ref/gpstate.xml#topic1" type="topic"
-              format="dita"/></codeph> with the <codeph>-f</codeph> option to check the standby
-          master status:<codeblock>$ gpstate -f</codeblock> The standby master status should be
-            <codeph>passive</codeph>, and the WAL sender state should be
-          <codeph>streaming</codeph>.</li>
-      </ol>
-    </section>
-    <section id="ki160986">
-      <title>To restore the master and standby instances on original hosts (optional)</title>
-      <p>Make sure you have first followed the steps to restore the master mirroring after a
-        recovery.</p>
-      <ol>
-        <li>Stop the Greenplum Database master instance on the standby master. For
-          example:<codeblock>$ gpstop -m</codeblock></li>
-        <li id="ki160961">Run the <codeph>gpactivatestandby</codeph> utility from the original
-          master host, mdw, that is currently a standby master. For
-            example:<codeblock>$ gpactivatestandby -d $COORDINATOR_DATA_DIRECTORY</codeblock><p>Where the
-              <codeph>-d</codeph> option specifies the data directory of the host you are
-            activating.</p></li>
-        <li id="ki165618">After the utility completes, run <codeph>gpstate</codeph> with the
-            <codeph>-b</codeph> option to display a summary of the system
-            status:<codeblock>$ gpstate -b</codeblock><p>The master instance status should be
-              <codeph>Active</codeph>. When a standby master is not configured, the command displays
-              <codeph>No master standby configured</codeph> for the standby master state.</p></li>
-        <li>On the standby master host, move or remove the data directory, <codeph>gpseg-1</codeph>.
-          This example moves the
-            directory:<codeblock>$ mv /data/master/gpseg-1 /data/master/backup_gpseg-1</codeblock><p>You
-            can remove the backup directory once the standby is successfully configured.</p></li>
-        <li id="ki165609">After the original master host runs the primary Greenplum Database master,
-          you can initialize a standby master on the original standby master host. For
-            example:<codeblock>$ gpinitstandby -s smdw</codeblock><p>After the command completes,
-            you can run the <codeph>gpstate -f</codeph> command on the primary master host, to check
-            the standby master status. </p></li>
-      </ol>
-    </section>
-    <section>
-      <title>To check the status of the master mirroring process (optional)</title>
-      <p>You can run the <codeph>gpstate</codeph> utility with the <codeph>-f</codeph> option to
-        display details of the standby master host. <codeblock>$ gpstate -f</codeblock></p>
-      <p>The standby master status should be <codeph>passive</codeph>, and the WAL sender state
-        should be <codeph>streaming</codeph>.</p>
-      <p>For information about the <codeph><xref
-            href="../../../utility_guide/ref/gpstate.xml" type="topic" format="dita"
-          /></codeph> utility, see the <cite>Greenplum Database Utility Guide</cite>.</p>
-    </section>
   </body>
+  <topic id="topic_us3_md4_npb">
+    <title>To restore the master mirroring after a recovery</title>
+    <body>
+      <section>
+        <ol id="ol_lxq_dh3_npb">
+          <li>Ensure the original master host is in dependable running condition; ensure the cause
+            of the original failure is fixed.</li>
+          <li>On the original master host, move or remove the data directory,
+              <codeph>gpseg-1</codeph>. This example moves the directory to
+              <codeph>backup_gpseg-1</codeph>:<codeblock>$ mv /data/master/gpseg-1 /data/master/backup_gpseg-1</codeblock><p>You
+              can remove the backup directory once the standby is successfully configured.</p></li>
+          <li>Initialize a standby master on the original master host. For example, run this command
+            from the current master host, smdw:<codeblock>$ gpinitstandby -s mdw</codeblock></li>
+          <li>After the initialization completes, check the status of standby master, mdw. Run
+                <codeph><xref href="../../../utility_guide/ref/gpstate.xml#topic1" type="topic"
+                format="dita"/></codeph> with the <codeph>-f</codeph> option to check the standby
+            master status:<codeblock>$ gpstate -f</codeblock> The standby master status should be
+              <codeph>passive</codeph>, and the WAL sender state should be
+              <codeph>streaming</codeph>.</li>
+        </ol>
+      </section>
+    </body>
+  </topic>
+  <topic id="topic_dr3_ld4_npb">
+    <title>To restore the master and standby instances on original hosts (optional)</title>
+    <body>
+      <section id="ki160986">
+        <note>Before performing the steps in this section, be sure you have followed the steps to
+          restore master mirroring after a recovery, as described in the <xref href="#topic_us3_md4_npb"
+            format="dita"/>previous section.</note>
+        <ol id="ol_dfy_ld4_npb">
+          <li>Stop the Greenplum Database master instance on the standby master. For
+            example:<codeblock>$ gpstop -m</codeblock></li>
+          <li id="ki160961">Run the <codeph>gpactivatestandby</codeph> utility from the original
+            master host, mdw, that is currently a standby master. For
+              example:<codeblock>$ gpactivatestandby -d $COORDINATOR_DATA_DIRECTORY</codeblock><p>Where
+              the <codeph>-d</codeph> option specifies the data directory of the host you are
+              activating.</p></li>
+          <li id="ki165618">After the utility completes, run <codeph>gpstate</codeph> with the
+              <codeph>-b</codeph> option to display a summary of the system
+              status:<codeblock>$ gpstate -b</codeblock><p>The master instance status should be
+                <codeph>Active</codeph>. When a standby master is not configured, the command
+              displays <codeph>No master standby configured</codeph> for the standby master
+              state.</p></li>
+          <li>On the standby master host, move or remove the data directory,
+              <codeph>gpseg-1</codeph>. This example moves the
+              directory:<codeblock>$ mv /data/master/gpseg-1 /data/master/backup_gpseg-1</codeblock><p>You
+              can remove the backup directory once the standby is successfully configured.</p></li>
+          <li id="ki165609">After the original master host runs the primary Greenplum Database
+            master, you can initialize a standby master on the original standby master host. For
+              example:<codeblock>$ gpinitstandby -s smdw</codeblock><p>After the command completes,
+              you can run the <codeph>gpstate -f</codeph> command on the primary master host, to
+              check the standby master status. </p></li>
+        </ol>
+      </section>
+    </body>
+  </topic>
+  <topic id="topic_i1h_kd4_npb">
+    <title>To check the status of the master mirroring process (optional)</title>
+    <body>
+      <section>
+        <p>You can run the <codeph>gpstate</codeph> utility with the <codeph>-f</codeph> option to
+          display details of the standby master host. <codeblock>$ gpstate -f</codeblock></p>
+        <p>The standby master status should be <codeph>passive</codeph>, and the WAL sender state
+          should be <codeph>streaming</codeph>.</p>
+        <p>For information about the <codeph><xref href="../../../utility_guide/ref/gpstate.xml"
+              type="topic" format="dita"/></codeph> utility, see the <cite>Greenplum Database
+            Utility Guide</cite>.</p>
+      </section>
+    </body>
+  </topic>
 </topic>

--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-restoring-master-mirroring-after-a-recovery.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-restoring-master-mirroring-after-a-recovery.xml
@@ -21,24 +21,30 @@
       operation.</note>
     <p>For information about the Greenplum Database utilities, see the <cite>Greenplum Database
         Utility Guide</cite>.</p>
-    <section id="ki160986">
-      <title>To restore the master and standby instances on original hosts (optional)</title>
-      <ol>
-        <li id="ki160936">Ensure the original master host is in dependable running condition; ensure
-          the cause of the original failure is fixed.</li>
+    <section>
+      <title>To restore the master mirroring after a recovery</title>
+      <ol id="ol_lxq_dh3_npb">
+        <li>Ensure the original master host is in dependable running condition; ensure the cause of
+          the original failure is fixed.</li>
         <li>On the original master host, move or remove the data directory,
           <codeph>gpseg-1</codeph>. This example moves the directory to
             <codeph>backup_gpseg-1</codeph>:<codeblock>$ mv /data/master/gpseg-1 /data/master/backup_gpseg-1</codeblock><p>You
             can remove the backup directory once the standby is successfully configured.</p></li>
-        <li id="ki160940">Initialize a standby master on the original master host. For example, run
-          this command from the current master host,
-          smdw:<codeblock>$ gpinitstandby -s mdw</codeblock></li>
+        <li>Initialize a standby master on the original master host. For example, run this command
+          from the current master host, smdw:<codeblock>$ gpinitstandby -s mdw</codeblock></li>
         <li>After the initialization completes, check the status of standby master, mdw. Run
-              <codeph><xref href="../../../utility_guide/ref/gpstate.xml#topic1"
-              type="topic" format="dita"/></codeph> with the <codeph>-f</codeph> option to check the
-          standby master status:<codeblock>$ gpstate -f</codeblock> The standby master status should
-          be <codeph>passive</codeph>, and the WAL sender state should be
+              <codeph><xref href="../../../utility_guide/ref/gpstate.xml#topic1" type="topic"
+              format="dita"/></codeph> with the <codeph>-f</codeph> option to check the standby
+          master status:<codeblock>$ gpstate -f</codeblock> The standby master status should be
+            <codeph>passive</codeph>, and the WAL sender state should be
           <codeph>streaming</codeph>.</li>
+      </ol>
+    </section>
+    <section id="ki160986">
+      <title>To restore the master and standby instances on original hosts (optional)</title>
+      <p>Make sure you have first followed the steps to restore the master mirroring after a
+        recovery.</p>
+      <ol>
         <li>Stop the Greenplum Database master instance on the standby master. For
           example:<codeblock>$ gpstop -m</codeblock></li>
         <li id="ki160961">Run the <codeph>gpactivatestandby</codeph> utility from the original


### PR DESCRIPTION
The first 4 steps instruct user on how to restore master mirroring, and the following steps are optional if user wants to swap roles again between master/standby.
@VMWareJennyBeth can you confirm if it looks clear? I have added a paragraph on the second process to make sure user follows the first 4 steps before moving on to the optional one:
https://mireia-standby.sc2-04-pcf1-apps.oc.vmware.com/7-0/admin_guide/highavail/topics/g-restoring-master-mirroring-after-a-recovery.html
thanks!