### PR TITLE
docs: removed reference of openssl.conf

### DIFF
--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -518,6 +518,13 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
 </codeblock></p></li>
           </ul></p>
       </section>
+      <section>
+        <title>OpenSSL Configuration</title>
+        <p>You can make changes to the OpenSSL configuration by updating the
+            <codeph>openssl.cnf</codeph> file under your OpenSSL installation directory, or the file
+          referenced by <codeph>OPENSSL_CONF</codeph>, if present, and then restarting the Greenplum
+          Database server.</p>
+      </section>
       <section id="create_a_cert">
         <title>Creating a Self-Signed Certificate</title>
         <p>A self-signed certificate can be used for testing, but a certificate signed by a

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -522,8 +522,8 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
         <title>OpenSSL Configuration</title>
         <p>You can make changes to the OpenSSL configuration by updating the
             <codeph>openssl.cnf</codeph> file under your OpenSSL installation directory, or the file
-          referenced by <codeph>OPENSSL_CONF</codeph>, if present, and then restarting the Greenplum
-          Database server.</p>
+          referenced by <codeph>$OPENSSL_CONF</codeph>, if present, and then restarting the
+          Greenplum Database server.</p>
       </section>
       <section id="create_a_cert">
         <title>Creating a Self-Signed Certificate</title>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -518,13 +518,6 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
 </codeblock></p></li>
           </ul></p>
       </section>
-      <section id="openssl_config">
-        <title>OpenSSL Configuration</title>
-        <p>Greenplum Database reads the OpenSSL configuration file specified in
-            <codeph>$GP_HOME/etc/openssl.cnf</codeph> by default. You can make changes to the
-          default configuration for OpenSSL by modifying or updating this file and restarting the
-          server.</p>
-      </section>
       <section id="create_a_cert">
         <title>Creating a Self-Signed Certificate</title>
         <p>A self-signed certificate can be used for testing, but a certificate signed by a


### PR DESCRIPTION
We do not ship a version of openssl with Greenplum 6 so there is no openssl.conf file under $GPHOME/etc.
It is now listed as a requirement https://greenplum.docs.pivotal.io/6-16/install_guide/platform-requirements.html
I removed the whole OpenSSL Configuration section since it only consisted of an explanation of that file. I can add it again with references to how to configure OpenSSL or references to OpenSSL documentation if that makes more sense?