### PR TITLE
gprecoverseg: Skip pg_hba update on non-failed hosts

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_conf.py
@@ -2,8 +2,10 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
-from mock import patch, Mock
+from mock import call, patch, Mock
+import os
 
+from gppylib.commands.base import REMOTE
 from gppylib.gparray import Segment, GpArray
 from gppylib.operations.update_pg_hba_conf import config_primaries_for_replication
 from test.unit.gp_unittest import GpTestCase, run_tests
@@ -32,12 +34,48 @@ class UpdatePgHBAConfTests(GpTestCase):
         ])
         self.logger = self.get_mock_from_apply_patch('logger')
 
-    @patch('gppylib.operations.update_pg_hba_conf.Command')
-    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
-    def test_pghbaconf_updated_successfully(self, mock_cmd, mock_list_addrs):
+        self.entries_block = """
+host  replication gpadmin samehost trust
+host all gpadmin {ip_mirror1}/32 trust
+host all gpadmin {ip_mirror2}/32 trust
+host replication gpadmin {ip_mirror1}/32 trust
+host replication gpadmin {ip_mirror2}/32 trust
+host replication gpadmin {ip_primary1}/32 trust
+host replication gpadmin {ip_primary2}/32 trust"""
+
+    @patch('gppylib.commands.unix.getUserName', return_value="gpadmin")
+    @patch('gppylib.operations.update_pg_hba_conf.Command', return_value=Mock())
+    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', side_effect=[ ['192.168.1.1', '192.168.2.1'], ['10.172.56.16', '10.172.56.20'], ['10.172.56.16', '10.172.56.20'], ['192.168.1.1', '192.168.2.1'], ])
+    def test_pghbaconf_updated_successfully_all_failed_segments(self, mock_list_addrs, mock_cmd, mock_username):
+        os.environ["GPHOME"] = "/usr/local/gpdb"
         config_primaries_for_replication(self.gparray, False)
         self.logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
         self.logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
+
+        entries0 = self.entries_block.format(ip_primary1 = '10.172.56.16', ip_primary2 = '10.172.56.20', ip_mirror1 = '192.168.1.1', ip_mirror2 = '192.168.2.1')
+        entries1 = self.entries_block.format(ip_primary1 = '192.168.1.1', ip_primary2 = '192.168.2.1', ip_mirror1 = '10.172.56.16', ip_mirror2 = '10.172.56.20')
+
+        self.assertEqual(mock_cmd.call_count, 2)
+        mock_cmd.assert_has_calls([
+            call(name="append to pg_hba.conf", cmdStr=". /usr/local/gpdb/greenplum_path.sh; echo '%s' >> /data/primary0/pg_hba.conf; pg_ctl -D /data/primary0 reload" % entries0, ctxt=REMOTE, remoteHost="sdw1"),
+            call(name="append to pg_hba.conf", cmdStr=". /usr/local/gpdb/greenplum_path.sh; echo '%s' >> /data/primary1/pg_hba.conf; pg_ctl -D /data/primary1 reload" % entries1, ctxt=REMOTE, remoteHost="sdw2"),
+        ])
+
+    @patch('gppylib.commands.unix.getUserName', return_value="gpadmin")
+    @patch('gppylib.operations.update_pg_hba_conf.Command', return_value=Mock())
+    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.1.1', '192.168.2.1'])
+    def test_pghbaconf_updated_successfully_one_failed_segment(self, mock_list_addrs, mock_cmd, mock_username):
+        os.environ["GPHOME"] = "/usr/local/gpdb"
+        config_primaries_for_replication(self.gparray, False, contents_to_update=[0])
+        self.logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+        self.logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
+
+        entries = self.entries_block.format(ip_primary1 = '192.168.1.1', ip_primary2 = '192.168.2.1', ip_mirror1 = '192.168.1.1', ip_mirror2 = '192.168.2.1')
+
+        self.assertEqual(mock_cmd.call_count, 1)
+        mock_cmd.assert_has_calls([
+            call(name="append to pg_hba.conf", cmdStr=". /usr/local/gpdb/greenplum_path.sh; echo '%s' >> /data/primary0/pg_hba.conf; pg_ctl -D /data/primary0 reload" % entries, ctxt=REMOTE, remoteHost="sdw1"),
+        ])
 
     @patch('gppylib.operations.update_pg_hba_conf.Command', side_effect=Exception("boom"))
     @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -641,7 +641,8 @@ class GpRecoverSegmentProgram:
             if new_hosts:
                 self.syncPackages(new_hosts)
 
-            config_primaries_for_replication(gpArray, self.__options.hba_hostnames)
+            contentsToUpdate = [seg.getLiveSegment().getSegmentContentId() for seg in mirrorBuilder.getMirrorsToBuild()]
+            config_primaries_for_replication(gpArray, self.__options.hba_hostnames, contentsToUpdate)
             if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
                 sys.exit(1)
 


### PR DESCRIPTION
Currently, when recovering segments gprecoverseg updates the pg_hba.conf
entries on every acting primary regardless of whether those primaries
have mirrors to be recovered.  This commit restricts the update to only
those primaries that need to be updated.
