### PR TITLE
movemirrors/recoverseg: -B option fix parallel processes 

### DIFF
--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -31,8 +31,6 @@ except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 # constants
-MAX_BATCH_SIZE = 128
-
 GPDB_STOPPED = 1
 GPDB_STARTED = 2
 GPDB_UTILITY = 3
@@ -71,7 +69,9 @@ def parseargs():
                       help='The coordinator data directory for the system. If this option is not specified, \
                             the value is obtained from the $COORDINATOR_DATA_DIRECTORY environment variable.')
     parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=16, metavar="<batch_size>",
-                      help='Expansion configuration batch size. Valid values are 1-%d' % MAX_BATCH_SIZE)
+                      help='Max number of hosts to operate on in parallel. Valid values are 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
+    parser.add_option('-b', '--segment-batch-size', dest='segment_batch_size', type='int', default=gp.DEFAULT_SEGHOST_NUM_WORKERS, metavar="<segment_batch_size>",
+                      help='Max number of segments per host to operate on in parallel. Valid values are: 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
     parser.add_option('-v', '--verbose', dest="verbose", action='store_true',
                       help='debug output.')
     parser.add_option('-l', '--log-file-directory', dest="logfile_directory",
@@ -94,8 +94,13 @@ def parseargs():
         logger.error('Unknown argument %s' % args[0])
         parser.exit()
 
-    if options.batch_size < 1 or options.batch_size > 128:
-        logger.error('Invalid argument.  -B value must be >= 1 and <= %s' % MAX_BATCH_SIZE)
+    if options.batch_size < 1 or options.batch_size > gp.MAX_SEGHOST_NUM_WORKERS:
+        logger.error('Invalid value for argument -B. Value must be >= 1 and <= %d' % gp.MAX_SEGHOST_NUM_WORKERS)
+        parser.print_help()
+        parser.exit()
+
+    if options.segment_batch_size < 1 or options.segment_batch_size > gp.MAX_SEGHOST_NUM_WORKERS:
+        logger.error('Invalid value for argument -b. Value must be >= 1 and <= %d' % gp.MAX_SEGHOST_NUM_WORKERS)
         parser.print_help()
         parser.exit()
 
@@ -129,6 +134,7 @@ def logOptionValues(options):
     logger.info("  --input                 = " + str(options.input_filename))
     logger.info("  --master-data-directory = " + str(options.coordinator_data_directory))
     logger.info("  --batch-size            = " + str(options.batch_size))
+    logger.info("  --segment-batch-size    = " + str(options.segment_batch_size))
     if options.verbose != None:
         logger.info("  --verbose               = " + str(options.verbose))
     if options.continue_move != None:
@@ -426,7 +432,8 @@ try:
     newConfig.write_output_file(backout_filename, False)
 
     """ Start gprecoverseg. """
-    recoversegOptions = "-i " + newConfig.inputFile + " -v -a -d " + options.coordinator_data_directory
+    recoversegOptions = "-i " + newConfig.inputFile + " -B " + str(options.batch_size) + \
+                        " -b " + str(options.segment_batch_size) + " -v -a -d " + options.coordinator_data_directory
     if options.logfile_directory != None:
         recoversegOptions = recoversegOptions + " -l " + str(options.logfile_directory)
     logger.info('About to run gprecoverseg with options: ' + recoversegOptions)

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -66,6 +66,7 @@ class WorkerPool(object):
             self.workers.append(w)
             w.start()
         self.numWorkers = numWorkers
+        self.logger.debug("WorkerPool() initialized with %d workers" % self.numWorkers)
 
     ###
     def getNumWorkers(self):

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -40,6 +40,12 @@ COMMAND_NOT_FOUND=127
 #Default size of thread pool for gpstart and gpsegstart
 DEFAULT_GPSTART_NUM_WORKERS=64
 
+#Default size of thread pool on segment hosts
+DEFAULT_SEGHOST_NUM_WORKERS=64
+
+#max size of thread pool on segment hosts
+MAX_SEGHOST_NUM_WORKERS=128
+
 # Application name used by the pg_rewind instance that gprecoverseg starts
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.
@@ -624,7 +630,7 @@ class GpSegStartArgs(CmdArgs):
         @param parallel - maximum size of a thread pool to start segments
         """
         if parallel is not None:
-            self.append("-B")
+            self.append("-b")
             self.append(str(parallel))
         return self
 
@@ -661,7 +667,7 @@ class GpSegStartCmd(Command):
 #-----------------------------------------------
 class GpSegStopCmd(Command):
     def __init__(self, name, gphome, version,mode,dbs,timeout=SEGMENT_STOP_TIMEOUT_DEFAULT,
-                 verbose=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
+                 verbose=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False, segment_batch_size=DEFAULT_SEGHOST_NUM_WORKERS):
         self.gphome=gphome
         self.dblist=dbs
         self.dirportlist=[]
@@ -678,8 +684,8 @@ class GpSegStopCmd(Command):
         else:
             setverbose=""
 
-        self.cmdStr="$GPHOME/sbin/gpsegstop.py %s -D %s -m %s -t %s -V '%s'"  %\
-                        (setverbose,dirstr,mode,timeout,version)
+        self.cmdStr="$GPHOME/sbin/gpsegstop.py %s -D %s -m %s -t %s -V '%s' -b %d" %\
+                        (setverbose,dirstr,mode,timeout,version,segment_batch_size)
 
         if (logfileDirectory):
             self.cmdStr = self.cmdStr + " -l '" + logfileDirectory + "'"
@@ -917,7 +923,7 @@ class ConfigureNewSegment(Command):
         if verbose:
             cmdStr += ' -v '
         if batchSize:
-            cmdStr += ' -B %s' % batchSize
+            cmdStr += ' -b %s' % batchSize
         if validationOnly:
             cmdStr += " --validation-only"
         if writeGpIdFileOnly:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -26,6 +26,7 @@ class Options:
 
         self.outputSampleConfigFile = None
         self.parallelDegree = 1
+        self.parallelPerHost = 1
         self.forceFullResynchronization = None
         self.persistent_check = None
         self.quiet = None

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -309,7 +309,7 @@ def parseargs():
     parser.add_option('-c', '--confinfo', type='string')
     parser.add_option('-t', '--tarfile', type='string')
     parser.add_option('-n', '--newsegments', action='store_true')
-    parser.add_option('-B', '--batch-size', type='int', default=DEFAULT_BATCH_SIZE, metavar='<batch_size>')
+    parser.add_option('-b', '--batch-size', type='int', default=DEFAULT_BATCH_SIZE, metavar='<batch_size>')
     parser.add_option("-V", "--validation-only", dest="validationOnly", action='store_true', default=False)
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
     parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -132,7 +132,7 @@ class GpSegStart:
 
     def __init__(self, dblist, gpversion, mirroringMode, num_cids, era,
                  timeout, pickledTransitionData, specialMode, wrapper, wrapper_args,
-                 coordinator_checksum_version, parallel, logfileDirectory=False):
+                 coordinator_checksum_version, segment_batch_size, logfileDirectory=False):
 
         # validate/store arguments
         #
@@ -160,7 +160,7 @@ class GpSegStart:
 
         # initialize state
         #
-        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), parallel))
+        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), segment_batch_size))
         self.logger                = logger
         self.overall_status        = None
 
@@ -353,7 +353,8 @@ class GpSegStart:
         parser.add_option('', '--wrapper', dest="wrapper", default=None, type='string')
         parser.add_option('', '--wrapper-args', dest="wrapper_args", default=None, type='string')
         parser.add_option('', '--coordinator-checksum-version', dest="coordinator_checksum_version", default=None, type='string', action="store")
-        parser.add_option('-B', '--parallel', type="int", dest="parallel", default=gp.DEFAULT_GPSTART_NUM_WORKERS, help='maximum size of a threadpool to start segments')
+        parser.add_option('-b', '--segment-batch-size', type="int", dest="segment_batch_size", default=gp.DEFAULT_GPSTART_NUM_WORKERS,
+                          help='Max number of segments per host to operate on in parallel.')
 
         return parser
 
@@ -375,7 +376,7 @@ class GpSegStart:
                           options.wrapper,
                           options.wrapper_args,
                           options.coordinator_checksum_version,
-                          options.parallel,
+                          options.segment_batch_size,
                           logfileDirectory=logfileDirectory)
 
 #-------------------------------------------------------------------------

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -96,6 +96,9 @@ def before_scenario(context, scenario):
     if 'gpmovemirrors' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()
 
+    if 'gprecoverseg' in context.feature.tags:
+        context.mirror_context = MirrorMgmtContext()
+
     if 'gpconfig' in context.feature.tags:
         context.gpconfig_context = GpConfigContext()
 

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -69,6 +69,27 @@ Feature: Tests for gpmovemirrors
           And verify that mirrors are recognized after a restart
           And the tablespace is valid
 
+    Scenario Outline: gpmovemirrors limits number of parallel processes correctly
+        Given a standard local demo cluster is created
+        And a tablespace is created with data
+        And 2 gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
+        And a good gpmovemirrors file is created for moving 2 mirrors
+        When the user runs gpmovemirrors with additional args "<args>"
+        Then gpmovemirrors should return a return code of 0
+        And check if gpmovemirrors ran "$GPHOME/bin/gprecoverseg" 1 times with args "<args>"
+        And gpmovemirrors should only spawn up to <coordinator_workers> workers in WorkerPool
+        And verify the database has mirrors
+        And all the segments are running
+        And the segments are synchronized
+        And verify that mirrors are recognized after a restart
+        And the tablespace is valid
+
+    Examples:
+        | args      | coordinator_workers |
+        | -B 1 -b 1 |  1                  |
+        | -B 2 -b 1 |  2                  |
+        | -B 1 -b 2 |  1                  |
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -504,6 +504,34 @@ def impl(context, command, out_msg, num):
         raise Exception("Expected %s to occur %s times. Found %d" % (out_msg, num, count))
 
 
+def lines_matching_both(in_str, str_1, str_2):
+    lines = [x.strip() for x in in_str.split('\n')]
+    return [x for x in lines if x.count(str_1) and x.count(str_2)]
+
+
+@then('check if {command} ran "{called_command}" {num} times with args "{args}"')
+def impl(context, command, called_command, num, args):
+    run_cmd_out = "Running Command: %s" % called_command
+    matches = lines_matching_both(context.stdout_message, run_cmd_out, args)
+
+    if len(matches) != int(num):
+        raise Exception("Expected %s to occur with %s args %s times. Found %d. \n %s"
+                        % (called_command, args, num, len(matches), context.stdout_message))
+
+
+@then('{command} should only spawn up to {num} workers in WorkerPool')
+def impl(context, command, num):
+    workerPool_out = "WorkerPool() initialized with"
+    matches = lines_matching_both(context.stdout_message, workerPool_out, command)
+
+    for matched_line in matches:
+        iw_re = re.search('initialized with (\d+) workers', matched_line)
+        init_workers = int(iw_re.group(1))
+        if init_workers > int(num):
+            raise Exception("Expected Workerpool for %s to be initialized with %d workers. Found %d. \n %s"
+                            % (command, num, init_workers, context.stdout_message))
+
+
 @given('{command} should return a return code of {ret_code}')
 @when('{command} should return a return code of {ret_code}')
 @then('{command} should return a return code of {ret_code}')


### PR DESCRIPTION
gpmovemirrors and gprecoverseg spawn more parallel processes than the options passed in.
This change fixes that, correctly limiting the number of parallel processes we can spawn on coordinator.
And also introduces an option to limit it on each individual host.

6X PR: https://github.com/greenplum-db/gpdb/pull/12000

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpmovemirrors_fix_parallel)