### PR TITLE
6X: pg_dump(all): Allow quote_all_identifiers for 8.3

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1335,7 +1335,7 @@ setup_connection(Archive *AH, const char *dumpencoding, char *use_role)
 	/*
 	 * Quote all identifiers, if requested.
 	 */
-	if (quote_all_identifiers && AH->remoteVersion >= 90100)
+	if (quote_all_identifiers && AH->remoteVersion >= 80300)
 		ExecuteSqlStatement(AH, "SET quote_all_identifiers = true");
 
 	/*

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -503,7 +503,7 @@ main(int argc, char *argv[])
 	}
 
 	/* Force quoting of all identifiers if requested. */
-	if (quote_all_identifiers && server_version >= 90100)
+	if (quote_all_identifiers && server_version >= 80300)
 		executeCommand(conn, "SET quote_all_identifiers = true");
 
 	fprintf(OPF,"--\n-- Greenplum Database cluster dump\n--\n\n");


### PR DESCRIPTION
`pg_dump/pg_dumpall --quote-all-identifiers` and the `quote_all_identifiers`
GUC ensures that all identifiers generated by the dump are quoted. This
facility was introduced in upsteam commit: ce68df468a in response to bug
report 5488, which dealt with a 8.3 table using "window" as a column
name, which lead to a failure to upgrade to 8.4 (window became a
reserved keyword in 8.4). Thus quoting all identifiers in the dump
output prevents problems due to newly introduced reserved keywords when
restoring to a higher version.

Also, since upstream commit 1c36700e9e3, `pg_upgrade` passes
`--quote-all-identifiers` to `pg_dumpall`.

However, `quote_all_identifiers`  was not backported below 9.1 (the
community considered it as unjustified cost to do so. See:
https://www.postgresql.org/message-id/15639.1367366007%40sss.pgh.pa.us)

This commit ensures that we make use of the GUC when 6X
`pg_dump/pg_dumpall` is run against 5X during an upgrade to 6X. Note that
a separate commit is going to backport the `quote_all_identifiers` GUC to
5X (PR: #11940).

In GP, with this feature, we get further benefits. GP maintains a
separate list of keywords and unreserved keywords for partitioned
tables, that differs from that of other objects. See: `PartitionIdentKeyword`
This is less than ideal and problematic.
So even though a certain keyword is non-reserved and can thus be used as
an identifier name, we would fail like:

```sql
CREATE TABLE rank (id int, rank int, year int, gender
char(1), count int)
DISTRIBUTED BY (id)
PARTITION BY RANGE (year)
( START (2006) END (2016) EVERY (1),
  DEFAULT PARTITION current );
ERROR:  syntax error at or near "current"
LINE 6:   DEFAULT PARTITION current );
```

Note that "current" is a non-reserved keyword.
Using the GUC and flag combo will ensure that we properly quote the
partition name during an upgrade:
`...DEFAULT PARTITION "current" );` which will restore successfully.

Additional notes:

* Attempts were made to reconcile the list of partition specific
keywords with the upstream list (unreserved_keyword). They were
abandoned as there were too many invasive changes to the parser. See:
https://github.com/greenplum-db/gpdb/pull/9984

* Postgres Bug 5488:
https://www.postgresql.org/message-id/flat/201006031326.o53DQt56017667%40wwwmaster.postgresql.org
