### PR TITLE
5X: Backport quote_all_identifiers GUC

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -123,6 +123,7 @@ static SPIPlanPtr plan_getrulebyoid = NULL;
 static const char *query_getrulebyoid = "SELECT * FROM pg_catalog.pg_rewrite WHERE oid = $1";
 static SPIPlanPtr plan_getviewrule = NULL;
 static const char *query_getviewrule = "SELECT * FROM pg_catalog.pg_rewrite WHERE ev_class = $1 AND rulename = $2";
+bool quote_all_identifiers;
 
 
 /* ----------
@@ -6580,6 +6581,9 @@ quote_identifier(const char *ident)
 				nquotes++;
 		}
 	}
+
+	if (quote_all_identifiers)
+		safe = false;
 
 	if (safe)
 	{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1197,6 +1197,15 @@ static struct config_bool ConfigureNamesBool[] =
 		false, NULL, NULL
 	},
 
+	{
+		{"quote_all_identifiers", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
+			gettext_noop("When generating SQL fragments, quote all identifiers."),
+			NULL,
+		},
+		&quote_all_identifiers,
+		false, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -511,6 +511,7 @@ max_appendonly_tables = 10000 # Maximum number of append only tables that can
 #backslash_quote = safe_encoding	# on, off, or safe_encoding
 #escape_string_warning = on
 #regex_flavor = advanced		# advanced, extended, or basic
+#quote_all_identifiers = off
 #standard_conforming_strings = on
 #synchronize_seqscans = on
 

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -588,6 +588,7 @@ extern Datum record_recv(PG_FUNCTION_ARGS);
 extern Datum record_send(PG_FUNCTION_ARGS);
 
 /* ruleutils.c */
+extern bool quote_all_identifiers;
 extern Datum pg_get_ruledef(PG_FUNCTION_ARGS);
 extern Datum pg_get_ruledef_ext(PG_FUNCTION_ARGS);
 extern Datum pg_get_viewdef(PG_FUNCTION_ARGS);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -7962,3 +7962,82 @@ select * from exchange_part;
 
 drop table exchange_part;
 drop table exchange1;
+-- check if partition names having keywords (reserved, non-reserved and
+-- unclassified) are properly quoted when dumped with the quote_all_identifiers
+-- GUC set. For a comprehensive list, please refer:
+-- https://www.postgresql.org/docs/8.3/sql-keywords-appendix.html
+SET quote_all_identifiers TO on;
+CREATE TABLE t_quote_test (a int, b int, c int, d int, e text)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        SUBPARTITION BY RANGE (c)
+            SUBPARTITION TEMPLATE (
+            START (1) END (2) EVERY (1),
+            DEFAULT SUBPARTITION "current" )
+        SUBPARTITION BY LIST (e)
+            SUBPARTITION TEMPLATE (
+            SUBPARTITION "at" VALUES ('val1'),
+            SUBPARTITION "window" VALUES ('val2'),
+            DEFAULT SUBPARTITION dsp )
+        ( START (2002) END (2003) EVERY (1),
+        DEFAULT PARTITION dp );
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp" for table "t_quote_test"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_current" for table "t_quote_test_1_prt_dp"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_current_3_prt_at" for table "t_quote_test_1_prt_dp_2_prt_current"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_current_3_prt_window" for table "t_quote_test_1_prt_dp_2_prt_current"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_current_3_prt_dsp" for table "t_quote_test_1_prt_dp_2_prt_current"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_2" for table "t_quote_test_1_prt_dp"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_2_3_prt_at" for table "t_quote_test_1_prt_dp_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_2_3_prt_window" for table "t_quote_test_1_prt_dp_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_dp_2_prt_2_3_prt_dsp" for table "t_quote_test_1_prt_dp_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2" for table "t_quote_test"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_current" for table "t_quote_test_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_current_3_prt_at" for table "t_quote_test_1_prt_2_2_prt_current"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_current_3_prt_window" for table "t_quote_test_1_prt_2_2_prt_current"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_current_3_prt_dsp" for table "t_quote_test_1_prt_2_2_prt_current"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_2" for table "t_quote_test_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_2_3_prt_at" for table "t_quote_test_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_2_3_prt_window" for table "t_quote_test_1_prt_2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "t_quote_test_1_prt_2_2_prt_2_3_prt_dsp" for table "t_quote_test_1_prt_2_2_prt_2"
+SELECT pg_get_partition_def('t_quote_test'::regclass, true, true);
+                                                                  pg_get_partition_def                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ PARTITION BY RANGE("b")                                                                                                                                 
+           SUBPARTITION BY RANGE("c")                                                                                                                    
+                   SUBPARTITION BY LIST("e")                                                                                                             
+           (                                                                                                                                             
+           START (2002) END (2003) EVERY (1) WITH (tablename='t_quote_test_1_prt_2', appendonly=false )                                                  
+                   (                                                                                                                                     
+                   START (1) END (2) EVERY (1) WITH (tablename='t_quote_test_1_prt_2_2_prt_2', appendonly=false )                                        
+                           (                                                                                                                             
+                           SUBPARTITION "at" VALUES('val1') WITH (tablename='t_quote_test_1_prt_2_2_prt_2_3_prt_at', appendonly=false ),                 
+                           SUBPARTITION "window" VALUES('val2') WITH (tablename='t_quote_test_1_prt_2_2_prt_2_3_prt_window', appendonly=false ),         
+                           DEFAULT SUBPARTITION "dsp"  WITH (tablename='t_quote_test_1_prt_2_2_prt_2_3_prt_dsp', appendonly=false )                      
+                           ),                                                                                                                            
+                   DEFAULT SUBPARTITION "current"  WITH (tablename='t_quote_test_1_prt_2_2_prt_current', appendonly=false )                              
+                           (                                                                                                                             
+                           SUBPARTITION "at" VALUES('val1') WITH (tablename='t_quote_test_1_prt_2_2_prt_current_3_prt_at', appendonly=false ),           
+                           SUBPARTITION "window" VALUES('val2') WITH (tablename='t_quote_test_1_prt_2_2_prt_current_3_prt_window', appendonly=false ),   
+                           DEFAULT SUBPARTITION "dsp"  WITH (tablename='t_quote_test_1_prt_2_2_prt_current_3_prt_dsp', appendonly=false )                
+                           )                                                                                                                             
+                   ),                                                                                                                                    
+           DEFAULT PARTITION "dp"  WITH (tablename='t_quote_test_1_prt_dp', appendonly=false )                                                           
+                   (                                                                                                                                     
+                   START (1) END (2) EVERY (1) WITH (tablename='t_quote_test_1_prt_dp_2_prt_2', appendonly=false )                                       
+                           (                                                                                                                             
+                           SUBPARTITION "at" VALUES('val1') WITH (tablename='t_quote_test_1_prt_dp_2_prt_2_3_prt_at', appendonly=false ),                
+                           SUBPARTITION "window" VALUES('val2') WITH (tablename='t_quote_test_1_prt_dp_2_prt_2_3_prt_window', appendonly=false ),        
+                           DEFAULT SUBPARTITION "dsp"  WITH (tablename='t_quote_test_1_prt_dp_2_prt_2_3_prt_dsp', appendonly=false )                     
+                           ),                                                                                                                            
+                   DEFAULT SUBPARTITION "current"  WITH (tablename='t_quote_test_1_prt_dp_2_prt_current', appendonly=false )                             
+                           (                                                                                                                             
+                           SUBPARTITION "at" VALUES('val1') WITH (tablename='t_quote_test_1_prt_dp_2_prt_current_3_prt_at', appendonly=false ),          
+                           SUBPARTITION "window" VALUES('val2') WITH (tablename='t_quote_test_1_prt_dp_2_prt_current_3_prt_window', appendonly=false ),  
+                           DEFAULT SUBPARTITION "dsp"  WITH (tablename='t_quote_test_1_prt_dp_2_prt_current_3_prt_dsp', appendonly=false )               
+                           )                                                                                                                             
+                   )                                                                                                                                     
+           )
+(1 row)
+
+DROP TABLE t_quote_test;
+RESET quote_all_identifiers;


### PR DESCRIPTION
This backports ONLY the quote_all_identifiers GUC from upstream commit:
ce68df4 (leaves the --quote-all-identifiers options alone).

This is done in response to customer issues with upgrades involving
reserved/unreserved keywords in partition names. This commit, in
combination with future version PRs such as for 6X: PR #11939, enables
future major versions of pg_dump(all) binaries to dump these names in a
safe manner when executed against a 5X server (which is typical during
an upgrade).  Please refer to #11939 for more detailed commentary.

A test is also added to partition.sql to exercise the GUC with
partitioned tables carrying keywords.

Original commit message follows from Robert Haas:---------------------

Add options to force quoting of all identifiers.

I've added a quote_all_identifiers GUC which affects the behavior
of the backend, and a --quote-all-identifiers argument to pg_dump
and pg_dumpall which sets the GUC and also affects the quoting done
internally by those applications.

Design by Tom Lane; review by Alex Hunsaker; in response to bug #5488
filed by Hartmut Goebel.