### PR TITLE
Fix travis clang-11 dependencies issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,9 @@ matrix:
           dist: focal
           addons:
             apt:
+              sources:
+                - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+                  key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
               packages:
                 - ninja-build
                 - clang-11
@@ -120,6 +123,9 @@ matrix:
           dist: focal
           addons:
             apt:
+              sources:
+                - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+                  key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
               packages:
                 - clang-format-11
                 - parallel


### PR DESCRIPTION
Ubuntu vanilla 20.04 (focal) doesn't have clang-11, it's in
focal-updates, use llvm apt source then.

ref: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=clang-11&searchon=names