### PR TITLE
Workaround yanked libc version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,11 @@ matrix:
           addons:
             apt:
               packages:
+                # FIXME: the following two are workarounds for broken libc version in Travis
+                # BEGIN HACK
+                - libc6-dev=2.31-0ubuntu9.2
+                - libc6=2.31-0ubuntu9.2
+                # END HACK
                 - ninja-build
                 - clang-11
                 - clang-tidy-11


### PR DESCRIPTION
Canonical yanked a (higher) version of libc6 from Ubuntu Focal recently after the Travis CI image was built, leaving us with a fairly mysterious package installation conflict.

Until Travis publishes a new image, work around this by downgrading libc to the published and available version to unblock CI.
