### PR TITLE
6X: Improve getversion logic when .git directory does not exist.

### DIFF
--- a/getversion
+++ b/getversion
@@ -30,15 +30,15 @@ if type git >/dev/null 2>&1 && [ -d '.git' ] ; then
 	fi
 # If not a git repository and VERSION file exists, use version string from file.
 elif [[ -s ./VERSION ]]; then
-	cat ./VERSION
-	exit 0
+	VERSION=$(awk -F' build ' '{print $1}' ./VERSION)
+	BUILDNUMBER=$(awk -F' build ' '{print $2}' ./VERSION)
 fi
 
 FLAG="${1:-noflag}"
 if [ "$FLAG" = '--short' ] ; then
     echo "${VERSION}"
 else
-    if [ -f BUILD_NUMBER ] ; then
+    if [[ ${BUILDNUMBER} = 'dev' && -f BUILD_NUMBER ]] ; then
         BUILDNUMBER=`cat BUILD_NUMBER`
     fi
     echo "${VERSION} build ${BUILDNUMBER}"


### PR DESCRIPTION
Allow `./getversion` and `./getversion --short` commands to function as expected when source directory is not a git repo and a VERSION file exists.

```
./getversion
TAG build commit:SHA

./getversion --short
TAG
```
Authored-by: Brent Doil <bdoil@vmware.com>