### PR TITLE
7X: getversion: If not a git repository and VERSION file exists, derive version from file.

### DIFF
--- a/getversion
+++ b/getversion
@@ -28,13 +28,17 @@ if type git >/dev/null 2>&1 && [ -d '.git' ] ; then
 		VERSION+=+
 		VERSION+=$(git rev-parse --short HEAD)
 	fi
+# If not a git repository and VERSION file exists, use version string from file.
+elif [[ -s ./VERSION ]]; then
+	VERSION=$(awk -F' build ' '{print $1}' ./VERSION)
+	BUILDNUMBER=$(awk -F' build ' '{print $2}' ./VERSION)
 fi
 
 FLAG="${1:-noflag}"
 if [ "$FLAG" = '--short' ] ; then
     echo "${VERSION}"
 else
-    if [ -f BUILD_NUMBER ] ; then
+    if [[ ${BUILDNUMBER} = 'dev' && -f BUILD_NUMBER ]] ; then
         BUILDNUMBER=`cat BUILD_NUMBER`
     fi
     echo "${VERSION} build ${BUILDNUMBER}"


### PR DESCRIPTION
Allow `./getversion` and `./getversion --short` commands to function as expected when source does not contain a `.git` directory and a non-empty VERSION file exists in the source top directory.

```
./getversion
TAG build commit:SHA

./getversion --short
TAG
```
Authored-by: Brent Doil <bdoil@vmware.com>
