### PR TITLE
Constraint Interval of BoolopAnd childs under Not

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -55,6 +55,10 @@ private:
 	// does the interval include the null value
 	BOOL m_fIncludesNull;
 
+	// set to true if any of the constraint interval for a scalar expression
+	// child cannot be created
+	BOOL m_is_partial;
+
 	// hidden copy ctor
 	CConstraintInterval(const CConstraintInterval &);
 
@@ -120,7 +124,7 @@ private:
 public:
 	// ctor
 	CConstraintInterval(CMemoryPool *mp, const CColRef *colref,
-						CRangeArray *pdrgprng, BOOL is_null);
+						CRangeArray *pdrgprng, BOOL is_null, BOOL is_partial=false);
 
 	// dtor
 	virtual ~CConstraintInterval();
@@ -250,6 +254,10 @@ public:
 	static CConstraintInterval *PcnstrIntervalFromScalarArrayCmp(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref,
 		BOOL infer_nulls_as = false);
+
+	BOOL IsPartial();
+
+	void SetIsPartial();
 
 };	// class CConstraintInterval
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13357,3 +13357,15 @@ select enable_xform('CXformInnerJoin2NLJoin');
 
 reset optimizer_enable_hashjoin;
 reset optimizer_trace_fallback;
+-- ensure that orca does not evaluate the max card to be zero
+-- based on constraint contradiction and must return a row
+create table constraints_tbl (a int, b int, check (NOT(b IS NOT NULL AND b IN (1, 2))));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into constraints_tbl values (1, 3);
+select * from constraints_tbl where b=3;
+ a | b 
+---+---
+ 1 | 3
+(1 row)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13612,3 +13612,15 @@ select enable_xform('CXformInnerJoin2NLJoin');
 
 reset optimizer_enable_hashjoin;
 reset optimizer_trace_fallback;
+-- ensure that orca does not evaluate the max card to be zero
+-- based on constraint contradiction and must return a row
+create table constraints_tbl (a int, b int, check (NOT(b IS NOT NULL AND b IN (1, 2))));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into constraints_tbl values (1, 3);
+select * from constraints_tbl where b=3;
+ a | b 
+---+---
+ 1 | 3
+(1 row)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2875,6 +2875,12 @@ select enable_xform('CXformInnerJoin2NLJoin');
 reset optimizer_enable_hashjoin;
 reset optimizer_trace_fallback;
 
+-- ensure that orca does not evaluate the max card to be zero
+-- based on constraint contradiction and must return a row
+create table constraints_tbl (a int, b int, check (NOT(b IS NOT NULL AND b IN (1, 2))));
+insert into constraints_tbl values (1, 3);
+select * from constraints_tbl where b=3;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
If constraint creation fails for any of the child of BoolopAnd mark
m_is_partial flag to true. This allows the constraint to be rejected
if under NOT operator.

Earlier, even if one of the child constraint interval was created it was
returned as the constraint interval for the input scalar expression
which was incorrect if it was under NOT operator.
For instance, if a scalar condition is like below:
  Input: NOT (b in (1,2) and b is not NULL)
The returned constraint interval ignored the condition b in (1,2)
and applied a compliment on the constraint interval: (-inf, inf). Thus,
the returned constraint does not represent the original scalar
condition and was incorrect.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
