### PR TITLE
Avoid dispatch OIDs during planning when refresh matview.

### DIFF
--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -193,6 +193,12 @@ ClearOidAssignmentsOnCommit(void)
 	preserve_oids_on_commit = false;
 }
 
+extern void
+RestoreOidAssignments(List *oid_assignments)
+{
+	dispatch_oids = oid_assignments;
+}
+
 /* ----------------------------------------------------------------
  * Functions for use in QE.
  * ----------------------------------------------------------------

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -116,6 +116,7 @@ extern void RememberPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid chil
 /* Functions used in master and QE nodes */
 extern void PreserveOidAssignmentsOnCommit(void);
 extern void ClearOidAssignmentsOnCommit(void);
+extern void RestoreOidAssignments(List *oid_assignments);
 
 /* Functions used in binary upgrade */
 extern bool IsOidAcceptable(Oid oid);

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -621,3 +621,20 @@ SELECT * FROM mvtest2;
 ERROR:  materialized view "mvtest2" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
 ROLLBACK;
+-- make sure refresh mat view will dispatch oid at the final
+-- execution of the mat view's body query. See Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/11956 for details.
+create table t_github_issue_11956(a int, b int) distributed randomly;
+insert into t_github_issue_11956 values (1, 1);
+create function f_github_issue_11956() returns int as
+$$
+select sum(a+b)::int from t_github_issue_11956
+$$
+language sql stable;
+create materialized view mat_view_github_issue_11956
+as
+select * from t_github_issue_11956 where a > f_github_issue_11956()
+distributed randomly;
+refresh materialized view mat_view_github_issue_11956;
+drop materialized view mat_view_github_issue_11956;
+drop table t_github_issue_11956;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -631,3 +631,20 @@ SELECT * FROM mvtest2;
 ERROR:  materialized view "mvtest2" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
 ROLLBACK;
+-- make sure refresh mat view will dispatch oid at the final
+-- execution of the mat view's body query. See Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/11956 for details.
+create table t_github_issue_11956(a int, b int) distributed randomly;
+insert into t_github_issue_11956 values (1, 1);
+create function f_github_issue_11956() returns int as
+$$
+select sum(a+b)::int from t_github_issue_11956
+$$
+language sql stable;
+create materialized view mat_view_github_issue_11956
+as
+select * from t_github_issue_11956 where a > f_github_issue_11956()
+distributed randomly;
+refresh materialized view mat_view_github_issue_11956;
+drop materialized view mat_view_github_issue_11956;
+drop table t_github_issue_11956;

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -235,3 +235,26 @@ SELECT mvtest_func();
 SELECT * FROM mvtest1;
 SELECT * FROM mvtest2;
 ROLLBACK;
+
+-- make sure refresh mat view will dispatch oid at the final
+-- execution of the mat view's body query. See Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/11956 for details.
+
+create table t_github_issue_11956(a int, b int) distributed randomly;
+insert into t_github_issue_11956 values (1, 1);
+
+create function f_github_issue_11956() returns int as
+$$
+select sum(a+b)::int from t_github_issue_11956
+$$
+language sql stable;
+
+create materialized view mat_view_github_issue_11956
+as
+select * from t_github_issue_11956 where a > f_github_issue_11956()
+distributed randomly;
+
+refresh materialized view mat_view_github_issue_11956;
+
+drop materialized view mat_view_github_issue_11956;
+drop table t_github_issue_11956;


### PR DESCRIPTION
Refresh materialized view will first create a temp table on QD, this will
save the table's oid in static variable of QD, dispatch will use it. Then
QD try to execute the query, first generate a plan, it might pre-evaluted
some function during planning, if the function invokes SQL, it will lead
to dispatch and consume the oids. So later dispatch ref mat view will
dispatch no OIDs.

This comit fixes this by first saving the OIDs before planning the matview's
body query and then restoring it when dispatching the ref query.

Fix Github Issue: https://github.com/greenplum-db/gpdb/issues/11956
