### PR TITLE
Prevent REINDEX TABLE partitioned table statement in transaction block

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -948,7 +948,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 						ReindexIndex(stmt);
 						break;
 					case REINDEX_OBJECT_TABLE:
-						ReindexTable(stmt);
+						ReindexTable(stmt, isTopLevel);
 						break;
 					case REINDEX_OBJECT_SCHEMA:
 					case REINDEX_OBJECT_SYSTEM:

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -38,7 +38,7 @@ extern ObjectAddress DefineIndex(Oid relationId,
 								 bool quiet,
 								 bool is_new_table);
 extern void ReindexIndex(ReindexStmt *stmt);
-extern Oid	ReindexTable(ReindexStmt *stmt);
+extern Oid	ReindexTable(ReindexStmt *stmt, bool isTopLevel);
 extern void ReindexMultipleTables(const char *objectName, ReindexObjectType objectKind,
 								  int options, bool concurrent);
 extern char *makeObjectName(const char *name1, const char *name2,

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -631,3 +631,51 @@ select relhassubclass from pg_class where relname = 'gpidxpart_idx';
 (1 row)
 
 drop index gpidxpart_idx;
+-- GPDB: Prevent REINDEX TABLE on partitioned table run in transaction block.
+-- Since we expand partitioned table when do the reindex, and try to reindex
+-- each table in new transaction, this will lead non-rollback-able side effects.
+create table reindex_part(id int, r int) partition by range (r);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table reindex_part_1 partition of reindex_part for values from (1) TO (11);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table reindex_part_2 partition of reindex_part for values from (11) TO (21);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create index reidx_idx on reindex_part (id);
+-- This should raise error
+begin;
+reindex table reindex_part;
+ERROR:  REINDEX TABLE(on partitioned table) cannot run inside a transaction block
+end;
+-- This should success
+begin;
+reindex table reindex_part_1;
+end;
+-- This should raise error
+CREATE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ERROR:  REINDEX TABLE(on partitioned table) cannot be executed from a function
+CONTEXT:  SQL statement "reindex table reindex_part"
+PL/pgSQL function reindex_in_func() line 3 at SQL statement
+-- This should success
+CREATE OR REPLACE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part_1;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ reindex_in_func 
+-----------------
+ 
+(1 row)
+
+drop table reindex_part;
+drop function reindex_in_func();


### PR DESCRIPTION
As different from upstream, we support REINDEX TABLE on partitioned
table which will expand the partitioned table and start new transaction
to do the reindex for each table. This will have non-rollback-able side
effects, so we need to make sure it must not run inside a transaction
block.
This fix is related to issue https://github.com/greenplum-db/gpdb/issues/11948.
Although it happens on 6X only.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
