### PR TITLE
fix missing DESTDIR in pygresql Makefile target

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -76,7 +76,7 @@ PYGRESQL_DIR=PyGreSQL-$(PYGRESQL_VERSION)
 pygresql:
 	@echo "--- PyGreSQL"
 	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PYGRESQL_DIR).tar.gz
-	cd $(PYLIB_SRC_EXT)/$(PYGRESQL_DIR)/ && PATH=$(bindir):$$PATH LDFLAGS='$(LDFLAGS) $(PYGRESQL_LDFLAGS)' python3 setup.py build
+	cd $(PYLIB_SRC_EXT)/$(PYGRESQL_DIR)/ && PATH=$(DESTDIR)$(bindir):$$PATH LDFLAGS='$(LDFLAGS) $(PYGRESQL_LDFLAGS)' python3 setup.py build
 	cp -r $(PYLIB_SRC_EXT)/$(PYGRESQL_DIR)/build/lib*-3*/* $(PYLIB_DIR)/
 
 


### PR DESCRIPTION
Mentioned mistake makes impossible to proceed install
with custom DESTDIR

There are recommendations about PyGreSQL and Postgres components from system repositories:

1. https://github.com/greenplum-db/gpdb/blob/c3846b85afab67496717a348b69283367f38066e/python-dependencies.txt#L2
2. https://github.com/greenplum-db/gpdb/blob/c3846b85afab67496717a348b69283367f38066e/README.CentOS.bash#L28-L31

But gpdb builds PyGreSQL from its submodule with python modules now. Do we really need these dependencies?

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
