### PR TITLE
[5X only] Defensive check to catch invalid page LSN as early as possible

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -35,7 +35,7 @@ function configure() {
 
 function make_cluster() {
   source /usr/local/greenplum-db-devel/greenplum_path.sh
-  export BLDWRAP_POSTGRES_CONF_ADDONS=${BLDWRAP_POSTGRES_CONF_ADDONS}
+  export BLDWRAP_POSTGRES_CONF_ADDONS="${BLDWRAP_POSTGRES_CONF_ADDONS} gp_debug_invalid_page_lsn=on"
   # Currently, the max_concurrency tests in src/test/isolation2
   # require max_connections of at least 129.
   export DEFAULT_QD_MAX_CONNECT=150

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -177,6 +177,7 @@ int			Test_blocksize_override = 0;
 int			Test_safefswritesize_override = 0;
 bool		Master_mirroring_administrator_disable = false;
 int			gp_max_local_distributed_cache = 1024;
+bool		gp_debug_invalid_page_lsn = false;
 bool		gp_appendonly_verify_block_checksums = true;
 bool		gp_appendonly_verify_write_block = false;
 bool		gp_appendonly_verify_eof = true;
@@ -1127,6 +1128,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_debug_pgproc,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_debug_invalid_page_lsn", PGC_SIGHUP, DEVELOPER_OPTIONS,
+			gettext_noop("PANIC if invalid LSN is assigned to a heap page."),
+			NULL /* long description */ ,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_debug_invalid_page_lsn,
 		false, NULL, NULL
 	},
 

--- a/src/include/storage/bufpage.h
+++ b/src/include/storage/bufpage.h
@@ -383,11 +383,16 @@ PageGetLSN(Page page)
 	return ((PageHeader) page)->pd_lsn;
 }
 
+extern bool gp_debug_invalid_page_lsn;
 /*
  * Additional macros for access to page headers
  */
-#define PageSetLSN(page, lsn) \
-	(((PageHeader) (page))->pd_lsn = (lsn))
+#define PageSetLSN(page, lsn)												\
+	do {																	\
+		if (gp_debug_invalid_page_lsn && XLogRecPtrIsInvalid(lsn))			\
+			elog(PANIC, "setting invalid LSN");								\
+		(((PageHeader) (page))->pd_lsn = (lsn));							\
+	} while (0)
 
 #define PageHasFreeLinePointers(page) \
 	(((PageHeader) (page))->pd_flags & PD_HAS_FREE_LINES)

--- a/src/test/binary_swap/test_binary_swap.sh
+++ b/src/test/binary_swap/test_binary_swap.sh
@@ -142,6 +142,7 @@ clean_output
 start_binary $GPHOME_CURRENT
 run_pre_test
 run_tests schedule1${VARIANT}
+gpconfig -r gp_debug_invalid_page_lsn --skipvalidation
 
 ## Change the binary, dump, and then compare the two dumps generated
 ## by both binaries. Then we do some inserts and dump again. We source


### PR DESCRIPTION
In a production deployment, several on-disk pages of a relation were found to have invalid LSN (all zeros).  The problem was uncovered only when queries were made against the table and "invalid page in block ..." errors were reported.  It was already too late to diagnose the problem afterwards, beause the LSN might have been invalidated way back in the past.  A page with invalid LSN should never be written to disk.  This patch introduces a check in PageSetLSN API.  PANIC level message is
generated if LSN being set is invalid.  The core file generated subsequently should provide some clues on the problem.

Let us hope that this is a temporary workaround and we are able to revert it by solving the mystery.

This is a 5X only patch.  Although the `PageSetLSN()` API exists in 6X, the code is significantly diverged by merging several versions of upstream PostgreSQL (8.3 to 9.4) and a major portion of legacy code is eliminated in 6X.  Until we solve this mystery on 5X, it seems premature to add the check to 6X and above.