### PR TITLE
Material operator does not support projection.

### DIFF
--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -304,15 +304,6 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 	}
 
 	outerPlan = outerPlan(node);
-	/*
-	 * A very basic check to see if the optimizer requires the material to do a projection.
-	 * Ideally, this check would recursively compare all the target list expressions. However,
-	 * such a check is tricky because of the varno mismatch (outer plan may have a varno that
-	 * index into range table, while the material may refer to the same relation as "outer" varno)
-	 * [JIRA: MPP-25365]
-	 */
-	if (list_length(node->plan.targetlist) != list_length(outerPlan->targetlist))
-		elog(ERROR, "Material operator does not support projection");
 	outerPlanState(matstate) = ExecInitNode(outerPlan, estate, eflags);
 
 	/*


### PR DESCRIPTION
As mentioned in [groups](https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/lVqSGTMame8/m/PukQrW2WBwAJ), over the past month we've seen two people which faced the following error during sql execution.
`ERROR: Material operator does not support projection (nodeMaterial.c:361)`

Based on the [comment](https://github.com/greenplum-db/gpdb/blob/24f51bb06b8595ca2dc583004b5191fad72f4e4c/src/backend/executor/nodeMaterial.c#L307) above the check, I was planning to make a quick fix which will respect the case when outerPlan's _targetList_ contains only vars with non-special _varno_ values and all varno's values are the same.
Digging deeper, I starting to think I misunderstood the problem and we probably don't need this check at all. Asim [agrees](https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/lVqSGTMame8/m/xwu1ePO-CAAJ), but relies to someone more knowledgeable to make a conclusion.

The following proof works on 6X and 5X, but the problem can shoot on master branch someday.
> create table material_test(first_id int, second_id int);
> create index material_test_idx on material_test using btree (second_id);
> create table material_test2(first_id int, second_id int);
> 
> insert into material_test select generate_series(1,100), generate_series(1,100);
> insert into material_test2 select generate_series(1,100), generate_series(1,100);
> insert into material_test select generate_series(1,10000), generate_series(1,10000);
> insert into material_test2 select generate_series(1,10000), generate_series(1,10000);
> 
> analyze material_test;
> analyze material_test2;
> 
> with mat_w as (
> 	select first_id
> 	from material_test
> 	where second_id in (1,2,3,4)
> )
> select first_id
> from material_test2
> where first_id in (select first_id from mat_w)
> and first_id in (select first_id from mat_w);



_This is not a ready-to-go PR, but rather a starting point, which, at this time, only removes obsolete check._