### PR TITLE
gprecoverseg: Skip pg_hba update on non-failed hosts

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -645,7 +645,8 @@ class GpRecoverSegmentProgram:
             if new_hosts:
                 self.syncPackages(new_hosts)
 
-            config_primaries_for_replication(gpArray, self.__options.hba_hostnames)
+            contentsToUpdate = [seg.getLiveSegment().getSegmentContentId() for seg in mirrorBuilder.getMirrorsToBuild()]
+            config_primaries_for_replication(gpArray, self.__options.hba_hostnames, contentsToUpdate)
             if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
                 sys.exit(1)
 


### PR DESCRIPTION
Currently, when recovering segments gprecoverseg updates the pg_hba.conf
entries on every acting primary regardless of whether those primaries
have mirrors to be recovered.  This commit restricts the update to only
those primaries that need to be updated.