### PR TITLE
[6X backport] Fix the double-free issue of work_set

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -546,7 +546,13 @@ workfile_mgr_create_set(const char *operator_name, const char *prefix, bool hold
 
 	if (!proc_exit_hook_registered)
 	{
-		/* register proc-exit hook to ensure temp files are dropped at exit */
+		/*
+		 * register proc-exit hook to ensure temp files are dropped at exit.
+		 *
+		 * The hook must run after before_shmem_exit(), because before_shmem_exit may do
+		 * some cleanup in transaction level, but AtProcExit_WorkFile cleans up the session
+		 * level objects which may be referenced by some short-life objects, e.g. executor nodes.
+		 */
 		on_shmem_exit(AtProcExit_WorkFile, 0);
 		proc_exit_hook_registered = true;
 	}

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -547,7 +547,7 @@ workfile_mgr_create_set(const char *operator_name, const char *prefix, bool hold
 	if (!proc_exit_hook_registered)
 	{
 		/* register proc-exit hook to ensure temp files are dropped at exit */
-		before_shmem_exit(AtProcExit_WorkFile, 0);
+		on_shmem_exit(AtProcExit_WorkFile, 0);
 		proc_exit_hook_registered = true;
 	}
 


### PR DESCRIPTION
The workfile_set(or work_set referenced in the code) is used to
track the usage of the temporary files. For example, in hash join,
if the hash table is too large to put them all in the memory,
the hash table is split and saved in temporary files. When the
transaction is finished(no matter commit or abort), the workfile_set
referenced by the executor node will be freed(reference count).
There are also other workfile_set with different lifecycle(e.g. session).
The backend records the usage of the workfile_set in its local memory,
and it will free all the `workfile_set`s in the callback(AtProcExit_WorkFile)
when the backend is going to exit.

The problem is that the function `AtProcExit_WorkFile` is called before
the cleanup of the current transaction. So, the executor node may free
the workfile_set after all `workfile_set` in the current backend have been
freed.
The following backtrace shows a PANIC issue:
```
2021-05-12 01:35:59.902395 UTC,"gpadmin","gpadmin",p11681,th-22202240,"127.0.0.1","15174",2021-05-12 01:35:56 UTC,0,con10,cmd4,seg-1,,dx5,,sx1,"PANIC","XX000","workfile_set is not active",,,,,,,0,,"workfile_mgr.c",697,"Stack trace:
1    0xe0c7e4 postgres errstart (elog.c:557)
2    0xe99372 postgres workfile_mgr_close_set (workfile_mgr.c:697)
3    0xa8f36c postgres ExecHashTableDestroy (nodeHash.c:694)
4    0xa9347a postgres ExecEndHashJoin (nodeHashjoin.c:763)
5    0xa6b335 postgres ExecEndNode (execProcnode.c:1444)
6    0xa934ee postgres ExecEndHashJoin + 0xcc
7    0xa6b335 postgres ExecEndNode + 0x2ff
8    0xa8e7c5 postgres ExecEndHash + 0x30
9    0xa6b3ac postgres ExecEndNode + 0x376
10   0xa934fe postgres ExecEndHashJoin + 0xdc
11   0xa6b335 postgres ExecEndNode + 0x2ff
12   0xa64d7e postgres <symbol not found> (discriminator 2)
13   0xa61e3e postgres standard_ExecutorEnd + 0x381
14   0xa61aba postgres ExecutorEnd + 0x36
15   0x9ef89a postgres PortalCleanup (portalcmds.c:326)
16   0xe52e54 postgres AtAbort_Portals (portalmem.c:837)
17   0x8626ac postgres <symbol not found> (xact.c:3297)
18   0x864e02 postgres AbortOutOfAnyTransaction + 0x6e
19   0xe2894d postgres <symbol not found> (postinit.c:1348)
20   0xc6c672 postgres shmem_exit (ipc.c:256)
21   0xc6c567 postgres proc_exit_prepare + 0xcb
22   0xc6c465 postgres proc_exit (ipc.c:143)
23   0xca35ea postgres PostgresMain (postgres.c:5679)
24   0xc0f41c postgres <symbol not found> (postmaster.c:5442)
25   0xc0eaad postgres <symbol not found> + 0xc0eaad
26   0xc0a8ef postgres <symbol not found> + 0xc0a8ef
27   0xc09e3b postgres PostmasterMain + 0x12e5
28   0xb02495 postgres <symbol not found> (main.c:264)
29   0x7fb5fbb94505 libc.so.6 __libc_start_main + 0xf5
30   0x7b4729 postgres <symbol not found> + 0x7b4729
"
```

The issue occurs in JDBC. The driver uses extended query, after running
`exec_bind_message()` and `exec_execute_message()`, the portal is still
alive and its status is PORTAL_READY. When the user presses Ctl-C to
kill the session, the backend starts to do some cleanup and exit.

This commit reorder the cleanup function of the workfile_set(`AtProcExit_WorkFile`).
So, the `workfile_set` referenced in the executor node will be freed first,
then `AtProcExit_WorkFile` frees all remaining `workfile_set`s used by
the current backend.

Co-authored-by: Gang Xiong <gangx@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
