### PR TITLE
Fix the bug that the global transacation is not aborted when the session is reset.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -265,6 +265,7 @@ cdbdisp_finishCommand(struct CdbDispatcherState *ds)
 	}
 	PG_END_TRY();
 
+	SIMPLE_FAULT_INJECTOR(CdbDispFinishCommand);
 	/*
 	 * If no errors, free the CdbDispatchResults objects and return.
 	 */

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1342,7 +1342,7 @@ static bool cleanupGang(Gang *gp)
 		{
 			/* If cluster is reconfigured during a transaction, then error out */
 			if (IsTransactionState())
-				elog(ERROR, "cluster is reconfigured during a transaction");
+				elog(ERROR, "gang was lost due to cluster reconfiguration");
 			return false;
 		}
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1339,7 +1339,12 @@ static bool cleanupGang(Gang *gp)
 
 		/* if segment is down, the gang can not be reused */
 		if (!FtsTestConnection(segdbDesc->segment_database_info, false))
+		{
+			/* If cluster is reconfigured during a transaction, then error out */
+			if (IsTransactionState())
+				elog(ERROR, "cluster is reconfigured during a transaction");
 			return false;
+		}
 
 		/* Note, we cancel all "still running" queries */
 		if (!cdbconn_discardResults(segdbDesc, 20))

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -373,6 +373,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault when creating new TOAST tables, to modify the chunk size */
 	_("abort_after_procarray_end"),
 		/* inject fault in AbortTransaction after ProcArrayEndTransaction */
+	_("cdbdisp_finish_command"),
+		/* inject fault in cdbdisp_finishCommand */
 	_("not recognized"),
 };
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -254,6 +254,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	AbortAfterProcarrayEnd,
 
+	CdbDispFinishCommand,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -1,0 +1,89 @@
+-- This test performs segment reconfiguration when a distributed
+-- transaction is in progress. The expectation is that the first
+-- command in the transaction after reconfiguration should fail. It
+-- verifies a bug where a stale gang was reused in such a case, if the
+-- failed primary happened to be up and listening.
+
+-- start_ignore
+! gpconfig -c gp_fts_probe_timeout -v 2;
+
+! gpconfig -c gp_fts_probe_interval -v '10s';
+
+! gpstop -rai;
+-- end_ignore
+
+create table test_fts_session_reset(c1 int);
+CREATE
+create table test_fts_session_reset2(c1 int);
+CREATE
+insert into test_fts_session_reset2 values(1);
+INSERT 1
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- Helper function
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+create or replace function wait_until_all_segments_synchronized() returns text as $$ begin for i in 1..1200 loop if (select count(*) = 0 from gp_segment_configuration where content != -1 and mode != 's') then return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+1: BEGIN;
+BEGIN
+-- inject a fault in funcion cdbdisp_finish_command on coordinator, to suspend the execution of insert statement.
+1: select gp_inject_fault_new('cdbdisp_finish_command', 'suspend', dbid) from gp_segment_configuration where content=-1 and role='p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+-- insert data, it will hang here
+1&: insert into test_fts_session_reset select * from generate_series(1,20);  <waiting ...>
+
+-- inject a fault in primary segment, that will cause the coordinator to mark this primary down.
+3: select gp_inject_fault_new('segment_probe_response', 'sleep', '', '', '', 1, -1, 600, dbid) from gp_segment_configuration where content=0 and preferred_role='p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+-- wait one primary become down.
+2: select wait_until_segments_are_down(1);
+wait_until_segments_are_down
+----------------------------
+t                           
+(1 row)
+-- reset the fault in session1 to make session1 continue
+2: select gp_inject_fault_new('cdbdisp_finish_command', 'reset', dbid) from gp_segment_configuration where content=-1 and role='p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+
+-- insert data again and commit in serssion1, expect error and abort transaction
+1<:  <... completed>
+ERROR:  cluster is reconfigured during a transaction (cdbgang.c:1345)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:238)
+1: truncate test_fts_session_reset2;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+1: commit;
+COMMIT
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- start_ignore
+! gprecoverseg -a;
+
+! gprecoverseg -ar;
+-- end_ignore
+select wait_until_all_segments_synchronized();
+wait_until_all_segments_synchronized
+------------------------------------
+OK                                  
+(1 row)
+-- start_ignore
+! gpconfig -r gp_fts_probe_timeout;
+
+! gpconfig -r gp_fts_probe_interval;
+
+! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -60,7 +60,7 @@ t
 
 -- insert data again and commit in serssion1, expect error and abort transaction
 1<:  <... completed>
-ERROR:  cluster is reconfigured during a transaction (cdbgang.c:1345)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang.c:1345)
 ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:238)
 1: truncate test_fts_session_reset2;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -132,3 +132,4 @@ test: packcore
 test: cancel_plpython
 
 test: distributed_transactions
+test: fts_session_reset

--- a/src/test/isolation2/sql/fts_session_reset.sql
+++ b/src/test/isolation2/sql/fts_session_reset.sql
@@ -1,0 +1,81 @@
+-- This test performs segment reconfiguration when a distributed 
+-- transaction is in progress. The expectation is that the first 
+-- command in the transaction after reconfiguration should fail. It 
+-- verifies a bug where a stale gang was reused in such a case, if the 
+-- failed primary happened to be up and listening.
+
+-- start_ignore
+! gpconfig -c gp_fts_probe_timeout -v 2;
+! gpconfig -c gp_fts_probe_interval -v '10s';
+! gpstop -rai;
+-- end_ignore
+
+create table test_fts_session_reset(c1 int);
+create table test_fts_session_reset2(c1 int);
+insert into test_fts_session_reset2 values(1);
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Helper function
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int)
+RETURNS bool AS
+$$
+declare
+retries int; /* in func */
+begin /* in func */
+  retries := 1200; /* in func */
+  loop /* in func */
+    if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */
+      return true; /* in func */
+    end if; /* in func */
+    if retries <= 0 then /* in func */
+      return false; /* in func */
+    end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+    retries := retries - 1; /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+create or replace function wait_until_all_segments_synchronized() returns text as $$
+begin
+	for i in 1..1200 loop
+		if (select count(*) = 0 from gp_segment_configuration where content != -1 and mode != 's') then
+			return 'OK'; /* in func */
+		end if; /* in func */
+		perform pg_sleep(0.1); /* in func */
+	end loop; /* in func */
+	return 'Fail'; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+1: BEGIN;
+-- inject a fault in funcion cdbdisp_finish_command on coordinator, to suspend the execution of insert statement.
+1: select gp_inject_fault_new('cdbdisp_finish_command', 'suspend', dbid) from gp_segment_configuration where content=-1 and role='p';
+-- insert data, it will hang here
+1&: insert into test_fts_session_reset select * from generate_series(1,20);
+
+-- inject a fault in primary segment, that will cause the coordinator to mark this primary down.
+3: select gp_inject_fault_new('segment_probe_response', 'sleep', '', '', '', 1, -1, 600, dbid) from gp_segment_configuration where content=0 and preferred_role='p';
+-- wait one primary become down.
+2: select wait_until_segments_are_down(1);
+-- reset the fault in session1 to make session1 continue
+2: select gp_inject_fault_new('cdbdisp_finish_command', 'reset', dbid) from gp_segment_configuration where content=-1 and role='p';
+
+-- insert data again and commit in serssion1, expect error and abort transaction
+1<:
+1: truncate test_fts_session_reset2;
+1: commit;
+
+1q:
+2q:
+
+-- start_ignore
+! gprecoverseg -a;
+! gprecoverseg -ar;
+-- end_ignore
+select wait_until_all_segments_synchronized();
+-- start_ignore
+! gpconfig -r gp_fts_probe_timeout;
+! gpconfig -r gp_fts_probe_interval;
+! gpstop -rai;
+-- end_ignore


### PR DESCRIPTION
If FTS changed cluster configuration within a transaction, the session is reset and the global transaction should be aborted.
fts_session_reset.sql is the test case for the this fix.

Co-authored-by: Asim R P pasim@vmware.com
