### PR TITLE
gprecoverseg: remove isStandardArray

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -328,9 +328,6 @@ class GpRecoverSegmentProgram:
         recoverHostMap = {}
         interfaceHostnameWarnings = []
 
-        # Check if the array is a "standard" array
-        (isStandardArray, _ignore) = gpArray.isStandardArray()
-
         recoverHostIdx = 0
 
         if self.__options.newRecoverHosts and len(self.__options.newRecoverHosts) > 0:
@@ -348,19 +345,8 @@ class GpRecoverSegmentProgram:
                         raise Exception('Not enough new recovery hosts given for recovery.')
                     recoverHostIdx += 1
 
-                if isStandardArray:
-                    # We have a standard array configuration, so we'll try to use the same
-                    # interface naming convention.  If this doesn't work, we'll correct it
-                    # below during ping failure
-                    segInterface = segAddress[segAddress.rfind('-'):]
-                    destAddress = recoverHostMap[segHostname] + segInterface
-                    destHostname = recoverHostMap[segHostname]
-                else:
-                    # Non standard configuration so we won't make assumptions on
-                    # naming.  Instead we'll use the hostname passed in for both
-                    # hostname and address and flag for warning later.
-                    destAddress = recoverHostMap[segHostname]
-                    destHostname = recoverHostMap[segHostname]
+                destAddress = recoverHostMap[segHostname]
+                destHostname = recoverHostMap[segHostname]
 
                 # Save off the new host/address for this address.
                 recoverAddressMap[segAddress] = (destHostname, destAddress)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -66,7 +66,6 @@ class GpRecoversegTestCase(GpTestCase):
         self.gpArrayMock.getDbList.side_effect = [[self.primary0], [self.primary0], [self.primary0]]
         self.gpArrayMock.segmentPairs = []
         self.gpArrayMock.hasMirrors = True
-        self.gpArrayMock.isStandardArray.return_value = (True, None)
         self.gpArrayMock.coordinator = self.gparray.coordinator
 
         self.config_provider_mock.loadSystemConfig.return_value = self.gpArrayMock


### PR DESCRIPTION
This is tech-debt from DCA specific code. Also, it was determing interface incorrectly. Specifically,
`segAddress[segAddress.rfind('-'):]` returns the last character from the
hostname and appending that to the address.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-cm-gprecoverseg_remove_isStandardArray)

See #11968 as a related PR.