### PR TITLE
Fix double free of TupleSort memory context (5X)

### DIFF
--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -590,11 +590,13 @@ ExecReScanSort(SortState *node, ExprContext *exprCtxt)
 		if (gp_enable_mk_sort && NULL != node->tuplesortstate->sortstore_mk)
 		{
 			tuplesort_end_mk(node->tuplesortstate->sortstore_mk);
+			node->tuplesortstate->sortstore_mk = NULL;
 		}
 
 		if (!gp_enable_mk_sort && NULL != node->tuplesortstate->sortstore)
 		{
 			tuplesort_end(node->tuplesortstate->sortstore);
+			node->tuplesortstate->sortstore = NULL;
 		}
 
 		/*
@@ -617,6 +619,8 @@ ExecReScanSort(SortState *node, ExprContext *exprCtxt)
 			tuplesort_rescan(node->tuplesortstate->sortstore);
 		}
 	}
+
+    SIMPLE_FAULT_INJECTOR(ExecReScanSortEndOfFunc);
 }
 
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -273,6 +273,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in ExecSort before doing the actual sort */
 	_("execsort_mksort_mergeruns"),
 		/* inject fault in MKSort during the mergeruns phase */
+	_("execrescansort"),
+		/* inject fault at the end of ExecReScanSort */
 	_("execshare_input_next"),
 		/* inject fault after shared input scan retrieved a tuple */
 	_("base_backup_post_create_checkpoint"),
@@ -1228,6 +1230,7 @@ FaultInjector_NewHashEntry(
 		case WorkfileHashJoinFailure:
 		case UpdateCommittedEofInPersistentTable:
 		case ExecSortBeforeSorting:
+		case ExecReScanSortEndOfFunc:
 		case FaultDuringExecDynamicTableScan:
 		case FaultExecHashJoinNewBatch:
 		case RunawayCleanup:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -178,6 +178,7 @@ typedef enum FaultInjectorIdentifier_e {
 
 	ExecSortBeforeSorting,
 	ExecSortMKSortMergeRuns,
+	ExecReScanSortEndOfFunc,
 	ExecShareInputNext,
 	BaseBackupPostCreateCheckpoint,
 

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -169,3 +169,32 @@ NOTICE:  Success:
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+create table rescan_sort_cleanup_foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table rescan_sort_cleanup_bar (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into rescan_sort_cleanup_foo values (1, 1), (1, 2);
+insert into rescan_sort_cleanup_bar values (1, 1);
+select gp_inject_fault('execrescansort', 'finish_pending', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select *, (select row_number() over (order by c) from rescan_sort_cleanup_bar where d = a) from rescan_sort_cleanup_foo;
+ a | b | ?column? 
+---+---+----------
+ 1 | 1 |        1
+ 1 | 2 |         
+(2 rows)
+
+select gp_inject_fault('execrescansort', 'reset', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+

--- a/src/test/regress/expected/query_finish_pending_optimizer.out
+++ b/src/test/regress/expected/query_finish_pending_optimizer.out
@@ -169,3 +169,32 @@ NOTICE:  Success:
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+create table rescan_sort_cleanup_foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table rescan_sort_cleanup_bar (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into rescan_sort_cleanup_foo values (1, 1), (1, 2);
+insert into rescan_sort_cleanup_bar values (1, 1);
+select gp_inject_fault('execrescansort', 'finish_pending', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+select *, (select row_number() over (order by c) from rescan_sort_cleanup_bar where d = a) from rescan_sort_cleanup_foo;
+ a | b | ?column? 
+---+---+----------
+ 1 | 1 |        1
+ 1 | 2 |         
+(2 rows)
+
+select gp_inject_fault('execrescansort', 'reset', 2);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -79,3 +79,12 @@ select count(*) from _tmp_table1, _tmp_table2 where 100 / _tmp_table2.c2 > 1;
 select gp_inject_fault('before_read_command', 'reset', 2);
 drop table _tmp_table1;
 drop table _tmp_table2;
+
+create table rescan_sort_cleanup_foo (a int, b int);
+create table rescan_sort_cleanup_bar (c int, d int);
+insert into rescan_sort_cleanup_foo values (1, 1), (1, 2);
+insert into rescan_sort_cleanup_bar values (1, 1);
+
+select gp_inject_fault('execrescansort', 'finish_pending', 2);
+select *, (select row_number() over (order by c) from rescan_sort_cleanup_bar where d = a) from rescan_sort_cleanup_foo;
+select gp_inject_fault('execrescansort', 'reset', 2);


### PR DESCRIPTION
To trigger this bug, we need plan with a Sort node in a subplan that is
executed at least twice (viz. if there are multiple tuples on the outer
side).  Moreover, the QD must do a PQrequestFinish(), which sets
QueryFinishPending on all the QE processes, after the ExecRescanSort()
is executed, but before the next ExecSort(). This leaves the sort state
in an inconsistent state where node->tuplesortstate->sortstore != NULL,
but has already been freed. So another attempt to free it (in
ExecEndSort for example) will cause a crash.

This commit fixes this logic by setting the sortstore to NULL during
ExecRescanSort.

Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>
Co-authored-by: Alexandra Wang <lewang@pivotal.io>
