### PR TITLE
(6x backport)Avoid dispatch OIDs during planning when refresh matview.

### DIFF
--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -479,6 +479,12 @@ CreateKeyFromCatalogTuple(Relation catalogrel, HeapTuple tuple,
 	return key;
 }
 
+extern void
+RestoreOidAssignments(List *oid_assignments)
+{
+	dispatch_oids = oid_assignments;
+}
+
 /* ----------------------------------------------------------------
  * Functions for use in QE.
  * ----------------------------------------------------------------

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -21,6 +21,7 @@
 #include "catalog/catalog.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "catalog/oid_dispatch.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_operator.h"
@@ -397,6 +398,24 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	QueryDesc  *queryDesc;
 	Query	   *copied_query;
 
+	/*
+	 * Greenplum specific behavior:
+	 * MPP architecture need to make sure OIDs of the temp table are the same
+	 * among QD and all QEs. It stores the OID in the static variable dispatch_oids.
+	 * This variable will be consumed for each dispatch.
+	 *
+	 * During planning, Greenplum might pre-evalute some function expr, this will
+	 * lead to dispatch if the function is in SQL or PLPGSQL and consume the above
+	 * static variable. So later refresh matview's dispatch will not find the
+	 * oid on QEs.
+	 *
+	 * We first store the OIDs information in a local variable, and then restore
+	 * it for later refresh matview's dispatch to solve the above issue.
+	 *
+	 * See Github Issue for details: https://github.com/greenplum-db/gpdb/issues/11956
+	 */
+	List       *saved_dispatch_oids = GetAssignedOidsForDispatch();
+
 	/* Lock and rewrite, using a copy to preserve the original query. */
 	copied_query = copyObject(query);
 	AcquireRewriteLocks(copied_query, true, false);
@@ -428,6 +447,8 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	queryDesc = CreateQueryDesc(plan, queryString,
 								GetActiveSnapshot(), InvalidSnapshot,
 								dest, NULL, 0);
+
+	RestoreOidAssignments(saved_dispatch_oids);
 
 	/* call ExecutorStart to prepare the plan for execution */
 	ExecutorStart(queryDesc, EXEC_FLAG_WITHOUT_OIDS);

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -30,6 +30,9 @@ extern Oid GetPreassignedOidForType(Oid namespaceOid, const char *typname,
 									bool allowMissing);
 extern Oid GetPreassignedOidForDatabase(const char *datname);
 
+/* Functions used in master and QE nodes */
+extern void RestoreOidAssignments(List *oid_assignments);
+
 /* Functions used in binary upgrade */
 extern bool IsOidAcceptable(Oid oid);
 extern void MarkOidPreassignedFromBinaryUpgrade(Oid oid);

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -597,3 +597,20 @@ SELECT * FROM mvtest2;
 ERROR:  materialized view "mvtest2" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
 ROLLBACK;
+-- make sure refresh mat view will dispatch oid at the final
+-- execution of the mat view's body query. See Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/11956 for details.
+create table t_github_issue_11956(a int, b int) distributed randomly;
+insert into t_github_issue_11956 values (1, 1);
+create function f_github_issue_11956() returns int as
+$$
+select sum(a+b)::int from t_github_issue_11956
+$$
+language sql stable;
+create materialized view mat_view_github_issue_11956
+as
+select * from t_github_issue_11956 where a > f_github_issue_11956()
+distributed randomly;
+refresh materialized view mat_view_github_issue_11956;
+drop materialized view mat_view_github_issue_11956;
+drop table t_github_issue_11956;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -599,3 +599,20 @@ SELECT * FROM mvtest2;
 ERROR:  materialized view "mvtest2" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
 ROLLBACK;
+-- make sure refresh mat view will dispatch oid at the final
+-- execution of the mat view's body query. See Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/11956 for details.
+create table t_github_issue_11956(a int, b int) distributed randomly;
+insert into t_github_issue_11956 values (1, 1);
+create function f_github_issue_11956() returns int as
+$$
+select sum(a+b)::int from t_github_issue_11956
+$$
+language sql stable;
+create materialized view mat_view_github_issue_11956
+as
+select * from t_github_issue_11956 where a > f_github_issue_11956()
+distributed randomly;
+refresh materialized view mat_view_github_issue_11956;
+drop materialized view mat_view_github_issue_11956;
+drop table t_github_issue_11956;

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -223,3 +223,26 @@ SELECT mvtest_func();
 SELECT * FROM mvtest1;
 SELECT * FROM mvtest2;
 ROLLBACK;
+
+-- make sure refresh mat view will dispatch oid at the final
+-- execution of the mat view's body query. See Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/11956 for details.
+
+create table t_github_issue_11956(a int, b int) distributed randomly;
+insert into t_github_issue_11956 values (1, 1);
+
+create function f_github_issue_11956() returns int as
+$$
+select sum(a+b)::int from t_github_issue_11956
+$$
+language sql stable;
+
+create materialized view mat_view_github_issue_11956
+as
+select * from t_github_issue_11956 where a > f_github_issue_11956()
+distributed randomly;
+
+refresh materialized view mat_view_github_issue_11956;
+
+drop materialized view mat_view_github_issue_11956;
+drop table t_github_issue_11956;


### PR DESCRIPTION
Refresh materialized view will first create a temp table on QD, this will
save the table's oid in static variable of QD, dispatch will use it. Then
QD try to execute the query, first generate a plan, it might pre-evaluted
some function during planning, if the function invokes SQL, it will lead
to dispatch and consume the oids. So later dispatch ref mat view will
dispatch no OIDs.

This comit fixes this by first saving the OIDs before planning the matview's
body query and then restoring it when dispatching the ref query.

Fix Github Issue: https://github.com/greenplum-db/gpdb/issues/11956