### PR TITLE
Keep pg_rewind log if incremental gprecoverseg fails.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -433,7 +433,7 @@ class SegmentRewind(Command):
         # Build the pg_rewind command. Do not run pg_rewind if standby.signal
         # file exists in target data directory because the target instance can
         # be started up normally as a mirror for WAL replication catch up.
-        rewind_cmd = 'rm -f %s.success; if [ ! -f %s/standby.signal ]; then PGOPTIONS="-c gp_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --slot="internal_wal_replication_slot" --source-server="%s" --target-pgdata=%s' % (pipes.quote(progress_file), target_datadir, source_server, target_datadir)
+        rewind_cmd = 'if [ ! -f %s/standby.signal ]; then PGOPTIONS="-c gp_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --slot="internal_wal_replication_slot" --source-server="%s" --target-pgdata=%s' % (target_datadir, source_server, target_datadir)
 
         if verbose:
             rewind_cmd = rewind_cmd + ' --progress'

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -513,7 +513,7 @@ class GpMirrorListToBuild:
                                                               remoteHost=targetHostname)
 
         removeCmd = base.Command("remove file",
-                                 "[ ! -f %s.success ] || rm -f %s.success %s" % (pipes.quote(progressFile), pipes.quote(progressFile), pipes.quote(progressFile)),
+                                 "[ ! -f {0}.success ] || rm -f {0}.success ${0}".format(pipes.quote(progressFile)),
                                  ctxt=base.REMOTE,
                                  remoteHost=targetHostname)
 

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -385,7 +385,6 @@ class GpMirrorListToBuild:
             # object.
             cmd = gp.SegmentRewind('rewind dbid: %s' %
                                    rewindSeg.targetSegment.getSegmentDbId(),
-                                   rewindSeg.targetSegment.getSegmentDbId(),
                                    rewindSeg.targetSegment.getSegmentHostName(),
                                    rewindSeg.targetSegment.getSegmentDataDirectory(),
                                    rewindSeg.sourceHostname,
@@ -514,7 +513,7 @@ class GpMirrorListToBuild:
                                                               remoteHost=targetHostname)
 
         removeCmd = base.Command("remove file",
-                                 "[ ! -f %s/recovery.ok.dbid%s ] || rm -f %s/recovery.ok.dbid%s %s" % (gplog.get_logger_dir(), targetSegmentDbId, gplog.get_logger_dir(), targetSegmentDbId, pipes.quote(progressFile)),
+                                 "[ ! -f %s.success ] || rm -f %s.success %s" % (pipes.quote(progressFile), pipes.quote(progressFile), pipes.quote(progressFile)),
                                  ctxt=base.REMOTE,
                                  remoteHost=targetHostname)
 

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -385,6 +385,7 @@ class GpMirrorListToBuild:
             # object.
             cmd = gp.SegmentRewind('rewind dbid: %s' %
                                    rewindSeg.targetSegment.getSegmentDbId(),
+                                   rewindSeg.targetSegment.getSegmentDbId(),
                                    rewindSeg.targetSegment.getSegmentHostName(),
                                    rewindSeg.targetSegment.getSegmentDataDirectory(),
                                    rewindSeg.sourceHostname,
@@ -513,7 +514,7 @@ class GpMirrorListToBuild:
                                                               remoteHost=targetHostname)
 
         removeCmd = base.Command("remove file",
-                                 "rm -f %s" % pipes.quote(progressFile),
+                                 "[ ! -f %s/recovery.ok.dbid%s ] || rm -f %s/recovery.ok.dbid%s %s" % (gplog.get_logger_dir(), targetSegmentDbId, gplog.get_logger_dir(), targetSegmentDbId, pipes.quote(progressFile)),
                                  ctxt=base.REMOTE,
                                  remoteHost=targetHostname)
 


### PR DESCRIPTION
Previously if incremental gprecoverseg fails we have to rerun with -v
to get the pg_rewind log for debugging. This is not convenient and also
sometimes the log output is not complete in the gprecoverseg log somehow.
Let's keep the pg_rewind log if incremental gprecoverseg fails.