### PR TITLE
pg_dump(all): Allow quote_all_identifiers for 8.3

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1457,7 +1457,7 @@ setup_connection(Archive *AH, const char *dumpencoding,
 	/*
 	 * Quote all identifiers, if requested.
 	 */
-	if (quote_all_identifiers && AH->remoteVersion >= 90100)
+	if (quote_all_identifiers && AH->remoteVersion >= 80300)
 		ExecuteSqlStatement(AH, "SET quote_all_identifiers = true");
 
 	/*

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -578,7 +578,7 @@ main(int argc, char *argv[])
 	}
 
 	/* Force quoting of all identifiers if requested. */
-	if (quote_all_identifiers && server_version >= 90100)
+	if (quote_all_identifiers && server_version >= 80300)
 		executeCommand(conn, "SET quote_all_identifiers = true");
 
 	fprintf(OPF,"--\n-- Greenplum Database cluster dump\n--\n\n");


### PR DESCRIPTION
This commit enables the proper dump of keywords used as identifiers
during an upgrade in the context of partition tables and otherwise (the
upgrade being from versions 5 -> 7+)

This is a forward port of PR: #11939. Please refer to it for detailed
commentary.

(cherry picked from commit 86efbf09efffea8cc340ac8905f318719d5ee82e)
