### PR TITLE
ic-proxy: fix the sorting of addresses

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -64,11 +64,16 @@ static List *ic_proxy_unknown_addrs = NIL;
  */
 static ICProxyAddr *ic_proxy_my_addr = NULL;
 
+/*
+ * Compare function for list_qsort().
+ *
+ * The real type of the arguments is "const ListCell **".
+ */
 static int
 ic_proxy_addr_compare_dbid(const void *a, const void *b)
 {
-	const ICProxyAddr *addr1 = a;
-	const ICProxyAddr *addr2 = b;
+	const ICProxyAddr *addr1 = lfirst(*(const ListCell **) a);
+	const ICProxyAddr *addr2 = lfirst(*(const ListCell **) b);
 
 	return addr1->dbid - addr2->dbid;
 }

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -814,6 +814,27 @@ ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest)
 }
 
 /*
+ * Disconnect a peer.
+ *
+ * The peer can be in any state, the caller only needs to ensure not to call
+ * this function from a peer callback.
+ */
+void
+ic_proxy_peer_disconnect(ICProxyPeer *peer)
+{
+	/* No such a peer yet */
+	if (!peer)
+		return;
+
+	/* No connection is made or being made */
+	if (!(peer->state & IC_PROXY_PEER_STATE_CONNECTING))
+		return;
+
+	ic_proxy_log(LOG, "%s: disconnecting", peer->name);
+	ic_proxy_peer_shutdown(peer);
+}
+
+/*
  * Send a packet to a remote peer.
  */
 void

--- a/src/backend/cdb/motion/ic_proxy_server.h
+++ b/src/backend/cdb/motion/ic_proxy_server.h
@@ -127,6 +127,7 @@ extern ICProxyPeer *ic_proxy_peer_new(uv_loop_t *loop,
 extern void ic_proxy_peer_free(ICProxyPeer *peer);
 extern void ic_proxy_peer_read_hello(ICProxyPeer *peer);
 extern void ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest);
+extern void ic_proxy_peer_disconnect(ICProxyPeer *peer);
 extern void ic_proxy_peer_route_data(ICProxyPeer *peer, ICProxyPkt *pkt,
 									 ic_proxy_sent_cb callback, void *opaque);
 extern ICProxyPeer *ic_proxy_peer_lookup(int16 content, uint16 dbid);


### PR DESCRIPTION
When reloading the addresses we first sort them then classify them as
existing, added, or removed.  We use list_qsort() for the sorting, which
requires a compare function.  The compare function passes 2 pointers to
the list cells, the pointer type should be "ListCell **", but we used to
treat them as "ICProxyAddr *", so the adresses cannot be correctly
sorted and classified, this should cause problems when adding or
removing addresses.

Fixed the compare function.