### PR TITLE
Change DEFAULT_MAX_WAL_SEGS from 64 to 16

### DIFF
--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -90,7 +90,13 @@ typedef XLogLongPageHeaderData *XLogLongPageHeader;
 #define WalSegMaxSize (1024 * 1024 * 1024)
 /* default number of min and max wal segments */
 #define DEFAULT_MIN_WAL_SEGS 5
-#define DEFAULT_MAX_WAL_SEGS 64
+/*
+ * gpdb: PG hardcodes this as 64. We don't expect to keep that many segment
+ * files given we use 64MB as default segment file size while PG uses 16MB,
+ * also note this value affects that checkpoint frequency. Let's just ensure
+ * the max wal segment size is same on gpdb and PG.
+ */
+#define DEFAULT_MAX_WAL_SEGS (64*(16*1024*1024)/DEFAULT_XLOG_SEG_SIZE)
 
 /* check that the given size is a valid wal_segment_size */
 #define IsPowerOf2(x) (x > 0 && ((x) & ((x)-1)) == 0)


### PR DESCRIPTION
gpdb uses 64MB segment size while upstream uses 16MB by default, thus
DEFAULT_MAX_WAL_SEGS should be modified accordingly on gpdb.  This variable
affects guc max_wal_size_mb and max_wal_size_mb affects the variable
CheckPointSegments.  CheckPointSegments is a guc on gpdb6 with default value 8,
but on master & upstream it is calculated using max_wal_size_mb and guc
checkpoint_completion_target. With previous DEFAULT_MAX_WAL_SEGS value of 64,
CheckPointSegments is 42. This is not acceptable since this variable is used to
control checkpoint frequency.

With DEFAULT_MAX_WAL_SEGS as 16, CheckPointSegments becomes to 10 and this
should be ok for gpdb. In latest upstream code, checkpoint_completion_target is
changed from 0.5 to 0.9. CheckPointSegments would become to 8 when we merge to
that version in the future.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
