### PR TITLE
Free disk space for truncated/dropped relations on commit

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -484,6 +484,8 @@ AppendOnlyStorageWrite_FlushAndCloseFile(
 						storageWrite->segmentFileName,
 						storageWrite->relationName)));
 
+	FileClose(storageWrite->file);
+
 	storageWrite->file = -1;
 	storageWrite->formatVersion = -1;
 

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -323,6 +323,41 @@ mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 		mdunlinkfork(rnode, forkNum, isRedo);
 }
 
+/*
+ * Truncate a file to release disk space.
+ */
+static int
+do_truncate(const char *path)
+{
+	int			save_errno;
+	int			ret;
+	int			fd;
+
+	/* truncate(2) would be easier here, but Windows hasn't got it */
+	fd = OpenTransientFile(path, O_RDWR | PG_BINARY);
+	if (fd >= 0)
+	{
+		ret = ftruncate(fd, 0);
+		save_errno = errno;
+		CloseTransientFile(fd);
+		errno = save_errno;
+	}
+	else
+		ret = -1;
+
+	/* Log a warning here to avoid repetition in callers. */
+	if (ret < 0 && errno != ENOENT)
+	{
+		save_errno = errno;
+		ereport(WARNING,
+				(errcode_for_file_access(),
+				 errmsg("could not truncate file \"%s\": %m", path)));
+		errno = save_errno;
+	}
+
+	return ret;
+}
+
 static void
 mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 {
@@ -336,38 +371,31 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 	 */
 	if (isRedo || forkNum != MAIN_FORKNUM || RelFileNodeBackendIsTemp(rnode))
 	{
-		/* First, forget any pending sync requests for the first segment */
 		if (!RelFileNodeBackendIsTemp(rnode))
-			register_forget_request(rnode, forkNum, 0 /* first seg */ );
+		{
+			/* Prevent other backends' fds from holding on to the disk space */
+			ret = do_truncate(path);
 
-		/* Next unlink the file */
-		ret = unlink(path);
-		if (ret < 0 && errno != ENOENT)
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not remove file \"%s\": %m", path)));
+			/* Forget any pending sync requests for the first segment */
+			register_forget_request(rnode, forkNum, 0 /* first seg */ );
+		}
+		else
+			ret = 0;
+
+		/* Next unlink the file, unless it was already found to be missing */
+		if (ret == 0 || errno != ENOENT)
+		{
+			ret = unlink(path);
+			if (ret < 0 && errno != ENOENT)
+				ereport(WARNING,
+						(errcode_for_file_access(),
+						 errmsg("could not remove file \"%s\": %m", path)));
+		}
 	}
 	else
 	{
-		/* truncate(2) would be easier here, but Windows hasn't got it */
-		int			fd;
-
-		fd = OpenTransientFile(path, O_RDWR | PG_BINARY);
-		if (fd >= 0)
-		{
-			int			save_errno;
-
-			ret = ftruncate(fd, 0);
-			save_errno = errno;
-			CloseTransientFile(fd);
-			errno = save_errno;
-		}
-		else
-			ret = -1;
-		if (ret < 0 && errno != ENOENT)
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not truncate file \"%s\": %m", path)));
+		/* Prevent other backends' fds from holding on to the disk space */
+		ret = do_truncate(path);
 
 		/* Register request to unlink first segment later */
 		register_unlink_segment(rnode, forkNum, 0 /* first seg */ );
@@ -387,14 +415,24 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 		 */
 		for (segno = 1;; segno++)
 		{
-			/*
-			 * Forget any pending sync requests for this segment before we try
-			 * to unlink.
-			 */
-			if (!RelFileNodeBackendIsTemp(rnode))
-				register_forget_request(rnode, forkNum, segno);
-
 			sprintf(segpath, "%s.%u", path, segno);
+
+			if (!RelFileNodeBackendIsTemp(rnode))
+			{
+				/*
+				 * Prevent other backends' fds from holding on to the disk
+				 * space.
+				 */
+				if (do_truncate(segpath) < 0 && errno == ENOENT)
+					break;
+
+				/*
+				 * Forget any pending sync requests for this segment before we
+				 * try to unlink.
+				 */
+				register_forget_request(rnode, forkNum, segno);
+			}
+
 			if (unlink(segpath) < 0)
 			{
 				/* ENOENT is expected after the last segment... */


### PR DESCRIPTION
Originally the problem was detected on GPDB 6.15.0 with a mix usage of heap and AO/AOC tables. ETL process made intensive inserts in a highly skewed heap table with a final truncate command. Because of a big skew, the most of repeatedly inserted (about 100GB) data was located on a single segment and heap table blocks occupied all the shared buffers on that segment (default 125MB). In parallel another backend (AO backend) on the same segment executed a very long running slice with lots of hash aggregates populated from AO table with deleted rows. Because of deleted rows, AO backend had to validate tuples visibility with an auxiliary visibility map table and evict heap table's blocks to disk. As a result, AO backend's file descriptor cache contains all segment files descriptors of the heap table. When ETL backend truncates heap table it puts a system cache invalidation messages to shared memory and daisy chains an invalidation signal to the active backends. A backend invalidates a cache immediately if it is idle, otherwise backend waits till current command in transaction finishes. But our long running AO backend works on its command for hours and can't invalidate file descriptor cache - so, still holds all segment files descriptors.

Before this commit, "truncate" command shrank to a zero size only the first segment file before unlinking, but higher segments were unlinked without shrink. Because of such slow-running queries with stuck file descriptors, kernel can't free the space on disk immediately after successful unlink (waits till the file descriptor would be closed). As a result we can easily run out of disk space, when ETL repeats 100GB insert + truncate cycle. Surely, original problem has workarounds (replace heap with AO as the simplest one), but anyway, I believe this behaviour should be fixed.

Current PR is a backport of upstream PostgreSQL [commit](https://github.com/postgres/postgres/commit/9f35f943732eaf9121a107f54ea043925e9a5d7b). It should be backported to `6X_STABLE` as well.