### PR TITLE
Docs: Pgcrypto - Added extra step to create extension

### DIFF
--- a/gpdb-doc/dita/best_practices/encryption.xml
+++ b/gpdb-doc/dita/best_practices/encryption.xml
@@ -301,6 +301,8 @@ Pv2MikPS2fKOAg1R3LpMa8zDEtl4w3vckPQNrQNnYuUtfj6ZoCxv
 =XZ8J
 -----END PGP PUBLIC KEY BLOCK-----
 </codeblock></li>
+        <li>Enable the <codeph>pgcrypto</codeph>
+          extension:<codeblock>CREATE EXTENSION pgcrypto;</codeblock></li>
         <li>Create a table called <codeph>userssn</codeph> and insert some sensitive data, social
           security numbers for Bob and Alice, in this example. Paste the public.key contents after
           "dearmor(".

--- a/gpdb-doc/dita/best_practices/encryption.xml
+++ b/gpdb-doc/dita/best_practices/encryption.xml
@@ -326,7 +326,7 @@ HMUc55H0g2qQAY0BpnJHgOOQ45Q6pk3G2/7Dbek5WJ6K1wUrFy51sNlGWE8pvgEx
 /UUZB+dYqCwtvX0nnBu1KNCmk2AkEcFK3YoliCxomdOxhFOv9AKjjojDyC65KJci
 Pv2MikPS2fKOAg1R3LpMa8zDEtl4w3vckPQNrQNnYuUtfj6ZoCxv
 =XZ8J
------END PGP PUBLIC KEY BLOCK-----' AS pubkey) AS keys;
+-----END PGP PUBLIC KEY BLOCK-----') AS pubkey) AS keys;
 </codeblock></li>
         <li>Verify that the <codeph>ssn</codeph> column is
           encrypted.<codeblock>test_db=# select * from userssn;


### PR DESCRIPTION
Section "Encrypting Data in Tables using PGP" does not work if we don't create the pgcrypto extension before inserting data into the tables.
Also corrected the INSERT syntax since there was a ")" missing.