### PR TITLE
Docs: edited provided gplogfilter example

### DIFF
--- a/gpdb-doc/dita/security-guide/topics/Auditing.xml
+++ b/gpdb-doc/dita/security-guide/topics/Auditing.xml
@@ -498,7 +498,7 @@
         last three lines of each segment log
         file:<codeblock>$ gpssh -f seg_host_file
   => source /usr/local/greenplum-db/greenplum_path.sh
-  => gplogfilter -n 3 /gpdata/gp*/log/gpdb*.csv</codeblock></p>
+  => gplogfilter -n 3 /data*/*/gp*/pg_log/gpdb*.csv</codeblock></p>
       <p> The following are the Greenplum security-related audit (or logging) server configuration
         parameters that are set in the postgresql.conf configuration file:</p>
       <table>


### PR DESCRIPTION
Corrected example on how to use gplogfilter so it segment directory matches the path we specify under the installation guide ( /data*/*/gp*/pg_log/gpdb*.csv)