### PR TITLE
6x backport: movemirrors/recoverseg: -B option fix parallel processes

### DIFF
--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -30,8 +30,6 @@ except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 # constants
-MAX_BATCH_SIZE = 128
-
 GPDB_STOPPED = 1
 GPDB_STARTED = 2
 GPDB_UTILITY = 3
@@ -70,7 +68,9 @@ def parseargs():
                       help='The master data directory for the system. If this option is not specified, \
                             the value is obtained from the $MASTER_DATA_DIRECTORY environment variable.')
     parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=16, metavar="<batch_size>",
-                      help='Expansion configuration batch size. Valid values are 1-%d' % MAX_BATCH_SIZE)
+                      help='Max number of hosts to operate on in parallel. Valid values are 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
+    parser.add_option('-b', '--segment-batch-size', dest='segment_batch_size', type='int', default=gp.DEFAULT_SEGHOST_NUM_WORKERS, metavar="<segment_batch_size>",
+                      help='Max number of segments per host to operate on in parallel. Valid values are: 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
     parser.add_option('-v', '--verbose', dest="verbose", action='store_true',
                       help='debug output.')
     parser.add_option('-l', '--log-file-directory', dest="logfile_directory",
@@ -93,8 +93,13 @@ def parseargs():
         logger.error('Unknown argument %s' % args[0])
         parser.exit()
 
-    if options.batch_size < 1 or options.batch_size > 128:
-        logger.error('Invalid argument.  -B value must be >= 1 and <= %s' % MAX_BATCH_SIZE)
+    if options.batch_size < 1 or options.batch_size > gp.MAX_SEGHOST_NUM_WORKERS:
+        logger.error('Invalid value for argument -B. Value must be >= 1 and <= %d' % gp.MAX_SEGHOST_NUM_WORKERS)
+        parser.print_help()
+        parser.exit()
+
+    if options.segment_batch_size < 1 or options.segment_batch_size > gp.MAX_SEGHOST_NUM_WORKERS:
+        logger.error('Invalid value for argument -b. Value must be >= 1 and <= %d' % gp.MAX_SEGHOST_NUM_WORKERS)
         parser.print_help()
         parser.exit()
 
@@ -128,6 +133,7 @@ def logOptionValues(options):
     logger.info("  --input                 = " + str(options.input_filename))
     logger.info("  --master-data-directory = " + str(options.master_data_directory))
     logger.info("  --batch-size            = " + str(options.batch_size))
+    logger.info("  --segment-batch-size    = " + str(options.segment_batch_size))
     if options.verbose != None:
         logger.info("  --verbose               = " + str(options.verbose))
     if options.continue_move != None:
@@ -425,7 +431,8 @@ try:
     newConfig.write_output_file(backout_filename, False)
 
     """ Start gprecoverseg. """
-    recoversegOptions = "-i " + newConfig.inputFile + " -v -a -d " + options.master_data_directory
+    recoversegOptions = "-i " + newConfig.inputFile + " -B " + str(options.batch_size) + \
+                        " -b " + str(options.segment_batch_size) + " -v -a -d " + options.master_data_directory
     if options.logfile_directory != None:
         recoversegOptions = recoversegOptions + " -l " + str(options.logfile_directory)
     logger.info('About to run gprecoverseg with options: ' + recoversegOptions)

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -67,8 +67,8 @@ def parseargs():
     parser.add_option('-d', '--master-data-directory', dest='master_data_directory',
                       help='The master data directory for the system. If this option is not specified, \
                             the value is obtained from the $MASTER_DATA_DIRECTORY environment variable.')
-    parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=16, metavar="<batch_size>",
-                      help='Max number of hosts to operate on in parallel. Valid values are 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
+    parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=gp.DEFAULT_MASTER_NUM_WORKERS, metavar="<batch_size>",
+                      help='Max number of hosts to operate on in parallel. Valid values are 1-%d' % gp.MAX_MASTER_NUM_WORKERS)
     parser.add_option('-b', '--segment-batch-size', dest='segment_batch_size', type='int', default=gp.DEFAULT_SEGHOST_NUM_WORKERS, metavar="<segment_batch_size>",
                       help='Max number of segments per host to operate on in parallel. Valid values are: 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
     parser.add_option('-v', '--verbose', dest="verbose", action='store_true',
@@ -93,8 +93,8 @@ def parseargs():
         logger.error('Unknown argument %s' % args[0])
         parser.exit()
 
-    if options.batch_size < 1 or options.batch_size > gp.MAX_SEGHOST_NUM_WORKERS:
-        logger.error('Invalid value for argument -B. Value must be >= 1 and <= %d' % gp.MAX_SEGHOST_NUM_WORKERS)
+    if options.batch_size < 1 or options.batch_size > gp.MAX_MASTER_NUM_WORKERS:
+        logger.error('Invalid value for argument -B. Value must be >= 1 and <= %d' % gp.MAX_MASTER_NUM_WORKERS)
         parser.print_help()
         parser.exit()
 

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -68,6 +68,7 @@ class WorkerPool(object):
             self.workers.append(w)
             w.start()
         self.numWorkers = numWorkers
+        self.logger.debug("WorkerPool() initialized with %d workers" % self.numWorkers)
 
     ###
     def getNumWorkers(self):

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -47,6 +47,12 @@ DEFAULT_SEGHOST_NUM_WORKERS=64
 #max size of thread pool on segment hosts
 MAX_SEGHOST_NUM_WORKERS=128
 
+#default batch size of thread pool on master
+DEFAULT_MASTER_NUM_WORKERS=16
+
+#max batch size of thread pool on master
+MAX_MASTER_NUM_WORKERS=64
+
 # Application name used by the pg_rewind instance that gprecoverseg starts
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -41,6 +41,12 @@ COMMAND_NOT_FOUND=127
 #Default size of thread pool for gpstart and gpsegstart
 DEFAULT_GPSTART_NUM_WORKERS=64
 
+#Default size of thread pool on segment hosts
+DEFAULT_SEGHOST_NUM_WORKERS=64
+
+#max size of thread pool on segment hosts
+MAX_SEGHOST_NUM_WORKERS=128
+
 # Application name used by the pg_rewind instance that gprecoverseg starts
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.
@@ -612,7 +618,7 @@ class GpSegStartArgs(CmdArgs):
         @param parallel - maximum size of a thread pool to start segments
         """
         if parallel is not None:
-            self.append("-B")
+            self.append("-b")
             self.append(str(parallel))
         return self
 
@@ -649,7 +655,7 @@ class GpSegStartCmd(Command):
 #-----------------------------------------------
 class GpSegStopCmd(Command):
     def __init__(self, name, gphome, version,mode,dbs,timeout=SEGMENT_STOP_TIMEOUT_DEFAULT,
-                 verbose=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
+                 verbose=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False, segment_batch_size=DEFAULT_SEGHOST_NUM_WORKERS):
         self.gphome=gphome
         self.dblist=dbs
         self.dirportlist=[]
@@ -666,8 +672,8 @@ class GpSegStopCmd(Command):
         else:
             setverbose=""
 
-        self.cmdStr="$GPHOME/sbin/gpsegstop.py %s -D %s -m %s -t %s -V '%s'"  %\
-                        (setverbose,dirstr,mode,timeout,version)
+        self.cmdStr="$GPHOME/sbin/gpsegstop.py %s -D %s -m %s -t %s -V '%s' -b %d" %\
+                        (setverbose,dirstr,mode,timeout,version,segment_batch_size)
 
         if (logfileDirectory):
             self.cmdStr = self.cmdStr + " -l '" + logfileDirectory + "'"
@@ -905,7 +911,7 @@ class ConfigureNewSegment(Command):
         if verbose:
             cmdStr += ' -v '
         if batchSize:
-            cmdStr += ' -B %s' % batchSize
+            cmdStr += ' -b %s' % batchSize
         if validationOnly:
             cmdStr += " --validation-only"
         if writeGpIdFileOnly:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -535,10 +535,10 @@ class GpRecoverSegmentProgram:
         return res.fetchall()
 
     def run(self):
-        if self.__options.parallelDegree < 1 or self.__options.parallelDegree > 64:
+        if self.__options.parallelDegree < 1 or self.__options.parallelDegree > gp.MAX_MASTER_NUM_WORKERS:
             raise ProgramArgumentValidationException(
                 "Invalid parallelDegree value provided with -B argument: %d" % self.__options.parallelDegree)
-        if self.__options.parallelPerHost < 1 or self.__options.parallelPerHost > 128:
+        if self.__options.parallelPerHost < 1 or self.__options.parallelPerHost > gp.MAX_SEGHOST_NUM_WORKERS:
             raise ProgramArgumentValidationException(
                 "Invalid parallelPerHost value provided with -b argument: %d" % self.__options.parallelPerHost)
 
@@ -747,12 +747,12 @@ class GpRecoverSegmentProgram:
                          dest="forceFullResynchronization",
                          metavar="<forceFullResynchronization>",
                          help="Force full segment resynchronization")
-        addTo.add_option("-B", None, type="int", default=16,
+        addTo.add_option("-B", None, type="int", default=gp.DEFAULT_MASTER_NUM_WORKERS,
                          dest="parallelDegree",
                          metavar="<parallelDegree>",
                          help="Max number of hosts to operate on in parallel. Valid values are: 1-%d"
-                              % gp.MAX_SEGHOST_NUM_WORKERS)
-        addTo.add_option("-b", None, type="int", default=64,
+                              % gp.MAX_MASTER_NUM_WORKERS)
+        addTo.add_option("-b", None, type="int", default=gp.DEFAULT_SEGHOST_NUM_WORKERS,
                          dest="parallelPerHost",
                          metavar="<parallelPerHost>",
                          help="Max number of segments per host to operate on in parallel. Valid values are: 1-%d"

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -421,7 +421,7 @@ class GpRecoverSegmentProgram:
 
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
-            return GpSegmentRebalanceOperation(gpEnv, gpArray)
+            return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
         elif self.__options.recoveryConfigFile is not None:
             return self.getRecoveryActionsFromConfigFile(gpArray)
         else:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -296,7 +296,8 @@ class GpRecoverSegmentProgram:
 
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree, forceoverwrite=True,
-                                   progressMode=self.getProgressMode())
+                                   progressMode=self.getProgressMode(),
+                                   parallelPerHost=self.__options.parallelPerHost)
 
     def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
@@ -410,7 +411,8 @@ class GpRecoverSegmentProgram:
                                    self.__options.parallelDegree,
                                    interfaceHostnameWarnings,
                                    forceoverwrite=True,
-                                   progressMode=self.getProgressMode())
+                                   progressMode=self.getProgressMode(),
+                                   parallelPerHost=self.__options.parallelPerHost)
 
     def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
         if segs_persistent_mirroring_disabled:
@@ -535,7 +537,10 @@ class GpRecoverSegmentProgram:
     def run(self):
         if self.__options.parallelDegree < 1 or self.__options.parallelDegree > 64:
             raise ProgramArgumentValidationException(
-                "Invalid parallelDegree provided with -B argument: %d" % self.__options.parallelDegree)
+                "Invalid parallelDegree value provided with -B argument: %d" % self.__options.parallelDegree)
+        if self.__options.parallelPerHost < 1 or self.__options.parallelPerHost > 128:
+            raise ProgramArgumentValidationException(
+                "Invalid parallelPerHost value provided with -b argument: %d" % self.__options.parallelPerHost)
 
         self.__pool = WorkerPool(self.__options.parallelDegree)
         gpEnv = GpMasterEnvironment(self.__options.masterDataDirectory, True)
@@ -668,7 +673,7 @@ class GpRecoverSegmentProgram:
             self.logger.info("No checksum validation necessary when there are no segments to recover.")
             return
 
-        heap_checksum = HeapChecksum(gpArray, num_workers=len(live_segments), logger=self.logger)
+        heap_checksum = HeapChecksum(gpArray, num_workers=min(self.__options.parallelDegree, len(live_segments)), logger=self.logger)
         successes, failures = heap_checksum.get_segments_checksum_settings(live_segments)
         # go forward if we have at least one segment that has replied
         if len(successes) == 0:
@@ -745,7 +750,14 @@ class GpRecoverSegmentProgram:
         addTo.add_option("-B", None, type="int", default=16,
                          dest="parallelDegree",
                          metavar="<parallelDegree>",
-                         help="Max # of workers to use for building recovery segments.  [default: %default]")
+                         help="Max number of hosts to operate on in parallel. Valid values are: 1-%d"
+                              % gp.MAX_SEGHOST_NUM_WORKERS)
+        addTo.add_option("-b", None, type="int", default=64,
+                         dest="parallelPerHost",
+                         metavar="<parallelPerHost>",
+                         help="Max number of segments per host to operate on in parallel. Valid values are: 1-%d"
+                              % gp.MAX_SEGHOST_NUM_WORKERS)
+
         addTo.add_option("-r", None, default=False, action='store_true',
                          dest='rebalanceSegments', help='Rebalance synchronized segments.')
         addTo.add_option('', '--hba-hostnames', action='store_true', dest='hba_hostnames',

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -59,6 +59,9 @@ class GpAddMirrorsTest(GpTestCase):
         super(GpAddMirrorsTest, self).tearDown()
 
     def test_validate_heap_checksum_succeeds_if_cluster_consistent(self):
+        sys.argv = ['gpaddmirrors', '-a']
+        options, _ = self.parser.parse_args()
+        self.subject = GpAddMirrorsProgram(options)
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
         self.mock_heap_checksum.return_value.are_segments_consistent.return_value = True
         self.mock_heap_checksum.return_value.check_segment_consistency.return_value = ([2], [], 1)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -26,6 +26,7 @@ class Options:
 
         self.outputSampleConfigFile = None
         self.parallelDegree = 1
+        self.parallelPerHost = 1
         self.forceFullResynchronization = None
         self.persistent_check = None
         self.quiet = None

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -32,7 +32,7 @@ class RebalanceSegmentsTestCase(GpTestCase):
         self.success_command_mock.get_results.return_value = CommandResult(
             0, "stdout success text", "stderr text", True, False)
 
-        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors())
+        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors(), 1, 1)
         self.subject.logger = Mock()
 
     def tearDown(self):

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -286,7 +286,7 @@ def parseargs():
     parser.add_option('-c', '--confinfo', type='string')
     parser.add_option('-t', '--tarfile', type='string')
     parser.add_option('-n', '--newsegments', action='store_true')
-    parser.add_option('-B', '--batch-size', type='int', default=DEFAULT_BATCH_SIZE, metavar='<batch_size>')
+    parser.add_option('-b', '--batch-size', type='int', default=DEFAULT_BATCH_SIZE, metavar='<batch_size>')
     parser.add_option("-V", "--validation-only", dest="validationOnly", action='store_true', default=False)
     parser.add_option("-W", "--write-gpid-file-only", dest="writeGpidFileOnly", action='store_true', default=False)
     parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -132,7 +132,7 @@ class GpSegStart:
 
     def __init__(self, dblist, gpversion, mirroringMode, num_cids, era,
                  timeout, pickledTransitionData, specialMode, wrapper, wrapper_args,
-                 master_checksum_version, parallel, logfileDirectory=False):
+                 master_checksum_version, segment_batch_size, logfileDirectory=False):
 
         # validate/store arguments
         #
@@ -160,7 +160,7 @@ class GpSegStart:
 
         # initialize state
         #
-        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), parallel))
+        self.pool                  = base.WorkerPool(numWorkers=min(len(dblist), segment_batch_size))
         self.logger                = logger
         self.overall_status        = None
 
@@ -353,7 +353,8 @@ class GpSegStart:
         parser.add_option('', '--wrapper', dest="wrapper", default=None, type='string')
         parser.add_option('', '--wrapper-args', dest="wrapper_args", default=None, type='string')
         parser.add_option('', '--master-checksum-version', dest="master_checksum_version", default=None, type='string', action="store")
-        parser.add_option('-B', '--parallel', type="int", dest="parallel", default=gp.DEFAULT_GPSTART_NUM_WORKERS, help='maximum size of a threadpool to start segments')
+        parser.add_option('-b', '--segment-batch-size', type="int", dest="segment_batch_size", default=gp.DEFAULT_GPSTART_NUM_WORKERS,
+                          help='Max number of segments per host to operate on in parallel.')
 
         return parser
 
@@ -375,7 +376,7 @@ class GpSegStart:
                           options.wrapper,
                           options.wrapper_args,
                           options.master_checksum_version,
-                          options.parallel,
+                          options.segment_batch_size,
                           logfileDirectory=logfileDirectory)
 
 #-------------------------------------------------------------------------

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -95,6 +95,9 @@ def before_scenario(context, scenario):
     if 'gpmovemirrors' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()
 
+    if 'gprecoverseg' in context.feature.tags:
+        context.mirror_context = MirrorMgmtContext()
+
     if 'gpconfig' in context.feature.tags:
         context.gpconfig_context = GpConfigContext()
 

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -14,6 +14,27 @@ Feature: Tests for gpaddmirrors
           And user can start transactions
          Then the tablespace is valid
 
+    Scenario Outline: limits number of parallel processes correctly
+        Given the cluster is generated with "3" primaries only
+        And a tablespace is created with data
+        When gpaddmirrors adds 3 mirrors with additional args "<args>"
+        Then gpaddmirrors should only spawn up to <master_workers> workers in WorkerPool
+        And check if gpaddmirrors ran "$GPHOME/bin/lib/gpconfigurenewsegment" 2 times with args "-b <segHost_workers>"
+        And check if gpaddmirrors ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
+        And an FTS probe is triggered
+        And the segments are synchronized
+        And verify the database has mirrors
+        And the tablespace is valid
+        And user stops all primary processes
+        And user can start transactions
+        And the tablespace is valid
+
+    Examples:
+        | args      | master_workers | segHost_workers |
+        | -B 1 -b 1 |  1             |  1              |
+        | -B 2 -b 1 |  2             |  1              |
+        | -B 1 -b 2 |  1             |  2              |
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -69,6 +69,27 @@ Feature: Tests for gpmovemirrors
           And verify that mirrors are recognized after a restart
           And the tablespace is valid
 
+    Scenario Outline: gpmovemirrors limits number of parallel processes correctly
+        Given a standard local demo cluster is created
+        And a tablespace is created with data
+        And 2 gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
+        And a good gpmovemirrors file is created for moving 2 mirrors
+        When the user runs gpmovemirrors with additional args "<args>"
+        Then gpmovemirrors should return a return code of 0
+        And check if gpmovemirrors ran "$GPHOME/bin/gprecoverseg" 1 times with args "<args>"
+        And gpmovemirrors should only spawn up to <master_workers> workers in WorkerPool
+        And verify the database has mirrors
+        And all the segments are running
+        And the segments are synchronized
+        And verify that mirrors are recognized after a restart
+        And the tablespace is valid
+
+    Examples:
+        | args      | master_workers |
+        | -B 1 -b 1 |  1             |
+        | -B 2 -b 1 |  2             |
+        | -B 1 -b 2 |  1             |
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -35,6 +35,24 @@ Feature: gprecoverseg tests
           And the tablespace is valid
           And the other tablespace is valid
 
+    Scenario Outline: full recovery limits number of parallel processes correctly
+        Given a standard local demo cluster is created
+        And 2 gprecoverseg directory under '/tmp/recoverseg' with mode '0700' is created
+        And a good gprecoverseg input file is created for moving 2 mirrors
+        When the user runs gprecoverseg with input file and additional args "-a -F -v <args>"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should only spawn up to <master_workers> workers in WorkerPool
+        And check if gprecoverseg ran "$GPHOME/bin/lib/gpconfigurenewsegment" 2 times with args "-b <segHost_workers>"
+        And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
+        And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
+        And the segments are synchronized
+
+      Examples:
+        | args      | master_workers | segHost_workers |
+        | -B 1 -b 1 |  1             |  1              |
+        | -B 2 -b 1 |  2             |  1              |
+        | -B 1 -b 2 |  1             |  2              |
+
     Scenario: gprecoverseg should not output bootstrap error on success
         Given the database is running
         And user stops all primary processes

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -53,6 +53,25 @@ Feature: gprecoverseg tests
         | -B 2 -b 1 |  2             |  1              |
         | -B 1 -b 2 |  1             |  2              |
 
+    Scenario Outline: Rebalance correctly limits the number of concurrent processes
+      Given the database is running
+      And user stops all primary processes
+      And user can start transactions
+      And the user runs "gprecoverseg -a -v <args>"
+      And gprecoverseg should return a return code of 0
+      And the segments are synchronized
+      When the user runs "gprecoverseg -ra -v <args>"
+      Then gprecoverseg should return a return code of 0
+      And gprecoverseg should only spawn up to <master_workers> workers in WorkerPool
+      And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
+      And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
+
+    Examples:
+      | args      | master_workers | segHost_workers |
+      | -B 1 -b 1 |  1             |  1              |
+      | -B 2 -b 1 |  2             |  1              |
+      | -B 1 -b 2 |  1             |  2              |
+
     Scenario: gprecoverseg should not output bootstrap error on success
         Given the database is running
         And user stops all primary processes

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2700,6 +2700,7 @@ def impl(context):
 
 @given('an FTS probe is triggered')
 @when('an FTS probe is triggered')
+@then('an FTS probe is triggered')
 def impl(context):
     with dbconn.connect(dbconn.DbURL(dbname='postgres'), unsetSearchPath=False) as conn:
         dbconn.execSQLForSingleton(conn, "SELECT gp_request_fts_probe_scan()")

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -508,6 +508,34 @@ def impl(context, command, out_msg, num):
         raise Exception("Expected %s to occur %s times. Found %d" % (out_msg, num, count))
 
 
+def lines_matching_both(in_str, str_1, str_2):
+    lines = [x.strip() for x in in_str.split('\n')]
+    return [x for x in lines if x.count(str_1) and x.count(str_2)]
+
+
+@then('check if {command} ran "{called_command}" {num} times with args "{args}"')
+def impl(context, command, called_command, num, args):
+    run_cmd_out = "Running Command: %s" % called_command
+    matches = lines_matching_both(context.stdout_message, run_cmd_out, args)
+
+    if len(matches) != int(num):
+        raise Exception("Expected %s to occur with %s args %s times. Found %d. \n %s"
+                        % (called_command, args, num, len(matches), context.stdout_message))
+
+
+@then('{command} should only spawn up to {num} workers in WorkerPool')
+def impl(context, command, num):
+    workerPool_out = "WorkerPool() initialized with"
+    matches = lines_matching_both(context.stdout_message, workerPool_out, command)
+
+    for matched_line in matches:
+        iw_re = re.search('initialized with (\d+) workers', matched_line)
+        init_workers = int(iw_re.group(1))
+        if init_workers > int(num):
+            raise Exception("Expected Workerpool for %s to be initialized with %d workers. Found %d. \n %s"
+                            % (command, num, init_workers, context.stdout_message))
+
+
 @given('{command} should return a return code of {ret_code}')
 @when('{command} should return a return code of {ret_code}')
 @then('{command} should return a return code of {ret_code}')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -15,11 +15,11 @@ class MirrorMgmtContext:
         self.input_file = None
 
     def input_file_path(self):
-        if self.working_directory is None:
+        if not self.working_directory:
             raise Exception("working directory not set")
         if self.input_file is None:
             raise Exception("input file not set")
-        return path.normpath(path.join(self.working_directory,self.input_file))
+        return path.normpath(path.join(self.working_directory[0], self.input_file))
 
 
 def _generate_input_config(spread=False):
@@ -294,10 +294,16 @@ def impl(context, mirror_config):
                 raise Exception('Expected primaries on %s to all be mirrored to the same host, but they are mirrored to %d different hosts' %
                         (primary_host, num_mirror_hosts))
 
-@given("a gpmovemirrors directory under '{parent_dir}' with mode '{mode}' is created")
-def impl(context, parent_dir, mode):
-    make_temp_dir(context,parent_dir, mode)
-    context.mirror_context.working_directory = context.temp_base_dir
+@given("{num} gpmovemirrors directory under '{parent_dir}' with mode '{mode}' is created")
+@given("{num} gprecoverseg directory under '{parent_dir}' with mode '{mode}' is created")
+def impl(context, num, parent_dir, mode):
+    num_dirs = 1 if num == 'a' else int(num)
+    make_temp_dir(context, parent_dir, mode)
+    context.mirror_context.working_directory = []
+    for i in range(num_dirs):
+        ith_dir = os.path.join(context.temp_base_dir, 'tmp_' + str(i))
+        os.mkdir(ith_dir, int(mode,8))
+        context.mirror_context.working_directory.append(ith_dir)
 
 
 @given("a '{file_type}' gpmovemirrors file is created")
@@ -314,7 +320,7 @@ def impl(context, file_type):
     elif file_type == 'badhost':
         badhost_config = '%s|%s|%s' % ('badhost',
                                        mirror.getSegmentPort(),
-                                       context.mirror_context.working_directory)
+                                       context.mirror_context.working_directory[0])
         contents = '%s %s' % (valid_config, badhost_config)
     elif file_type == 'samedir':
         valid_config_with_same_dir = '%s|%s|%s' % (
@@ -334,7 +340,7 @@ def impl(context, file_type):
         valid_config_with_different_dir = '%s|%s|%s' % (
             mirror.getSegmentHostName(),
             mirror.getSegmentPort(),
-            context.mirror_context.working_directory
+            context.mirror_context.working_directory[0]
         )
         contents = '%s %s' % (valid_config, valid_config_with_different_dir)
     else:
@@ -344,6 +350,26 @@ def impl(context, file_type):
     with open(context.mirror_context.input_file_path(), 'w') as fd:
         fd.write(contents)
 
+@given("a good gpmovemirrors file is created for moving {num} mirrors")
+@given("a good gprecoverseg input file is created for moving {num} mirrors")
+def impl(context, num):
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    contents = ''
+    for i in range(int(num)):
+        mirror = segments[i].mirrorDB
+
+        valid_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
+                                     mirror.getSegmentPort(),
+                                     mirror.getSegmentDataDirectory())
+        valid_config_with_different_dir = '%s|%s|%s' % (
+            mirror.getSegmentHostName(),
+            mirror.getSegmentPort(),
+            context.mirror_context.working_directory[i]
+        )
+        contents += '%s %s\n' % (valid_config, valid_config_with_different_dir)
+    context.mirror_context.input_file = "gpmovemirrors_good_multi.txt"
+    with open(context.mirror_context.input_file_path(), 'w') as fd:
+        fd.write(contents)
 
 @when('the user runs gpmovemirrors')
 def impl(context):
@@ -353,6 +379,12 @@ def impl(context):
 @when('the user runs gpmovemirrors with additional args "{extra_args}"')
 def run_gpmovemirrors(context, extra_args=''):
     cmd = "gpmovemirrors --input=%s %s" % (
+        context.mirror_context.input_file_path(), extra_args)
+    run_gpcommand(context, cmd)
+
+@when('the user runs gprecoverseg with input file and additional args "{extra_args}"')
+def impl(context, extra_args=''):
+    cmd = "gprecoverseg -i %s %s" % (
         context.mirror_context.input_file_path(), extra_args)
     run_gpcommand(context, cmd)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -60,15 +60,18 @@ def _write_datadir_config_for_three_mirrors():
     return datadir_config
 
 
-@when("gpaddmirrors adds 3 mirrors")
-def add_three_mirrors(context):
+@when('gpaddmirrors adds 3 mirrors with additional args "{args}"' )
+def add_three_mirrors_with_args(context, args):
     datadir_config = _write_datadir_config_for_three_mirrors()
     mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
     cmd_str = 'gpaddmirrors -o %s -m %s' % (mirror_config_output_file, datadir_config)
     Command('generate mirror_config file', cmd_str).run(validateAfter=True)
-    cmd = Command('gpaddmirrors ', 'gpaddmirrors -a -i %s ' % mirror_config_output_file)
-    cmd.run(validateAfter=True)
+    cmd = 'gpaddmirrors -a -v -i %s %s' % (mirror_config_output_file, args)
+    run_gpcommand(context, command=cmd)
 
+@when("gpaddmirrors adds 3 mirrors")
+def add_three_mirrors(context):
+    add_three_mirrors_with_args(context, '')
 
 def add_mirrors(context, options):
     context.mirror_config = _generate_input_config()


### PR DESCRIPTION
This is a 6X backport for https://github.com/greenplum-db/gpdb/pull/11933, https://github.com/greenplum-db/gpdb/pull/12058, https://github.com/greenplum-db/gpdb/pull/12039

gpmovemirrors and gprecoverseg spawn more parallel processes than the options passed in.
This change fixes that, correctly limiting the number of parallel processes we can spawn on master.
And also introduces an option -b to limit number of segments recovered on each individual host in parallel.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6x_gpmovemirrors_fix_parallel)
