### PR TITLE
Fix compiling error for macro ZSTD_CLEVEL_DEFAULT for 1.3.3 zstd or before.

### DIFF
--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -512,6 +512,10 @@ gz_file_open(gfile_t *fd)
 }
 #endif
 #ifdef USE_ZSTD
+
+#ifndef ZSTD_CLEVEL_DEFAULT
+#  define ZSTD_CLEVEL_DEFAULT 3 /* In version before 1.3.7 the macro may not be defined */
+#endif
 struct zstdlib_stuff
 {
 	ZSTD_inBuffer in;

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -513,8 +513,12 @@ gz_file_open(gfile_t *fd)
 #endif
 #ifdef USE_ZSTD
 
+/* The value range of the level could be found at zstd.h at different versions.
+ * Although the level in ZSTD_initCStream() has the same meaning in different
+ * versions, the macro ZSTD_CLEVEL_DEFAULT may not be defined before 1.3.7.
+ * So we borrow the macro from zstd.h at 1.3.7 in case it is not defined */
 #ifndef ZSTD_CLEVEL_DEFAULT
-#  define ZSTD_CLEVEL_DEFAULT 3 /* In version before 1.3.7 the macro may not be defined */
+#  define ZSTD_CLEVEL_DEFAULT 3
 #endif
 struct zstdlib_stuff
 {


### PR DESCRIPTION


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
