### PR TITLE
Fix query string truncation while writing it to server logs [6X backport]

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3584,7 +3584,7 @@ append_string_to_pipe_chunk(PipeProtoChunk *buffer, const char* input)
 	 */
 	if (len >= PIPE_MAX_PAYLOAD * 20)
 	{
-		len = PIPE_MAX_PAYLOAD * 20 - 1;
+		len = pg_mbcliplen(input, len, PIPE_MAX_PAYLOAD * 20 - 1);
 	}
 
 	char *data = buffer->data + buffer->hdr.len;


### PR DESCRIPTION
Long queries are truncated when logged. This wasn't done correctly because it doesn't consider the encoding. This results in some utf characters being truncated in the middle.

Backport of 24f51bb06b8595ca2d
