### PR TITLE
fix 6x gpload to support column without quotes

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1860,6 +1860,20 @@ class gpload:
                     "the Greenplum Database running on port %i?" % (errorMessage,
                     self.options.p))
 
+    def add_quote_if_not(self, col):
+        '''
+        Judge if the column name string has quotations.
+        If not, return a string with double quotations.
+        pyyaml cannot preserve quotes of string in yaml file.
+        So we need to quote the string for furter comparison if it is not quoted.
+        '''
+        if col[0] == '"' and col[-1] == '"':
+            return col
+        elif col[0] == "'" and col[-1] == "'":
+            return col
+        else:
+            return quote_ident(col)
+
     def read_columns(self):
         columns = self.getconfig('gpload:input:columns',list,None, returnOriginal=True)
         if columns != None:
@@ -1873,6 +1887,7 @@ class gpload:
                 """ remove leading or trailing spaces """
                 d = { tempkey.strip() : value }
                 key = d.keys()[0]
+                col_name = self.add_quote_if_not(key)
                 if d[key] is None:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
@@ -1889,7 +1904,7 @@ class gpload:
 
                 # Mark this column as having no mapping, which is important
                 # for do_insert()
-                self.from_columns.append([key,d[key].lower(),None, False])
+                self.from_columns.append([col_name,d[key].lower(),None, False])
         else:
             self.from_columns = self.into_columns
             self.from_cols_from_user = False

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -490,7 +490,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,46):
+        for num in range(1,47):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -899,6 +899,18 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         f.write("\! gpload -f "+mkpath('config/config_file4')+ " -d reuse_gptest\n")
         f.close()
         self.doTest(45)
+
+    def test_46_gpload_col_without_quotes(self):
+        """46 test gpload column name without quotes but has capital letters and special characters"""
+        copy_data('external_file_15.txt','data_file.txt')
+        columns = ['Field1: bigint','Field#2: text' ]
+        write_config_file(mode='insert',reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='4',columns = columns, delimiter=";",SQL=True,sql_before='set standard_conforming_strings =on;')
+        write_config_file(mode='insert',config='config/config_file2', reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='4',columns = columns, delimiter=";",SQL=True,sql_before='set standard_conforming_strings =off;')
+        f = open(mkpath('query46.sql'),'w')
+        f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
+        f.write("\! gpload -f "+mkpath('config/config_file2')+ " -d reuse_gptest\n")
+        f.close()
+        self.doTest(46)
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gpload_test/gpload2/query44.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query44.ans
@@ -1,51 +1,57 @@
-2021-01-07 07:27:52|INFO|gpload session started 2021-01-07 07:27:52
-2021-01-07 07:27:52|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 07:27:52|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-01-07 07:27:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d9f87890_50b9_11eb_97d4_0242ac120005
-2021-01-07 07:27:52|ERROR|could not run SQL "create external table ext_gpload_reusable_d9f87890_50b9_11eb_97d4_0242ac120005("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-05-18 14:53:57|INFO|gpload session started 2021-05-18 14:53:57
+2021-05-18 14:53:57|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:57|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-05-18 14:53:57|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d1914634_b7a5_11eb_827c_0050569ea4ff
+2021-05-18 14:53:57|ERROR|could not run SQL "create external table ext_gpload_reusable_d1914634_b7a5_11eb_827c_0050569ea4ff("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
 
-2021-01-07 07:27:52|INFO|rows Inserted          = 0
-2021-01-07 07:27:52|INFO|rows Updated           = 0
-2021-01-07 07:27:52|INFO|data formatting errors = 0
-2021-01-07 07:27:52|INFO|gpload failed
-2021-01-07 07:27:52|INFO|gpload session started 2021-01-07 07:27:52
-2021-01-07 07:27:52|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 07:27:52|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-01-07 07:27:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_da410e34_50b9_11eb_b64d_0242ac120005
-2021-01-07 07:27:52|ERROR|could not run SQL "create external table ext_gpload_reusable_da410e34_50b9_11eb_b64d_0242ac120005("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-05-18 14:53:57|INFO|rows Inserted          = 0
+2021-05-18 14:53:57|INFO|rows Updated           = 0
+2021-05-18 14:53:57|INFO|data formatting errors = 0
+2021-05-18 14:53:57|INFO|gpload failed
+2021-05-18 14:53:57|INFO|gpload session started 2021-05-18 14:53:57
+2021-05-18 14:53:57|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-05-18 14:53:58|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d1a53f2c_b7a5_11eb_b420_0050569ea4ff
+2021-05-18 14:53:58|ERROR|could not run SQL "create external table ext_gpload_reusable_d1a53f2c_b7a5_11eb_b420_0050569ea4ff("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
 
-2021-01-07 07:27:52|INFO|rows Inserted          = 0
-2021-01-07 07:27:52|INFO|rows Updated           = 0
-2021-01-07 07:27:52|INFO|data formatting errors = 0
-2021-01-07 07:27:52|INFO|gpload failed
-2021-01-07 07:27:53|INFO|gpload session started 2021-01-07 07:27:53
-2021-01-07 07:27:53|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 07:27:53|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
-2021-01-07 07:27:53|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-01-07 07:27:53|INFO|did not find an external table to reuse. creating ext_gpload_reusable_da82af6a_50b9_11eb_a7cb_0242ac120005
-2021-01-07 07:27:53|ERROR|could not run SQL "create external table ext_gpload_reusable_da82af6a_50b9_11eb_a7cb_0242ac120005("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-05-18 14:53:58|INFO|rows Inserted          = 0
+2021-05-18 14:53:58|INFO|rows Updated           = 0
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload failed
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:58|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
+2021-05-18 14:53:58|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-18 14:53:58|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d1b8fddc_b7a5_11eb_800b_0050569ea4ff
+2021-05-18 14:53:58|ERROR|could not run SQL "create external table ext_gpload_reusable_d1b8fddc_b7a5_11eb_800b_0050569ea4ff("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
 
-2021-01-07 07:27:53|INFO|rows Inserted          = 0
-2021-01-07 07:27:53|INFO|rows Updated           = 0
-2021-01-07 07:27:53|INFO|data formatting errors = 0
-2021-01-07 07:27:53|INFO|gpload failed
-2021-01-07 07:27:53|INFO|gpload session started 2021-01-07 07:27:53
-2021-01-07 07:27:53|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 07:27:53|ERROR|no mapping for input column "'Field1'" to output table
-2021-01-07 07:27:53|INFO|rows Inserted          = 0
-2021-01-07 07:27:53|INFO|rows Updated           = 0
-2021-01-07 07:27:53|INFO|data formatting errors = 0
-2021-01-07 07:27:53|INFO|gpload failed
-2021-01-07 07:27:53|INFO|gpload session started 2021-01-07 07:27:53
-2021-01-07 07:27:53|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 07:27:54|ERROR|no mapping for input column "Field1" to output table
-2021-01-07 07:27:54|INFO|rows Inserted          = 0
-2021-01-07 07:27:54|INFO|rows Updated           = 0
-2021-01-07 07:27:54|INFO|data formatting errors = 0
-2021-01-07 07:27:54|INFO|gpload failed
+2021-05-18 14:53:58|INFO|rows Inserted          = 0
+2021-05-18 14:53:58|INFO|rows Updated           = 0
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload failed
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:58|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|ERROR|no mapping for input column "'Field1'" to output table
+2021-05-18 14:53:58|INFO|rows Inserted          = 0
+2021-05-18 14:53:58|INFO|rows Updated           = 0
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload failed
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:58|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
+2021-05-18 14:53:58|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-18 14:53:58|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d1df2b2e_b7a5_11eb_9f7c_0050569ea4ff
+2021-05-18 14:53:58|ERROR|could not run SQL "create external table ext_gpload_reusable_d1df2b2e_b7a5_11eb_9f7c_0050569ea4ff("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-18 14:53:58|INFO|rows Inserted          = 0
+2021-05-18 14:53:58|INFO|rows Updated           = 0
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query45.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query45.ans
@@ -1,42 +1,45 @@
-2021-01-07 03:26:41|INFO|gpload session started 2021-01-07 03:26:41
-2021-01-07 03:26:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 03:26:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-07 03:26:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_28d204da_5098_11eb_b7ae_0242ac120005
-2021-01-07 03:26:41|INFO|running time: 0.15 seconds
-2021-01-07 03:26:41|INFO|rows Inserted          = 8
-2021-01-07 03:26:41|INFO|rows Updated           = 0
-2021-01-07 03:26:41|INFO|data formatting errors = 0
-2021-01-07 03:26:41|INFO|gpload succeeded
-2021-01-07 03:26:41|INFO|gpload session started 2021-01-07 03:26:41
-2021-01-07 03:26:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 03:26:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-07 03:26:41|INFO|reusing external table ext_gpload_reusable_28d204da_5098_11eb_b7ae_0242ac120005
-2021-01-07 03:26:42|INFO|running time: 0.11 seconds
-2021-01-07 03:26:42|INFO|rows Inserted          = 8
-2021-01-07 03:26:42|INFO|rows Updated           = 0
-2021-01-07 03:26:42|INFO|data formatting errors = 0
-2021-01-07 03:26:42|INFO|gpload succeeded
-2021-01-07 03:26:42|INFO|gpload session started 2021-01-07 03:26:42
-2021-01-07 03:26:42|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 03:26:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
-2021-01-07 03:26:42|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-01-07 03:26:42|INFO|did not find an external table to reuse. creating ext_gpload_reusable_294a54da_5098_11eb_933f_0242ac120005
-2021-01-07 03:26:42|INFO|running time: 0.27 seconds
-2021-01-07 03:26:42|INFO|rows Inserted          = 2
-2021-01-07 03:26:42|INFO|rows Updated           = 12
-2021-01-07 03:26:42|INFO|data formatting errors = 0
-2021-01-07 03:26:42|INFO|gpload succeeded
-2021-01-07 03:26:42|INFO|gpload session started 2021-01-07 03:26:42
-2021-01-07 03:26:42|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 03:26:42|ERROR|no mapping for input column "'Field1'" to output table
-2021-01-07 03:26:42|INFO|rows Inserted          = 0
-2021-01-07 03:26:42|INFO|rows Updated           = 0
-2021-01-07 03:26:42|INFO|data formatting errors = 0
-2021-01-07 03:26:42|INFO|gpload failed
-2021-01-07 03:26:43|INFO|gpload session started 2021-01-07 03:26:43
-2021-01-07 03:26:43|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-07 03:26:43|ERROR|no mapping for input column "Field1" to output table
-2021-01-07 03:26:43|INFO|rows Inserted          = 0
-2021-01-07 03:26:43|INFO|rows Updated           = 0
-2021-01-07 03:26:43|INFO|data formatting errors = 0
-2021-01-07 03:26:43|INFO|gpload failed
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:58|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-18 14:53:58|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d1fd26ce_b7a5_11eb_b55e_0050569ea4ff
+2021-05-18 14:53:58|INFO|running time: 0.05 seconds
+2021-05-18 14:53:58|INFO|rows Inserted          = 8
+2021-05-18 14:53:58|INFO|rows Updated           = 0
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload succeeded
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:58|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-18 14:53:58|INFO|reusing external table ext_gpload_reusable_d1fd26ce_b7a5_11eb_b55e_0050569ea4ff
+2021-05-18 14:53:58|INFO|running time: 0.04 seconds
+2021-05-18 14:53:58|INFO|rows Inserted          = 8
+2021-05-18 14:53:58|INFO|rows Updated           = 0
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload succeeded
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:58|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:58|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-05-18 14:53:58|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-18 14:53:58|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d2275f8e_b7a5_11eb_aa7f_0050569ea4ff
+2021-05-18 14:53:58|INFO|running time: 0.06 seconds
+2021-05-18 14:53:58|INFO|rows Inserted          = 2
+2021-05-18 14:53:58|INFO|rows Updated           = 12
+2021-05-18 14:53:58|INFO|data formatting errors = 0
+2021-05-18 14:53:58|INFO|gpload succeeded
+2021-05-18 14:53:58|INFO|gpload session started 2021-05-18 14:53:58
+2021-05-18 14:53:59|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:59|ERROR|no mapping for input column "'Field1'" to output table
+2021-05-18 14:53:59|INFO|rows Inserted          = 0
+2021-05-18 14:53:59|INFO|rows Updated           = 0
+2021-05-18 14:53:59|INFO|data formatting errors = 0
+2021-05-18 14:53:59|INFO|gpload failed
+2021-05-18 14:53:59|INFO|gpload session started 2021-05-18 14:53:59
+2021-05-18 14:53:59|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-18 14:53:59|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-05-18 14:53:59|INFO|reusing staging table staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-18 14:53:59|INFO|reusing external table ext_gpload_reusable_d2275f8e_b7a5_11eb_aa7f_0050569ea4ff
+2021-05-18 14:53:59|INFO|running time: 0.06 seconds
+2021-05-18 14:53:59|INFO|rows Inserted          = 0
+2021-05-18 14:53:59|INFO|rows Updated           = 14
+2021-05-18 14:53:59|INFO|data formatting errors = 0
+2021-05-18 14:53:59|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query46.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query46.ans
@@ -1,0 +1,21 @@
+2021-05-19 15:50:13|INFO|gpload session started 2021-05-19 15:50:13
+2021-05-19 15:50:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-19 15:50:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-19 15:50:13|INFO|reusing external table ext_gpload_reusable_d74b616e_b876_11eb_a2da_0050569ea4ff
+2021-05-19 15:50:13|INFO|running time: 0.04 seconds
+2021-05-19 15:50:13|INFO|rows Inserted          = 8
+2021-05-19 15:50:13|INFO|rows Updated           = 0
+2021-05-19 15:50:13|INFO|data formatting errors = 0
+2021-05-19 15:50:13|INFO|gpload succeeded
+2021-05-19 15:50:13|INFO|gpload session started 2021-05-19 15:50:13
+2021-05-19 15:50:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-19 15:50:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-19 15:50:13|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d7d192d4_b876_11eb_82a7_0050569ea4ff
+2021-05-19 15:50:13|ERROR|could not run SQL "create external table ext_gpload_reusable_d7d192d4_b876_11eb_82a7_0050569ea4ff("Field1" bigint,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-19 15:50:13|INFO|rows Inserted          = 0
+2021-05-19 15:50:13|INFO|rows Updated           = 0
+2021-05-19 15:50:13|INFO|data formatting errors = 0
+2021-05-19 15:50:13|INFO|gpload failed


### PR DESCRIPTION
fix 6x gpload to support column name without quotes in yaml file

judge if an into_column name is quoted, if not, add double quotations to it. So we can compare it correctly with the column name from database for capital letters and special characters.

Pyyaml cannot check if a string is quoted or not, so we add double quotations to not quoted column names. This will support writing into columns like 'Col_name', "Col_name" and Col_name.  '"Col_name"' is also supported.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
