### PR TITLE
Fix double free of TupleSort memory context (6X)

### DIFF
--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -489,6 +489,7 @@ ExecReScanSort(SortState *node)
 		if (NULL != node->tuplesortstate->sortstore)
 		{
 			tuplesort_end(node->tuplesortstate->sortstore);
+			node->tuplesortstate->sortstore = NULL;
 		}
 
 		/*


### PR DESCRIPTION
This is a forward port of commit 0043ae4f from 5X, with the test
removed, since it did not reproduce in 6X. In fact, it is unlikely for
this bug to occur in 6X because QueryFinishPending does not get checked
in between ExecReScanSort() and ExecSort() in many cases. This behavior
is different from 5X. However, a crash can still theoretically occur in
6X, and its better to patch this, even without a repro/test since the
fix is fairly simple.

Notes from 5X commit:

To trigger this bug, we need plan with a Sort node in a subplan that is
executed at least twice (viz. if there are multiple tuples on the outer
side).  Moreover, the QD must do a PQrequestFinish(), which sets
QueryFinishPending on all the QE processes, after the ExecRescanSort()
is executed, but before the next ExecSort(). This leaves the sort state
in an inconsistent state where node->tuplesortstate->sortstore != NULL,
but has already been freed. So another attempt to free it (in
ExecEndSort for example) will cause a crash.

This commit fixes this logic by setting the sortstore to NULL during
ExecRescanSort.

Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>
Co-authored-by: Alexandra Wang <lewang@pivotal.io>
