### PR TITLE
Fix exec location INITPLAN not showing up in \df+

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -505,10 +505,12 @@ describeFunctions(const char *functypes, const char *pattern, bool verbose, bool
 						  "  WHEN p.proexeclocation = 'a' THEN '%s'\n"
 						  "  WHEN p.proexeclocation = 'm' THEN '%s'\n"
 						  "  WHEN p.proexeclocation = 's' THEN '%s'\n"
+						  "  WHEN p.proexeclocation = 'i' THEN '%s'\n"
 						  "END as \"%s\"",
 						  gettext_noop("any"),
 						  gettext_noop("master"),
 						  gettext_noop("all segments"),
+						  gettext_noop("initplan"),
 						  gettext_noop("Execute on"));
 		appendPQExpBuffer(&buf,
 				  ",\n CASE WHEN prosecdef THEN '%s' ELSE '%s' END AS \"%s\""

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -245,6 +245,25 @@ comment on operator family dd_opfamily using btree is 'this is an operator famil
  test_psql_schema | dd_opfamily | operator family | this is an operator family
 (3 rows)
 
+-- \df+ should list all exec locations
+CREATE FUNCTION foofunc_exec_on_any() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON ANY;
+ALTER FUNCTION foofunc_exec_on_any() OWNER TO test_psql_de_role;
+CREATE FUNCTION foofunc_exec_on_master() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON MASTER;
+ALTER FUNCTION foofunc_exec_on_master() OWNER TO test_psql_de_role;
+CREATE FUNCTION foofunc_exec_on_all_segments() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON ALL SEGMENTS;
+ALTER FUNCTION foofunc_exec_on_all_segments() OWNER TO test_psql_de_role;
+CREATE FUNCTION foofunc_exec_on_initplan() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON INITPLAN;
+ALTER FUNCTION foofunc_exec_on_initplan() OWNER TO test_psql_de_role;
+\df+ foofunc_exec_on_*
+                                                                                                 List of functions
+      Schema      |             Name             | Result data type | Argument data types |  Type  | Data access  |  Execute on  | Security | Volatility |       Owner       | Language | Source code | Description 
+------------------+------------------------------+------------------+---------------------+--------+--------------+--------------+----------+------------+-------------------+----------+-------------+-------------
+ test_psql_schema | foofunc_exec_on_all_segments | integer          |                     | normal | contains sql | all segments | invoker  | volatile   | test_psql_de_role | sql      | SELECT 1    | 
+ test_psql_schema | foofunc_exec_on_any          | integer          |                     | normal | contains sql | any          | invoker  | volatile   | test_psql_de_role | sql      | SELECT 1    | 
+ test_psql_schema | foofunc_exec_on_initplan     | integer          |                     | normal | contains sql | initplan     | invoker  | volatile   | test_psql_de_role | sql      | SELECT 1    | 
+ test_psql_schema | foofunc_exec_on_master       | integer          |                     | normal | contains sql | master       | invoker  | volatile   | test_psql_de_role | sql      | SELECT 1    | 
+(4 rows)
+
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -128,6 +128,17 @@ create operator family dd_opfamily using btree;
 comment on operator family dd_opfamily using btree is 'this is an operator family';
 \dd
 
+-- \df+ should list all exec locations
+CREATE FUNCTION foofunc_exec_on_any() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON ANY;
+ALTER FUNCTION foofunc_exec_on_any() OWNER TO test_psql_de_role;
+CREATE FUNCTION foofunc_exec_on_master() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON MASTER;
+ALTER FUNCTION foofunc_exec_on_master() OWNER TO test_psql_de_role;
+CREATE FUNCTION foofunc_exec_on_all_segments() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON ALL SEGMENTS;
+ALTER FUNCTION foofunc_exec_on_all_segments() OWNER TO test_psql_de_role;
+CREATE FUNCTION foofunc_exec_on_initplan() RETURNS int AS 'SELECT 1' LANGUAGE SQL EXECUTE ON INITPLAN;
+ALTER FUNCTION foofunc_exec_on_initplan() OWNER TO test_psql_de_role;
+\df+ foofunc_exec_on_*
+
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;


### PR DESCRIPTION
When running \df+ on a function that has exec location INITPLAN, the
"Execute on" column did not properly display INITPLAN. This is because
psql was not updated to recognize the new exec location. To fix, simply
add exec location INITPLAN to the \df+ query.

commit reference:
https://github.com/greenplum-db/gpdb/commit/a21ff23b615e5f9a7dd3b02d82fad86175b188ec

Co-authored-by: Kevin Yeap <kyeap@vmware.com>
Co-authored-by: Jimmy Yih <jyih@vmware.com>

Backport of master commit:
https://github.com/greenplum-db/gpdb/commit/e0a93797eae23396a1967002208e622139c5f849