### PR TITLE
Correct behavior of CTAS with no data

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -408,19 +408,10 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		/*
 		 * If this is CREATE TABLE AS ... WITH NO DATA, there's no need
 		 * need to actually execute the plan.
-		 *
-		 * GPDB_12_MERGE_FIXME: it would be nice to apply this optimization to
-		 * materialized views as well but then QEs cannot tell the difference
-		 * between CTAS and materialized view when CreateStmt is dispatched to
-		 * QEs (see createas.c).  QEs must populate rules for materialized
-		 * views, which doesn't happen if this optimization is applied as is.
 		 */
 		if (queryDesc->plannedstmt->intoClause &&
-			queryDesc->plannedstmt->intoClause->skipData &&
-			queryDesc->plannedstmt->intoClause->viewQuery == NULL)
-		{
+			queryDesc->plannedstmt->intoClause->skipData)
 			shouldDispatch = false;
-		}
 	}
 	else if (Gp_role == GP_ROLE_EXECUTE)
 	{

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3096,6 +3096,8 @@ _outCreateStmtInfo(StringInfo str, const CreateStmt *node)
 	WRITE_BOOL_FIELD(buildAoBlkdir);
 	WRITE_NODE_FIELD(attr_encodings);
 	WRITE_BOOL_FIELD(isCtas);
+	WRITE_NODE_FIELD(intoQuery);
+	WRITE_NODE_FIELD(intoPolicy);
 
 	WRITE_NODE_FIELD(part_idx_oids);
 	WRITE_NODE_FIELD(part_idx_names);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -745,6 +745,8 @@ _readCreateStmt_common(CreateStmt *local_node)
 	READ_BOOL_FIELD(buildAoBlkdir);
 	READ_NODE_FIELD(attr_encodings);
 	READ_BOOL_FIELD(isCtas);
+	READ_NODE_FIELD(intoQuery);
+	READ_NODE_FIELD(intoPolicy);
 
 	READ_NODE_FIELD(part_idx_oids);
 	READ_NODE_FIELD(part_idx_names);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2337,6 +2337,8 @@ typedef struct CreateStmt
 	bool		buildAoBlkdir; /* whether to build the block directory for an AO table */
 	List	   *attr_encodings; /* attribute storage directives */
 	bool		isCtas;			/* CDB: is create table as */
+	Node       *intoQuery;      /* CDB: only set for matview with no data */
+	GpPolicy   *intoPolicy;     /* CDB: only set for matview with no data */
 
 	/* names chosen for partition indexes */
 	List	   *part_idx_oids;

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -253,3 +253,53 @@ select count (distinct oid) from  (select oid from pg_class where relname = 't2_
 drop table t1_github_issue_10760;
 drop table t2_github_issue_10760;
 reset optimizer;
+-- CTAS with no data will not lead to catalog inconsistent
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/11999
+create or replace function mv_action_select_issue_11999() returns bool language sql as
+'declare c cursor for select 1/0; select true';
+create materialized view sro_mv_issue_11999 as select mv_action_select_issue_11999() with no data;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'mv_action_select_issue_11999' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_sro_mv_issue_11999 as select mv_action_select_issue_11999() with no data;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'mv_action_select_issue_11999' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select count(*)
+from
+(
+  select localoid, policytype, numsegments, distkey
+  from gp_distribution_policy
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+  union all
+  select localoid, policytype, numsegments, distkey
+  from gp_dist_random('gp_distribution_policy')
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+)x;
+ count 
+-------
+     8
+(1 row)
+
+select count(distinct (localoid, policytype, numsegments, distkey))
+from
+(
+  select localoid, policytype, numsegments, distkey
+  from gp_distribution_policy
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+  union all
+  select localoid, policytype, numsegments, distkey
+  from gp_dist_random('gp_distribution_policy')
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+)x;
+ count 
+-------
+     2
+(1 row)
+
+-- then refresh should error out
+refresh materialized view sro_mv_issue_11999;
+ERROR:  division by zero
+CONTEXT:  SQL function "mv_action_select_issue_11999" statement 1


### PR DESCRIPTION
Previously even the statement of CTAS (or matview) is specified
with the no data flag, we will execute the plan for matview.
Besides, in the function `create_ctas_internal`, it builds
a CreateStmt and then dispatch to QEs. The framework is from
upstream and works well for upstream because there is only
one instance and one catalog in single Postgres. For Greenplum,
the MPP architecture force that we have to make catalog consistent.
This commit fixes the issue by dispatching the related fields to
QEs in CreateStmt.

Fix github issue https://github.com/greenplum-db/gpdb/issues/11999