### PR TITLE
Docs: corrected statement about gplogfilter

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -778,8 +778,8 @@ Distributed by: (sale_id)
         <p>Greenplum Database provides a utility called <codeph>gplogfilter</codeph> can search
           through a Greenplum Database log file for entries matching the specified criteria. By
           default, this utility searches through the Greenplum Database master log file in the
-          default logging location. For example, to display the last three lines of the master log
-          file:</p>
+          default logging location. For example, to display the last three lines of each of the log
+          files under the master directory:</p>
         <p>
           <codeblock>$ gplogfilter -n 3
 </codeblock>


### PR DESCRIPTION
The command `gplogfilter -n 3` reads the last 3 lines of each of the log files located under the master directory, not only the last 3 lines of the master logs. Corrected the docs so it reflects this more clearly.