### PR TITLE
Remove Gpmon_Incr_Rows_Out() from tuplesort.c & tuplesort_mk.c

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -1810,8 +1810,6 @@ tuplesort_gettupleslot_pos(Tuplesortstate *state, TuplesortPos *pos,
 	if (stup.tuple)
 	{
 		ExecStoreMinimalTuple(stup.tuple, slot, should_free);
-		if (state->gpmon_pkt)
-			Gpmon_Incr_Rows_Out(state->gpmon_pkt);
 		return true;
 	}
 	else

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1702,9 +1702,6 @@ tuplesort_gettupleslot_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos,
 
 #endif
 
-		if (state->gpmon_pkt)
-			Gpmon_Incr_Rows_Out(state->gpmon_pkt);
-
 		return true;
 	}
 


### PR DESCRIPTION
Remove `Gpmon_Incr_Rows_Out()` calls from `tuplesort_gettupleslot_pos()` and `tuplesort_gettupleslot_pos_mk()`. The calls to `Gpmon_Incr_Rows_Out()` from these methods are redundant, as both of them are called only from `ExecProcNode()`, which [calls `Gpmon_Incr_Rows_Out()` itself](https://github.com/greenplum-db/gpdb/blob/e4986e82c293aa6e132f1e8b47a65ec4ff25d7bd/src/backend/executor/execProcnode.c#L1158-L1162).

`ExecProcNode()` calls `Gpmon_Incr_Rows_Out()` since https://github.com/greenplum-db/gpdb/commit/c16900105465fb0a89ddca416d603759a14357f9. Note that it removed a lot of `Gpmon_Incr_Rows_Out` calls, among others.

Current redundant calls make `gpperfmon` `qexec` packets' [`rowsout`](https://github.com/greenplum-db/gpdb/blob/e4986e82c293aa6e132f1e8b47a65ec4ff25d7bd/src/include/gpmon/gpmon.h#L205) field incorrect for `Sort` nodes: this field contains value twice greater than the actual one.

### Reproduce issue
Unfortunately, I am unable to provide an easy-to-execute reproduction scenario not involving code changes in GPDB (aimed at `gp_inject_fault` usage). A more complex reproduction scenario follows.

1. Run a GPDB [demo] cluster.
2. Execute the following queries:
    ```sql
    DROP TABLE IF EXISTS lab1;
    CREATE TABLE lab1 (id int, descr text) WITH (appendonly=true) DISTRIBUTED BY (id);
    INSERT INTO lab1 SELECT generate_series(1,5000) AS id, md5(random()::text) AS descr;
    ```
3. Create session's backends on each GPDB segment by opening a transaction:
    ```sql
    BEGIN;
    SELECT 1 FROM gp_dist_random('pg_class') LIMIT 3;
    ```
4. Attach to the current session's backend process on any GPDB _segment_ using a debugger.
5. Set a breakpoint at `ExecEndSort` ([`nodeSort.c:404`](https://github.com/greenplum-db/gpdb/blob/e4986e82c293aa6e132f1e8b47a65ec4ff25d7bd/src/backend/executor/nodeSort.c#L404))
6. Execute the following query. The breakpoint set at previous step should be hit:
    ```sql
    EXPLAIN ANALYZE SELECT * FROM lab1 ORDER BY descr;
    ```
7. At breakpoint, print the value of `node->ss.ps.gpmon_pkt.u.qexec.rowsout`. This is the value sent to gpperfmon by [`EndPlanStateGpmonPkt()`](https://github.com/greenplum-db/gpdb/blob/e4986e82c293aa6e132f1e8b47a65ec4ff25d7bd/src/backend/executor/execGpmon.c#L40-L53).
8. The printed value must be close to `EXPLAIN ANALYZE` output (actual rows) for `Sort` node.
