### PR TITLE
Change the default resource group when ALTER ROLE

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -20,6 +20,20 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
 -------------
  6438        
 (1 row)
+ALTER ROLE rg_test_role_super NOSUPERUSER;
+ALTER
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ rolresgroup 
+-------------
+ 6437        
+(1 row)
+ALTER ROLE rg_test_role_super SUPERUSER;
+ALTER
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ rolresgroup 
+-------------
+ 6438        
+(1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
 ALTER

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -9,6 +9,10 @@ CREATE ROLE rg_test_role;
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 CREATE ROLE rg_test_role_super SUPERUSER;
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ALTER ROLE rg_test_role_super NOSUPERUSER;
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ALTER ROLE rg_test_role_super SUPERUSER;
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';


### PR DESCRIPTION
When altering a role set superuser or nosuperuser, should change the default
resource group to admin_group or default_group accordingly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
