### PR TITLE
Explicity call out all locus types in adjust_setop_arguments()

### DIFF
--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -164,6 +164,7 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 						break;
 
 					case CdbLocusType_SingleQE:
+					case CdbLocusType_SegmentGeneral:
 						/*
 						 * The input was focused on a single QE, but we need it in the QD.
 						 * It's bit silly to add a Motion to just move the whole result from
@@ -178,7 +179,6 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 
 					case CdbLocusType_Entry:
 					case CdbLocusType_General:
-					case CdbLocusType_SegmentGeneral:
 					case CdbLocusType_OuterQuery:
 						break;
 

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -144,7 +144,8 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 					case CdbLocusType_Null:
 					case CdbLocusType_Entry:
 					case CdbLocusType_Replicated:
-					default:
+					case CdbLocusType_OuterQuery:
+					case CdbLocusType_End:
 						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 										errmsg("unexpected argument locus to set operation")));
 						break;
@@ -177,12 +178,13 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 
 					case CdbLocusType_Entry:
 					case CdbLocusType_General:
+					case CdbLocusType_SegmentGeneral:
 					case CdbLocusType_OuterQuery:
 						break;
 
 					case CdbLocusType_Null:
 					case CdbLocusType_Replicated:
-					default:
+					case CdbLocusType_End:
 						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 										errmsg("unexpected argument locus to set operation")));
 						break;
@@ -219,7 +221,7 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 					case CdbLocusType_Entry:
 					case CdbLocusType_Null:
 					case CdbLocusType_Replicated:
-					default:
+					case CdbLocusType_End:
 						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 										errmsg("unexpected argument locus to set operation")));
 						break;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -923,6 +923,17 @@ explain (costs off) insert into t_replicate_volatile select nextval('seq_for_ins
  Optimizer: Postgres query optimizer
 (5 rows)
 
+explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
+                     QUERY PLAN                     
+----------------------------------------------------
+ Append
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Subquery Scan on "*SELECT* 1"
+               ->  Seq Scan on t_replicate_volatile
+   ->  Function Scan on nextval
+ Optimizer: Postgres query optimizer
+(6 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2577)

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -909,6 +909,17 @@ explain (costs off) insert into t_replicate_volatile select nextval('seq_for_ins
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on t_replicate_volatile
+         ->  Broadcast Motion 1:1  (slice2)
+               ->  Function Scan on nextval
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2577)

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -415,6 +415,7 @@ explain (costs off) insert into t_replicate_volatile select random() from t_repl
 explain (costs off) insert into t_replicate_volatile select random(), a, a from generate_series(1, 10) a;
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
+explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;


### PR DESCRIPTION
An omission of CdbLocusType_SegmentGeneral led to an error error:
```
psql: ERROR:  unexpected argument locus to set operation (cdbsetop.c:187)
```

when running the following SQL statements:
```sql
CREATE TABLE reptable(a int) DISTRIBUTED REPLICATED;
CREATE SEQUENCE a_sequence;
SELECT a FROM reptable UNION ALL SELECT * FROM nextval('a_sequence');
```