### PR TITLE
Fix stale sequence reference causing duplicate nextval()

### DIFF
--- a/src/test/regress/expected/sequence_gp.out
+++ b/src/test/regress/expected/sequence_gp.out
@@ -194,3 +194,29 @@ SELECT seqrelid::regclass, seqtypid::regtype, seqstart, seqincrement, seqmax, se
  descending_sequence | bigint   | 9223372036854775806 |           -1 | 9223372036854775806 |      1 |        1 | f
 (1 row)
 
+-- Test that we don't produce duplicate sequence values
+DROP SEQUENCE IF EXISTS check_no_duplicates;
+NOTICE:  sequence "check_no_duplicates" does not exist, skipping
+CREATE SEQUENCE check_no_duplicates;
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');
+ nextval 
+---------
+       1
+      21
+      41
+(3 rows)
+
+SELECT nextval('check_no_duplicates');
+ nextval 
+---------
+      61
+(1 row)
+
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');
+ nextval 
+---------
+       2
+      22
+      42
+(3 rows)
+

--- a/src/test/regress/sql/sequence_gp.sql
+++ b/src/test/regress/sql/sequence_gp.sql
@@ -67,3 +67,10 @@ INSERT INTO descending_sequence_insert SELECT i, nextval('descending_sequence') 
 SELECT * FROM descending_sequence_insert ORDER BY b DESC;
 SELECT * FROM descending_sequence;
 SELECT seqrelid::regclass, seqtypid::regtype, seqstart, seqincrement, seqmax, seqmin, seqcache, seqcycle FROM pg_sequence WHERE seqrelid='descending_sequence'::regclass;
+
+-- Test that we don't produce duplicate sequence values
+DROP SEQUENCE IF EXISTS check_no_duplicates;
+CREATE SEQUENCE check_no_duplicates;
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');
+SELECT nextval('check_no_duplicates');
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');


### PR DESCRIPTION
Issue is that since `nextval_internal()` handles requests from both QD
and QE, it was possible to reference a `SeqTable` object containing
cached numbers that belonged to a different requestor. This led to a
chance to generate duplicate sequence values.

This issue may be benign as typical `nextval()` request flows from QE to
QD, except when user calls `SELECT nextval()` directly on QD itself.
However, seems better to be consistent and not produce any duplicate
sequence values.