### PR TITLE
(6x backport) Dispatch collClause field for CreateDomainStmt.

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -789,6 +789,7 @@ _outCreateDomainStmt(StringInfo str, CreateDomainStmt *node)
 	WRITE_NODE_TYPE("CREATEDOMAINSTMT");
 	WRITE_NODE_FIELD(domainname);
 	WRITE_NODE_FIELD(typeName);
+	WRITE_NODE_FIELD(collClause);
 	WRITE_NODE_FIELD(constraints);
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3000,6 +3000,7 @@ _outCreateDomainStmt(StringInfo str, const CreateDomainStmt *node)
 	WRITE_NODE_TYPE("CREATEDOMAINSTMT");
 	WRITE_NODE_FIELD(domainname);
 	WRITE_NODE_FIELD_AS(typeName, typename);
+	WRITE_NODE_FIELD(collClause);
 	WRITE_NODE_FIELD(constraints);
 }
 #endif /* COMPILING_BINARY_FUNCS */

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2544,6 +2544,7 @@ _readCreateDomainStmt(void)
 
 	READ_NODE_FIELD(domainname);
 	READ_NODE_FIELD(typeName);
+	READ_NODE_FIELD(collClause);
 	READ_NODE_FIELD(constraints);
 
 	READ_DONE();

--- a/src/test/regress/expected/domain.out
+++ b/src/test/regress/expected/domain.out
@@ -822,3 +822,24 @@ create domain testdomain1 as int constraint unsigned check (value > 0);
 alter domain testdomain1 rename constraint unsigned to unsigned_foo;
 alter domain testdomain1 drop constraint unsigned_foo;
 drop domain testdomain1;
+--
+-- Create Domain will dispatch collation
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/12015
+--
+create domain testdomain_issue_12015 as text collate "C";
+select count(distinct (typname, collname))
+from
+(
+  select  typname,
+          (select collname from pg_collation where oid = typcollation)
+  from pg_type where typname = 'testdomain_issue_12015'
+  union all
+  select typname,
+         (select collname from pg_collation where oid = typcollation)
+  from gp_dist_random('pg_type') where typname = 'testdomain_issue_12015'
+)x;
+ count 
+-------
+     1
+(1 row)
+

--- a/src/test/regress/expected/domain_optimizer.out
+++ b/src/test/regress/expected/domain_optimizer.out
@@ -823,3 +823,24 @@ create domain testdomain1 as int constraint unsigned check (value > 0);
 alter domain testdomain1 rename constraint unsigned to unsigned_foo;
 alter domain testdomain1 drop constraint unsigned_foo;
 drop domain testdomain1;
+--
+-- Create Domain will dispatch collation
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/12015
+--
+create domain testdomain_issue_12015 as text collate "C";
+select count(distinct (typname, collname))
+from
+(
+  select  typname,
+          (select collname from pg_collation where oid = typcollation)
+  from pg_type where typname = 'testdomain_issue_12015'
+  union all
+  select typname,
+         (select collname from pg_collation where oid = typcollation)
+  from gp_dist_random('pg_type') where typname = 'testdomain_issue_12015'
+)x;
+ count 
+-------
+     1
+(1 row)
+

--- a/src/test/regress/sql/domain.sql
+++ b/src/test/regress/sql/domain.sql
@@ -586,3 +586,22 @@ create domain testdomain1 as int constraint unsigned check (value > 0);
 alter domain testdomain1 rename constraint unsigned to unsigned_foo;
 alter domain testdomain1 drop constraint unsigned_foo;
 drop domain testdomain1;
+
+--
+-- Create Domain will dispatch collation
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/12015
+--
+
+create domain testdomain_issue_12015 as text collate "C";
+
+select count(distinct (typname, collname))
+from
+(
+  select  typname,
+          (select collname from pg_collation where oid = typcollation)
+  from pg_type where typname = 'testdomain_issue_12015'
+  union all
+  select typname,
+         (select collname from pg_collation where oid = typcollation)
+  from gp_dist_random('pg_type') where typname = 'testdomain_issue_12015'
+)x;


### PR DESCRIPTION
This field will be saved in catalog, if we do not
dispatch it then the catalog is not consistent among
the cluster.

Fix github issue: https://github.com/greenplum-db/gpdb/issues/12015

-------

This is in master branch, now backport.