### PR TITLE
Keep pg_rewind log if incremental gprecoverseg fails.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -416,9 +416,6 @@ class GpMirrorListToBuild:
                                                           suppressErrorCheck=True,
                                                           progressCmds=progressCmds)
 
-        self.__runWaitAndCheckWorkerPoolForErrorsAndClear(removeCmds, "removing rewind progress logfiles",
-                                                          suppressErrorCheck=False)
-
         rewindFailedSegments = []
         for cmd in completedCmds:
             self.__logger.debug('pg_rewind results: %s' % cmd.results)
@@ -428,6 +425,10 @@ class GpMirrorListToBuild:
                 self.__logger.warning(cmd.get_stdout())
                 self.__logger.warning("Incremental recovery failed for dbid %d. You must use gprecoverseg -F to recover the segment." % dbid)
                 rewindFailedSegments.append(rewindInfo[dbid].targetSegment)
+
+        if len(rewindFailedSegments) == 0:
+            self.__runWaitAndCheckWorkerPoolForErrorsAndClear(removeCmds, "removing rewind progress logfiles",
+                                                              suppressErrorCheck=False)
 
         return rewindFailedSegments
 

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -371,7 +371,7 @@ class GpMirrorListToBuild:
         # Run pg_rewind on all the targets
         cmds = []
         progressCmds = []
-        removeCmds= []
+        removeCmds = {}
         for rewindSeg in list(rewindInfo.values()):
             # Do CHECKPOINT on source to force TimeLineID to be updated in pg_control.
             # pg_rewind wants that to make incremental recovery successful finally.
@@ -403,11 +403,10 @@ class GpMirrorListToBuild:
                                    rewindSeg.sourcePort,
                                    rewindSeg.progressFile,
                                    verbose=True)
-            progressCmd, removeCmd = self.__getProgressAndRemoveCmds(rewindSeg.progressFile,
+            progressCmd, removeCmds[cmd] = self.__getProgressAndRemoveCmds(rewindSeg.progressFile,
                                                                      rewindSeg.targetSegment.getSegmentDbId(),
                                                                      rewindSeg.targetSegment.getSegmentHostName())
             cmds.append(cmd)
-            removeCmds.append(removeCmd)
             if progressCmd:
                 progressCmds.append(progressCmd)
 
@@ -425,9 +424,10 @@ class GpMirrorListToBuild:
                 self.__logger.warning(cmd.get_stdout())
                 self.__logger.warning("Incremental recovery failed for dbid %d. You must use gprecoverseg -F to recover the segment." % dbid)
                 rewindFailedSegments.append(rewindInfo[dbid].targetSegment)
+                del removeCmds[cmd]
 
-        if len(rewindFailedSegments) == 0:
-            self.__runWaitAndCheckWorkerPoolForErrorsAndClear(removeCmds, "removing rewind progress logfiles",
+        if removeCmds:
+            self.__runWaitAndCheckWorkerPoolForErrorsAndClear(list(removeCmds.values()), "removing rewind progress logfiles",
                                                               suppressErrorCheck=False)
 
         return rewindFailedSegments


### PR DESCRIPTION
Previously if incremental gprecoverseg fails we have to rerun with -v to get
the pg_rewind log for debugging. This is not convenient and also sometimes the
pg_rewind related log in gprecoverseg verbose output is not complete (seems is
being fixed though) somehow.  Let's keep the pg_rewind log if incremental
gprecoverseg fails.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
