### PR TITLE
6X: Remove AIX build support from gpAux.

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -77,7 +77,7 @@ Pipeline validated: all jobs accounted for
   Generate Pipeline type: .. : prod
   Pipeline file ............ : ~/workspace/gpdb/concourse/pipelines/gpdb_6X_STABLE-generated.yml
   Template file ............ : gpdb-tpl.yml
-  OS Types ................. : ['centos6', 'centos7', 'aix7', 'win']
+  OS Types ................. : ['centos6', 'centos7', 'win']
   Test sections ............ : ['ICW', 'Replication', 'ResourceGroups', 'Interconnect', 'CLI', 'UD', 'AA', 'Extensions', 'Gpperfmon']
   test_trigger ............. : True
 ======================================================================

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -124,15 +124,9 @@ DEFPORT=5432
 
 ORCA_CONFIG=--enable-orca
 
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
-APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
-endif
-
-aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-orca --without-zstd $(APR_CONFIG)
 rhel6_x86_64_CONFIGFLAGS=--with-quicklz  --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
 rhel7_x86_64_CONFIGFLAGS=--with-quicklz  --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
 rhel8_x86_64_CONFIGFLAGS=--with-quicklz  --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
-linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
 ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
 sles12_x86_64_CONFIGFLAGS=--with-quicklz --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
 photon3_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
@@ -144,11 +138,6 @@ ifdef CONFIGURE_FLAGS
 CONFIGFLAGS+= $(CONFIGURE_FLAGS)
 endif
 
-# PL/Python does not compile on Tiger, skipping it on AIX
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
-PG_LANG=false
-endif
-
 ifneq (false, ${PG_LANG})
 CONFIGFLAGS+= --with-perl --with-python
 ifdef TCL_CFG
@@ -156,32 +145,10 @@ CONFIGFLAGS+= --with-tcl-config=${TCL_CFG}
 endif
 endif
 
-# Configure in the extra path AIX requires for pthread support
-aix7_ppc_64_PTHREADS_LIB_DIR=/usr/lib/threads
-BLD_PTHREADS_LIB_DIR=$($(BLD_ARCH)_PTHREADS_LIB_DIR)
-
 # Configure in thirdparty libraries from the ext/ directory
 CONFIG_INCLUDES=$(BLD_THIRDPARTY_INCLUDE_DIR) $(BLD_THIRDPARTY_INCLUDE_DIR)/libxml2
 CONFIG_LIBRARIES=$(strip $(BLD_THIRDPARTY_LIB_DIR) $(BLD_CXX_LIB_DIR) $(BLD_PTHREADS_LIB_DIR))
-CONFIGFLAGS+= --with-includes="$(CONFIG_INCLUDES)" --with-libraries="$(CONFIG_LIBRARIES)"
-
-# Configure in "authlibs"...
-# ...without an ext/ dir copy of curl-config on Tiger or AIX
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 rhel6_x86_64 rhel7_x86_64 rhel8_x86_64 ubuntu18.04_x86_64 sles12_x86_64 photon3_x86_64)" ""
-BLD_CURL_CONFIG=CURL_CONFIG=$(BLD_THIRDPARTY_BIN_DIR)/curl-config
-endif
-# ...and do not include the authlibs on Windows or AIX
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
-CONFIGFLAGS+= --with-openssl --with-pam --with-ldap $(BLD_CURL_CONFIG) $(APR_CONFIG)
-endif
-
-# ...but do include some of the authlibs on AIX
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
-CONFIGFLAGS+= --with-openssl --with-pam --without-krb5 --with-ldap $(BLD_CURL_CONFIG)
-endif
-
-# Platform-specific config flags
-aix7_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
+CONFIGFLAGS+= --with-openssl --with-pam --with-ldap --with-includes="$(CONFIG_INCLUDES)" --with-libraries="$(CONFIG_LIBRARIES)"
 
 CONFIG_ADDITIONS=$($(BLD_ARCH)_CONFIG_ADDITIONS)
 
@@ -194,15 +161,12 @@ RECONFIG :
 	rm -f Release/GNUmakefile
 	rm -f $(GPPGDIR)/GNUmakefile
 
-# avoid AIX's restricted shell
-aix7_ppc_64_CONFIG_SHELL=/usr/bin/bash
-BLD_CONFIG_SHELL=$($(BLD_ARCH)_CONFIG_SHELL)
 $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p $(GPPGDIR)
 	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
 	cd $(GPPGDIR) && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"    \
-                     CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL) \
+                     CFLAGS=$(INSTCFLAGS) 					  \
                      ./configure $(CONFIGFLAGS)               \
                          --prefix=$(INSTLOC)                  \
                          --mandir=$(INSTLOC)/man
@@ -212,7 +176,7 @@ Debug/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	mkdir -p Debug
 	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
 	cd Debug && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"        \
-                CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)     \
+                CFLAGS=$(INSTCFLAGS)					     \
                 ./configure $(CONFIGFLAGS)                   \
                     --prefix=$(INSTLOC)                      \
                     --mandir=$(INSTLOC)/man
@@ -222,7 +186,7 @@ Release/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	mkdir -p Release
 	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
 	cd Release && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"     \
-                  CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)  \
+                  CFLAGS=$(INSTCFLAGS) 	                    \
                   ./configure $(CONFIGFLAGS)                \
                       --prefix=$(INSTLOC)                   \
                       --mandir=$(INSTLOC)/man
@@ -248,8 +212,6 @@ autoconf : RECONFIG
 BLD_LD_LIBRARY_PATH:=$($(BLD_ARCH)_LD_LIBRARY_PATH):$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
 export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE)=$(BLD_LD_LIBRARY_PATH)
 
-# how much of GPDB to build by platform (default is "full")
-aix7_ppc_64_GPDB_BUILDSET=aix_subset
 BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
 perl_archlibexp:=$(shell perl -MConfig -e 'print $$Config{archlibexp}')
 
@@ -270,27 +232,6 @@ define BUILD_STEPS
                          CLIENTSINSTLOC=$(CLIENTSINSTLOC)
 endef
 
-ifeq "$(BLD_GPDB_BUILDSET)" "aix_subset"
-define BUILD_STEPS
-	rm -rf $(INSTLOC)
-	cd $(BUILDDIR)/gpMgmt/ && $(MAKE) generate_greenplum_path_file
-	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/parser/gram.h
-	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/errcodes.h
-	cd $(BUILDDIR)/src/backend/ && $(MAKE) ../../src/include/utils/fmgroids.h
-	cd $(BUILDDIR)/src/include/ && $(MAKE) install
-	cd $(BUILDDIR)/src/interfaces/libpq/ && $(MAKE) install
-	cd $(BUILDDIR)/src/bin/pg_config/ && $(MAKE) install
-	cd $(BUILDDIR)/src/bin/psql/ && $(MAKE) install
-	cd $(BUILDDIR)/src/bin/pg_dump/ && $(MAKE) install
-	cd $(BUILDDIR)/src/bin/gpfdist && $(MAKE) install
-	@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
-	@$(MAKE) copylibs INSTLOC=$(INSTLOC)
-	@$(MAKE) copydocs INSTLOC=$(INSTLOC)
-	cd $(GPMGMT)/bin && $(MAKE) pygresql INSTLOC=$(INSTLOC)
-	@$(MAKE) clients INSTLOC=$(INSTLOC) CLIENTSINSTLOC=$(CLIENTSINSTLOC)
-	@$(MAKE) set_scripts_version INSTLOC=$(CLIENTSINSTLOC)
-endef
-endif
 ifeq "$(BLD_GPDB_BUILDSET)" "partial"
 define BUILD_STEPS
 	rm -rf $(INSTLOC)
@@ -444,13 +385,8 @@ CLIENTS_FILESET_BINEXT = $(strip $(tmpCLIENTS_FILESET_BINEXT))
 
 # define python file subset to ship by platform, as desired
 BLD_PYTHON_FILESET=.
-aix7_ppc_64_PYTHON_FILESET=bin/python* lib/*python* lib64/*python* include/python*
-ifneq "$($(BLD_ARCH)_PYTHON_FILESET)" ""
-BLD_PYTHON_FILESET=$($(BLD_ARCH)_PYTHON_FILESET)
-endif
 
 BLD_OS:=$(shell uname -s)
-AIX_CLIENTS_LIBS=libbz2.a libz.a libpq.a liblber*.a libldap*.a libyaml*.a libcrypto.so* libevent*.a
 Darwin_CLIENTS_LIBS=libcrypto.*.dylib libssl.*.dylib libpq.*.dylib* libkrb5.*.dylib libcom_err.*.dylib libldap_r-*.dylib libk5crypto.*.dylib libkrb5support.*.dylib liblber-*.dylib libyaml*.dylib
 Linux_CLIENTS_LIBS=libpq.so*
 define tmpCLIENTS_FILESET_LIB
@@ -458,21 +394,6 @@ define tmpCLIENTS_FILESET_LIB
 endef
 CLIENTS_FILESET_LIB = $(strip $(tmpCLIENTS_FILESET_LIB))
 
-aix7_ppc_64_CLIENTS_LIBS_GCC=libgcc_s.a
-aix7_ppc_64_CLIENTS_LIBS_GCC_LOC=/opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/4.8.5/ppc64/
-
-FILESET_LIB_GCC=$($(BLD_ARCH)_CLIENTS_LIBS_GCC)
-FILESET_LIB_GCC_LOC=$($(BLD_ARCH)_CLIENTS_LIBS_GCC_LOC)
-
-aix7_ppc_64_CLIENTS_LIBS_PERZL=libcrypto.a libssl.a
-
-aix7_ppc_64_CLIENTS_LIBS_PERZL_LOC=$(BLD_TOP)/ext/aix7_ppc_64/lib
-
-CLIENTS_FILESET_LIB_PERZL=$($(BLD_ARCH)_CLIENTS_LIBS_PERZL)
-CLIENTS_FILESET_LIB_PERZL_LOC=$($(BLD_ARCH)_CLIENTS_LIBS_PERZL_LOC)
-
-AIX_CLIENTS_LIBS_PWARE=libbz2.a libiconv.a libintl.a libncurses.a libpanel.a libsqlite3.a
-CLIENTS_FILESET_LIB_PWARE=$($(BLD_OS)_CLIENTS_LIBS_PWARE)
 
 ifeq "$(MPP_ARCH)" ""
 rhel6_x86_64_MPP_ARCH=RHEL6-x86_64
@@ -511,19 +432,6 @@ endif
  ifneq "$(CLIENTS_FILESET_LIB)" ""
 	 (cd $(INSTLOC)/lib/ && $(TAR) cf - $(CLIENTS_FILESET_LIB)) | (cd $(CLIENTSINSTLOC_LIB)/ && $(TAR) xpf -)$(check_pipe_for_errors)
  endif
-ifneq "$(FILESET_LIB_GCC)" ""
-	(cd $(CLIENTSINSTLOC_LIB)/ && $(TAR) cf - -C $(FILESET_LIB_GCC_LOC) $(FILESET_LIB_GCC) | $(TAR) xpf -)$(check_pipe_for_errors)
-endif
-ifneq "$(CLIENTS_FILESET_LIB_PERZL)" ""
-	# include libraries from www.perzl.org needed by the pware Python-2.6.1 build
-	mkdir -p $(CLIENTSINSTLOC_LIB_PWARE)
-	($(TAR) cf - -C $(CLIENTS_FILESET_LIB_PERZL_LOC) $(CLIENTS_FILESET_LIB_PERZL)) | ($(TAR) xpf - -C $(CLIENTSINSTLOC_LIB_PWARE))$(check_pipe_for_errors)
-endif
-ifneq "$(CLIENTS_FILESET_LIB_PWARE)" ""
-	# include libraries from pware needed by the pware Python-2.6.1 build
-	mkdir -p $(CLIENTSINSTLOC_LIB_PWARE)
-	($(TAR) cf - -C $(PYTHONHOME)/lib $(CLIENTS_FILESET_LIB_PWARE)) | ($(TAR) xpf - -C $(CLIENTSINSTLOC_LIB_PWARE))$(check_pipe_for_errors)
-endif
 	# ---- copy scripts fileset ----
 	mkdir -p $(CLIENTSINSTLOC)
 	cp -f client/scripts/greenplum_$@_path$(SCRIPT) $(CLIENTSINSTLOC)/

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -8,7 +8,6 @@ endif
 
 # include thirdparty infrastructure which depends on WHERE_THE...
 BLD_WHERE_THE_LIBRARY_THINGS_ARE=LD_LIBRARY_PATH
-aix7_ppc_64_WHERE_THE_LIBRARY_THINGS_ARE=LIBPATH
 ifneq "$($(BLD_ARCH)_WHERE_THE_LIBRARY_THINGS_ARE)" ""
 BLD_WHERE_THE_LIBRARY_THINGS_ARE=$($(BLD_ARCH)_WHERE_THE_LIBRARY_THINGS_ARE)
 endif
@@ -37,26 +36,6 @@ ifneq "$($(BLD_ARCH)_CXX)" ""
 export CXX=$($(BLD_ARCH)_CXX)
 endif
 
-# take over the path
-ifneq "$(BLD_PATH_FIXED)" "true"
-aix7_ppc_64_PATH_PREPEND=/opt/freeware/bin
-BLD_PATH_PREPEND=$($(BLD_ARCH)_PATH_PREPEND)
-ifneq "$(BLD_PATH_PREPEND)" ""
-export PATH:=$(BLD_PATH_PREPEND):$(PATH)
-endif
-export BLD_PATH_FIXED=true
-endif
-
-# take over the library search path
-aix7_ppc_64_LD_LIBRARY_PATH_PREPEND=/opt/freeware/lib
-BLD_LD_LIBRARY_PATH_PREPEND=$($(BLD_ARCH)_LD_LIBRARY_PATH_PREPEND)
-ifneq "$(BLD_LD_LIBRARY_PATH_PREPEND)" ""
-export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE):=$(BLD_LD_LIBRARY_PATH_PREPEND):$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
-endif
-export BLD_LD_LIBRARY_PATH_FIXED=true
-
-# specify python version to use for build-time and run-time
-aix7_ppc_64_PYTHONHOME=/opt/freeware
 rhel6_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 rhel7_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 rhel8_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.17
@@ -71,20 +50,14 @@ endif
 export PYTHON=python
 ifneq "$(PYTHONHOME)" ""
 export PYTHON=$(PYTHONHOME)/bin/python
-aix7_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
-ifneq "$($(BLD_ARCH)_PYTHON)" ""
-export PYTHON=$($(BLD_ARCH)_PYTHON)
-endif
 endif
 
 # if PYTHONHOME was specified above, use it for the build
 ifneq "$(PYTHONHOME)" ""
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 tmpPATH=$(PYTHONHOME)/bin:$(PATH)
 export PATH:=$(tmpPATH)
 tmpLD_LIBRARY_PATH=$(PYTHONHOME)/lib:$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
 export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE):=$(tmpLD_LIBRARY_PATH)
-endif
 endif
 
 ##
@@ -103,21 +76,12 @@ export NO_M64=1
 rhel6_x86_64_BLD_CFLAGS=-m64 -gdwarf-2 -gstrict-dwarf
 rhel7_x86_64_BLD_CFLAGS=-m64
 rhel8_x86_64_BLD_CFLAGS=-m64
-aix7_ppc_64_BLD_CFLAGS=-maix64
 BLD_CFLAGS=$($(BLD_ARCH)_BLD_CFLAGS)
 
-aix7_ppc_64_BLD_LDFLAGS=-maix64 -Wl,-bbigtoc
 BLD_LDFLAGS=$($(BLD_ARCH)_BLD_LDFLAGS)
-
-# See http://www.postgresql.org/docs/faqs.FAQ_AIX.html for an explanation of this
-ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
-export OBJECT_MODE=64
-export CONFIG_SHELL=/usr/bin/bash
-endif
 
 BLD_BITS:=$(strip $(findstring 32,$(BLD_ARCH)) $(findstring 64,$(BLD_ARCH)))
 ifeq "$(BLD_BITS)" ""
-aix7_ppc_64_BLD_BITS=64
 BLD_BITS=$($(BLD_ARCH)_BLD_BITS)
 endif
 
@@ -129,27 +93,10 @@ ifeq "$(BLD_BITS)" ""
 $(error Unable to determine value for BLD_BITS!  You may set this on the command line.)
 endif
 
-# grep by platform
 GREP=grep
-aix7_ppc_64_GREP=/opt/freeware/bin/grep
-ifneq "$($(BLD_ARCH)_GREP)" ""
-GREP=$($(BLD_ARCH)_GREP)
-endif
-
-# tar by platform
 TAR=tar
-aix7_ppc_64_TAR=gtar
-ifneq "$($(BLD_ARCH)_TAR)" ""
-TAR=$($(BLD_ARCH)_TAR)
-endif
-
-# awk by platform
-aix7_ppc_64_AWK=gawk
-ifneq "$($(BLD_ARCH)_AWK)" ""
-AWK=$($(BLD_ARCH)_AWK)
-else
 AWK=awk
-endif
+
 
 # Functions for use in this and including makefiles
 

--- a/gpAux/Makefile.thirdparty
+++ b/gpAux/Makefile.thirdparty
@@ -20,7 +20,6 @@ ifeq "$(BLD_ARCH)" ""
 BLD_ARCH:=$(shell $(BLD_TOP)/releng/set_bld_arch.sh)
 endif
 
-aix7_ppc_64_BLD_BITS=64
 rhel6_x86_64_BLD_BITS=64
 rhel7_x86_64_BLD_BITS=64
 rhel8_x86_64_BLD_BITS=64
@@ -110,9 +109,6 @@ BLD_ZLIB-1.2.3_INCDIR=$(BLD_ZLIB_HOME)/include
 .PHONY: thirdparty-dist thirdparty-dist-base thirdparty-dist-exceptions
 
 BLD_DYLIB_NAME=so
-ifeq "$(findstring aix,$(BLD_ARCH))" "aix"
-BLD_DYLIB_NAME=a
-endif
 
 ifneq "$(wildcard $(BLD_THIRDPARTY_LIB_DIR))" ""
 BLD_THIRDPARTY_BASE_SHARED_OBJECTS_DIRS=$(shell find $(BLD_THIRDPARTY_LIB_DIR) -type d)

--- a/gpAux/client/scripts/greenplum_clients_path.sh
+++ b/gpAux/client/scripts/greenplum_clients_path.sh
@@ -18,15 +18,6 @@ else
   export LD_LIBRARY_PATH
 fi
 
-# AIX uses yet another library path variable
-# Also, Python on AIX requires special copies of some libraries.  Hence, lib/pware.
-if [ xAIX = x`uname -s` ]; then
-  LIBPATH=${GPHOME_CLIENTS}/lib/pware:${GPHOME_CLIENTS}/lib:${GPHOME_CLIENTS}/ext/python/lib64:/usr/lib/threads:${LIBPATH}
-  export LIBPATH
-  GP_LIBPATH_FOR_PYTHON=${GPHOME_CLIENTS}/lib/pware
-  export GP_LIBPATH_FOR_PYTHON
-fi
-
 if [ "$1" != "-q" ]; then
   type python >/dev/null 2>&1
   if [ $? -ne 0 ]; then

--- a/gpAux/releng/set_bld_arch.sh
+++ b/gpAux/releng/set_bld_arch.sh
@@ -15,11 +15,6 @@ case "`uname -s`" in
         BLD_ARCH_HOST="$(. /etc/os-release; echo ${ID}${VERSION_ID}_$(uname -p))"
     fi
     ;;
-
-    AIX)
-    BLD_ARCH_HOST="aix`uname -v`_`prtconf | grep 'Processor Type' | awk '{print $3}' | perl -p -i -e 's,PowerPC_POWER.,ppc,'`_`prtconf -k | perl -p -i -e 's,Kernel Type: (\d+)-bit,\1,'`"
-    ;;
-
     *)
     BLD_ARCH_HOST="BLD_ARCH_unknown"
     ;;

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -81,9 +81,7 @@ pygresql:
 		./generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
 	fi
 	PATH=$(bindir):$$PATH && \
-	if [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \
-	    unset PYTHONPATH && cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
-	elif [ `uname -s` = 'OpenBSD' ]; then \
+	if [ `uname -s` = 'OpenBSD' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC=cc python setup.py build; \
 	else \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS='$(LDFLAGS) $(PYGRESQL_LDFLAGS)' python setup.py build; \
@@ -91,8 +89,6 @@ pygresql:
 	mkdir -p $(PYLIB_DIR)/pygresql
 	if [ `uname -s` = 'Darwin' ]; then \
 	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.macosx*/* $(PYLIB_DIR)/pygresql; \
-	elif [ `uname -s` = 'AIX' ]; then \
-	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.aix*/* $(PYLIB_DIR)/pygresql; \
 	elif [ `uname -s` = 'OpenBSD' ]; then \
 	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.openbsd*/* $(PYLIB_DIR)/pygresql; \
 	else \
@@ -119,11 +115,10 @@ PSUTIL_DIR=psutil-$(PSUTIL_VERSION)
 
 psutil:
 	@echo "--- psutil"
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 )" ""
 	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PSUTIL_DIR).tar.gz
 	cd $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/ && CC="$(CC)" python setup.py build
 	cp -r $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/build/lib.*/psutil $(PYLIB_DIR)
-endif
+
 
 #
 # PYYAML

--- a/gpMgmt/bin/gpload
+++ b/gpMgmt/bin/gpload
@@ -5,10 +5,6 @@ fi
 if [ ! -z "$GPHOME_LOADERS" ]; then
     . $GPHOME_LOADERS/greenplum_loaders_path.sh
 fi
-if [ `uname -s` = "AIX" ]; then
-    LIBPATH=$GP_LIBPATH_FOR_PYTHON:$LIBPATH
-    export LIBPATH
-    python_64 `which gpload.py` $*
-else
-    exec gpload.py $*
-fi
+
+exec gpload.py $*
+

--- a/gpMgmt/bin/gpload_test/gpload2/README
+++ b/gpMgmt/bin/gpload_test/gpload2/README
@@ -28,6 +28,3 @@ ssh -R8081:127.0.0.1:8081 -R8082:127.0.0.1:8082 \
 
 Finally start the test by:
 python TEST_REMOTE.py
-
-On AIX7, you need to run:
-python_64 TEST_REMOTE.py

--- a/gpdb-doc/dita/install_guide/platform-requirements.xml
+++ b/gpdb-doc/dita/install_guide/platform-requirements.xml
@@ -292,8 +292,6 @@
           <li class="- topic/li ">Red Hat Enterprise Linux x86_64 8.x (RHEL 8)</li>
           <li>Ubuntu 18.04 LTS</li>
           <li>SUSE Linux Enterprise Server x86_64 12 (SLES 12)</li>
-          <!-- li dir="ltr">AIX 7.2 (64-bit) (Client and Load Tools only)</li>
-          <li id="pm445742" class="- topic/li ">SuSE Linux Enterprise Server x86_64 SLES 11</li> -->
           <li dir="ltr">Windows 10 (32-bit and 64-bit)</li>
           <li dir="ltr">Windows 8 (32-bit and 64-bit)</li>
           <li>Windows Server 2012 (32-bit and 64-bit)</li>

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -12,10 +12,6 @@ OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 # need to link with unnecessary libraries.
 GPFDIST_LIBS =-levent
 
-ifeq ($(PORTNAME),aix)
-  GPFDIST_LIBS += -lbz2 -lbsd
-endif
-
 ifeq ($(have_yaml),yes)
   GPFDIST_LIBS += -lyaml
   OBJS += transform.o

--- a/src/template/aix
+++ b/src/template/aix
@@ -16,4 +16,3 @@ fi
 # 	AIX 5.1 and 5.2, XLC 6.0 (IBM's cc)
 # 	AIX 5.3 ML3, gcc 4.0.1
 MEMSET_LOOP_LIMIT=0
-EXTRA_LDAP_LIBS="-llber -lssl -lcrypto"


### PR DESCRIPTION
AIX has never been supported for GP6. Remove code supporting AIX in the
enterprise build system.

Authored-by: Brent Doil <bdoil@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
