### PR TITLE
gpaddmirrors: fix parallel processes -B/-b option

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -46,6 +46,12 @@ DEFAULT_SEGHOST_NUM_WORKERS=64
 #max size of thread pool on segment hosts
 MAX_SEGHOST_NUM_WORKERS=128
 
+#default batch size of thread pool on coordinator
+DEFAULT_COORDINATOR_NUM_WORKERS=16
+
+#max batch size of thread pool on coordinator
+MAX_COORDINATOR_NUM_WORKERS=64
+
 # Application name used by the pg_rewind instance that gprecoverseg starts
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -60,6 +60,9 @@ class GpAddMirrorsTest(GpTestCase):
         super(GpAddMirrorsTest, self).tearDown()
 
     def test_validate_heap_checksum_succeeds_if_cluster_consistent(self):
+        sys.argv = ['gpaddmirrors', '-a']
+        options, _ = self.parser.parse_args()
+        self.subject = GpAddMirrorsProgram(options)
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
         self.mock_heap_checksum.return_value.are_segments_consistent.return_value = True
         self.mock_heap_checksum.return_value.check_segment_consistency.return_value = ([2], [], 1)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2601,6 +2601,7 @@ def impl(context):
 
 @given('an FTS probe is triggered')
 @when('an FTS probe is triggered')
+@then('an FTS probe is triggered')
 def impl(context):
     with closing(dbconn.connect(dbconn.DbURL(dbname='postgres'), unsetSearchPath=False)) as conn:
         dbconn.querySingleton(conn, "SELECT gp_request_fts_probe_scan()")

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -63,15 +63,18 @@ def _write_datadir_config_for_three_mirrors():
     return datadir_config
 
 
-@when("gpaddmirrors adds 3 mirrors")
-def add_three_mirrors(context):
+@when('gpaddmirrors adds 3 mirrors with additional args "{args}"' )
+def add_three_mirrors_with_args(context, args):
     datadir_config = _write_datadir_config_for_three_mirrors()
     mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
     cmd_str = 'gpaddmirrors -o %s -m %s' % (mirror_config_output_file, datadir_config)
     Command('generate mirror_config file', cmd_str).run(validateAfter=True)
-    cmd = Command('gpaddmirrors ', 'gpaddmirrors -a -i %s ' % mirror_config_output_file)
-    cmd.run(validateAfter=True)
+    cmd = 'gpaddmirrors -a -v -i %s %s' % (mirror_config_output_file, args)
+    run_gpcommand(context, command=cmd)
 
+@when("gpaddmirrors adds 3 mirrors")
+def add_three_mirrors(context):
+    add_three_mirrors_with_args(context, '')
 
 def add_mirrors(context, options):
     context.mirror_config = _generate_input_config()


### PR DESCRIPTION
gpaddmirrors does not spawn correct number of parallel processes as intended by -B option.
This change fixes that behavior
We would be using two options for finer control.
'-B' option limits the number of hosts working in parallel for recovery
'-b' option limits the number of segments working in parallel on a host

https://github.com/greenplum-db/gpdb/pull/11933 added a similar feature to gpmovemirrors.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpaddmirrors_fix_parallel)