### PR TITLE
Unload hba and ident files from some processes to save memory

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -439,7 +439,23 @@ ClientAuthentication(Port *port)
 	if (is_internal_gpdb_conn(port))
 	{
 		if (internal_client_authentication(port))
+		{
+			/*
+			 * Unload hba and ident files to save memory, they are useless if
+			 * we decide to short circuit the client authentication.
+			 *
+			 * In a corner case, these flat files could be big, it would be a
+			 * serious issue if the postmaster forks them with thousands of
+			 * copies without vmem tracking.
+			 *
+			 * FYI, CoW memory is counted by system OOM killer if the Linux
+			 * configuration `vm.overcommit_memory` is 2.
+			 */
+			unload_hba();
+			unload_ident();
+
 			return;
+		}
 
 		/* Else, try the normal authentication */
 	}

--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -1832,8 +1832,8 @@ load_hba(void)
 	}
 
 	/* Loaded new file successfully, replace the one we use */
-	if (parsed_hba_context != NULL)
-		MemoryContextDelete(parsed_hba_context);
+	unload_hba();
+
 	parsed_hba_context = hbacxt;
 	parsed_hba_lines = new_parsed_lines;
 
@@ -2210,15 +2210,13 @@ load_ident(void)
 				pg_regfree(&newline->re);
 		}
 	}
-	if (parsed_ident_context != NULL)
-		MemoryContextDelete(parsed_ident_context);
+	unload_ident();
 
 	parsed_ident_context = ident_context;
 	parsed_ident_lines = new_parsed_lines;
 
 	return true;
 }
-
 
 
 /*
@@ -2233,4 +2231,21 @@ void
 hba_getauthmethod(hbaPort *port)
 {
 	check_hba(port);
+}
+
+/*
+ * Extend the visibility of these functions for memory saving
+ */
+void
+unload_hba(void)
+{
+	if (parsed_hba_context != NULL)
+		MemoryContextDelete(parsed_hba_context);
+}
+
+void
+unload_ident(void)
+{
+	if (parsed_ident_context != NULL)
+		MemoryContextDelete(parsed_ident_context);
 }

--- a/src/include/libpq/hba.h
+++ b/src/include/libpq/hba.h
@@ -98,6 +98,8 @@ typedef struct Port hbaPort;
 
 extern bool load_hba(void);
 extern bool load_ident(void);
+extern void unload_hba(void);
+extern void unload_ident(void);
 extern void hba_getauthmethod(hbaPort *port);
 extern int check_usermap(const char *usermap_name,
 			  const char *pg_role, const char *auth_user,

--- a/src/test/isolation2/expected/oom_startup_memory.out
+++ b/src/test/isolation2/expected/oom_startup_memory.out
@@ -100,3 +100,81 @@ ERROR:  failed to acquire resources on one or more segments
 DETAIL:  FATAL:  Out of memory
 DETAIL:  VM Protect failed to allocate 8388608 bytes, 0 MB available
  (seg0 192.168.99.100:25432)
+
+-- start_ignore
+! for i in `seq 1 10000`; do echo "host all gpadmin 2001:db8:3333:4444:5555:6666:7777:8888/128 trust" >> ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf; done;
+
+! gpstop -rai;
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14653.ge4c0aab229b build dev'
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/greenplum-db-data/gpseg-1
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/greenplum-db-data/gpseg-1
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-No standby coordinator host configured
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:17:20:24:2494274 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:17:20:24:2494274 gpstop:minion:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210602:17:20:24:2494274 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore
+
+-- The per segment limit should be reached sooner this time, because the
+-- startup memory got bigger.
+-- start_ignore
+9: set gp_vmem_idle_resource_timeout to '1h';
+SET
+10: set gp_vmem_idle_resource_timeout to '1h';
+SET
+11: set gp_vmem_idle_resource_timeout to '1h';
+SET
+-- end_ignore
+12: set gp_vmem_idle_resource_timeout to '1h';
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  Out of memory
+DETAIL:  VM Protect failed to allocate 18999952 bytes, 0 MB available
+ (seg0 127.0.1.1:7002)
+
+-- start_ignore
+! head -n -10000 ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf > /tmp/pg_hba.txt && mv /tmp/pg_hba.txt ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf;
+
+! gpstop -rai;
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14653.ge4c0aab229b build dev'
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-No standby coordinator host configured
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:18:05:38:2634623 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:18:05:38:2634623 gpstop:minion:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210602:18:05:38:2634623 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore

--- a/src/test/isolation2/sql/oom_startup_memory.sql
+++ b/src/test/isolation2/sql/oom_startup_memory.sql
@@ -58,3 +58,22 @@
 7: set gp_vmem_idle_resource_timeout to '1h';
 -- end_ignore
 8: set gp_vmem_idle_resource_timeout to '1h';
+
+-- start_ignore
+! for i in `seq 1 10000`; do echo "host all gpadmin 2001:db8:3333:4444:5555:6666:7777:8888/128 trust" >> ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf; done;
+! gpstop -rai;
+-- end_ignore
+
+-- The per segment limit should be reached sooner this time, because the
+-- startup memory got bigger.
+-- start_ignore
+9: set gp_vmem_idle_resource_timeout to '1h';
+10: set gp_vmem_idle_resource_timeout to '1h';
+11: set gp_vmem_idle_resource_timeout to '1h';
+-- end_ignore
+12: set gp_vmem_idle_resource_timeout to '1h';
+
+-- start_ignore
+! head -n -10000 ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf > /tmp/pg_hba.txt && mv /tmp/pg_hba.txt ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf;
+! gpstop -rai;
+-- end_ignore


### PR DESCRIPTION
They are useless if we decide to short circuit the client
authentication.

In a corner case, these flat files could be big, it would be a
serious issue if the postmaster forks them with thousands of
copies without vmem tracking.

FYI, CoW memory is counted by system OOM killer if the Linux
configuration `vm.overcommit_memory` is 2.