### PR TITLE
Unload hba, ident and role files from some processes to save memory

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -439,7 +439,25 @@ ClientAuthentication(Port *port)
 	if (is_internal_gpdb_conn(port))
 	{
 		if (internal_client_authentication(port))
+		{
+			/*
+			 * Unload hba, ident and role files to save memory, they are
+			 * useless if we decide to short circuit the client authentication.
+			 *
+			 * In a corner case, these flat files could be big, it would be a
+			 * serious issue if the postmaster forks them with thousands of
+			 * copies without vmem tracking.
+			 *
+			 * FYI, CoW memory is counted by system OOM killer if the Linux
+			 * configuration `vm.overcommit_memory` is 2.
+			 */
+			unload_hba();
+			unload_ident();
+			unload_role();
+			unload_role_interval();
+
 			return;
+		}
 
 		/* Else, try the normal authentication */
 	}

--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -1705,12 +1705,7 @@ load_role(void)
 	FILE	   *role_file;
 
 	/* Discard any old data */
-	if (role_lines || role_line_nums)
-		free_lines(&role_lines, &role_line_nums);
-	if (role_sorted)
-		pfree(role_sorted);
-	role_sorted = NULL;
-	role_length = 0;
+	unload_role();
 
 	/* Read in the file contents */
 	filename = auth_getflatfilename();
@@ -1760,12 +1755,7 @@ load_role_interval(void)
 	FILE		*role_interval_file;
 
 	/* Discard any old data */
-	if (role_interval_lines || role_interval_line_nums)
-		free_lines(&role_interval_lines, &role_interval_line_nums);
-	if (role_interval_sorted)
-		pfree(role_interval_sorted);
-	role_interval_sorted = NULL;
-	role_interval_length = 0;
+	unload_role_interval();
 
 	/* Read in the file contents */
 	filename = auth_time_getflatfilename();
@@ -1938,7 +1928,7 @@ load_hba(void)
 	}
 
 	/* Loaded new file successfully, replace the one we use */
-	clean_hba_list(parsed_hba_lines);
+	unload_hba();
 	parsed_hba_lines = new_parsed_lines;
 
 	return true;
@@ -2251,8 +2241,8 @@ load_ident(void)
 {
 	FILE	   *file;
 
-	if (ident_lines || ident_line_nums)
-		free_lines(&ident_lines, &ident_line_nums);
+	/* Discard any old data */
+	unload_ident();
 
 	file = AllocateFile(IdentFileName, "r");
 	if (file == NULL)
@@ -2287,4 +2277,42 @@ hba_getauthmethod(hbaPort *port)
 		return STATUS_OK;
 	else
 		return STATUS_ERROR;
+}
+
+/*
+ * Extend the visibility of these functions for memory saving
+ */
+void
+unload_hba(void)
+{
+	clean_hba_list(parsed_hba_lines);
+}
+
+void
+unload_ident(void)
+{
+	if (ident_lines || ident_line_nums)
+		free_lines(&ident_lines, &ident_line_nums);
+}
+
+void
+unload_role(void)
+{
+	if (role_lines || role_line_nums)
+		free_lines(&role_lines, &role_line_nums);
+	if (role_sorted)
+		pfree(role_sorted);
+	role_sorted = NULL;
+	role_length = 0;
+}
+
+void
+unload_role_interval(void)
+{
+	if (role_interval_lines || role_interval_line_nums)
+		free_lines(&role_interval_lines, &role_interval_line_nums);
+	if (role_interval_sorted)
+		pfree(role_interval_sorted);
+	role_interval_sorted = NULL;
+	role_interval_length = 0;
 }

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -80,6 +80,19 @@ static pthread_t memprotOwnerThread = {0,0};
 bool gp_mp_inited = false;
 
 /*
+ * Roughly track the memory without protection
+ *
+ * Greenplum doesn't enable the memory protection on postmaster, since it has
+ * no session, and the CoW memory aquired by fork() could not be accounted.
+ *
+ * So here roughly track the unprotected memory and count it into the startup
+ * memory. In a corner case, this memory could be big, which would be a serious
+ * issue if the postmaster forks them with thousands of copies without this
+ * tracking.
+ */
+static int64 unprotected_vmem_size;
+
+/*
  * UpdateTimeAtomically
  *
  * Updates a OOMTimeType variable atomically, using compare_and_swap_*
@@ -238,10 +251,12 @@ GPMemoryProtect_TrackStartupMemory(void)
 	Assert(gp_mp_inited);
 
 	/*
-	 * When compile without ORCA a postgress process will commit 6MB, this
-	 * includes the memory allocated before vmem tracker initialization.
+	 * This is the memory allocated before vmem tracker initialization.
+	 *
+	 * When compile without ORCA a clean postgress process will commit 6MB, as
+	 * observed.
 	 */
-	bytes += 6L << BITS_IN_MB;
+	bytes += unprotected_vmem_size > (6L << BITS_IN_MB) ? unprotected_vmem_size : (6L << BITS_IN_MB);
 
 #ifdef USE_ORCA
 	/* When compile with ORCA it will commit 6MB more */
@@ -489,12 +504,16 @@ void *gp_malloc(int64 sz)
 
 	void *ret;
 
-	if(gp_mp_inited)
+	if (gp_mp_inited)
 	{
 		return gp_malloc_internal(sz);
 	}
 
 	ret = malloc_and_store_metadata(sz);
+	if (ret)
+	{
+		unprotected_vmem_size += UserPtrSize_GetVmemPtrSize(sz);
+	}
 	return ret;
 }
 
@@ -506,14 +525,15 @@ void *gp_realloc(void *ptr, int64 new_size)
 
 	void *ret = NULL;
 
-	if(!gp_mp_inited)
-	{
-		ret = realloc_and_store_metadata(ptr, new_size);
-		return ret;
-	}
-
 	size_t old_size = UserPtr_GetUserPtrSize(ptr);
 	int64 size_diff = (new_size - old_size);
+
+	if (!gp_mp_inited)
+	{
+		ret = realloc_and_store_metadata(ptr, new_size);
+		unprotected_vmem_size += size_diff;
+		return ret;
+	}
 
 	if(new_size <= old_size || MemoryAllocation_Success == VmemTracker_ReserveVmem(size_diff))
 	{
@@ -574,4 +594,6 @@ void gp_free(void *user_pointer)
 	UserPtr_VerifyChecksum(user_pointer);
 	free(malloc_pointer);
 	VmemTracker_ReleaseVmem(UserPtrSize_GetVmemPtrSize(usable_size));
+	if (!gp_mp_inited)
+		unprotected_vmem_size -= usable_size;
 }

--- a/src/include/libpq/hba.h
+++ b/src/include/libpq/hba.h
@@ -89,6 +89,10 @@ extern bool load_hba(void);
 extern void load_ident(void);
 extern void load_role(void);
 extern void load_role_interval(void);
+extern void unload_hba(void);
+extern void unload_ident(void);
+extern void unload_role(void);
+extern void unload_role_interval(void);
 extern void force_load_role(void);
 extern int	hba_getauthmethod(hbaPort *port);
 extern bool read_pg_database_line(FILE *fp, char *dbname, Oid *dboid,

--- a/src/test/isolation2/expected/oom_startup_memory.out
+++ b/src/test/isolation2/expected/oom_startup_memory.out
@@ -100,3 +100,81 @@ ERROR:  failed to acquire resources on one or more segments
 DETAIL:  FATAL:  Out of memory
 DETAIL:  VM Protect failed to allocate 8388608 bytes, 0 MB available
  (seg0 192.168.99.100:25432)
+
+-- start_ignore
+! for i in `seq 1 10000`; do echo "host all gpadmin 2001:db8:3333:4444:5555:6666:7777:8888/128 trust" >> ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf; done;
+
+! gpstop -rai;
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14653.ge4c0aab229b build dev'
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/greenplum-db-data/gpseg-1
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/greenplum-db-data/gpseg-1
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-No standby coordinator host configured
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210602:17:20:23:2494274 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:17:20:24:2494274 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:17:20:24:2494274 gpstop:minion:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210602:17:20:24:2494274 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20210602:17:20:25:2494274 gpstop:minion:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore
+
+-- The per segment limit should be reached sooner this time, because the
+-- startup memory got bigger.
+-- start_ignore
+9: set gp_vmem_idle_resource_timeout to '1h';
+SET
+10: set gp_vmem_idle_resource_timeout to '1h';
+SET
+11: set gp_vmem_idle_resource_timeout to '1h';
+SET
+-- end_ignore
+12: set gp_vmem_idle_resource_timeout to '1h';
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  Out of memory
+DETAIL:  VM Protect failed to allocate 18999952 bytes, 0 MB available
+ (seg0 127.0.1.1:7002)
+
+-- start_ignore
+! head -n -10000 ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf > /tmp/pg_hba.txt && mv /tmp/pg_hba.txt ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf;
+
+! gpstop -rai;
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Gathering information and validating the environment...
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14653.ge4c0aab229b build dev'
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-No standby coordinator host configured
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20210602:18:05:37:2634623 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:18:05:38:2634623 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:18:05:38:2634623 gpstop:minion:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20210602:18:05:38:2634623 gpstop:minion:gpadmin-[INFO]:-0.00% of jobs completed
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-100.00% of jobs completed
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-----------------------------------------------------
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20210602:18:05:39:2634623 gpstop:minion:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore

--- a/src/test/isolation2/sql/oom_startup_memory.sql
+++ b/src/test/isolation2/sql/oom_startup_memory.sql
@@ -58,3 +58,22 @@
 7: set gp_vmem_idle_resource_timeout to '1h';
 -- end_ignore
 8: set gp_vmem_idle_resource_timeout to '1h';
+
+-- start_ignore
+! for i in `seq 1 10000`; do echo "host all gpadmin 2001:db8:3333:4444:5555:6666:7777:8888/128 trust" >> ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf; done;
+! gpstop -rai;
+-- end_ignore
+
+-- The per segment limit should be reached sooner this time, because the
+-- startup memory got bigger.
+-- start_ignore
+9: set gp_vmem_idle_resource_timeout to '1h';
+10: set gp_vmem_idle_resource_timeout to '1h';
+11: set gp_vmem_idle_resource_timeout to '1h';
+-- end_ignore
+12: set gp_vmem_idle_resource_timeout to '1h';
+
+-- start_ignore
+! head -n -10000 ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf > /tmp/pg_hba.txt && mv /tmp/pg_hba.txt ${MASTER_DATA_DIRECTORY}/../../dbfast1/demoDataDir0/pg_hba.conf;
+! gpstop -rai;
+-- end_ignore


### PR DESCRIPTION
They are useless if we decide to short circuit the client
authentication.

In a corner case, these flat files could be big, it would be a
serious issue if the postmaster forks them with thousands of
copies without vmem tracking.

FYI, CoW memory is counted by system OOM killer if the Linux
configuration `vm.overcommit_memory` is 2.