### PR TITLE
(backport to 6x) Correct behavior of CTAS with no data.

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -175,6 +175,8 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 	create->relStorage = relstorage;
 	create->ownerid = GetUserId();
 	create->isCtas = true;
+	create->intoQuery = into->viewQuery;
+	create->intoPolicy = queryDesc->plannedstmt->intoPolicy;
 
 	/*
 	 * Create the relation.  (This will error out if there's an existing view,
@@ -422,7 +424,7 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 	if (query_info_collect_hook)
 		(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 	
-	if (into->skipData && !is_matview)
+	if (into->skipData)
 	{
 		/*
 		 * If WITH NO DATA was specified, do not go through the rewriter,
@@ -632,8 +634,13 @@ intorel_initplan(struct QueryDesc *queryDesc, int eflags)
 	
 	/*
 	 * Actually create the target table.
+	 * We also get here with CREATE TABLE AS EXECUTE ... WITH NO DATA. In that
+	 * case, dispatch the creation of the table immediately. Normally, the table
+	 * is created in the initialization of the plan in QEs, but with NO DATA, we
+	 * don't need to dispatch the plan during ExecutorStart().
 	 */
-	intoRelationId = create_ctas_internal(attrList, into, queryDesc, false);
+	intoRelationId = create_ctas_internal(attrList, into, queryDesc,
+										  into->skipData ? true : false);
 
 	/*
 	 * Finally we can open the target table

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -619,6 +619,15 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		}
 
 		/*
+		 * If this is CREATE TABLE AS ... WITH NO DATA, there's no need
+		 * need to actually execute the plan.
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH &&
+			queryDesc->plannedstmt->intoClause &&
+			queryDesc->plannedstmt->intoClause->skipData)
+			shouldDispatch = false;
+
+		/*
 		 * if in dispatch mode, time to serialize plan and query
 		 * trees, and fire off cdb_exec command to each of the qexecs
 		 */

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -731,6 +731,9 @@ _outCreateStmt_common(StringInfo str, CreateStmt *node)
 	WRITE_BOOL_FIELD(buildAoBlkdir);
 	WRITE_NODE_FIELD(attr_encodings);
 	WRITE_BOOL_FIELD(isCtas);
+
+	WRITE_NODE_FIELD(intoQuery);
+	WRITE_NODE_FIELD(intoPolicy);
 }
 
 static void

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2595,6 +2595,8 @@ _outCreateStmtInfo(StringInfo str, const CreateStmt *node)
 	WRITE_BOOL_FIELD(buildAoBlkdir);
 	WRITE_NODE_FIELD(attr_encodings);
 	WRITE_BOOL_FIELD(isCtas);
+	WRITE_NODE_FIELD(intoQuery);
+	WRITE_NODE_FIELD(intoPolicy);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1074,6 +1074,8 @@ _readCreateStmt_common(CreateStmt *local_node)
 	READ_BOOL_FIELD(buildAoBlkdir);
 	READ_NODE_FIELD(attr_encodings);
 	READ_BOOL_FIELD(isCtas);
+	READ_NODE_FIELD(intoQuery);
+	READ_NODE_FIELD(intoPolicy);
 
 	/*
 	 * Some extra checks to make sure we didn't get lost

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1153,7 +1153,8 @@ ProcessUtilitySlow(Node *parsetree,
 							relOid = DefineRelation((CreateStmt *) stmt,
 													relKind,
 													((CreateStmt *) stmt)->ownerid,
-													relStorage, false, true, NULL);
+													relStorage, false, true,
+													cstmt->intoPolicy);
 
 							/*
 							 * Let NewRelationCreateToastTable decide if this
@@ -1213,12 +1214,33 @@ ProcessUtilitySlow(Node *parsetree,
 																cstmt->is_part_parent);
 							}
 							if (Gp_role == GP_ROLE_DISPATCH)
+							{
 								CdbDispatchUtilityStatement((Node *) stmt,
 															DF_CANCEL_ON_ERROR |
 															DF_NEED_TWO_PHASE |
 															DF_WITH_SNAPSHOT,
 															GetAssignedOidsForDispatch(),
 															NULL);
+							}
+							else
+							{
+								/*
+								 * Greenplum specific behavior
+								 * If intoQuery field is set, it means this is Create Matview.
+								 * To keep catalog consistent, QEs should also store the viewquery.
+								 * The call chain is:
+								 *   create_ctas_nodata()(QD) --> create_ctas_internal()(QD) -->
+								 *   dispatch create stmt(QD) --> ProcessUtilitySlow(on QE) --> StoreViewQuery()(QE).
+								 */
+								if (cstmt->intoQuery)
+								{
+									/* StoreViewQuery scribbles on tree, so make a copy */
+									Query	   *query = (Query *) copyObject(cstmt->intoQuery);
+
+									StoreViewQuery(relOid, query, false);
+								}
+							}
+
 							CommandCounterIncrement();
 							/*
 							 * Deferred statements should be evaluated *after* AO tables

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1848,6 +1848,9 @@ typedef struct CreateStmt
 	bool		buildAoBlkdir; /* whether to build the block directory for an AO table */
 	List	   *attr_encodings; /* attribute storage directives */
 	bool		isCtas;			/* CDB: is create table as */
+
+	Node       *intoQuery;      /* CDB: only set for matview with no data */
+	GpPolicy   *intoPolicy;     /* CDB: only set for matview with no data */
 } CreateStmt;
 
 /* ----------------------

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -211,3 +211,53 @@ select count (distinct oid) from  (select oid from pg_class where relname = 't2_
 drop table t1_github_issue_10760;
 drop table t2_github_issue_10760;
 reset optimizer;
+-- CTAS with no data will not lead to catalog inconsistent
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/11999
+create or replace function mv_action_select_issue_11999() returns bool language sql as
+'declare c cursor for select 1/0; select true';
+create materialized view sro_mv_issue_11999 as select mv_action_select_issue_11999() with no data;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'mv_action_select_issue_11999' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_sro_mv_issue_11999 as select mv_action_select_issue_11999() with no data;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'mv_action_select_issue_11999' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select count(*)
+from
+(
+  select localoid, policytype, numsegments, distkey
+  from gp_distribution_policy
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+  union all
+  select localoid, policytype, numsegments, distkey
+  from gp_dist_random('gp_distribution_policy')
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+)x;
+ count 
+-------
+     8
+(1 row)
+
+select count(distinct (localoid, policytype, numsegments, distkey))
+from
+(
+  select localoid, policytype, numsegments, distkey
+  from gp_distribution_policy
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+  union all
+  select localoid, policytype, numsegments, distkey
+  from gp_dist_random('gp_distribution_policy')
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+)x;
+ count 
+-------
+     2
+(1 row)
+
+-- then refresh should error out
+refresh materialized view sro_mv_issue_11999;
+ERROR:  division by zero
+CONTEXT:  SQL function "mv_action_select_issue_11999" during startup

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -121,3 +121,42 @@ drop table t1_github_issue_10760;
 drop table t2_github_issue_10760;
 
 reset optimizer;
+
+-- CTAS with no data will not lead to catalog inconsistent
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/11999
+create or replace function mv_action_select_issue_11999() returns bool language sql as
+'declare c cursor for select 1/0; select true';
+
+create materialized view sro_mv_issue_11999 as select mv_action_select_issue_11999() with no data;
+create table t_sro_mv_issue_11999 as select mv_action_select_issue_11999() with no data;
+
+select count(*)
+from
+(
+  select localoid, policytype, numsegments, distkey
+  from gp_distribution_policy
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+  union all
+  select localoid, policytype, numsegments, distkey
+  from gp_dist_random('gp_distribution_policy')
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+)x;
+
+select count(distinct (localoid, policytype, numsegments, distkey))
+from
+(
+  select localoid, policytype, numsegments, distkey
+  from gp_distribution_policy
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+  union all
+  select localoid, policytype, numsegments, distkey
+  from gp_dist_random('gp_distribution_policy')
+  where localoid::regclass::text = 'sro_mv_issue_11999' or
+        localoid::regclass::text = 't_sro_mv_issue_11999'
+)x;
+
+-- then refresh should error out
+refresh materialized view sro_mv_issue_11999;


### PR DESCRIPTION
Previously even the statement of CTAS (or matview) is specified
with the no data flag, we will execute the plan for matview.
Besides, in the function `create_ctas_internal`, it builds
a CreateStmt and then dispatch to QEs. The framework is from
upstream and works well for upstream because there is only
one instance and one catalog in single Postgres. For Greenplum,
the MPP architecture force that we have to make catalog consistent.
This commit fixes the issue by dispatching the related fields to
QEs in CreateStmt.

Fix github issue #11999

-----------------------------------

PR for master branch is merged, backporting to 6X.
