### PR TITLE
fix gpload to support column without quotes

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1869,6 +1869,20 @@ class gpload:
                     "the Greenplum Database running on port %i?" % (errorMessage,
                     self.options.p))
 
+    def add_quote_if_not(self, col):
+        '''
+        Judge if the column name string has quotations.
+        If not, return a string with double quotations.
+        pyyaml cannot preserve quotes of string in yaml file.
+        So we need to quote the string for furter comparison if it is not quoted.
+        '''
+        if col[0] == '"' and col[-1] == '"':
+            return col
+        elif col[0] == "'" and col[-1] == "'":
+            return col
+        else:
+            return quote_ident(col)
+
     def read_columns(self):
         '''
         get from columns
@@ -1885,6 +1899,7 @@ class gpload:
                 """ remove leading or trailing spaces """
                 d = { tempkey.strip() : value }
                 key = list(d.keys())[0]
+                col_name = self.add_quote_if_not(key)
                 if d[key] is None or not d[key]:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
@@ -1901,7 +1916,7 @@ class gpload:
 
                 # Mark this column as having no mapping, which is important
                 # for do_insert()
-                self.from_columns.append([key,d[key].lower(),None, False])
+                self.from_columns.append([col_name,d[key].lower(),None, False])
         else:
             self.from_columns = self.into_columns
             self.from_cols_from_user = False
@@ -2640,7 +2655,6 @@ class gpload:
                 strE = e.__str__().encode().decode('unicode-escape')
                 strF = sql.encode().decode('unicode-escape')
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
-
         #progress.condition.acquire()
         #progress.number = 1
         #progress.condition.wait()

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
@@ -104,7 +104,7 @@ def test_74_gpload_insert_partial_columns():
 def test_75_gpload_merge_chinese_standard_conforming_str_on():
     """75 gpload merge data with different quotations '"col"'  "\"col\""  "'col'" and "col" 
     with standard_conforming_strings on"""
-    copy_data("external_file_18.txt", "data_file.txt")
+    copy_data("external_file_19.txt", "data_file.txt")
     # '"col"'
     columns1 = {"'\"列1\"'": 'text',"'\"列#2\"'": 'int', "'\"lie3\"'": 'timestamp'}
     # "\"col\""

--- a/gpMgmt/bin/gpload_test/gpload2/query73.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query73.ans
@@ -1,14 +1,14 @@
-2020-12-14 17:19:12|INFO|gpload session started 2020-12-14 17:19:12
-2020-12-14 17:19:12|INFO|setting schema 'public' for table 'chinese表'
-2020-12-14 17:19:12|ERROR|no mapping for input column "notexist" to output table
-2020-12-14 17:19:12|INFO|rows Inserted          = 0
-2020-12-14 17:19:12|INFO|rows Updated           = 0
-2020-12-14 17:19:12|INFO|data formatting errors = 0
-2020-12-14 17:19:12|INFO|gpload failed
-2020-12-14 17:19:12|INFO|gpload session started 2020-12-14 17:19:12
-2020-12-14 17:19:12|INFO|setting schema 'public' for table 'chinese表'
-2020-12-14 17:19:12|ERROR|no mapping for input column "notexist" to output table
-2020-12-14 17:19:12|INFO|rows Inserted          = 0
-2020-12-14 17:19:12|INFO|rows Updated           = 0
-2020-12-14 17:19:12|INFO|data formatting errors = 0
-2020-12-14 17:19:12|INFO|gpload failed
+2021-05-24 17:37:12|INFO|gpload session started 2021-05-24 17:37:12
+2021-05-24 17:37:12|INFO|setting schema 'public' for table 'chinese表'
+2021-05-24 17:37:12|ERROR|no mapping for input column ""notexist"" to output table
+2021-05-24 17:37:12|INFO|rows Inserted          = 0
+2021-05-24 17:37:12|INFO|rows Updated           = 0
+2021-05-24 17:37:12|INFO|data formatting errors = 0
+2021-05-24 17:37:12|INFO|gpload failed
+2021-05-24 17:37:12|INFO|gpload session started 2021-05-24 17:37:12
+2021-05-24 17:37:12|INFO|setting schema 'public' for table 'chinese表'
+2021-05-24 17:37:12|ERROR|no mapping for input column ""notexist"" to output table
+2021-05-24 17:37:12|INFO|rows Inserted          = 0
+2021-05-24 17:37:12|INFO|rows Updated           = 0
+2021-05-24 17:37:12|INFO|data formatting errors = 0
+2021-05-24 17:37:12|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -10,36 +10,44 @@ WARNING:  nonstandard use of \' in a string literal
 LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\') encod...
                                                              ^
 HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
-2021-01-08 16:58:46|INFO|gpload session started 2021-01-08 16:58:46
-2021-01-08 16:58:46|INFO|setting schema 'public' for table 'chinese表'
-2021-01-08 16:58:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-08 16:58:46|INFO|did not find an external table to reuse. creating ext_gpload_reusable_b76b0b68_518f_11eb_9406_00505698707d
-2021-01-08 16:58:46|ERROR|unexpected error -- backtrace written to log file
-2021-01-08 16:58:46|INFO|rows Inserted          = 0
-2021-01-08 16:58:46|INFO|rows Updated           = 0
-2021-01-08 16:58:46|INFO|data formatting errors = 0
-2021-01-08 16:58:46|INFO|gpload failed
-2021-01-08 16:58:46|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
-2021-01-08 16:58:47|INFO|gpload session started 2021-01-08 16:58:47
-2021-01-08 16:58:47|INFO|setting schema 'public' for table 'chinese表'
-2021-01-08 16:58:47|ERROR|no mapping for input column "'列1'" to output table
-2021-01-08 16:58:47|INFO|rows Inserted          = 0
-2021-01-08 16:58:47|INFO|rows Updated           = 0
-2021-01-08 16:58:47|INFO|data formatting errors = 0
-2021-01-08 16:58:47|INFO|gpload failed
+2021-05-24 17:37:14|INFO|gpload session started 2021-05-24 17:37:14
+2021-05-24 17:37:14|INFO|setting schema 'public' for table 'chinese表'
+2021-05-24 17:37:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-24 17:37:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_9f043ff0_bc73_11eb_b2b2_0050569e2380
+2021-05-24 17:37:14|ERROR|unexpected error -- backtrace written to log file
+2021-05-24 17:37:14|INFO|rows Inserted          = 0
+2021-05-24 17:37:14|INFO|rows Updated           = 0
+2021-05-24 17:37:14|INFO|data formatting errors = 0
+2021-05-24 17:37:14|INFO|gpload failed
+2021-05-24 17:37:14|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
+2021-05-24 17:37:14|INFO|gpload session started 2021-05-24 17:37:14
+2021-05-24 17:37:14|INFO|setting schema 'public' for table 'chinese表'
+2021-05-24 17:37:14|ERROR|no mapping for input column "'列1'" to output table
+2021-05-24 17:37:14|INFO|rows Inserted          = 0
+2021-05-24 17:37:14|INFO|rows Updated           = 0
+2021-05-24 17:37:14|INFO|data formatting errors = 0
+2021-05-24 17:37:14|INFO|gpload failed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '列1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  nonstandard use of \\ in a string literal
 LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
                                                  ^
 HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
-2021-01-08 16:58:47|INFO|gpload session started 2021-01-08 16:58:47
-2021-01-08 16:58:47|INFO|setting schema 'public' for table 'chinese表'
-2021-01-08 16:58:47|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-08 16:58:47|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
-2021-01-08 16:58:47|INFO|did not find an external table to reuse. creating ext_gpload_reusable_b7f9950e_518f_11eb_93a8_00505698707d
-2021-01-08 16:58:47|ERROR|unexpected error -- backtrace written to log file
-2021-01-08 16:58:47|INFO|rows Inserted          = 0
-2021-01-08 16:58:47|INFO|rows Updated           = 0
-2021-01-08 16:58:47|INFO|data formatting errors = 0
-2021-01-08 16:58:47|INFO|gpload failed
+WARNING:  nonstandard use of escape in a string literal
+LINE 1: .../data_file.txt') format'text' (delimiter ';' null '\N' escap...
+                                                             ^
+HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
+WARNING:  nonstandard use of \' in a string literal
+LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\') encod...
+                                                             ^
+HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
+2021-05-24 17:37:14|INFO|gpload session started 2021-05-24 17:37:14
+2021-05-24 17:37:14|INFO|setting schema 'public' for table 'chinese表'
+2021-05-24 17:37:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-24 17:37:14|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-05-24 17:37:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_9f4cab14_bc73_11eb_b77d_0050569e2380
+2021-05-24 17:37:14|ERROR|unexpected error -- backtrace written to log file
+2021-05-24 17:37:14|INFO|rows Inserted          = 0
+2021-05-24 17:37:14|INFO|rows Updated           = 0
+2021-05-24 17:37:14|INFO|data formatting errors = 0
+2021-05-24 17:37:14|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query77.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query77.ans
@@ -10,15 +10,15 @@ WARNING:  nonstandard use of \' in a string literal
 LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\') encod...
                                                              ^
 HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
-2021-01-11 14:36:40|INFO|gpload session started 2021-01-11 14:36:40
-2021-01-11 14:36:40|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-11 14:36:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-11 14:36:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_5cfb15b6_53d7_11eb_ae6a_00505698707d
-2021-01-11 14:36:40|ERROR|unexpected error -- backtrace written to log file
-2021-01-11 14:36:40|INFO|rows Inserted          = 0
-2021-01-11 14:36:40|INFO|rows Updated           = 0
-2021-01-11 14:36:40|INFO|data formatting errors = 0
-2021-01-11 14:36:40|INFO|gpload failed
+2021-05-24 17:37:14|INFO|gpload session started 2021-05-24 17:37:14
+2021-05-24 17:37:14|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-24 17:37:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-24 17:37:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_9f7ab7d4_bc73_11eb_94c6_0050569e2380
+2021-05-24 17:37:14|ERROR|unexpected error -- backtrace written to log file
+2021-05-24 17:37:14|INFO|rows Inserted          = 0
+2021-05-24 17:37:14|INFO|rows Updated           = 0
+2021-05-24 17:37:14|INFO|data formatting errors = 0
+2021-05-24 17:37:14|INFO|gpload failed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'Field1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  nonstandard use of \\ in a string literal
@@ -33,27 +33,44 @@ WARNING:  nonstandard use of \' in a string literal
 LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\') encod...
                                                              ^
 HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
-2021-01-11 14:36:41|INFO|gpload session started 2021-01-11 14:36:41
-2021-01-11 14:36:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-11 14:36:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-11 14:36:41|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
-2021-01-11 14:36:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_5d335b1a_53d7_11eb_b06b_00505698707d
-2021-01-11 14:36:41|ERROR|unexpected error -- backtrace written to log file
-2021-01-11 14:36:41|INFO|rows Inserted          = 0
-2021-01-11 14:36:41|INFO|rows Updated           = 0
-2021-01-11 14:36:41|INFO|data formatting errors = 0
-2021-01-11 14:36:41|INFO|gpload failed
-2021-01-11 14:36:41|INFO|gpload session started 2021-01-11 14:36:41
-2021-01-11 14:36:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-11 14:36:41|ERROR|no mapping for input column "'Field1'" to output table
-2021-01-11 14:36:41|INFO|rows Inserted          = 0
-2021-01-11 14:36:41|INFO|rows Updated           = 0
-2021-01-11 14:36:41|INFO|data formatting errors = 0
-2021-01-11 14:36:41|INFO|gpload failed
-2021-01-11 14:36:41|INFO|gpload session started 2021-01-11 14:36:41
-2021-01-11 14:36:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-01-11 14:36:41|ERROR|no mapping for input column "Field1" to output table
-2021-01-11 14:36:41|INFO|rows Inserted          = 0
-2021-01-11 14:36:41|INFO|rows Updated           = 0
-2021-01-11 14:36:41|INFO|data formatting errors = 0
-2021-01-11 14:36:41|INFO|gpload failed
+2021-05-24 17:37:14|INFO|gpload session started 2021-05-24 17:37:14
+2021-05-24 17:37:14|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-24 17:37:15|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-24 17:37:15|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
+2021-05-24 17:37:15|INFO|did not find an external table to reuse. creating ext_gpload_reusable_9f96c500_bc73_11eb_90c0_0050569e2380
+2021-05-24 17:37:15|ERROR|unexpected error -- backtrace written to log file
+2021-05-24 17:37:15|INFO|rows Inserted          = 0
+2021-05-24 17:37:15|INFO|rows Updated           = 0
+2021-05-24 17:37:15|INFO|data formatting errors = 0
+2021-05-24 17:37:15|INFO|gpload failed
+2021-05-24 17:37:15|INFO|gpload session started 2021-05-24 17:37:15
+2021-05-24 17:37:15|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-24 17:37:15|ERROR|no mapping for input column "'Field1'" to output table
+2021-05-24 17:37:15|INFO|rows Inserted          = 0
+2021-05-24 17:37:15|INFO|rows Updated           = 0
+2021-05-24 17:37:15|INFO|data formatting errors = 0
+2021-05-24 17:37:15|INFO|gpload failed
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'Field1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
+                                                 ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of escape in a string literal
+LINE 1: .../data_file.txt') format'text' (delimiter ';' null '\N' escap...
+                                                             ^
+HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
+WARNING:  nonstandard use of \' in a string literal
+LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\') encod...
+                                                             ^
+HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
+2021-05-24 17:37:15|INFO|gpload session started 2021-05-24 17:37:15
+2021-05-24 17:37:15|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-24 17:37:15|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-24 17:37:15|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
+2021-05-24 17:37:15|INFO|did not find an external table to reuse. creating ext_gpload_reusable_9fcc9f7c_bc73_11eb_aab0_0050569e2380
+2021-05-24 17:37:15|ERROR|unexpected error -- backtrace written to log file
+2021-05-24 17:37:15|INFO|rows Inserted          = 0
+2021-05-24 17:37:15|INFO|rows Updated           = 0
+2021-05-24 17:37:15|INFO|data formatting errors = 0
+2021-05-24 17:37:15|INFO|gpload failed


### PR DESCRIPTION
fix 6x gpload to support column name without quotes in yaml file

judge if an into_column name is quoted, if not, add double quotations to it. So we can compare it correctly with the column name from database for capital letters and special characters.

Pyyaml cannot check if a string is quoted or not, so we add double quotations to not quoted column names. This will support writing into columns like 'Col_name', "Col_name" and Col_name. '"Col_name"' is also supported.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
