### PR TITLE
[5X backport]Prevent REINDEX TABLE partitioned table statement in transaction block

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1710,7 +1710,7 @@ ReindexRelationList(List *relids)
  *		Recreate all indexes of a table (and of its toast table, if any)
  */
 void
-ReindexTable(ReindexStmt *stmt)
+ReindexTable(ReindexStmt *stmt, bool isTopLevel)
 {
 	Oid			relid;
 	MemoryContext	private_context, oldcontext;
@@ -1757,6 +1757,45 @@ ReindexTable(ReindexStmt *stmt)
 	relids = lappend_oid(relids, relid);
 	relids = list_concat_unique_oid(relids, prels);
 	MemoryContextSwitchTo(oldcontext);
+
+	if (list_length(relids) == 1)
+	{
+		bool result;
+
+		MemoryContextDelete(private_context);
+		result = reindex_relation(relid, true);
+		if (!result)
+			ereport(NOTICE,
+			        (errmsg("table \"%s\" has no indexes to reindex",
+			                stmt->relation->relname)));
+
+		if (result && Gp_role == GP_ROLE_DISPATCH)
+		{
+			ReindexStmt    *qestmt;
+			qestmt = makeNode(ReindexStmt);
+			qestmt->relid = relid;
+			qestmt->kind = OBJECT_TABLE;
+
+			CdbDispatchUtilityStatement((Node *) qestmt,
+			                            DF_CANCEL_ON_ERROR |
+				                            DF_WITH_SNAPSHOT |
+				                            DF_NEED_TWO_PHASE,
+			                            GetAssignedOidsForDispatch(),
+			                            NULL);
+		}
+
+		return;
+	}
+
+	/*
+	 * We cannot run REINDEX TABLE on partitioned table inside a user
+	 * transaction block; if we were inside a transaction, then our commit-
+	 * and start-transaction-command calls would not have the intended effect!
+	 * For example, if it gets called under pl language, it'll mess up
+	 * pl language's transaction management which may cause panic.
+	 */
+	PreventTransactionChain(isTopLevel,
+	                        "REINDEX TABLE <partitioned_table>");
 
 	/* various checks on each partition */
 	foreach (lc, relids)

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1752,7 +1752,7 @@ ProcessUtility(Node *parsetree,
 						ReindexIndex(stmt);
 						break;
 					case OBJECT_TABLE:
-						ReindexTable(stmt);
+						ReindexTable(stmt, isTopLevel);
 						break;
 					case OBJECT_DATABASE:
 

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -38,7 +38,7 @@ extern void DefineIndex(RangeVar *heapRelation,
 			IndexStmt *stmt /* MPP */);
 extern void RemoveIndex(RangeVar *relation, DropBehavior behavior);
 extern void ReindexIndex(ReindexStmt *stmt);
-extern void ReindexTable(ReindexStmt *stmt);
+extern void ReindexTable(ReindexStmt *stmt, bool isTopLevel);
 extern void ReindexDatabase(ReindexStmt *stmt);
 extern char *makeObjectName(const char *name1, const char *name2,
 			   const char *label);

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -1707,3 +1707,50 @@ select count(*) from mpp3033b;
   1000
 (1 row)
 
+-- GPDB: Prevent REINDEX TABLE on partitioned table run in transaction block.
+-- Since we expand partitioned table when do the reindex, and try to reindex
+-- each table in its own transaction.
+create table reindex_part(id int, r int) partition by range (r)
+    ( start (1) end (21) every (10) );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "reindex_part_1_prt_1" for table "reindex_part"
+NOTICE:  CREATE TABLE will create partition "reindex_part_1_prt_2" for table "reindex_part"
+create index reidx_idx on reindex_part (id);
+-- This should raise error
+begin;
+reindex table reindex_part;
+ERROR:  REINDEX TABLE <partitioned_table> cannot run inside a transaction block
+end;
+-- This should success
+begin;
+reindex table reindex_part_1_prt_1;
+end;
+-- This should raise error
+CREATE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ERROR:  REINDEX TABLE <partitioned_table> cannot be executed from a function or multi-command string
+CONTEXT:  SQL statement "reindex table reindex_part"
+PL/pgSQL function "reindex_in_func" line 2 at SQL statement
+-- This should success
+CREATE OR REPLACE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part_1_prt_1;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ reindex_in_func 
+-----------------
+
+(1 row)
+
+drop table reindex_part;
+drop function reindex_in_func();

--- a/src/test/regress/sql/partition_indexing.sql
+++ b/src/test/regress/sql/partition_indexing.sql
@@ -609,3 +609,43 @@ reindex index mpp3033b_stringu1;
 
 select count(*) from mpp3033a;
 select count(*) from mpp3033b;
+
+-- GPDB: Prevent REINDEX TABLE on partitioned table run in transaction block.
+-- Since we expand partitioned table when do the reindex, and try to reindex
+-- each table in its own transaction.
+create table reindex_part(id int, r int) partition by range (r)
+    ( start (1) end (21) every (10) );
+create index reidx_idx on reindex_part (id);
+
+-- This should raise error
+begin;
+reindex table reindex_part;
+end;
+
+-- This should success
+begin;
+reindex table reindex_part_1_prt_1;
+end;
+
+-- This should raise error
+CREATE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+
+-- This should success
+CREATE OR REPLACE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part_1_prt_1;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+
+drop table reindex_part;
+drop function reindex_in_func();


### PR DESCRIPTION
As different from upstream, we support REINDEX TABLE on partitioned
table which will expand the partitioned table and start new transaction
to do the reindex for each table. This has side effects that cannot be
rolled back if it gets called in PL language and may crash, so we need
to make sure it must not run inside a transaction block.
This fix is related to issue https://github.com/greenplum-db/gpdb/issues/11948.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
