### PR TITLE
Check delay eager free in squelch functions

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -784,7 +784,8 @@ ExecEagerFreeFunctionScan(FunctionScanState *node)
 void
 ExecSquelchFunctionScan(FunctionScanState *node)
 {
-	ExecEagerFreeFunctionScan(node);
+	if (!node->delayEagerFree)
+		ExecEagerFreeFunctionScan(node);
 }
 
 void

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -509,8 +509,11 @@ ExecEagerFreeSort(SortState *node)
 void
 ExecSquelchSort(SortState *node)
 {
-	ExecEagerFreeSort(node);
-	ExecSquelchNode(outerPlanState(node));
+	if (!node->delayEagerFree)
+	{
+		ExecEagerFreeSort(node);
+		ExecSquelchNode(outerPlanState(node));
+	}
 }
 
 /* ----------------------------------------------------------------

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -94,3 +94,16 @@ select number_of_days(start, stop) from datetab;
  full days: 10
 (1 row)
 
+-- Check delay eager free in squelch functions
+CREATE TABLE subselect2_foo (a int, b int);
+CREATE TABLE subselect2_bar (c int, d int);
+CREATE TABLE subselect2_baz (x int, y int);
+INSERT INTO subselect2_foo VALUES (1,1), (1,2);
+INSERT INTO subselect2_bar VALUES (1,1);
+SELECT *, (SELECT x FROM subselect2_baz EXCEPT SELECT c FROM subselect2_bar WHERE d = a) FROM subselect2_foo;
+ a | b | x 
+---+---+---
+ 1 | 1 |  
+ 1 | 2 |  
+(2 rows)
+

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -63,3 +63,17 @@ $$ language plpgsql;
 
 -- Run the function in QEs.
 select number_of_days(start, stop) from datetab;
+
+-- Check delay eager free in squelch functions
+CREATE TABLE subselect2_foo (a int, b int);
+CREATE TABLE subselect2_bar (c int, d int);
+CREATE TABLE subselect2_baz (x int, y int);
+
+INSERT INTO subselect2_foo VALUES (1,1), (1,2);
+INSERT INTO subselect2_bar VALUES (1,1);
+
+SELECT *, (SELECT x FROM subselect2_baz EXCEPT SELECT c FROM subselect2_bar WHERE d = a) FROM subselect2_foo;
+
+
+
+


### PR DESCRIPTION
Executor try to squelch nodes in it‘s subtree after a node returning a
NULL tuple. But sometimes squelching is not safe. If the node is not
safe to squelch, the parameter ’delayEagerFree‘ will be set to true. We
should check the parameter when we squelch the node both on 'Execxxx'
function and 'ExecSquelchxxxx' function.

So add code checking 'delayEagerFree' in ExecSquelchSort and
ExecSquelchFunction.

Co-authored-by: Wen Lin <linw@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
