### PR TITLE
Fix array overflow for function argument types in orca

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -352,27 +352,29 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 //---------------------------------------------------------------------------
 IMdIdArray *
 CTranslatorUtils::ResolvePolymorphicTypes(CMemoryPool *mp,
-										  IMdIdArray *mdid_array,
-										  List *arg_types_list,
+										  IMdIdArray *return_arg_mdids,
+										  List *input_arg_types,
 										  FuncExpr *funcexpr)
 {
 	ULONG arg_index = 0;
 
-	const ULONG num_arg_types = gpdb::ListLength(arg_types_list);
+	const ULONG num_arg_types = gpdb::ListLength(input_arg_types);
 	const ULONG num_args_from_query = gpdb::ListLength(funcexpr->args);
-	const ULONG num_return_args = mdid_array->Size();
-	const ULONG num_args = num_arg_types < num_args_from_query
-							   ? num_arg_types
-							   : num_args_from_query;
+	const ULONG num_return_args = return_arg_mdids->Size();
+	const ULONG num_args = std::min(num_arg_types, num_args_from_query);
 	const ULONG total_args = num_args + num_return_args;
 
-	OID arg_types[num_args];
+	OID arg_types[total_args];
 	char arg_modes[total_args];
 
-	// copy function argument types
+	// copy the first 'num_args' function argument types
 	ListCell *arg_type = NULL;
-	ForEach(arg_type, arg_types_list)
+	ForEach(arg_type, input_arg_types)
 	{
+		if (arg_index >= num_args)
+		{
+			break;
+		}
 		arg_types[arg_index] = lfirst_oid(arg_type);
 		arg_modes[arg_index++] = PROARGMODE_IN;
 	}
@@ -380,7 +382,7 @@ CTranslatorUtils::ResolvePolymorphicTypes(CMemoryPool *mp,
 	// copy function return types
 	for (ULONG ul = 0; ul < num_return_args; ul++)
 	{
-		IMDId *mdid = (*mdid_array)[ul];
+		IMDId *mdid = (*return_arg_mdids)[ul];
 		arg_types[arg_index] = CMDIdGPDB::CastMdid(mdid)->Oid();
 		arg_modes[arg_index++] = PROARGMODE_TABLE;
 	}
@@ -394,7 +396,7 @@ CTranslatorUtils::ResolvePolymorphicTypes(CMemoryPool *mp,
 				"could not determine actual argument/return type for polymorphic function"));
 	}
 
-	// generate a new array of mdids based on the resolved types
+	// generate a new array of mdids based on the resolved return types
 	IMdIdArray *resolved_types = GPOS_NEW(mp) IMdIdArray(mp);
 
 	// get the resolved return types

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -91,9 +91,9 @@ private:
 	// resolve polymorphic types in the given array of type ids, replacing
 	// them with the actual types obtained from the query
 	static IMdIdArray *ResolvePolymorphicTypes(CMemoryPool *mp,
-											   IMdIdArray *mdid_array,
-											   List *arg_types,
-											   FuncExpr *func_expr);
+											   IMdIdArray *return_arg_mdids,
+											   List *input_arg_types,
+											   FuncExpr *funcexpr);
 
 	// update grouping col position mappings
 	static void UpdateGrpColMapping(CMemoryPool *mp,

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10931,6 +10931,16 @@ SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], '
 (1 row)
 
 DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM);
+--TVF accepts ANYENUM, ANYELEMENT, ANYELEMENT return ANYENUM, ANYARRAY
+CREATE FUNCTION return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT) RETURNS TABLE (ae ANYENUM, aa ANYARRAY)
+AS $$ SELECT $1, array[$2, $3] $$ LANGUAGE SQL STABLE;
+SELECT * FROM return_enum_as_array('red'::rainbow, 'yellow'::rainbow, 'blue'::rainbow);
+ ae  |      aa       
+-----+---------------
+ red | {yellow,blue}
+(1 row)
+
+DROP FUNCTION IF EXISTS return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT);
 -- start_ignore
 drop table foo;
 -- end_ignore

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11054,6 +11054,19 @@ CONTEXT:  SQL function "func_array_nonarray_enum" during startup
 (1 row)
 
 DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM);
+--TVF accepts ANYENUM, ANYELEMENT, ANYELEMENT return ANYENUM, ANYARRAY
+CREATE FUNCTION return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT) RETURNS TABLE (ae ANYENUM, aa ANYARRAY)
+AS $$ SELECT $1, array[$2, $3] $$ LANGUAGE SQL STABLE;
+SELECT * FROM return_enum_as_array('red'::rainbow, 'yellow'::rainbow, 'blue'::rainbow);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+CONTEXT:  SQL function "return_enum_as_array" during startup
+ ae  |      aa       
+-----+---------------
+ red | {yellow,blue}
+(1 row)
+
+DROP FUNCTION IF EXISTS return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT);
 -- start_ignore
 drop table foo;
 -- end_ignore

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1968,6 +1968,12 @@ AS $$ SELECT $1[1]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], 'red'::rainbow, 'yellow'::rainbow);
 DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM);
 
+--TVF accepts ANYENUM, ANYELEMENT, ANYELEMENT return ANYENUM, ANYARRAY
+CREATE FUNCTION return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT) RETURNS TABLE (ae ANYENUM, aa ANYARRAY)
+AS $$ SELECT $1, array[$2, $3] $$ LANGUAGE SQL STABLE;
+SELECT * FROM return_enum_as_array('red'::rainbow, 'yellow'::rainbow, 'blue'::rainbow);
+DROP FUNCTION IF EXISTS return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT);
+
 -- start_ignore
 drop table foo;
 -- end_ignore


### PR DESCRIPTION
in function CTranslatorUtils::ResolvePolymorphicTypes(), the size
of array arg_types is num_args, and it is smaller than total_args,
this causes a memory corruption and a backend crash. Fixed by
correcting the array size "total_args"(num_args + num_return_args).

Fixes GitHub issue #11880

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
