### PR TITLE
gprecoverseg rebalance: fix parallel processes -B/-b option

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -420,7 +420,7 @@ class GpRecoverSegmentProgram:
 
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
-            return GpSegmentRebalanceOperation(gpEnv, gpArray)
+            return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
         elif self.__options.recoveryConfigFile is not None:
             return self.getRecoveryActionsFromConfigFile(gpArray)
         else:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -32,7 +32,7 @@ class RebalanceSegmentsTestCase(GpTestCase):
         self.success_command_mock.get_results.return_value = CommandResult(
             0, b"stdout success text", b"stderr text", True, False)
 
-        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors())
+        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors(), 1, 1)
         self.subject.logger = Mock()
 
     def tearDown(self):

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -53,6 +53,25 @@ Feature: gprecoverseg tests
         | -B 2 -b 1 |  2                  |  1              |
         | -B 1 -b 2 |  1                  |  2              |
 
+    Scenario Outline: Rebalance correctly limits the number of concurrent processes
+      Given the database is running
+      And user stops all primary processes
+      And user can start transactions
+      And the user runs "gprecoverseg -a -v <args>"
+      And gprecoverseg should return a return code of 0
+      And the segments are synchronized
+      When the user runs "gprecoverseg -ra -v <args>"
+      Then gprecoverseg should return a return code of 0
+      And gprecoverseg should only spawn up to <coordinator_workers> workers in WorkerPool
+      And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
+      And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
+
+    Examples:
+      | args      | coordinator_workers | segHost_workers |
+      | -B 1 -b 1 |  1                  |  1              |
+      | -B 2 -b 1 |  2                  |  1              |
+      | -B 1 -b 2 |  1                  |  2              |
+
     Scenario: gprecoverseg should not output bootstrap error on success
         Given the database is running
         And user stops all primary processes


### PR DESCRIPTION
gprecoverseg -r didn't pick up the -B/-b options for spawning correct number of parallel processes.
This change fixes that behaviour.

Co-authored-by: Orhan Kislal <okislal@vmware.com>

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/recoverseg_rebalance_fix_parallel)