### PR TITLE
fsync related optimization for gpdb recovery

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -3379,6 +3379,22 @@ looks_like_temp_rel_name(const char *name)
 	return true;
 }
 
+/*
+ * Synchronize all xlog files and pg_wal itself in pg_wal
+ *
+ * This is called at the beginning of recovery.
+ */
+void
+SyncAllXLogFiles(void)
+{
+	/* We can skip this whole thing if fsync is disabled. */
+	if (!enableFsync)
+		return;
+
+	ereport(LOG, (errmsg("Synchronization of the wal directory starts.")));
+	walkdir("pg_wal", datadir_fsync_fname, false, LOG);
+	ereport(LOG, (errmsg("synchronization of the wal directory finishes.")));
+}
 
 /*
  * Issue fsync recursively on PGDATA and all its contents.

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -154,6 +154,7 @@ extern void fsync_fname(const char *fname, bool isdir);
 extern int	durable_rename(const char *oldfile, const char *newfile, int loglevel);
 extern int	durable_unlink(const char *fname, int loglevel);
 extern int	durable_link_or_rename(const char *oldfile, const char *newfile, int loglevel);
+extern void SyncAllXLogFiles(void);
 extern void SyncDataDirectory(void);
 extern int	data_sync_elevel(int elevel);
 

--- a/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
+++ b/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
@@ -40,6 +40,8 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid) FROM gp_segment_confi
 -- before unlink the file. This cased the crash recovery to PANIC as
 -- couldn't complete the stale fsync request registered by file
 -- truncate WAL record.
+-- Also this is a chance of simply testing SyncAllXLogFile() thats fsync wal
+-- files only during crash recovery.
 1: CHECKPOINT;
 CHECKPOINT
 1: BEGIN;

--- a/src/test/isolation2/sql/ao_same_trans_truncate_crash.sql
+++ b/src/test/isolation2/sql/ao_same_trans_truncate_crash.sql
@@ -22,6 +22,8 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
 -- before unlink the file. This cased the crash recovery to PANIC as
 -- couldn't complete the stale fsync request registered by file
 -- truncate WAL record.
+-- Also this is a chance of simply testing SyncAllXLogFile() thats fsync wal
+-- files only during crash recovery.
 1: CHECKPOINT;
 1: BEGIN;
 1: CREATE TABLE ao_same_trans_truncate(a int, b int) WITH (appendonly=true, orientation=column);


### PR DESCRIPTION
This is an alternative method for the issue discussed in https://github.com/greenplum-db/gpdb/pull/11896. The PR includes two commits.

```
commit 90219f3935e7bb8a9adb63823dca1926803b955e (HEAD -> sync_opt, origin/sync_opt)
Author: Paul Guo <guopa@vmware.com>
Date:   Wed Jan 20 16:05:34 2021 +0800

    Just fsync those affected files during pg_rewind.

    In gpdb we've ensured that the database is in sync state before rewinding, so
    we could just fsync those affected files after rewinding.

commit 8d3100bb7400d909a6c6093baafc6f0c5922700b
Author: Paul Guo <pguo@pivotal.io>
Date:   Thu May 27 14:18:41 2021 +0800

    Optimize the pgdata directory fsync during startup.

    Previously startup would fsync all files under the whole pgdata directory if
    the database is not cleanly shutdown. This step could be rather slow if pgdata
    directory includes millions of table files. Latest upstream provides syncfs()
    instead fsync() as an alternative but that is not enough for us since firstly
    stable syncfs() implementation needs 5.8+ Linux kernel support (or low-version
    kernel with related patches backported) but mainline linux stable releases do
    not seem to be qualified, second is that the current upstream code does not
    return error if syncfs() fails but we depend on this much if we skip fsync in
    pg_basebackup/pg_rewind, last is that syncfs() operates on one file system that
    could be shared my other applications or segments so it is not convenient for
    us to determine the default value.

    While this is a big pain for some users, we decide another gpdb specific
    solution: For the full/incremental recovery cases, we assume those files are
    synchronized already (the utilities ensure this) so we simply skip the fsync
    step, while for other cases (crash recovery), we do synchronize the wal files
    only if full page writes is on (should be on in production environments), else
    we still synchronize all the files in the pgdata directory. Note why wal files
    sync is needed? That's because during wal redo if partial flushing of buffer
    pages happens and if those related wal contents are missing during system
    crash, those pages would be broken forever.
```

The first patch was submitted to upstream. Our gp version is a bit different.
- The gp version is more correct - I found some small issues in the pg version (I'll update the pg version later).
- The gp version removes pre_sync_fname() calls since else we will add more conflicts with upstream code and also upstream pre_sync seems to be a bit buggy and may harm if we have millions of files.

I've done a lot of manual testing for the code change and it seems work well.