### PR TITLE
Fix numsegments is not set correctly for general locus 

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4841,7 +4841,8 @@ create_minmaxagg_path(PlannerInfo *root,
 	if (mmaggregates == NIL)
 	{
 		locustype = CdbLocusType_General;
-		numsegments = getgpsegmentCount();
+		/* numsegments is useless for general locus, so should be -1 */
+		numsegments = -1;
 	}
 
 	/* we checked that all the child paths have compatible loci */

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -2912,3 +2912,19 @@ drop table agg_hash_1;
 --  drop table agg_hash_2;
 drop table agg_hash_3;
 drop table agg_hash_4;
+-- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=10000000025.03..10000000025.05 rows=1 width=8) (actual time=0.214..0.214 rows=1 loops=1)
+   ->  Nested Loop  (cost=10000000000.02..10000000023.48 rows=622 width=0) (actual time=0.013..0.179 rows=848 loops=1)
+         ->  Aggregate  (cost=0.02..0.03 rows=1 width=1) (actual time=0.003..0.003 rows=1 loops=1)
+               ->  Result  (cost=0.00..0.01 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=1)
+         ->  Seq Scan on pg_class  (cost=0.00..17.22 rows=622 width=0) (actual time=0.010..0.116 rows=848 loops=1)
+ Planning Time: 0.534 ms
+   (slice0)    Executor memory: 50K bytes.
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 0.302 ms
+(10 rows)
+

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -3187,3 +3187,21 @@ drop table agg_hash_1;
 --  drop table agg_hash_2;
 drop table agg_hash_3;
 drop table agg_hash_4;
+-- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=10000000017.74..10000000017.75 rows=1 width=8) (actual time=0.142..0.142 rows=1 loops=1)
+   ->  Nested Loop  (cost=10000000000.02..10000000016.44 rows=520 width=0) (actual time=0.016..0.114 rows=686 loops=1)
+         ->  Aggregate  (cost=0.02..0.03 rows=1 width=1) (actual time=0.003..0.003 rows=1 loops=1)
+               ->  Result  (cost=0.00..0.01 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=1)
+         ->  Seq Scan on pg_class  (cost=0.00..11.20 rows=520 width=0) (actual time=0.012..0.071 rows=686 loops=1)
+ Planning Time: 1.961 ms
+   (slice0)    Executor memory: 50K bytes.
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 0.198 ms
+(10 rows)
+

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -1312,3 +1312,6 @@ drop table agg_hash_1;
 --  drop table agg_hash_2;
 drop table agg_hash_3;
 drop table agg_hash_4;
+
+-- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;


### PR DESCRIPTION
In Github issue #12061, there is an assert failure that the numsegments is
wrongly set to segnum for general locus in function create_minmaxagg_path.
General Locus means the tuples could be fetched from any segments or
coordinator, so the numsegments of general locus should always be -1.

This PR simpely set numsegments of general locus to -1 in create_minmaxagg_path.

Co-authored-by: pingfu li <peefau@163.com>
Co-authored-by: Peng Han <parker.han@outlook.com>
Co-authored-by: xianglli <mail@plizong.com>
Co-authored-by: miaopo <992470565@qq.com>
Co-authored-by: ranger0925 <youxinhua0925@126.com>
Co-authored-by: mabingbing <290800656@qq.com>
Co-authored-by: jianfei wen <wenjianfei@163.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
