### PR TITLE
[6X backport] Change the default resource group when ALTER ROLE

### DIFF
--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -1020,11 +1020,34 @@ AlterRole(AlterRoleStmt *stmt)
 	 */
 	if (issuper >= 0)
 	{
+		bool isNull;
+		Oid roleResgroup;
+
 		new_record[Anum_pg_authid_rolsuper - 1] = BoolGetDatum(issuper > 0);
 		new_record_repl[Anum_pg_authid_rolsuper - 1] = true;
 
 		new_record[Anum_pg_authid_rolcatupdate - 1] = BoolGetDatum(issuper > 0);
 		new_record_repl[Anum_pg_authid_rolcatupdate - 1] = true;
+
+		roleResgroup = heap_getattr(tuple, Anum_pg_authid_rolresgroup,
+								   pg_authid_dsc, &isNull);
+		if (!isNull)
+		{
+			/*
+			 * change the default resource group accordingly: admin_group
+			 * for superuser and default_group for non-superuser
+			 */
+			if (issuper == 0 && roleResgroup == ADMINRESGROUP_OID)
+			{
+				new_record[Anum_pg_authid_rolresgroup - 1] = ObjectIdGetDatum(DEFAULTRESGROUP_OID);
+				new_record_repl[Anum_pg_authid_rolresgroup - 1] = true;
+			}
+			else if (issuper > 0 && roleResgroup == DEFAULTRESGROUP_OID)
+			{
+				new_record[Anum_pg_authid_rolresgroup - 1] = ObjectIdGetDatum(ADMINRESGROUP_OID);
+				new_record_repl[Anum_pg_authid_rolresgroup - 1] = true;
+			}
+		}
 
 		/* get current superuser status */
 		bWas_super = (issuper > 0);

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -20,6 +20,20 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
 -------------
  6438        
 (1 row)
+ALTER ROLE rg_test_role_super NOSUPERUSER;
+ALTER
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ rolresgroup 
+-------------
+ 6437        
+(1 row)
+ALTER ROLE rg_test_role_super SUPERUSER;
+ALTER
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ rolresgroup 
+-------------
+ 6438        
+(1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
 ALTER

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -9,6 +9,10 @@ CREATE ROLE rg_test_role;
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 CREATE ROLE rg_test_role_super SUPERUSER;
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ALTER ROLE rg_test_role_super NOSUPERUSER;
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
+ALTER ROLE rg_test_role_super SUPERUSER;
+SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role_super';
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';


### PR DESCRIPTION
When altering a role set superuser or nosuperuser, should change the default
resource group to admin_group or default_group accordingly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
