### PR TITLE
fix gpload 5x support column name with capital letters

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_15.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_15.txt
@@ -1,0 +1,8 @@
+1;Line 1
+2;2nd line
+3;test
+4;
+5;Vide
+6;Field 2
+8;Line 8
+9;Line 9

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_16.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_16.txt
@@ -1,0 +1,8 @@
+1;Line 1
+2;2nd line
+3;test
+4;
+5;Vide
+6;Field 2
+8;new line
+9;Line 10

--- a/gpMgmt/bin/gpload_test/gpload2/query40.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query40.ans
@@ -1,0 +1,57 @@
+2021-05-21 14:15:40|INFO|gpload session started 2021-05-21 14:15:40
+2021-05-21 14:15:40|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-21 14:15:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f799c466_b9fb_11eb_9059_0050569e5d5e
+2021-05-21 14:15:40|ERROR|could not run SQL "create external table ext_gpload_reusable_f799c466_b9fb_11eb_9059_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://10.117.190.97:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...t'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-21 14:15:40|INFO|rows Inserted          = 0
+2021-05-21 14:15:40|INFO|rows Updated           = 0
+2021-05-21 14:15:40|INFO|data formatting errors = 0
+2021-05-21 14:15:40|INFO|gpload failed
+2021-05-21 14:15:40|INFO|gpload session started 2021-05-21 14:15:40
+2021-05-21 14:15:40|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-21 14:15:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f7ac9ece_b9fb_11eb_a501_0050569e5d5e
+2021-05-21 14:15:40|ERROR|could not run SQL "create external table ext_gpload_reusable_f7ac9ece_b9fb_11eb_a501_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://10.117.190.97:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...t'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-21 14:15:40|INFO|rows Inserted          = 0
+2021-05-21 14:15:40|INFO|rows Updated           = 0
+2021-05-21 14:15:40|INFO|data formatting errors = 0
+2021-05-21 14:15:40|INFO|gpload failed
+2021-05-21 14:15:40|INFO|gpload session started 2021-05-21 14:15:40
+2021-05-21 14:15:40|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-05-21 14:15:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-21 14:15:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f7bf67fc_b9fb_11eb_884f_0050569e5d5e
+2021-05-21 14:15:40|ERROR|could not run SQL "create external table ext_gpload_reusable_f7bf67fc_b9fb_11eb_884f_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://10.117.190.97:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...t'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-21 14:15:40|INFO|rows Inserted          = 0
+2021-05-21 14:15:40|INFO|rows Updated           = 0
+2021-05-21 14:15:40|INFO|data formatting errors = 0
+2021-05-21 14:15:40|INFO|gpload failed
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|ERROR|no mapping for input column "'Field1'" to output table
+2021-05-21 14:15:41|INFO|rows Inserted          = 0
+2021-05-21 14:15:41|INFO|rows Updated           = 0
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload failed
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-05-21 14:15:41|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-21 14:15:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f7e45b02_b9fb_11eb_859f_0050569e5d5e
+2021-05-21 14:15:41|ERROR|could not run SQL "create external table ext_gpload_reusable_f7e45b02_b9fb_11eb_859f_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://10.117.190.97:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...t'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-21 14:15:41|INFO|rows Inserted          = 0
+2021-05-21 14:15:41|INFO|rows Updated           = 0
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query41.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query41.ans
@@ -1,0 +1,45 @@
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-21 14:15:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f7fb3214_b9fb_11eb_9d73_0050569e5d5e
+2021-05-21 14:15:41|INFO|running time: 0.04 seconds
+2021-05-21 14:15:41|INFO|rows Inserted          = 8
+2021-05-21 14:15:41|INFO|rows Updated           = 0
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload succeeded
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-21 14:15:41|INFO|reusing external table ext_gpload_reusable_f7fb3214_b9fb_11eb_9d73_0050569e5d5e
+2021-05-21 14:15:41|INFO|running time: 0.04 seconds
+2021-05-21 14:15:41|INFO|rows Inserted          = 8
+2021-05-21 14:15:41|INFO|rows Updated           = 0
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload succeeded
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-05-21 14:15:41|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-21 14:15:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f823dd5e_b9fb_11eb_bca1_0050569e5d5e
+2021-05-21 14:15:41|INFO|running time: 0.07 seconds
+2021-05-21 14:15:41|INFO|rows Inserted          = 2
+2021-05-21 14:15:41|INFO|rows Updated           = 12
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload succeeded
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|ERROR|no mapping for input column "'Field1'" to output table
+2021-05-21 14:15:41|INFO|rows Inserted          = 0
+2021-05-21 14:15:41|INFO|rows Updated           = 0
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload failed
+2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
+2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-05-21 14:15:41|INFO|reusing staging table staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-05-21 14:15:41|INFO|reusing external table ext_gpload_reusable_f823dd5e_b9fb_11eb_bca1_0050569e5d5e
+2021-05-21 14:15:41|INFO|running time: 0.07 seconds
+2021-05-21 14:15:41|INFO|rows Inserted          = 0
+2021-05-21 14:15:41|INFO|rows Updated           = 14
+2021-05-21 14:15:41|INFO|data formatting errors = 0
+2021-05-21 14:15:41|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query42.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query42.ans
@@ -1,0 +1,21 @@
+2021-05-21 14:15:42|INFO|gpload session started 2021-05-21 14:15:42
+2021-05-21 14:15:42|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-21 14:15:42|INFO|reusing external table ext_gpload_reusable_f7fb3214_b9fb_11eb_9d73_0050569e5d5e
+2021-05-21 14:15:42|INFO|running time: 0.04 seconds
+2021-05-21 14:15:42|INFO|rows Inserted          = 8
+2021-05-21 14:15:42|INFO|rows Updated           = 0
+2021-05-21 14:15:42|INFO|data formatting errors = 0
+2021-05-21 14:15:42|INFO|gpload succeeded
+2021-05-21 14:15:42|INFO|gpload session started 2021-05-21 14:15:42
+2021-05-21 14:15:42|INFO|setting schema 'public' for table 'testspecialchar'
+2021-05-21 14:15:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-05-21 14:15:42|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f87b7460_b9fb_11eb_a987_0050569e5d5e
+2021-05-21 14:15:42|ERROR|could not run SQL "create external table ext_gpload_reusable_f87b7460_b9fb_11eb_a987_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://10.117.190.97:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...t'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-05-21 14:15:42|INFO|rows Inserted          = 0
+2021-05-21 14:15:42|INFO|rows Updated           = 0
+2021-05-21 14:15:42|INFO|data formatting errors = 0
+2021-05-21 14:15:42|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -6,12 +6,16 @@ You are now connected to database "reuse_gptest" as user "gpadmin".
 CREATE SCHEMA test;
 CREATE SCHEMA
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
+NOTICE:  table "temp_gpload_staging_table" does not exist, skipping
 DROP EXTERNAL TABLE
 DROP TABLE IF EXISTS texttable;
 NOTICE:  table "texttable" does not exist, skipping
 DROP TABLE
 DROP TABLE IF EXISTS csvtable;
 NOTICE:  table "csvtable" does not exist, skipping
+DROP TABLE
+DROP TABLE IF EXISTS testSpecialChar;
+NOTICE:  table "testspecialchar" does not exist, skipping
 DROP TABLE
 CREATE TABLE texttable (
             s1 text, s2 text, s3 text, dt timestamp,
@@ -25,4 +29,6 @@ CREATE TABLE
 CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);
+CREATE TABLE
+CREATE TABLE testSpecialChar("Field1" bigint, "Field#2" text) DISTRIBUTED BY ("Field1");
 CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -9,6 +9,8 @@ CREATE SCHEMA test;
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
 DROP TABLE IF EXISTS texttable;
 DROP TABLE IF EXISTS csvtable;
+DROP TABLE IF EXISTS testSpecialChar;
+
 CREATE TABLE texttable (
             s1 text, s2 text, s3 text, dt timestamp,
             n1 smallint, n2 integer, n3 bigint, n4 decimal,
@@ -19,3 +21,4 @@ CREATE TABLE csvtable (
 CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);
+CREATE TABLE testSpecialChar("Field1" bigint, "Field#2" text) DISTRIBUTED BY ("Field1");


### PR DESCRIPTION
back port fix from 6x to support gpload column name having capital letters without quotes.
fix 5x gpload to support column name without quotes in yaml file

judge if an into_column name is quoted, if not, add double quotations to it. So we can compare it correctly with the column name from database for capital letters and special characters.

Pyyaml cannot check if a string is quoted or not, so we add double quotations to not quoted column names. This will support writing into columns like 'Col_name', "Col_name" and Col_name. '"Col_name"' is also supported.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
