### PR TITLE
[6X only] Fix walsender state transition for obsolete replication slot

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -19,6 +19,7 @@
 #include "replication/walsender.h"
 #include "storage/lwlock.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 
 /* Set at database system is ready to accept connections */
 extern pg_time_t PMAcceptingConnectionsStartTime;
@@ -253,6 +254,7 @@ FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state)
 
 	if (state == WALSNDSTATE_CATCHUP || state == WALSNDSTATE_STREAMING)
 	{
+		SIMPLE_FAULT_INJECTOR("enter_catchup_or_streaming");
 		/*
 		 * We can clear the disconnect time once the connection established.
 		 * We only clean the failure count when the wal start streaming, since

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -283,6 +283,56 @@ END
  walread    
 (1 row)
 
+-- Fault to check if walsender enters catchup state.
+1: select gp_inject_fault('enter_catchup_or_streaming', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Wait for the mirror to make the next connection attempt.
+1: SELECT gp_inject_fault('initialize_wal_sender', 'skip',  dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Note that we wait until the fault is triggered twice.  Waiting
+-- until the second trigger guarantees that first connection attempt
+-- is fully processed and the status check that follows is accurate.
+1: SELECT gp_wait_until_triggered_fault('initialize_wal_sender', 2, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Validate that walsender does not enter catchup state, once the
+-- replication slot is obsoleted.  There used to be a bug that caused
+-- FTS to be mislead by a walsender that entered catchup state but
+-- failed shorty after due to the requested start point not available.
+-- FTS marked the mirror as up and turn synchronous replication on and
+-- later found it down.  If walsender fails before entering catchup
+-- state, FTS cannot be misled into thinking the mirror is up.  The
+-- following query should show "num times hit" as 0.
+1: select gp_inject_fault('enter_catchup_or_streaming', 'status', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault                                                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'enter_catchup_or_streaming' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(1 row)
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(8 rows)
+
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
 ALTER
 0U: ALTER SYSTEM RESET checkpoint_segments;

--- a/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
+++ b/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
@@ -174,6 +174,32 @@ SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content 
 1: SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
 1: SELECT sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
 
+-- Fault to check if walsender enters catchup state.
+1: select gp_inject_fault('enter_catchup_or_streaming', 'skip', dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Wait for the mirror to make the next connection attempt.
+1: SELECT gp_inject_fault('initialize_wal_sender', 'skip',  dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+-- Note that we wait until the fault is triggered twice.  Waiting
+-- until the second trigger guarantees that first connection attempt
+-- is fully processed and the status check that follows is accurate.
+1: SELECT gp_wait_until_triggered_fault('initialize_wal_sender', 2, dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Validate that walsender does not enter catchup state, once the
+-- replication slot is obsoleted.  There used to be a bug that caused
+-- FTS to be mislead by a walsender that entered catchup state but
+-- failed shorty after due to the requested start point not available.
+-- FTS marked the mirror as up and turn synchronous replication on and
+-- later found it down.  If walsender fails before entering catchup
+-- state, FTS cannot be misled into thinking the mirror is up.  The
+-- following query should show "num times hit" as 0.
+1: select gp_inject_fault('enter_catchup_or_streaming', 'status', dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
+
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
 0U: ALTER SYSTEM RESET checkpoint_segments;
 0U: ALTER SYSTEM RESET wal_keep_segments;


### PR DESCRIPTION
An active replication slot is obsoleted when replication lag grows beyond max_slot_wal_keep_size limit.  This is a point of no return, the mirror must be destroyed and recreated using `pg_basebackup` (`gprecoverseg -F`).  The walsender process exits when this happens. However, the walreceiver on mirror is oblivious to this and keeps on attempting new replication connections.

This patch fixes a bug in walsender's state transition, in handling such incoming connection requests.  Walsender used to enter catchup state immediately upon receiving a connection request.  The request would fail at a later time, when an attempt to locate the requested start LSN failed.  An FTS probe within this window would erroneously treat the mirror as up and turn syncrep on.  This is definitely not desirable.  The fix is fail early, without entering catchup state if the replication slot is obsoleted.
