### PR TITLE
[Backport 6X] Check delay eager free in squelch functions.

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -808,7 +808,8 @@ ExecEagerFreeFunctionScan(FunctionScanState *node)
 void
 ExecSquelchFunctionScan(FunctionScanState *node)
 {
-	ExecEagerFreeFunctionScan(node);
+	if (!node->delayEagerFree)
+		ExecEagerFreeFunctionScan(node);
 }
 
 void

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -571,6 +571,9 @@ ExecEagerFreeSort(SortState *node)
 void
 ExecSquelchSort(SortState *node)
 {
-	ExecEagerFreeSort(node);
-	ExecSquelchNode(outerPlanState(node));
+	if (!node->delayEagerFree)
+	{
+		ExecEagerFreeSort(node);
+		ExecSquelchNode(outerPlanState(node));
+	}
 }

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -64,3 +64,16 @@ select * from subselect_t2 where false and exists (select generate_series(1,2));
 ---+---+---
 (0 rows)
 
+-- Check delay eager free in squelch functions
+CREATE TABLE subselect2_foo (a int, b int);
+CREATE TABLE subselect2_bar (c int, d int);
+CREATE TABLE subselect2_baz (x int, y int);
+INSERT INTO subselect2_foo VALUES (1,1), (1,2);
+INSERT INTO subselect2_bar VALUES (1,1);
+SELECT *, (SELECT x FROM subselect2_baz EXCEPT SELECT c FROM subselect2_bar WHERE d = a) FROM subselect2_foo;
+ a | b | x 
+---+---+---
+ 1 | 1 |  
+ 1 | 2 |  
+(2 rows)
+

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -37,3 +37,13 @@ select * from subselect_t1 where NULL in (select c from subselect_t2) and exists
 -- Planner test to make sure initplan is removed when no param is used
 select * from subselect_t2 where false and exists (select generate_series(1,2));
 
+-- Check delay eager free in squelch functions
+CREATE TABLE subselect2_foo (a int, b int);
+CREATE TABLE subselect2_bar (c int, d int);
+CREATE TABLE subselect2_baz (x int, y int);
+
+INSERT INTO subselect2_foo VALUES (1,1), (1,2);
+INSERT INTO subselect2_bar VALUES (1,1);
+
+SELECT *, (SELECT x FROM subselect2_baz EXCEPT SELECT c FROM subselect2_bar WHERE d = a) FROM subselect2_foo;
+


### PR DESCRIPTION
Executor try to squelch nodes in it‘s subtree after a node returning a NULL tuple.
But sometimes squelching is not safe. If the node is not safe to squelch, the
parameter ’delayEagerFree‘ will be set to true. We should check the parameter
when we squelch the node both on 'Execxxx' function and 'ExecSquelchxxxx' function.

So add code checking 'delayEagerFree' in ExecSquelchSort and
ExecSquelchFunction.

This is a backport of commit 361f211 from master.

Co-authored-by: Jinbao Chen <cjinbao@vmware.com>

