### PR TITLE
The gpdb5-centos6-build-mingw image has been changed to private.

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -463,8 +463,10 @@ resources:
 - name: centos-mingw
   type: registry-image
   source:
-    repository: gcr.io/data-gpdb-public-images/gpdb5-centos6-build-mingw
+    repository: gcr.io/data-gpdb-private-images/gpdb5-centos6-build-mingw
     tag: 'latest'
+    username: _json_key
+    password: ((container-registry-readonly-service-account-key))
 
 - name: bin_gpdb_centos6
   type: s3


### PR DESCRIPTION
Change pipeline to use the private gpdb5-centos6-build-mingw image.

Also, remove unused python-behave resource.

[GP-588]

Dev pipleine - https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-batturu

Authored-by: Bhanu Kiran Atturu <batturu@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
