### PR TITLE
Turn fsync off correctly in some tests

### DIFF
--- a/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
+++ b/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
@@ -70,10 +70,7 @@ SELECT gp_inject_fault('fts_probe', 'reset', dbid) FROM gp_segment_configuration
 -----------------
  Success:        
 (1 row)
-!\retcode gpconfig -r fsync --skipvalidation;
--- start_ignore
-
--- end_ignore
+!\retcode gpconfig -c fsync -v off --skipvalidation;
 (exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore

--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -265,11 +265,7 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where
 
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r fsync --skipvalidation;
--- start_ignore
-20191204:17:13:27:024868 gpconfig:asimmac:apraveen-[INFO]:-completed successfully with parameters '-r fsync --skipvalidation'
-
--- end_ignore
+!\retcode gpconfig -c fsync -v off --skipvalidation;
 (exited with code 0)
 !\retcode gpstop -u;
 -- start_ignore

--- a/src/test/isolation2/sql/ao_same_trans_truncate_crash.sql
+++ b/src/test/isolation2/sql/ao_same_trans_truncate_crash.sql
@@ -35,5 +35,5 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
 -- cleanup
 SELECT gp_inject_fault('fts_probe', 'reset', dbid)
 FROM gp_segment_configuration WHERE role='p' AND content=-1;
-!\retcode gpconfig -r fsync --skipvalidation;
+!\retcode gpconfig -c fsync -v off --skipvalidation;
 !\retcode gpstop -u;

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -125,5 +125,5 @@ select gp_inject_fault('ao_fsync_counter', 'status', dbid)
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content = 0;
 
 !\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
-!\retcode gpconfig -r fsync --skipvalidation;
+!\retcode gpconfig -c fsync -v off --skipvalidation;
 !\retcode gpstop -u;


### PR DESCRIPTION
Some tests enable fsync temporarily, but disable fsync incorrectly finally
since they use "gpconfig -r". "gpconfig -r" comments out the guc setting so
finally the system uses the default guc value but for guc fsync the default
value is off. Fixing this by explicitly set fsync off with gpconfig in those
tests.

This change should be able to speed up testing some since all subsequent tests
after those tests could be accelerated now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
