### PR TITLE
Try to fix flaky test fsync/sql/bgwriter_checkpoint

### DIFF
--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -18,6 +18,17 @@
 -- m/num times hit:\'[4-9]\'/
 -- s/num times hit:\'[4-9]\'/num times hit:\'greater_than_two\'/
 -- end_matchsubs
+-- Prevent autovacuum from dirty-ing buffers.
+alter system set autovacuum = off;
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+             2 | t
+             1 | t
+             0 | t
+            -1 | t
+(4 rows)
+
 begin;
 create function num_dirty_on_qes(relid oid) returns setof bigint as
 $$
@@ -226,4 +237,15 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
  Success:
  Success:
 (8 rows)
+
+-- Reset autovacuum;
+alter system set autovacuum = on;
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+             2 | t
+             1 | t
+             0 | t
+            -1 | t
+(4 rows)
 

--- a/src/test/fsync/sql/bgwriter_checkpoint.sql
+++ b/src/test/fsync/sql/bgwriter_checkpoint.sql
@@ -18,6 +18,11 @@
 -- m/num times hit:\'[4-9]\'/
 -- s/num times hit:\'[4-9]\'/num times hit:\'greater_than_two\'/
 -- end_matchsubs
+
+-- Prevent autovacuum from dirty-ing buffers.
+alter system set autovacuum = off;
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+
 begin;
 create function num_dirty_on_qes(relid oid) returns setof bigint as
 $$
@@ -141,3 +146,7 @@ select gp_inject_fault('fsync_counter', 'status', 2::smallint);
 
 -- Reset all faults.
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+
+-- Reset autovacuum;
+alter system set autovacuum = on;
+select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');


### PR DESCRIPTION
Saw this on CI. Here is the diff. The reason might be autovacuum relevant.
Let's disable autovacuum during testing to see if the failure is gone.

@@ -121,7 +121,8 @@
  as (tablespace oid, database oid, relfilenode oid, block int);
  tablespace | database | relfilenode | block
 ------------+----------+-------------+-------
-(0 rows)
+       1663 |    16384 |       17756 |   101
+(1 row)

 -- Make buffers dirty.  At least two relfiles must be sync'ed during
 -- next checkpoint.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
