### PR TITLE
gprecoverseg: refactor creation of recovery triples

### DIFF
--- a/gpMgmt/bin/gppylib/gpMgmttest/__init__.py
+++ b/gpMgmt/bin/gppylib/gpMgmttest/__init__.py
@@ -13,13 +13,19 @@ class GpMgmtTextTestResult(unittest.TextTestResult):
         self.startTime = 0
 
     def getDescription(self, test):
-        case_name, full_name = test.__str__().split()
+        test_descr = test.__str__().split()
+        case_name = test_descr[0]
+        full_name = test_descr[1]
+        subtest_name = test_descr[2] if len(test_descr) > 2 else ''
         suite_name, class_name = full_name.strip('()').rsplit('.',1)
         if self.verbosity > 1:
             if test.shortDescription():
-                return 'Test Suite Name|%s|Test Case Name|%s|Test Details|%s' % (suite_name, case_name, test.shortDescription())
+                msg = 'Test Suite Name|%s|Test Case Name|%s|Test Details|%s' % (suite_name, case_name, test.shortDescription())
             else:
-                return 'Test Suite Name|%s|Test Case Name|%s|Test Details|' % (suite_name, case_name)
+                msg = 'Test Suite Name|%s|Test Case Name|%s|Test Details|' % (suite_name, case_name)
+            if subtest_name:
+                msg = "{0}Sub Test Name|{1}".format(msg, subtest_name)
+            return msg
 
     def startTest(self, test):
         super(GpMgmtTextTestResult, self).startTest(test)

--- a/gpMgmt/bin/gppylib/programs/Makefile
+++ b/gpMgmt/bin/gppylib/programs/Makefile
@@ -6,7 +6,7 @@ include $(top_builddir)/src/Makefile.global
 PROGRAMS= initstandby.py test_utils_helper.py
 
 DATA= __init__.py clsAddMirrors.py clsRecoverSegment.py clsSystemState.py \
-	programIoUtils.py
+	programIoUtils.py clsRecoverSegment_triples.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(libdir)/python/gppylib/programs'
@@ -19,6 +19,7 @@ install: installdirs
 	$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/gppylib/programs/gppkg.py'
 	$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/gppylib/programs/clsAddMirrors.py'
 	$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/gppylib/programs/clsRecoverSegment.py'
+	$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/gppylib/programs/clsRecoverSegment_triples.py'
 	$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/gppylib/programs/clsSystemState.py'
 
 uninstall:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -42,57 +42,9 @@ from gppylib.operations.utils import ParallelOperation
 from gppylib.operations.package import SyncPackages
 from gppylib.heapchecksum import HeapChecksum
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
+from gppylib.programs import clsRecoverSegment_triples
 
 logger = gplog.get_default_logger()
-
-
-class PortAssigner:
-    """
-    Used to assign new ports to segments on a host
-
-    Note that this could be improved so that we re-use ports for segments that are being recovered but this
-      does not seem necessary.
-
-    """
-
-    MAX_PORT_EXCLUSIVE = 65536
-
-    def __init__(self, gpArray):
-        #
-        # determine port information for recovering to a new host --
-        #   we need to know the ports that are in use and the valid range of ports
-        #
-        segments = gpArray.getDbList()
-        ports = [seg.getSegmentPort() for seg in segments if seg.isSegmentQE()]
-        if len(ports) > 0:
-            self.__minPort = min(ports)
-        else:
-            raise Exception("No segment ports found in array.")
-        self.__usedPortsByHostName = {}
-
-        byHost = GpArray.getSegmentsByHostName(segments)
-        for hostName, segments in byHost.items():
-            usedPorts = self.__usedPortsByHostName[hostName] = {}
-            for seg in segments:
-                usedPorts[seg.getSegmentPort()] = True
-
-    def findAndReservePort(self, hostName, address):
-        """
-        Find a port not used by any postmaster process.
-        When found, add an entry:  usedPorts[port] = True   and return the port found
-        Otherwise raise an exception labeled with the given address
-        """
-        if hostName not in self.__usedPortsByHostName:
-            self.__usedPortsByHostName[hostName] = {}
-        usedPorts = self.__usedPortsByHostName[hostName]
-
-        minPort = self.__minPort
-        for port in range(minPort, PortAssigner.MAX_PORT_EXCLUSIVE):
-            if port not in usedPorts:
-                usedPorts[port] = True
-                return port
-        raise Exception("Unable to assign port on %s" % address)
-
 
 # -------------------------------------------------------------------------
 
@@ -167,252 +119,6 @@ class GpRecoverSegmentProgram:
             lines.append(output_str)
         writeLinesToFile(fileName, lines)
 
-    def _getParsedRow(self, filename, lineno, line):
-        groups = line.split()  # NOT line.split(' ') due to MPP-15675
-        if len(groups) not in [1, 2]:
-            msg = "line %d of file %s: expected 1 or 2 groups but found %d" % (lineno, filename, len(groups))
-            raise ExceptionNoStackTraceNeeded(msg)
-        parts = groups[0].split('|')
-        if len(parts) != 3:
-            msg = "line %d of file %s: expected 3 parts on failed segment group, obtained %d" % (
-                lineno, filename, len(parts))
-            raise ExceptionNoStackTraceNeeded(msg)
-        address, port, datadir = parts
-        check_values(lineno, address=address, port=port, datadir=datadir)
-        row = {
-            'failedAddress': address,
-            'failedPort': port,
-            'failedDataDirectory': datadir,
-            'lineno': lineno
-        }
-        if len(groups) == 2:
-            parts2 = groups[1].split('|')
-            if len(parts2) != 3:
-                msg = "line %d of file %s: expected 3 parts on new segment group, obtained %d" % (
-                    lineno, filename, len(parts2))
-                raise ExceptionNoStackTraceNeeded(msg)
-            address2, port2, datadir2 = parts2
-            check_values(lineno, address=address2, port=port2, datadir=datadir2)
-            row.update({
-                'newAddress': address2,
-                'newPort': port2,
-                'newDataDirectory': datadir2
-            })
-
-        return row
-
-    def getRecoveryActionsFromConfigFile(self, gpArray):
-        """
-        getRecoveryActionsFromConfigFile
-
-        returns: a tuple (segments in change tracking disabled mode which are unable to recover, GpMirrorListToBuild object
-                 containing information of segments which are able to recover)
-        """
-        filename = self.__options.recoveryConfigFile
-        rows = []
-        with open(filename) as f:
-            for lineno, line in line_reader(f):
-                rows.append(self._getParsedRow(filename, lineno, line))
-
-        allAddresses = [row["newAddress"] for row in rows if "newAddress" in row]
-
-        failedSegments = []
-        failoverSegments = []
-        for row in rows:
-            # find the failed segment
-            failedAddress = row['failedAddress']
-            failedPort = row['failedPort']
-            failedDataDirectory = normalizeAndValidateInputPath(row['failedDataDirectory'],
-                                                                "config file", row['lineno'])
-            failedSegment = None
-            for segment in gpArray.getDbList():
-                if (segment.getSegmentAddress() == failedAddress
-                        and str(segment.getSegmentPort()) == failedPort
-                        and segment.getSegmentDataDirectory() == failedDataDirectory):
-
-                    if failedSegment is not None:
-                        # this could be an assertion -- configuration should not allow multiple entries!
-                        raise Exception(("A segment to recover was found twice in configuration.  "
-                                         "This segment is described by address|port|directory '%s|%s|%s' "
-                                         "on the input line: %s") %
-                                        (failedAddress, failedPort, failedDataDirectory, row['lineno']))
-                    failedSegment = segment
-
-            if failedSegment is None:
-                raise Exception("A segment to recover was not found in configuration.  " \
-                                "This segment is described by address|port|directory '%s|%s|%s' on the input line: %s" %
-                                (failedAddress, failedPort, failedDataDirectory, row['lineno']))
-
-            failoverSegment = None
-            if "newAddress" in row:
-                """
-                When the second set was passed, the caller is going to tell us to where we need to failover, so
-                  build a failover segment
-                """
-                # these two lines make it so that failoverSegment points to the object that is registered in gparray
-                failoverSegment = failedSegment
-                failedSegment = failoverSegment.copy()
-
-                address = row["newAddress"]
-                try:
-                    port = int(row["newPort"])
-                except ValueError:
-                    raise Exception('Config file format error, invalid number value in line: %s' % (row['lineno']))
-
-                dataDirectory = normalizeAndValidateInputPath(row["newDataDirectory"], "config file",
-                                                              row['lineno'])
-                # FIXME: hostname probably should not be address, but to do so, "hostname" should be added to gpaddmirrors config file
-                # FIXME: This appears identical to __getMirrorsToBuildFromConfigFilein clsAddMirrors
-                hostName = address
-
-                # now update values in failover segment
-                failoverSegment.setSegmentAddress(address)
-                failoverSegment.setSegmentHostName(hostName)
-                failoverSegment.setSegmentPort(port)
-                failoverSegment.setSegmentDataDirectory(dataDirectory)
-
-            # this must come AFTER the if check above because failedSegment can be adjusted to
-            #   point to a different object
-            failedSegments.append(failedSegment)
-            failoverSegments.append(failoverSegment)
-
-        peersForFailedSegments = self.findAndValidatePeersForFailedSegments(gpArray, failedSegments)
-
-        segs = []
-        segs_with_persistent_mirroring_disabled = []
-        for index, failedSegment in enumerate(failedSegments):
-            peerForFailedSegment = peersForFailedSegments[index]
-
-            peerForFailedSegmentDbId = peerForFailedSegment.getSegmentDbId()
-
-            if failedSegment.unreachable:
-                continue
-
-            segs.append(GpMirrorToBuild(failedSegment, peerForFailedSegment, failoverSegments[index],
-                                        self.__options.forceFullResynchronization))
-
-        self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
-
-        return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                   self.__options.parallelDegree, forceoverwrite=True,
-                                   progressMode=self.getProgressMode(),
-                                   parallelPerHost=self.__options.parallelPerHost)
-
-    def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
-        dbIdToPeerMap = gpArray.getDbIdToPeerMap()
-        peersForFailedSegments = [dbIdToPeerMap.get(seg.getSegmentDbId()) for seg in failedSegments]
-
-        for i in range(len(failedSegments)):
-            peer = peersForFailedSegments[i]
-            if peer is None:
-                raise Exception("No peer found for dbid %s" % failedSegments[i].getSegmentDbId())
-            elif peer.isSegmentDown():
-                raise Exception(
-                    "Both segments for content %s are down; Try restarting Greenplum DB and running %s again." %
-                    (peer.getSegmentContentId(), getProgramName()))
-        return peersForFailedSegments
-
-    def getRecoveryActionsFromConfiguration(self, gpEnv, gpArray):
-        """
-        getRecoveryActionsFromConfiguration
-
-        returns: a tuple (segments in change tracking disabled mode which are unable to recover, GpMirrorListToBuild object
-                 containing information of segments which are able to recover)
-        """
-        segments = gpArray.getSegDbList()
-
-        failedSegments = [seg for seg in segments if seg.isSegmentDown()]
-        peersForFailedSegments = self.findAndValidatePeersForFailedSegments(gpArray, failedSegments)
-
-        # Dictionaries used for building mapping to new hosts
-        recoverAddressMap = {}
-        recoverHostMap = {}
-        interfaceHostnameWarnings = []
-
-        recoverHostIdx = 0
-
-        if self.__options.newRecoverHosts and len(self.__options.newRecoverHosts) > 0:
-            for seg in failedSegments:
-                segAddress = seg.getSegmentAddress()
-                segHostname = seg.getSegmentHostName()
-
-                # Haven't seen this hostname before so we put it on a new host
-                if segHostname not in recoverHostMap:
-                    try:
-                        recoverHostMap[segHostname] = self.__options.newRecoverHosts[recoverHostIdx]
-                    except:
-                        # If we get here, not enough hosts were specified in the -p option.  Need 1 new host
-                        # per 1 failed host.
-                        raise Exception('Not enough new recovery hosts given for recovery.')
-                    recoverHostIdx += 1
-
-                destAddress = recoverHostMap[segHostname]
-                destHostname = recoverHostMap[segHostname]
-
-                # Save off the new host/address for this address.
-                recoverAddressMap[segAddress] = (destHostname, destAddress)
-
-            new_recovery_hosts = [destHostname for (destHostname, destAddress) in recoverAddressMap.values()]
-            unreachable_hosts = get_unreachable_segment_hosts(new_recovery_hosts, len(new_recovery_hosts))
-            if unreachable_hosts:
-                raise ExceptionNoStackTraceNeeded("Cannot recover. The recovery target host %s is unreachable." % (' '.join(map(str, unreachable_hosts))))
-
-            for key in list(recoverAddressMap.keys()):
-                (newHostname, newAddress) = recoverAddressMap[key]
-                try:
-                    unix.Ping.local("ping new address", newAddress)
-                except:
-                    # new address created is invalid, so instead use same hostname for address
-                    self.logger.info("Ping of %s failed, Using %s for both hostname and address.", newAddress, newHostname)
-                    newAddress = newHostname
-                recoverAddressMap[key] = (newHostname, newAddress)
-
-            if len(self.__options.newRecoverHosts) != recoverHostIdx:
-                interfaceHostnameWarnings.append("The following recovery hosts were not needed:")
-                for h in self.__options.newRecoverHosts[recoverHostIdx:]:
-                    interfaceHostnameWarnings.append("\t%s" % h)
-
-        portAssigner = PortAssigner(gpArray)
-
-        forceFull = self.__options.forceFullResynchronization
-
-        segs = []
-        segs_with_persistent_mirroring_disabled = []
-        for i in range(len(failedSegments)):
-
-            failoverSegment = None
-            failedSegment = failedSegments[i]
-            liveSegment = peersForFailedSegments[i]
-
-            if self.__options.newRecoverHosts and len(self.__options.newRecoverHosts) > 0:
-                (newRecoverHost, newRecoverAddress) = recoverAddressMap[failedSegment.getSegmentAddress()]
-                # these two lines make it so that failoverSegment points to the object that is registered in gparray
-                failoverSegment = failedSegment
-                failedSegment = failoverSegment.copy()
-                failoverSegment.unreachable = False  # recover to a new host; it is reachable as checked above.
-                failoverSegment.setSegmentHostName(newRecoverHost)
-                failoverSegment.setSegmentAddress(newRecoverAddress)
-                port = portAssigner.findAndReservePort(newRecoverHost, newRecoverAddress)
-                failoverSegment.setSegmentPort(port)
-            else:
-                # we are recovering to the same host("in place") and hence
-                # cannot recover if the failed segment is unreachable.
-                # This is equivalent to failoverSegment.unreachable that we should be doing here but
-                # due to how the code is factored failoverSegment is None here.
-                if failedSegment.unreachable:
-                    continue
-
-            segs.append(GpMirrorToBuild(failedSegment, liveSegment, failoverSegment, forceFull))
-
-        self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
-
-        return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                   self.__options.parallelDegree,
-                                   interfaceHostnameWarnings,
-                                   forceoverwrite=True,
-                                   progressMode=self.getProgressMode(),
-                                   parallelPerHost=self.__options.parallelPerHost)
-
     def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
         if segs_persistent_mirroring_disabled:
             self.logger.warn('Segments with dbid %s not recovered; persistent mirroring state is disabled.' %
@@ -421,10 +127,23 @@ class GpRecoverSegmentProgram:
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
-        elif self.__options.recoveryConfigFile is not None:
-            return self.getRecoveryActionsFromConfigFile(gpArray)
         else:
-            return self.getRecoveryActionsFromConfiguration(gpEnv, gpArray)
+            segs_with_persistent_mirroring_disabled = []
+            self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
+
+            instance = clsRecoverSegment_triples.MirrorBuilderFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts,
+                                                     self.logger)
+            segs = []
+            for t in instance.getMirrorTriples():
+                #TODO pass just t to GpMirrorToBuild
+                segs.append(GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization))
+
+            return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
+                                       self.__options.parallelDegree,
+                                       instance.getInterfaceHostnameWarnings(),
+                                       forceoverwrite=True,
+                                       progressMode=self.getProgressMode(),
+                                       parallelPerHost=self.__options.parallelPerHost)
 
     def syncPackages(self, new_hosts):
         # The design decision here is to squash any exceptions resulting from the

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
@@ -1,0 +1,396 @@
+import abc
+from typing import List
+from gppylib.commands import unix
+from gppylib.mainUtils import ExceptionNoStackTraceNeeded
+from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
+from gppylib.parseutils import line_reader, check_values, canonicalize_address
+from gppylib.utils import normalizeAndValidateInputPath
+from gppylib.gparray import GpArray, Segment
+
+class RecoverTriplet:
+    """
+    Represents the segments needed to perform a recovery on a given segment.
+    failed   = acting mirror that needs to be recovered
+    live     = acting primary to use to recover that failed segment
+    failover = failed segment will be recovered here
+    """
+    def __init__(self, failed: Segment, live: Segment, failover: Segment):
+        self.failed = failed
+        self.live = live
+        self.failover = failover
+
+    def __repr__(self):
+        return "Failed: {0} Live: {1} Failover: {2}".format(self.failed, self.live, self.failover)
+
+    def __eq__(self, other):
+        return self.failed == other.failed and self.live == other.live and self.failover == other.failover
+
+class MirrorBuilderFactory:
+    @staticmethod
+    def instance(gpArray, config_file=None, new_hosts=[], logger=None):
+        """
+
+        :param gpArray: The variable gpArray may get mutated when the getMirrorTriples function is called on this instance.
+        :param config_file:
+        :param new_hosts:
+        :param logger:
+        :return:
+        """
+        if config_file:
+            return ConfigFileMirrorBuilder(gpArray, config_file)
+
+        return GpArrayMirrorBuilder(gpArray, new_hosts, logger)
+
+
+class MirrorBuilder(abc.ABC):
+    def __init__(self, gpArray):
+        """
+
+        :param gpArray: Needs to be a shallow copy since we may return a mutated gpArray
+        """
+        self.gpArray = gpArray
+        self.recoveryTriples = []
+        self.interfaceHostnameWarnings = []
+
+    def getInterfaceHostnameWarnings(self):
+        return self.interfaceHostnameWarnings
+
+    @abc.abstractmethod
+    def getMirrorTriples(self) -> List[RecoverTriplet]:
+        """
+
+        :return: Returns a list of tuples that describes the following
+        Failed Segment:
+        Live Segment
+        Failover Segment
+        This function ignores the status (i.e. u or d) of the segment because this function is used by gpaddmirrors,
+        gpmovemirrors and gprecoverseg. For gpaddmirrors and gpmovemirrors, the segment to be moved should not
+        be marked as down whereas for gprecoverseg the segment to be recovered needs to marked as down.
+        """
+        pass
+
+
+class GpArrayMirrorBuilder(MirrorBuilder):
+    def __init__(self, gpArray, newHosts, logger):
+        super().__init__(gpArray)
+        self.newHosts = []
+        if newHosts:
+            self.newHosts = newHosts[:]
+        self.logger = logger
+
+
+    def getMirrorTriples(self):
+        segments = self.gpArray.getSegDbList()
+
+        failedSegments = [seg for seg in segments if seg.isSegmentDown()]
+        peersForFailedSegments = _findAndValidatePeersForFailedSegments(self.gpArray, failedSegments)
+
+        # Dictionaries used for building mapping to new hosts
+        recoverAddressMap = {}
+        recoverHostMap = {}
+
+        recoverHostIdx = 0
+
+        if self.newHosts and len(self.newHosts) > 0:
+            for seg in failedSegments:
+                segAddress = seg.getSegmentAddress()
+                segHostname = seg.getSegmentHostName()
+
+                # Haven't seen this hostname before so we put it on a new host
+                if segHostname not in recoverHostMap:
+                    try:
+                        recoverHostMap[segHostname] = self.newHosts[recoverHostIdx]
+                    except:
+                        # TODO only catch IndexError
+                        raise Exception('Not enough new recovery hosts given for recovery.')
+                    recoverHostIdx += 1
+
+                destAddress = recoverHostMap[segHostname]
+                destHostname = recoverHostMap[segHostname]
+
+                # Save off the new host/address for this address.
+                recoverAddressMap[segAddress] = (destHostname, destAddress)
+
+            new_recovery_hosts = [destHostname for (destHostname, destAddress) in recoverAddressMap.values()]
+            unreachable_hosts = get_unreachable_segment_hosts(new_recovery_hosts, len(new_recovery_hosts))
+            if unreachable_hosts:
+                raise ExceptionNoStackTraceNeeded("Cannot recover. The following recovery target hosts are "
+                                                  "unreachable: %s" % unreachable_hosts)
+
+            for key in list(recoverAddressMap.keys()):
+                (newHostname, newAddress) = recoverAddressMap[key]
+                try:
+                    unix.Ping.local("ping new address", newAddress)
+                except:
+                    # new address created is invalid, so instead use same hostname for address
+                    self.logger.info("Ping of %s failed, Using %s for both hostname and address.", newAddress,
+                                     newHostname)
+                    newAddress = newHostname
+                recoverAddressMap[key] = (newHostname, newAddress)
+
+            if len(self.newHosts) != recoverHostIdx:
+                self.interfaceHostnameWarnings.append("The following recovery hosts were not needed:")
+                for h in self.newHosts[recoverHostIdx:]:
+                    self.interfaceHostnameWarnings.append("\t%s" % h)
+
+        portAssigner = _PortAssigner(self.gpArray)
+
+        for i in range(len(failedSegments)):
+
+            failoverSegment = None
+            failedSegment = failedSegments[i]
+            liveSegment = peersForFailedSegments[i]
+
+            if self.newHosts and len(self.newHosts) > 0:
+                (newRecoverHost, newRecoverAddress) = recoverAddressMap[failedSegment.getSegmentAddress()]
+                # these two lines make it so that failoverSegment points to the object that is registered in gparray
+                failoverSegment = failedSegment
+                failedSegment = failoverSegment.copy()
+                failoverSegment.unreachable = False  # recover to a new host; it is reachable as checked above.
+                failoverSegment.setSegmentHostName(newRecoverHost)
+                failoverSegment.setSegmentAddress(newRecoverAddress)
+                port = portAssigner.findAndReservePort(newRecoverHost, newRecoverAddress)
+                failoverSegment.setSegmentPort(port)
+            else:
+                # we are recovering to the same host("in place") and hence
+                # cannot recover if the failed segment is unreachable.
+                # This is equivalent to failoverSegment.unreachable that we should be doing here but
+                # due to how the code is factored failoverSegment is None here.
+                if failedSegment.unreachable:
+                    continue
+            self.recoveryTriples.append(RecoverTriplet(failedSegment, liveSegment, failoverSegment))
+
+        return self.recoveryTriples
+
+
+class ConfigFileMirrorBuilder(MirrorBuilder):
+    def __init__(self, gpArray, config_file):
+        super().__init__(gpArray)
+        self.config_file = config_file
+        self.rows = self._parseConfigFile(self.config_file)
+
+    def getMirrorTriples(self):
+        failedSegments = []
+        failoverSegments = []
+        for row in self.rows:
+            # find the failed segment
+            failedAddress = row['failedAddress']
+            failedPort = row['failedPort']
+            failedDataDirectory = normalizeAndValidateInputPath(row['failedDataDirectory'],
+                                                                "config file", row['lineno'])
+            failedSegment = None
+            for segment in self.gpArray.getDbList():
+                if (segment.getSegmentAddress() == failedAddress
+                        and str(segment.getSegmentPort()) == failedPort
+                        and segment.getSegmentDataDirectory() == failedDataDirectory):
+
+                    if failedSegment is not None:
+                        # this could be an assertion -- configuration should not allow multiple entries!
+                        raise Exception(("A segment to recover was found twice in configuration.  "
+                                         "This segment is described by address|port|directory '%s|%s|%s' "
+                                         "on the input line: %s") %
+                                        (failedAddress, failedPort, failedDataDirectory, row['lineno']))
+                    failedSegment = segment
+
+            if failedSegment is None:
+                raise Exception("A segment to recover was not found in configuration.  " \
+                                "This segment is described by address|port|directory '%s|%s|%s' on the input line: %s" %
+                                (failedAddress, failedPort, failedDataDirectory, row['lineno']))
+
+            # TODO: These 2 cases have different behavior which might be confusing to the user.
+            # "<failed_address>|<port>|<data_dir> <recovery_address>|<port>|<data_dir>" does full recovery
+            # "<failed_address>|<port>|<data_dir>" does incremental recovery
+            failoverSegment = None
+            if "newAddress" in row:
+                """
+                When the second set was passed, the caller is going to tell us to where we need to failover, so
+                  build a failover segment
+                """
+                # these two lines make it so that failoverSegment points to the object that is registered in gparray
+                failoverSegment = failedSegment
+                failedSegment = failoverSegment.copy()
+
+                address = row["newAddress"]
+                try:
+                    port = int(row["newPort"])
+                except ValueError:
+                    raise Exception('Config file format error, invalid number value in line: %s' % (row['lineno']))
+
+                dataDirectory = normalizeAndValidateInputPath(row["newDataDirectory"], "config file",
+                                                              row['lineno'])
+                # TODO: hostname probably should not be address, but to do so, "hostname" should be added to gpaddmirrors config file
+                # TODO: This appears identical to __getMirrorsToBuildFromConfigFilein clsAddMirrors
+                hostName = address
+
+                # now update values in failover segment
+                failoverSegment.setSegmentAddress(address)
+                failoverSegment.setSegmentHostName(hostName)
+                failoverSegment.setSegmentPort(port)
+                failoverSegment.setSegmentDataDirectory(dataDirectory)
+
+            # this must come AFTER the if check above because failedSegment can be adjusted to
+            #   point to a different object
+            failedSegments.append(failedSegment)
+            failoverSegments.append(failoverSegment)
+
+        peersForFailedSegments = _findAndValidatePeersForFailedSegments(self.gpArray, failedSegments)
+
+        for index, failedSegment in enumerate(failedSegments):
+            peerForFailedSegment = peersForFailedSegments[index]
+
+            if failedSegment.unreachable:
+                continue
+
+            self.recoveryTriples.append(RecoverTriplet(failedSegment, peerForFailedSegment, failoverSegments[index]))
+
+        return self.recoveryTriples
+
+    @staticmethod
+    def _parseConfigFile(config_file):
+        """
+        Parse the config file
+        :param config_file:
+        :return: List of dictionaries with each dictionary containing the failed and failover information??
+        """
+        rows = []
+        with open(config_file) as f:
+            for lineno, line in line_reader(f):
+
+                groups = line.split()  # NOT line.split(' ') due to MPP-15675
+                if len(groups) not in [1, 2]:
+                    msg = "line %d of file %s: expected 1 or 2 groups but found %d" % (lineno, config_file, len(groups))
+                    raise ExceptionNoStackTraceNeeded(msg)
+                parts = groups[0].split('|')
+                if len(parts) != 3:
+                    msg = "line %d of file %s: expected 3 parts on failed segment group, obtained %d" % (
+                        lineno, config_file, len(parts))
+                    raise ExceptionNoStackTraceNeeded(msg)
+                address, port, datadir = parts
+                check_values(lineno, address=address, port=port, datadir=datadir)
+                row = {
+                    'failedAddress': address,
+                    'failedPort': port,
+                    'failedDataDirectory': datadir,
+                    'lineno': lineno
+                }
+                if len(groups) == 2:
+                    parts2 = groups[1].split('|')
+                    if len(parts2) != 3:
+                        msg = "line %d of file %s: expected 3 parts on new segment group, obtained %d" % (
+                            lineno, config_file, len(parts2))
+                        raise ExceptionNoStackTraceNeeded(msg)
+                    address2, port2, datadir2 = parts2
+                    check_values(lineno, address=address2, port=port2, datadir=datadir2)
+                    row.update({
+                        'newAddress': address2,
+                        'newPort': port2,
+                        'newDataDirectory': datadir2
+                    })
+
+                rows.append(row)
+
+        ConfigFileMirrorBuilder._validate(rows)
+
+        return rows
+
+    @staticmethod
+    def _validate(rows):
+        """
+        Runs checks for making sure all the rows are consistent
+        :param rows:
+        :return:
+        """
+        failed = {}
+        new = {}
+        for row in rows:
+            address, port, datadir, lineno = \
+                row['failedAddress'], row['failedPort'], row['failedDataDirectory'], row['lineno']
+
+            if address+datadir in failed:
+                msg = 'config file lines {0} and {1} conflict: ' \
+                      'Cannot recover the same failed segment {2} and data directory {3} twice.' \
+                    .format(failed[address+datadir], lineno, address, datadir)
+                raise ExceptionNoStackTraceNeeded(msg)
+
+            failed[address+datadir] = lineno
+
+            if 'newAddress' not in row:
+                if address+datadir in new:
+                    msg = 'config file lines {0} and {1} conflict: ' \
+                          'Cannot recover segment {2} with data directory {3} in place if it is used as a recovery segment.' \
+                        .format(new[address+datadir], lineno, address, datadir)
+                    raise ExceptionNoStackTraceNeeded(msg)
+
+                continue
+
+            address2, port2, datadir2 = row['newAddress'], row['newPort'], row['newDataDirectory']
+
+            if address2+datadir2 in new:
+                msg = 'config file lines {0} and {1} conflict: ' \
+                      'Cannot recover to the same segment {2} and data directory {3} twice.' \
+                    .format(new[address2+datadir2], lineno, address2, datadir2)
+                raise ExceptionNoStackTraceNeeded(msg)
+
+            new[address2+datadir2] = lineno
+
+
+def _findAndValidatePeersForFailedSegments(gpArray, failedSegments):
+    dbIdToPeerMap = gpArray.getDbIdToPeerMap()
+    peersForFailedSegments = [dbIdToPeerMap.get(seg.getSegmentDbId()) for seg in failedSegments]
+
+    for i in range(len(failedSegments)):
+        peer = peersForFailedSegments[i]
+        if peer is None:
+            raise Exception("No peer found for dbid %s" % failedSegments[i].getSegmentDbId())
+        elif peer.isSegmentDown():
+            raise Exception(
+                "Both segments for content %s are down; Try restarting Greenplum DB and running the program again." %
+                (peer.getSegmentContentId()))
+    return peersForFailedSegments
+
+class _PortAssigner:
+    """
+    Used to assign new ports to segments on a host
+
+    Note that this could be improved so that we re-use ports for segments that are being recovered but this
+      does not seem necessary.
+
+    """
+
+    MAX_PORT_EXCLUSIVE = 65536
+
+    def __init__(self, gpArray):
+        #
+        # determine port information for recovering to a new host --
+        #   we need to know the ports that are in use and the valid range of ports
+        #
+        segments = gpArray.getDbList()
+        ports = [seg.getSegmentPort() for seg in segments if seg.isSegmentQE()]
+        if len(ports) > 0:
+            self.__minPort = min(ports)
+        else:
+            raise Exception("No segment ports found in array.")
+        self.__usedPortsByHostName = {}
+
+        byHost = GpArray.getSegmentsByHostName(segments)
+        for hostName, segments in byHost.items():
+            usedPorts = self.__usedPortsByHostName[hostName] = {}
+            for seg in segments:
+                usedPorts[seg.getSegmentPort()] = True
+
+    def findAndReservePort(self, hostName, address):
+        """
+        Find a port not used by any postmaster process.
+        When found, add an entry:  usedPorts[port] = True   and return the port found
+        Otherwise raise an exception labeled with the given address
+        """
+        if hostName not in self.__usedPortsByHostName:
+            self.__usedPortsByHostName[hostName] = {}
+        usedPorts = self.__usedPortsByHostName[hostName]
+
+        minPort = self.__minPort
+        for port in range(minPort, _PortAssigner.MAX_PORT_EXCLUSIVE):
+            if port not in usedPorts:
+                usedPorts[port] = True
+                return port
+        raise Exception("Unable to assign port on %s" % address)

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+
+import copy
+import io
+from mock import Mock, patch, MagicMock
+import tempfile
+
+import gppylib
+from gparray import Segment, GpArray
+from gppylib.programs import clsRecoverSegment_triples
+from gppylib.programs.clsRecoverSegment_triples import ConfigFileMirrorBuilder, MirrorBuilderFactory, RecoverTriplet
+from test.unit.gp_unittest import GpTestCase
+
+class MirrorBuilderFactoryTestCase(GpTestCase):
+    def setUp(self):
+        # Set maxDiff to None to see the entire diff on the console in case of failure
+        self.maxDiff = None
+
+        # we always mock ping.local to be a no-op. Once we refactor -i and -p to
+        # use the same code path, this mock will no longer be needed
+        clsRecoverSegment_triples.unix.Ping.local = Mock()
+
+    def run_single_ConfigFile_test(self, test):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(test["config"].encode("utf-8"))
+            f.flush()
+            return self._run_single_GpArrayMirrorBuilder_test(test["gparray"], f.name, None, None, test.get("unreachable_existing_hosts"))
+
+    def run_single_GpArray_test(self, test):
+        return self._run_single_GpArrayMirrorBuilder_test(test["gparray"], None, test["new_hosts"], test.get("unreachable_hosts"),
+                                     test.get("unreachable_existing_hosts"))
+
+    #TODO: do we want new hosts here?  We do not officially support new hosts with "-i"
+    def test_ConfigFileMirrorBuilder_getMirrorTriples_should_pass(self):
+        tests = [
+            {
+                "name": "blank_config_file",
+                "gparray": self.all_up_gparray_str,
+                "config": "",
+                "expected": [],
+            },
+            {
+                "name": "single_old_and_new",
+                "gparray": self.all_up_gparray_str,
+                "config": "sdw2|21000|/mirror/gpseg0 sdw3|41000|/mirror/gpseg5_new",
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '10|0|m|m|s|u|sdw3|sdw3|41000|/mirror/gpseg5_new')]
+            },
+            {
+                "name": "multiple_old_and_new",
+                "gparray": self.all_up_gparray_str,
+                "config": """sdw2|21000|/mirror/gpseg0 sdw3|41001|/mirror/gpseg4
+                             sdw2|21001|/mirror/gpseg1 sdw2|41001|/mirror/gpseg_new
+                             sdw4|21000|/mirror/gpseg4
+                             sdw1|21000|/mirror/gpseg6 sdw4|41000|/mirror/gpseg7""",
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '10|0|m|m|s|u|sdw3|sdw3|41001|/mirror/gpseg4'),
+                             self._triplet('11|1|m|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|p|p|s|u|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '11|1|m|m|s|u|sdw2|sdw2|41001|/mirror/gpseg_new'),
+                             self._triplet('14|4|m|m|s|u|sdw4|sdw4|21000|/mirror/gpseg4',
+                                           '6|4|p|p|s|u|sdw3|sdw3|20000|/primary/gpseg4',
+                                           None),
+                             self._triplet('16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6',
+                                           '8|6|p|p|s|u|sdw4|sdw4|20000|/primary/gpseg6',
+                                           '16|6|m|m|s|u|sdw4|sdw4|41000|/mirror/gpseg7')]
+            },
+            # TODO: this should work but the failedSegment in the gparray is mutated but should not be...
+            # {
+            #     "name": "multiple_old_with_unreachable_existing_hosts",
+            #     "gparray": self.all_up_gparray_str,
+            #     "config": """sdw2|21000|/mirror/gpseg0 sdw3|41001|/mirror/gpseg4
+            #                  sdw4|21000|/mirror/gpseg4
+            #                  sdw1|21000|/mirror/gpseg6 sdw4|41000|/mirror/gpseg7""",
+            #     "unreachable_existing_hosts": ['sdw2'],
+            #     "expected": [self._triplet('14|4|m|m|s|u|sdw4|sdw4|21000|/mirror/gpseg4',
+            #                                '6|4|p|p|s|u|sdw3|sdw3|20000|/primary/gpseg4',
+            #                                None),
+            #                  self._triplet('16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6',
+            #                                '8|6|p|p|s|u|sdw4|sdw4|20000|/primary/gpseg6',
+            #                                '16|6|m|m|s|u|sdw4|sdw4|41000|/mirror/gpseg7')]
+            # },
+            {
+                "name": "in_place_1_part",
+                "gparray": self.all_up_gparray_str,
+                "config": "sdw2|21000|/mirror/gpseg0",
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           None)]
+            },
+            {
+                "name": "in_place_2_parts",
+                "gparray": self.all_up_gparray_str,
+                "config": "sdw2|21000|/mirror/gpseg0 sdw2|21000|/mirror/gpseg0",
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0')]
+            },
+            {
+                "name": "in_place_1_part_unreachable_exising_host",
+                "gparray": self.all_up_gparray_str,
+                "config": "sdw2|21000|/mirror/gpseg0",
+                "unreachable_existing_hosts": ['sdw2'],
+                "expected": []
+            }
+        ]
+        self.run_pass_tests(tests, self.run_single_ConfigFile_test)
+
+    def test_ConfigFileMirrorBuilder_getMirrorTriples_should_fail(self):
+        tests = [
+            {
+                "name": "invalid_failed_address",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "seg_does_not_exist|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5",
+                "expected": "segment to recover was not found in configuration.*described by.*seg_does_not_exist"
+            },
+            {
+                "name": "invalid_failed_port1",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "sdw1|99999|/primary/gpseg0 sdw3|20001|/primary/gpseg5",
+                "expected": "segment to recover was not found in configuration.*described by.*99999"
+            },
+            {
+                "name": "invalid_failed_port2",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "sdw1|port_does_not_exist|/primary/gpseg0 sdw3|20001|/primary/gpseg5",
+                "expected": "Invalid port"
+            },
+            {
+                "name": "invalid_failed_data_dir",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "sdw1|20000|/does/not/exist sdw3|20001|/primary/gpseg5",
+                "expected": "segment to recover was not found in configuration.*described by.*exist"
+            },
+            {
+                "name": "invalid_failed_and_new_address",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "seg_does_not_exist_old|20000|/primary/gpseg0 seg_does_not_exist_new|20001|/primary/gpseg5",
+                "expected": "segment to recover was not found in configuration.*described by.*seg_does_not_exist_old"
+            },
+            {
+                "name": "invalid_recovery_port1",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "sdw1|20000|/primary/gpseg0 sdw3|port_does_not_exist|/primary/gpseg5",
+                "expected": "Invalid port"
+            },
+            {
+                "name": "no_peer_for_failed_seg",
+                "gparray": self.content0_no_peer_gparray_str,
+                "config": "sdw1|20000|/primary/gpseg0 sdw3|20000|/primary/gpseg5",
+                "expected": "No peer found for dbid 2"
+            },
+            {
+                "name": "both_peers_down",
+                "gparray": self.content0_mirror_and_its_peer_down_gparray_str,
+                "config": "sdw1|20000|/primary/gpseg0 sdw3|20000|/primary/gpseg5",
+                "expected": "Both segments for content 0 are down. Try restarting"
+            },
+            #
+            #
+            # TODO: these should fail, but right now do not.  For recovery port and host, we should detect them here.
+            #   For recovery data directory, it is not clear where the check should go.
+            # {
+            #     "name": "invalid_recovery_address",
+            #     "config": "sdw1|20000|/primary/gpseg0 host_does_not_exist|20001|/primary/gpseg5",
+            # },
+            # {
+            #     "name": "invalid_recovery_port",
+            #     "config": "sdw1|20000|/primary/gpseg0 sdw3|99999|/primary/gpseg5",
+            # },
+            # {
+            #     "name": "invalid_recovery_data_dir",
+            #     "config": "sdw1|20000|/primary/gpseg0 sdw3|20001|/does/not/exist",
+            # },
+        ]
+        self.run_fail_tests(tests, self.run_single_ConfigFile_test)
+
+    def test_GpArrayMirrorBuilder_getMirrorTriples_should_pass(self):
+        tests = [{
+                "name": "no_new_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": [],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           None),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           None),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           None)]
+            },
+            {
+                "name": "one_existing_host_down",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": [],
+                "unreachable_existing_hosts": ['sdw1'],
+                "expected": [self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           None)]
+            },
+            {
+                "name": "all_relevant_existing_hosts_down",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": [],
+                "unreachable_existing_hosts": ['sdw1', 'sdw2'],
+                "expected": []
+            },
+            {
+                "name": "no_segs_to_recover",
+                "gparray": self.all_up_gparray_str,
+                "new_hosts": ['new_1'],
+                "expected": []
+            },
+            {
+                "name": "enough_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": ['new_1', 'new_2'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0'),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|m|p|s|d|new_1|new_1|20001|/primary/gpseg1'),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           '4|2|m|p|s|d|new_2|new_2|20000|/primary/gpseg2')]
+            },
+            {
+                "name": "more_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": ['new_1', 'new_2', 'new_3'], # This test assumes there is only one extra host
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0'),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|m|p|s|d|new_1|new_1|20001|/primary/gpseg1'),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           '4|2|m|p|s|d|new_2|new_2|20000|/primary/gpseg2')]
+            }
+        ]
+
+        self.run_pass_tests(tests, self.run_single_GpArray_test)
+
+    def test_GpArrayMirrorBuilder_getMirrorTriples_should_fail(self):
+        tests = [
+            {
+                "name": "not_enough_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": ['new_1'],
+                "unreachable_hosts": [],
+                "expected": "Not enough new recovery hosts given for recovery."
+            },
+            {
+                "name": "all_hosts_unreachable1",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": ['new_1'],
+                "unreachable_hosts": ['new_1'],
+                "expected": "Not enough new recovery hosts given for recovery."
+            },
+            {
+                "name": "all_hosts_unreachable2",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": ['new_1', 'new_2'],
+                "unreachable_hosts": ['new_1', 'new_2'],
+                "expected": "Cannot recover. The following recovery target hosts are unreachable: \['new_1', 'new_2'\]"
+            },
+            {
+                "name": "some_hosts_unreachable",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": ['new_1', 'new_2'],
+                "unreachable_hosts": ['new_2'],
+                "expected": "Cannot recover. The following recovery target hosts are unreachable: \['new_2'\]"
+            },
+            {
+                "name": "no_peer_for_failed_seg",
+                "gparray": self.content0_no_peer_gparray_str,
+                "new_hosts": ['new_1'],
+                "unreachable_hosts": [],
+                "expected": "No peer found for dbid 2"
+            },
+            {
+                "name": "both_peers_down",
+                "gparray": self.content0_mirror_and_its_peer_down_gparray_str,
+                "new_hosts": ['new_1'],
+                "unreachable_hosts": [],
+                "expected": "Both segments for content 0 are down. Try restarting"
+            }
+        ]
+        self.run_fail_tests(tests, self.run_single_GpArray_test)
+
+    def run_pass_tests(self, tests, fn_to_test):
+        for test in tests:
+            with self.subTest(msg=test["name"]):
+
+                initial_gparray, actual_gparray, actual = fn_to_test(test)
+                self.assertEqual(test["expected"], actual,
+                                 msg="\n\nTest {} failed.\n\nexpected:\n{}\n\ngot:\n{}".format(
+                                     test["name"], test["expected"], actual))
+
+                expected_gparray = self.get_expected_gparray(initial_gparray, test["expected"])
+                self.assertEqual(self.get_gparray_for_cmp(expected_gparray), self.get_gparray_for_cmp(actual_gparray),
+                                 msg="\n\nTest {} failed.\n\ninitial:\n{}\n\nexpected:\n{}\n\ngot:\n{}".format(
+                                     test["name"],
+                                     self.get_gparray_for_cmp(initial_gparray),
+                                     self.get_gparray_for_cmp(expected_gparray),
+                                     self.get_gparray_for_cmp(actual_gparray)))
+
+    def run_fail_tests(self, tests, fn_to_test):
+        for test in tests:
+            with self.subTest(msg=test["name"]):
+                # make sure test does not pass trivially("" will pass assertRaisesRegex)
+                self.assertTrue(test["expected"].strip() != "")
+                # TODO it is possible to match partial strings with regex that might be a typo. Should we instead not
+                #  use Regex and type out the exact error message ?
+                with self.assertRaisesRegex(Exception, test["expected"]):
+                    fn_to_test(test)
+
+    def __init__(self, arg):
+        super().__init__(arg)
+
+        # It's possible to have no down segments, as gpmovemirrors also calls gprecoverseg.
+        self.all_up_gparray_str = '''1|-1|p|p|n|u|mdw|mdw|5432|/master/gpseg-1
+                                  2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0
+                                  3|1|p|p|s|u|sdw1|sdw1|20001|/primary/gpseg1
+                                  16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6
+                                  17|7|m|m|s|u|sdw1|sdw1|21001|/mirror/gpseg7
+                                  10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0
+                                  11|1|m|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1
+                                  4|2|p|p|s|u|sdw2|sdw2|20000|/primary/gpseg2
+                                  5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3
+                                  12|2|m|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2
+                                  13|3|m|m|s|u|sdw3|sdw3|21001|/mirror/gpseg3
+                                  6|4|p|p|s|u|sdw3|sdw3|20000|/primary/gpseg4
+                                  7|5|p|p|s|u|sdw3|sdw3|20001|/primary/gpseg5
+                                  14|4|m|m|s|u|sdw4|sdw4|21000|/mirror/gpseg4
+                                  15|5|m|m|s|u|sdw4|sdw4|21001|/mirror/gpseg5
+                                  8|6|p|p|s|u|sdw4|sdw4|20000|/primary/gpseg6
+                                  9|7|p|p|s|u|sdw4|sdw4|20001|/primary/gpseg7'''
+
+        # We include down segments, so that gprecoverseg can find them automatically
+        self.three_failedover_segs_gparray_str = '''1|-1|p|p|n|u|mdw|mdw|5432|/master/gpseg-1
+                                  2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0
+                                  3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1
+                                  8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2
+                                  9|3|m|m|s|u|sdw3|sdw3|21001|/mirror/gpseg3
+                                  6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0
+                                  7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1
+                                  4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2
+                                  5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3'''
+
+        self.content0_no_peer_gparray_str = '''1|-1|p|p|n|u|mdw|mdw|5432|/master/gpseg-1
+                                  2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0
+                                  3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1
+                                  8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2
+                                  9|3|m|m|s|u|sdw3|sdw3|21001|/mirror/gpseg3
+                                  7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1
+                                  4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2
+                                  5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3'''
+
+        self.content0_mirror_and_its_peer_down_gparray_str = '''1|-1|p|p|n|u|mdw|mdw|5432|/master/gpseg-1
+                                  2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0
+                                  3|1|p|p|s|u|sdw1|sdw1|20001|/primary/gpseg1
+                                  8|2|m|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2
+                                  9|3|m|m|s|u|sdw3|sdw3|21001|/mirror/gpseg3
+                                  6|0|p|m|s|d|sdw2|sdw2|21000|/mirror/gpseg0
+                                  7|1|m|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1
+                                  4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2
+                                  5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3'''
+
+    def _run_single_GpArrayMirrorBuilder_test(self, gparray_str, config_file, new_hosts, unreachable_hosts,
+                                              unreachable_existing_hosts=None):
+        unreachable_hosts = unreachable_hosts if unreachable_hosts else []
+        gppylib.programs.clsRecoverSegment_triples.get_unreachable_segment_hosts = Mock(return_value=unreachable_hosts)
+
+        initial_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
+        mutated_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
+        i = MirrorBuilderFactory.instance(mutated_gparray,
+                                          config_file=config_file,
+                                          new_hosts=new_hosts)
+        triples = i.getMirrorTriples()
+
+        warnings = i.getInterfaceHostnameWarnings()
+        if warnings:
+            # TODO Currently we do not assert if warnings should have been populated.
+            expected = ["The following recovery hosts were not needed:", "\t{}".format(new_hosts[-1])]
+            self.assertEqual(expected, warnings)
+
+        return initial_gparray, mutated_gparray, triples
+
+    @staticmethod
+    def _triplet(failed, live, failover):
+        return RecoverTriplet(Segment.initFromString(failed),
+                              Segment.initFromString(live),
+                              Segment.initFromString(failover) if failover else None)
+
+    @staticmethod
+    def get_gp_array(gparray_str, unreachable_existing_hosts=None):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(gparray_str.encode('utf-8'))
+            f.flush()
+
+            gparray = GpArray.initFromFile(f.name)
+            if not unreachable_existing_hosts:
+                return gparray
+
+            # the caller of the function under test sets to True the "unreachable"
+            # member on any segment on an unreachable host; we emulate that here.
+            for seg in gparray.getSegDbList():
+                if seg.getSegmentHostName() in unreachable_existing_hosts:
+                    seg.unreachable = True
+            return gparray
+
+    # apply the "recover_triplets" to the "gparray" such that the "result"ing gparray
+    # will be the result of a successful gprecoverseg.
+    @staticmethod
+    def get_expected_gparray(gparray, recover_triplets):
+        result = copy.copy(gparray)
+        segMap = result.getSegDbMap()
+
+        for t in recover_triplets:
+            failed, failover = t.failed, t.failover
+
+            if not failover:
+                continue
+
+            if not failed.getSegmentDbId() in segMap:
+                continue
+
+            # these are the only fields we can change in the failed segment
+            segMap[failed.getSegmentDbId()].address = failover.address
+            segMap[failed.getSegmentDbId()].hostname = failover.hostname
+            segMap[failed.getSegmentDbId()].port = failover.port
+            segMap[failed.getSegmentDbId()].datadir = failover.datadir
+
+        return result
+
+    def get_gparray_for_cmp(self, gparray):
+        """
+        TODO This should ideally be in the __repr__ function in GpArray class.
+
+        Get a string representation of gparray for comparison in our tests.
+        We cannot rely on str(gparray) for comparison since the __str__ function for the Segment class
+        does not include the port and address.
+        """
+        segMap = gparray.getSegDbMap()
+        gparray_str = io.StringIO()
+        for seg in sorted(segMap.keys()):
+            gparray_str.write(repr(segMap[seg]))
+            gparray_str.write('\n')
+
+        return gparray_str.getvalue()
+
+
+class MirrorBuilderConfigFileParserTestCase(GpTestCase):
+
+    @staticmethod
+    def run_single_parser_test(test):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(test["config"].encode("utf-8"))
+            f.flush()
+            return ConfigFileMirrorBuilder._parseConfigFile(f.name)
+
+    passing_tests = [
+        {
+            "name": "simple_pass",
+            "config": """sdw1|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5
+                      sdw1|20001|/primary/gpseg1 sdw1|40001|/primary/gpseg_new
+                      sdw3|20000|/primary/gpseg4
+                      sdw4|20000|/primary/gpseg6 sdw4|20000|/primary/gpseg6"""
+        },
+        {
+            "name": "6X_web_doc",
+            "config": """sdw2|50000|/data2/mirror/gpseg0 sdw3|50000|/data/mirror/gpseg0
+                     sdw2|50001|/data2/mirror/gpseg1 sdw4|50001|/data/mirror/gpseg1
+                     sdw3|50002|/data2/mirror/gpseg2 sdw1|50002|/data/mirror/gpseg2"""},
+        {
+            "name": "old_to_new_new_to_other",
+            "config": """sdw1|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5
+                      sdw3|20001|/primary/gpseg5 sdw4|20000|/primary/gpseg6"""
+        },
+        {
+            "name": "old_to_new_new_to_old",
+            "config": """sdw1|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5
+                      sdw3|20001|/primary/gpseg5 sdw1|20000|/primary/gpseg0"""
+        }
+        ]
+
+    def test_parsing_should_pass(self):
+        for test in self.passing_tests:
+            with self.subTest(msg=test["name"]):
+
+                rows = self.run_single_parser_test(test)
+                self.assertEqual(self._get_expected_config(test["config"]), rows)
+
+    failing_tests = [
+        {
+            "name":
+                "too_many_groups",
+            "config":
+                """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5 sdw3|20001|/mirror/gpseg5""",
+            "expected":
+                "line 1 of file .*: expected 1 or 2 groups but found 3"
+        },
+        {
+            "name":
+                "too_few_parts_in_group_1",
+            "config":
+                """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                   sdw1|20000 sdw3|20001|/mirror/gpseg5""",
+            "expected":
+                "line 2 of file .*: expected 3 parts on failed segment group, obtained 2"
+        },
+        {
+            "name":
+                "too_few_parts_in_group_2",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw2|50001|/data2/mirror/gpseg1 sdw4|50001""",
+            "expected":
+                "line 2 of file .*: expected 3 parts on new segment group, obtained 2"
+        },
+        {
+            "name":
+                "old_inplace_and_old_to_old",
+            "config":
+                """sdw1|20000|/mirror/gpseg0
+                   sdw1|20000|/mirror/gpseg0 sdw1|20000|/mirror/gpseg0""",
+            "expected":
+                "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                "directory /mirror/gpseg0 twice"
+        },
+        {
+            "name": "old_inplace_and_old_to_old",
+            "config": """sdw1|20000|/mirror/gpseg0
+                         sdw1|20000|/mirror/gpseg0 sdw1|20000|/mirror/gpseg0""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+
+        },
+        {
+            "name": "old_inplace_and_old_inplace",
+            "config": """sdw1|20000|/mirror/gpseg0
+                         sdw1|20000|/mirror/gpseg0""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+
+        },
+        {
+            "name": "old1_to_new_and_old2_to_new",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw2|20001|/mirror/gpseg3 sdw3|20001|/mirror/gpseg5""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover to the same segment sdw3 and data directory "
+                        "/mirror/gpseg5 twice"
+        },
+        {
+            "name": "old_to_old_and_old_to_old",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw1|20000|/mirror/gpseg0
+                         sdw1|20000|/mirror/gpseg0 sdw1|20000|/mirror/gpseg0""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+        },
+        {
+            "name": "old_to_new_and_old_inplace",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw1|20000|/mirror/gpseg0""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+
+        },
+        {
+            "name": "old_to_new_and_old_to_old",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw1|20000|/mirror/gpseg0 sdw1|20000|/mirror/gpseg0""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+
+        },
+        {
+            "name": "old_to_new1_and_old_to_new2",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw1|20000|/mirror/gpseg0 sdw2|20001|/mirror/gpseg3""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+        },
+        {
+            "name": "old_to_new_and_new_to_new",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw3|20001|/mirror/gpseg5 sdw3|20001|/mirror/gpseg5""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover to the same segment sdw3 and data directory "
+                        "/mirror/gpseg5 twice"
+        },
+        {
+            "name": "old_to_new_and_old_to_new",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover the same failed segment sdw1 and data "
+                        "directory /mirror/gpseg0 twice"
+        },
+        {
+            "name": "old_to_new_and_new_inplace",
+            "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
+                         sdw3|20001|/mirror/gpseg5""",
+            "expected": "config file lines 1 and 2 conflict: Cannot recover segment sdw3 with data directory "
+                        "/mirror/gpseg5 in place if it is used as a recovery segment"
+        }
+    ]
+
+    def test_parsing_should_fail(self):
+        for test in self.failing_tests:
+            with self.subTest(msg=test["name"]):
+                # make sure test does not pass trivially("" will pass assertRaisesRegex)
+                self.assertTrue(test["expected"].strip() != "")
+
+                with self.assertRaisesRegex(Exception, test["expected"]):
+                    self.run_single_parser_test(test)
+
+    @staticmethod
+    def _get_expected_config(config_str):
+        rows = []
+        lineno = 0
+
+        for line in config_str.splitlines():
+            lineno += 1
+            groups = line.split()
+
+            address, port, datadir = groups[0].split('|')
+            row = {
+                'failedAddress': address,
+                'failedPort': port,
+                'failedDataDirectory': datadir,
+                'lineno': lineno
+            }
+
+            if len(groups) > 1:
+                address, port, datadir = groups[1].split('|')
+                row.update({
+                    'newAddress': address,
+                    'newPort': port,
+                    'newDataDirectory': datadir
+                })
+
+            rows.append(row)
+
+        return rows

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -22,7 +22,6 @@ Feature: Tests for gpmovemirrors
         When the user runs gpmovemirrors with additional args "--invalid-option"
         Then gpmovemirrors should return a return code of 2
 
-    @wip
     Scenario: gpmovemirrors can change the location of mirrors within a single host
         Given a standard local demo cluster is created
         And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -22,6 +22,7 @@ Feature: Tests for gpmovemirrors
         When the user runs gpmovemirrors with additional args "--invalid-option"
         Then gpmovemirrors should return a return code of 2
 
+    @wip
     Scenario: gpmovemirrors can change the location of mirrors within a single host
         Given a standard local demo cluster is created
         And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created


### PR DESCRIPTION
gprecoverseg: refactor code to enable unit testing of recovery triples

gprecoverseg has two main parts: determining the segment information
necessary for recovery and then performing that recovery.  This commit
simplifies the determination of the segment information necessary for
    recovery.

This commit provides a minor refactor of the code with extensive unit
testing.

The main information needed is the list of Segment triples:
[ (failed, live, failover),... ]

The failed Segment is recovered to the failover segment using the live
segment information.

Refactoring the current implementation to return only the recovery
triples information allows unit testing.  We have added tests for:

- "-i config_file.txt" that provides inconsistent information.  For
instance, specifying two different failover segments for a given
    failed segment
- unreachable existing hosts
- unreachable new hosts

Co-authored-by: David Krieger <dkrieger@vmware.com>

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/7x_gprecoverseg_refactor)