### PR TITLE
[5X backport] Allow debug_query_string exception log messages to be suppressed

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4748,7 +4748,7 @@ PostgresMain(int argc, char *argv[],
 		 */
 		if (debug_query_string != NULL)
 		{
-			write_stderr("An exception was encountered during the execution of statement: %s", debug_query_string);
+			elog(LOG, "An exception was encountered during the execution of statement: %s", debug_query_string);
 			debug_query_string = NULL;
 		}
 


### PR DESCRIPTION
At the moment, an error will always generate a debug_query_string
exception message in the logs even when log_min_messages is set to
PANIC. This can be a security concern if the query string is not meant
to be logged (e.g. a failed pgcrypto decrypt query is logged which can
be equivalent to logging a plaintext password).

Fix the issue by changing the call function from write_stderr to elog.
With elog, the log message will be controlled by log_min_messages and
may enhance the original debugging intent (the debug_query_string log
will always show the user-executed query along with the actual query
that failed).

GPDB references:
https://github.com/greenplum-db/gpdb/pull/1456
https://github.com/greenplum-db/gpdb/commit/bd7f682392b30b859588d0d60f2625095f1cd63f

Backport of https://github.com/greenplum-db/gpdb/commit/e1c553bb9e4772a4124f7c2a41c552998f14cf88.