### PR TITLE
Fix misleading log: libpq says we are still busy

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -723,7 +723,8 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 			}
 
 			if (PQisBusy(dispatchResult->segdbDesc->conn))
-				elog(LOG, "We thought we were done, because finished==true, but libpq says we are still busy");
+				elog(DEBUG1, "did not receive query results on libpq connection %s",
+					 dispatchResult->segdbDesc->whoami);
 		}
 		else
 			ELOG_DISPATCHER_DEBUG("processResults says we have more to do with %d of %d (%s)",


### PR DESCRIPTION
This PR will fix #10955

In short: 
most in the case, this log is printed on connection broken, the previous message is misleading to user.
so improve the message and adjust log level from INFO to DEBUG.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
