### PR TITLE
pg_upgrade_support: Fix 6X->6X upgrade path

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -1428,6 +1428,14 @@ check_views_referencing_deprecated_tables()
 	int			dbnum;
 	int			i_viewname;
 
+	/*
+	 * An upgrade check for deprecated objects only applies to a major version
+	 * upgrade.
+	 */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) ==
+		GET_MAJOR_VERSION(new_cluster.major_version))
+		return;
+
 	prep_status("Checking for views referencing deprecated tables");
 
 	snprintf(output_path, sizeof(output_path), "view_deprecated_tables.txt");


### PR DESCRIPTION
This fixes the upgrade path for 6X->6X upgrades which was broken by
67df5542a8 with the following error during a 6X->6X upgrade:

```
Checking for views referencing deprecated tables            SQL command failed
CREATE OR REPLACE FUNCTION view_references_deprecated_tables(OID) RETURNS BOOL AS '$libdir/pg_upgrade_support' LANGUAGE C STRICT;
ERROR:  could not find function "view_references_deprecated_tables" in file "/usr/local/greenplum-db-devel/lib/postgresql/pg_upgrade_support.so"
```

For upgrades from 6X->6X, we should not have to run this check as
deprecated object detection only applies to major version upgrades.