### PR TITLE
[6X] Correct locus type for replicated table's upper gather motion node 

### DIFF
--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -296,7 +296,7 @@ copyFlow(Flow *model_flow, bool withExprs, bool withSort)
 Motion *
 make_motion_gather_to_QD(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
 {
-	return make_motion_gather(root, subplan, sortPathKeys);
+	return make_motion_gather(root, subplan, sortPathKeys, CdbLocusType_Entry);
 }
 
 /*
@@ -308,7 +308,7 @@ make_motion_gather_to_QD(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
 Motion *
 make_motion_gather_to_QE(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
 {
-	return make_motion_gather(root, subplan, sortPathKeys);
+	return make_motion_gather(root, subplan, sortPathKeys, CdbLocusType_SingleQE);
 }
 
 /*
@@ -318,7 +318,7 @@ make_motion_gather_to_QE(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
  *      subplan.
  */
 Motion *
-make_motion_gather(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
+make_motion_gather(PlannerInfo *root, Plan *subplan, List *sortPathKeys, CdbLocusType targetLocus)
 {
 	Motion	   *motion;
 
@@ -350,14 +350,15 @@ make_motion_gather(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
 										  sort->sortOperators,
 										  sort->collations,sort->nullsFirst,
 										  false,
-										  subplan->flow->numsegments);
+										  subplan->flow->numsegments,
+										  targetLocus);
 
 		/* throw away the Sort */
 		pfree(sort);
 	}
 	else
 	{
-		motion = make_union_motion(subplan, false, subplan->flow->numsegments);
+		motion = make_union_motion(subplan, false, subplan->flow->numsegments, targetLocus);
 	}
 
 	return motion;
@@ -415,7 +416,7 @@ make_motion_hash_all_targets(PlannerInfo *root, Plan *subplan)
 		 * produce a different plan, with Sorts in the segments, and an
 		 * order-preserving gather on the top.)
 		 */
-		return make_motion_gather(root, subplan, NIL);
+		return make_motion_gather(root, subplan, NIL, CdbLocusType_SingleQE);
 	}
 }
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1691,7 +1691,7 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		(contain_volatile_functions((Node *) rel->subplan->targetlist) ||
 		 contain_volatile_functions(subquery->havingQual)))
 	{
-		rel->subplan = (Plan *) make_motion_gather(subroot, rel->subplan, NIL);
+		rel->subplan = (Plan *) make_motion_gather(subroot, rel->subplan, NIL, CdbLocusType_SingleQE);
 	}
 
 	rel->subroot = subroot;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7205,18 +7205,18 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 				 */
 				subplan = prep;
 				motion = make_sorted_union_motion(root, subplan, numSortCols, sortColIdx, sortOperators, collations,
-												  nullsFirst, false, numsegments);
+												  nullsFirst, false, numsegments, path->path.locus.locustype);
 			}
 			else
 			{
 				/* Degenerate ordering... build unordered Union Receive */
-				motion = make_union_motion(subplan, false, numsegments);
+				motion = make_union_motion(subplan, false, numsegments, path->path.locus.locustype);
 			}
 		}
 
 		/* Unordered Union Receive */
 		else
-			motion = make_union_motion(subplan, false, numsegments);
+			motion = make_union_motion(subplan, false, numsegments, path->path.locus.locustype);
 	}
 
 	/* Send all of the tuples to all of the QEs in gang above... */

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2981,7 +2981,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				}
 				else
 				{
-					result_plan = (Plan *) make_motion_gather(root, result_plan, current_pathkeys);
+					result_plan = (Plan *) make_motion_gather(root, result_plan, current_pathkeys, CdbLocusType_SingleQE);
 				}
 				result_plan->total_cost += motion_cost_per_row * result_plan->plan_rows;
 			}
@@ -3070,7 +3070,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				result_plan = (Plan *) make_unique(result_plan, parse->distinctClause);
 				result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 
-				result_plan = (Plan *) make_motion_gather(root, result_plan, current_pathkeys);
+				result_plan = (Plan *) make_motion_gather(root, result_plan, current_pathkeys, CdbLocusType_SingleQE);
 			}
 
 			result_plan = (Plan *) make_unique(result_plan,
@@ -3109,7 +3109,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			 * handling below.
 			 */
 			current_pathkeys = root->sort_pathkeys;
-			result_plan = (Plan *) make_motion_gather(root, result_plan, current_pathkeys);
+			result_plan = (Plan *) make_motion_gather(root, result_plan, current_pathkeys, CdbLocusType_SingleQE);
 		}
 	}
 

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -474,7 +474,7 @@ generate_recursion_plan(SetOperationStmt *setOp, PlannerInfo *root,
 			/* do nothing, will set flow correct at the end of the function */
 		}
 		else if (lplan->flow->locustype == CdbLocusType_SegmentGeneral)
-			lplan = (Plan *) make_motion_gather(root, lplan, NIL);
+			lplan = (Plan *) make_motion_gather(root, lplan, NIL, rplan->flow->locustype);
 		else
 		{
 			elog(ERROR,

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -23,9 +23,20 @@
 
 extern Plan *apply_motion(struct PlannerInfo *root, Plan *plan, Query *query);
 
-extern Motion *make_union_motion(Plan *lefttree, bool useExecutorVarFormat, int numsegments);
-extern Motion *make_sorted_union_motion(PlannerInfo *root, Plan *lefttree, int numSortCols, AttrNumber *sortColIdx, Oid *sortOperators,
-										Oid *collations, bool *nullsFirst, bool useExecutorVarFormat, int numsegments);
+extern Motion *make_union_motion(Plan *lefttree,
+								 bool useExecutorVarFormat,
+								 int numsegments,
+								 CdbLocusType targetLocus);
+extern Motion *make_sorted_union_motion(PlannerInfo *root,
+										Plan *lefttree,
+										int numSortCols,
+										AttrNumber *sortColIdx,
+										Oid *sortOperators,
+										Oid *collations,
+										bool *nullsFirst,
+										bool useExecutorVarFormat,
+										int numsegments,
+										CdbLocusType targetLocus);
 extern Motion *make_hashed_motion(Plan *lefttree,
 								  List *hashExpr,
 								  List *hashOpfamilies,

--- a/src/include/cdb/cdbsetop.h
+++ b/src/include/cdb/cdbsetop.h
@@ -72,7 +72,7 @@ extern
 Motion* make_motion_gather_to_QE(PlannerInfo *root, Plan *subplan, List *sortPathKeys);
 
 extern
-Motion *make_motion_gather(PlannerInfo *root, Plan *subplan, List *sortPathKeys);
+Motion *make_motion_gather(PlannerInfo *root, Plan *subplan, List *sortPathKeys, CdbLocusType targetLocus);
 
 extern
 void mark_append_locus(Plan *plan, GpSetOpType optype);

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -933,12 +933,97 @@ explain (costs off) select * from t_hashdist cross join (select * from t_replica
  Optimizer: Postgres query optimizer
 (8 rows)
 
+create table rtbl (a int, b int, c int, t text) distributed replicated;
+insert into t_hashdist values (1, 1, 1);
+insert into rtbl values (1, 1, 1, 'rtbl');
+-- The below tests used to do replicated table scan on entry db which contains empty data.
+-- So a motion node is needed to gather replicated table on entry db.
+-- See issue: https://github.com/greenplum-db/gpdb/issues/11945
+-- 1. CTAS when join replicated table with catalog table
+explain (costs off) create temp table tmp as select * from pg_class c join rtbl on c.relname = rtbl.t;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Redistribute Motion 1:3  (slice2)
+   Hash Key: c.relname
+   ->  Hash Join
+         Hash Cond: ((c.relname)::text = rtbl.t)
+         ->  Seq Scan on pg_class c
+         ->  Hash
+               ->  Gather Motion 1:1  (slice1; segments: 1)
+                     ->  Seq Scan on rtbl
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+create temp table tmp as select * from pg_class c join rtbl on c.relname = rtbl.t;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'relname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select count(*) from tmp; -- should contain 1 row
+ count 
+-------
+     1
+(1 row)
+
+-- 2. Join hashed table with (replicated table join catalog) should return 1 row
+explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rtbl.a = t_hashdist.a)
+         ->  Redistribute Motion 1:3  (slice2)
+               Hash Key: rtbl.a
+               ->  Hash Join
+                     Hash Cond: ((c.relname)::text = rtbl.t)
+                     ->  Bitmap Heap Scan on pg_class c
+                           ->  Bitmap Index Scan on pg_class_relname_nsp_index
+                     ->  Hash
+                           ->  Gather Motion 1:1  (slice1; segments: 1)
+                                 ->  Seq Scan on rtbl
+         ->  Hash
+               ->  Seq Scan on t_hashdist
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
+ relname 
+---------
+ rtbl
+(1 row)
+
+-- 3. Join hashed table with (set operation on catalog and replicated table)
+explain (costs off) select a from t_hashdist, (select oid from pg_class union all select a from rtbl) vtest;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Subquery Scan on vtest
+                     ->  Append
+                           ->  Bitmap Heap Scan on pg_class
+                                 ->  Bitmap Index Scan on pg_class_oid_index
+                           ->  Gather Motion 1:1  (slice1; segments: 1)
+                                 ->  Subquery Scan on "*SELECT* 2"
+                                       ->  Seq Scan on rtbl
+         ->  Materialize
+               ->  Seq Scan on t_hashdist
+ Optimizer: Postgres query optimizer
+(12 rows)
+
 reset optimizer;
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 11 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
+drop cascades to view v_foo
 drop cascades to table baz
 drop cascades to table qux
+drop cascades to table cursor_update
+drop cascades to table minmaxtest
+drop cascades to table t_hashdist
+drop cascades to table t_replicate_volatile
+drop cascades to sequence seq_for_insert_replicated_table
+drop cascades to table rtbl
 -- end_ignore

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -403,6 +403,26 @@ explain (costs off) update t_replicate_volatile set a = random();
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit 1;
 explain (costs off) select * from t_hashdist cross join (select * from t_replicate_volatile limit 1) x;
 
+create table rtbl (a int, b int, c int, t text) distributed replicated;
+insert into t_hashdist values (1, 1, 1);
+insert into rtbl values (1, 1, 1, 'rtbl');
+
+-- The below tests used to do replicated table scan on entry db which contains empty data.
+-- So a motion node is needed to gather replicated table on entry db.
+-- See issue: https://github.com/greenplum-db/gpdb/issues/11945
+
+-- 1. CTAS when join replicated table with catalog table
+explain (costs off) create temp table tmp as select * from pg_class c join rtbl on c.relname = rtbl.t;
+create temp table tmp as select * from pg_class c join rtbl on c.relname = rtbl.t;
+select count(*) from tmp; -- should contain 1 row
+
+-- 2. Join hashed table with (replicated table join catalog) should return 1 row
+explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
+select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
+
+-- 3. Join hashed table with (set operation on catalog and replicated table)
+explain (costs off) select a from t_hashdist, (select oid from pg_class union all select a from rtbl) vtest;
+
 reset optimizer;
 
 -- start_ignore


### PR DESCRIPTION
Set correctlocus type for gather motion since if we operate(join, set
operation, etc.) replicated table with catalog table, we may scan the
replicated table on entry DB, but entry DB does not contain data for
replicated table.
The fix logic is to set the correct locus type for the motion node,
so when we try to optimize out motion node in apply_motion_mutator,
it shouldn't remove it.
This fixed the issue: https://github.com/greenplum-db/gpdb/issues/11945

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
