### PR TITLE
fsync the pgdata directory itself after pg_rewind.

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -878,6 +878,7 @@ syncTargetDirectory(void)
 	fsync_fname("global/pg_control", false);
 	fsync_fname("backup_label", false);
 	fsync_fname("postgresql.auto.conf", false);
+	fsync_fname(".", true); /* due to new file backup_label. */
 }
 
 /*


### PR DESCRIPTION
commit f695018614ea6e17849bb36442db7e9bf23b7e68 does fsync affected files after
pg_rewind. It forgets to fsync the pgdata directory itself since we write a new
file backup_label under the directory.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
