### PR TITLE
Mirror is up only if it has received WAL

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -19,6 +19,7 @@
 #include "replication/walsender.h"
 #include "storage/lwlock.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 
 /* Set at database system is ready to accept connections */
 extern pg_time_t PMAcceptingConnectionsStartTime;
@@ -42,6 +43,7 @@ static void FTSReplicationStatusClearAttempts(FTSReplicationStatus *replication_
 static uint32 FTSReplicationStatusRetrieveAttempts(FTSReplicationStatus *replication_status);
 static pg_time_t FTSReplicationStatusRetrieveDisconnectTime(FTSReplicationStatus *replication_status);
 static void FTSReplicationStatusMarkDisconnect(FTSReplicationStatus *replication_status);
+static bool is_mirror_up(WalSnd *walsender);
 
 /* Report shared-memory space needed by FTSReplicationStatusShmemInit */
 Size
@@ -251,8 +253,14 @@ FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state)
 	/* replication_status must exist */
 	Assert(replication_status);
 
-	if (state == WALSNDSTATE_CATCHUP || state == WALSNDSTATE_STREAMING)
+	bool is_up;
+	SpinLockAcquire(&MyWalSnd->mutex);
+	is_up = is_mirror_up(MyWalSnd);
+	SpinLockRelease(&MyWalSnd->mutex);
+
+	if (is_up)
 	{
+		SIMPLE_FAULT_INJECTOR("is_mirror_up");
 		/*
 		 * We can clear the disconnect time once the connection established.
 		 * We only clean the failure count when the wal start streaming, since
@@ -472,13 +480,15 @@ is_mirror_up(WalSnd *walsender)
 	bool walsender_has_pid = walsender->pid != 0;
 
 	/*
-	 * WalSndSetState() resets replica_disconnected_at for
-	 * below states. If modifying below states then be sure
-	 * to update corresponding logic in WalSndSetState() as
-	 * well.
+	 * A mirror is up only if it has received at least one chunk of WAL.  The
+	 * CATCHUP state is entered as soon as a connection request from mirror is
+	 * received.  The connection may fail soon after if the requested
+	 * startpoint is not found in the WAL files available on primary.
 	 */
-	bool is_communicating_with_mirror = walsender->state == WALSNDSTATE_CATCHUP ||
-		walsender->state == WALSNDSTATE_STREAMING;
+	bool is_communicating_with_mirror =
+		(walsender->state == WALSNDSTATE_CATCHUP &&
+		 !XLogRecPtrIsInvalid(walsender->write)) ||
+		 walsender->state == WALSNDSTATE_STREAMING;
 
 	return walsender_has_pid && is_communicating_with_mirror;
 }

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -56,6 +56,7 @@ test_setup(int pid, WalSndState state, int count)
 	WalSndCtl->walsnds[0].pid = pid;
 	WalSndCtl->walsnds[0].state = state;
 	WalSndCtl->walsnds[0].is_for_gp_walreceiver = true;
+	WalSndCtl->walsnds[0].write = InvalidXLogRecPtr;
 	SpinLockInit(&WalSndCtl->walsnds[0].mutex);
 
 	FTSRepStatusCtl = (FTSReplicationStatusCtlData *)malloc(FTSReplicationStatusShmemSize());
@@ -264,11 +265,12 @@ test_GetMirrorStatus_WALSNDSTATE_CATCHUP(void **state)
 	FtsResponse response = { .IsMirrorUp = false };
 	FTSReplicationStatusCtlData *data;
 
-	data = test_setup(1, WALSNDSTATE_CATCHUP, 0);
+	data = test_setup(1, WALSNDSTATE_CATCHUP, 3);
 
 	GetMirrorStatus(&response);
 
-	assert_true(response.IsMirrorUp);
+	/* For mirror to be up in catchup state, WalSnd.write must be a valid. */
+	assert_false(response.IsMirrorUp);
 	assert_false(response.IsInSync);
 }
 
@@ -286,6 +288,21 @@ test_GetMirrorStatus_WALSNDSTATE_STREAMING(void **state)
 	assert_true(response.IsInSync);
 }
 
+static void
+test_GetMirrorStatus_up_not_in_sync(void **state)
+{
+	FtsResponse response = { .IsMirrorUp = false };
+	FTSReplicationStatusCtlData *data;
+
+	data = test_setup(1, WALSNDSTATE_CATCHUP, 0);
+	WalSndCtl->walsnds[0].write = 12345;
+
+	GetMirrorStatus(&response);
+
+	assert_true(response.IsMirrorUp);
+	assert_false(response.IsInSync);
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -300,7 +317,8 @@ main(int argc, char* argv[])
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_STARTUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_BACKUP),
 		unit_test(test_GetMirrorStatus_WALSNDSTATE_CATCHUP),
-		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING)
+		unit_test(test_GetMirrorStatus_WALSNDSTATE_STREAMING),
+		unit_test(test_GetMirrorStatus_up_not_in_sync)
 	};
 	return run_tests(tests);
 }

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -283,6 +283,55 @@ END
  walread    
 (1 row)
 
+-- Fault to check if walsender enters catchup state.
+1: select gp_inject_fault('is_mirror_up', 'skip', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Wait for the mirror to make the next connection attempt.
+1: SELECT gp_inject_fault('initialize_wal_sender', 'skip',  dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Note that we wait until the fault is triggered twice.  Waiting
+-- until the second trigger guarantees that first connection attempt
+-- is fully processed and the status check that follows is accurate.
+1: SELECT gp_wait_until_triggered_fault('initialize_wal_sender', 2, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Validate that the mirror is not marked as up after replication slot
+-- is obsoleted.  There used to be a bug that caused FTS to be mislead
+-- by a walsender that entered catchup state but failed shorty after
+-- due to the requested start point not available.  FTS marked the
+-- mirror as up and turned synchronous replication on.  The following
+-- query should show "num times hit" as 0, implying that the mirror's
+-- status was not changed from down to up.
+1: select gp_inject_fault('is_mirror_up', 'status', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault                                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'is_mirror_up' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(1 row)
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(8 rows)
+
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
 ALTER
 0U: ALTER SYSTEM RESET checkpoint_segments;

--- a/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
+++ b/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
@@ -174,6 +174,31 @@ SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content 
 1: SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
 1: SELECT sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
 
+-- Fault to check if walsender enters catchup state.
+1: select gp_inject_fault('is_mirror_up', 'skip', dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Wait for the mirror to make the next connection attempt.
+1: SELECT gp_inject_fault('initialize_wal_sender', 'skip',  dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+-- Note that we wait until the fault is triggered twice.  Waiting
+-- until the second trigger guarantees that first connection attempt
+-- is fully processed and the status check that follows is accurate.
+1: SELECT gp_wait_until_triggered_fault('initialize_wal_sender', 2, dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- Validate that the mirror is not marked as up after replication slot
+-- is obsoleted.  There used to be a bug that caused FTS to be mislead
+-- by a walsender that entered catchup state but failed shorty after
+-- due to the requested start point not available.  FTS marked the
+-- mirror as up and turned synchronous replication on.  The following
+-- query should show "num times hit" as 0, implying that the mirror's
+-- status was not changed from down to up.
+1: select gp_inject_fault('is_mirror_up', 'status', dbid)
+   FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
+
 0U: ALTER SYSTEM RESET max_slot_wal_keep_size;
 0U: ALTER SYSTEM RESET checkpoint_segments;
 0U: ALTER SYSTEM RESET wal_keep_segments;


### PR DESCRIPTION
Previously, FTS used to treat a mirror as up as soon as the walsender enters `catchup` state.  This patch restricts that criterion.  A mirror is now considered up only if it at least one chunk of WAL has been transferred to it.

An active replication slot is obsoleted when replication lag grows beyond `max_slot_wal_keep_size` limit.  This is a point of no return, the mirror must be destroyed and recreated using `pg_basebackup` (`gprecoverseg -F`).  The walsender process exits when this happens.  However, the walreceiver on mirror is oblivious to this and keeps on attempting new replication connections.

Walsender enters `catchup` state immediately upon receiving a connection request.  The request fails soon after, when an attempt to locate the requested start LSN in locally available WAL fails.  An FTS probe within this window used to erroneously treat the mirror as up and turn syncrep on.  This is definitely not desirable.  The patch causes FTS to treat the mirror as down even if the walsender is found in `catchup` state.
