### PR TITLE
Drop PostmasterContext after InitPostgres()

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4612,6 +4612,19 @@ PostgresMain(int argc, char *argv[],
 			(errmsg_internal("InitPostgres")));
 	InitPostgres(dbname, InvalidOid, username, NULL);
 
+	/*
+	 * If the PostmasterContext is still around, recycle the space; we don't
+	 * need it anymore after InitPostgres completes.  Note this does not trash
+	 * *MyProcPort, because ConnCreate() allocated that space with malloc()
+	 * ... else we'd need to copy the Port data first.  Also, subsidiary data
+	 * such as the username isn't lost either; see ProcessStartupPacket().
+	 */
+	if (PostmasterContext)
+	{
+		MemoryContextDelete(PostmasterContext);
+		PostmasterContext = NULL;
+	}
+
 	SetProcessingMode(NormalProcessing);
 
 	/*


### PR DESCRIPTION
PostmasterContext is not necessary for a normal postgres backend
process, drop it to save memory.

In a corner case, the flat files it loaded into memory, like hba, ident
and role files, could be big, which would be a serious issue if the
postmaster forks them with thousands of copies without vmem tracking.

FYI, CoW memory is counted by system OOM killer if the Linux
configuration vm.overcommit_memory is 2.
