### PR TITLE
Adjust gpcheckcloud template print seq.

### DIFF
--- a/gpAux/extensions/gpcloud/bin/gpcheckcloud/gpcheckcloud.cpp
+++ b/gpAux/extensions/gpcloud/bin/gpcheckcloud/gpcheckcloud.cpp
@@ -138,8 +138,8 @@ static void validateCommandLineArgs(map<char, string> &optionPairs) {
 static void printTemplate() {
     printf(
         "[default]\n"
-        "secret = \"aws secret\"\n"
         "accessid = \"aws access id\"\n"
+        "secret = \"aws secret\"\n"
         "threadnum = 4\n"
         "chunksize = 67108864\n"
         "low_speed_limit = 10240\n"


### PR DESCRIPTION
Fix this issue greenplum-db/sre-test#73 to adjust to normal sequence.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
