### PR TITLE
[6X Backport] Fix misleading log: libpq says we are still busy (#12101)

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -718,7 +718,8 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 			}
 
 			if (PQisBusy(dispatchResult->segdbDesc->conn))
-				elog(LOG, "We thought we were done, because finished==true, but libpq says we are still busy");
+				elog(DEBUG1, "did not receive query results on libpq connection %s",
+					 dispatchResult->segdbDesc->whoami);
 		}
 		else
 			ELOG_DISPATCHER_DEBUG("processResults says we have more to do with %d of %d (%s)",


### PR DESCRIPTION
Demote and clarify a dispatcher log message:
this log is printed on a broken connection, the previous message is misleading to user.

Fixes Github issue #10955

Reviewed by: paul-guo-

(cherry picked from commit a76a939819adb3998e610add22bd751b5221bf15)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
