### PR TITLE
[6x backport and additional fixes] fsync related optimization for gpdb recovery

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6476,10 +6476,37 @@ StartupXLOG(void)
 	 * unflushed writes to be lost, even though more recent data written to
 	 * disk from here on would be persisted.  To avoid that, fsync the entire
 	 * data directory.
+	 *
+	 * GPDB: We don't force to fsync the whole pgdata directory as upstream
+	 * code since that could be very slow in cases that the pgdata
+	 * directory has a lot of (e.g. millions of) files. See below for details.
+	 *---------
 	 */
 	if (ControlFile->state != DB_SHUTDOWNED &&
 		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY)
-		SyncDataDirectory();
+	{
+		/*
+		 * 1. If the backup_label file exists, we assume the pgdata has already
+		 * been synchronized. This is true on gpdb since we do force fsync
+		 * during pg_basebackup and pg_rewind.
+		 *
+		 * 2. else for the crash recovery case.
+		 *
+		 *    2.1. if full page writes is enabled, we do synchronize the wal
+		 *    files only. wal files must be synchronized here, else if xlog
+		 *    redo writes some buffer pages and those pages are partly
+		 *    synchronized, and then system crashes and some xlogs are lost,
+		 *    those table file pages might be broken.
+		 *
+		 *    2.2. else, simply synchronize the whole pgdata directory though
+		 *    there might be room for optimization but we would mostly not run
+		 *    into this code branch. Since we can not get
+		 *    checkPoint.fullPageWrites here so we do pgdata fsync later (
+		 *    i.e. call SyncDataDirectory()) after reading the checkpoint.
+		 */
+		if (access(BACKUP_LABEL_FILE, F_OK) != 0)
+				SyncAllXLogFiles();
+	}
 
 	/*
 	 * Initialize on the assumption we want to recover to the latest timeline
@@ -6668,7 +6695,17 @@ StartupXLOG(void)
 	}
 
 	/*
-	 * If the location of the checkpoint record is not on the expected
+	 * gpdb specific: Do pgdata fsync for the case that is almost not possible
+	 * on real production scenarios. See previous code that calls
+	 * SyncAllXLogFiles() for details.
+	 */
+	if (!checkPoint.fullPageWrites &&
+		!haveBackupLabel &&
+		ControlFile->state != DB_SHUTDOWNED &&
+		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY)
+		SyncDataDirectory();
+
+	/* If the location of the checkpoint record is not on the expected
 	 * timeline in the history of the requested timeline, we cannot proceed:
 	 * the backup is not part of the history of the requested timeline.
 	 */

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -3019,6 +3019,22 @@ looks_like_temp_rel_name(const char *name)
 	return true;
 }
 
+/*
+ * Synchronize all xlog files and pg_wal itself in pg_wal
+ *
+ * This is called at the beginning of recovery.
+ */
+void
+SyncAllXLogFiles(void)
+{
+	/* We can skip this whole thing if fsync is disabled. */
+	if (!enableFsync)
+		return;
+
+	ereport(LOG, (errmsg("Synchronization of the wal directory starts.")));
+	walkdir("pg_xlog", datadir_fsync_fname, false, LOG);
+	ereport(LOG, (errmsg("synchronization of the wal directory finishes.")));
+}
 
 /*
  * Issue fsync recursively on PGDATA and all its contents.

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -643,6 +643,95 @@ updateControlFile(ControlFileData *ControlFile)
 }
 
 /*
+ * fsync_fname -- Try to fsync a file or directory
+ *
+ * Ignores errors trying to open unreadable files, or trying to fsync
+ * directories on systems where that isn't allowed/required.  Reports
+ * other errors non-fatally.
+ */
+static int
+fsync_fname(const char *fname, bool isdir)
+{
+	int			fd;
+	int			flags;
+	int			returncode;
+
+	/*
+	 * Some OSs require directories to be opened read-only whereas other
+	 * systems don't allow us to fsync files opened read-only; so we need both
+	 * cases here.  Using O_RDWR will cause us to fail to fsync files that are
+	 * not writable by our userid, but we assume that's OK.
+	 */
+	flags = PG_BINARY;
+	if (!isdir)
+		flags |= O_RDWR;
+	else
+		flags |= O_RDONLY;
+
+	/*
+	 * Open the file, silently ignoring errors about unreadable files (or
+	 * unsupported operations, e.g. opening a directory under Windows), and
+	 * logging others.
+	 */
+	fd = open(fname, flags, 0);
+	if (fd < 0)
+	{
+		if (errno == EACCES || (isdir && errno == EISDIR))
+			return 0;
+		else if (errno == ENOENT)
+			printf("skip sync-ing file \"%s\" since it does not exist (usually expected)\n", fname);
+		else
+			printf("could not open file \"%s\": %m\n", fname);
+		return -1;
+	}
+
+	returncode = fsync(fd);
+
+	/*
+	 * Some OSes don't allow us to fsync directories at all, so we can ignore
+	 * those errors. Anything else needs to be reported.
+	 */
+	if (returncode != 0 && !(isdir && (errno == EBADF || errno == EINVAL)))
+	{
+		printf("could not fsync file \"%s\": %m\n", fname);
+		(void) close(fd);
+		return -1;
+	}
+
+	(void) close(fd);
+	return 0;
+}
+
+/*
+ * fsync_parent_path -- fsync the parent path of a file or directory
+ *
+ * This is aimed at making file operations persistent on disk in case of
+ * an OS crash or power failure.
+ */
+static int
+fsync_parent_path(const char *fname)
+{
+	char		parentpath[MAXPGPATH];
+
+	strlcpy(parentpath, fname, MAXPGPATH);
+	get_parent_directory(parentpath);
+
+	/*
+	 * get_parent_directory() returns an empty string if the input argument is
+	 * just a file name (see comments in path.c), so handle that as being the
+	 * current directory.
+	 */
+	if (strlen(parentpath) == 0)
+		strlcpy(parentpath, ".", MAXPGPATH);
+
+	if (fsync_fname(parentpath, true) != 0)
+		return -1;
+
+	return 0;
+}
+
+
+/*
  * Sync target data directory to ensure that modifications are safely on disk.
  *
  * gpdb: We assume that all files are synchronized before rewinding and thus we
@@ -661,10 +750,7 @@ syncTargetDirectory()
 	int			  i;
 
 	if (chdir(datadir_target) < 0)
-	{
-		pg_log_error("could not change directory to \"%s\": %m", datadir_target);
-		exit(1);
-	}
+		pg_fatal("could not change directory to \"%s\": %m", datadir_target);
 
 	for (i = 0; i < filemap->narray; i++)
 	{

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -35,7 +35,7 @@ static void createBackupLabel(XLogRecPtr startpoint, TimeLineID starttli,
 static void digestControlFile(ControlFileData *ControlFile, char *source,
 				  size_t size);
 static void updateControlFile(ControlFileData *ControlFile);
-static void syncTargetDirectory(const char *argv0);
+static void syncTargetDirectory(void);
 static void sanityChecks(void);
 static void findCommonAncestorTimeline(XLogRecPtr *recptr, TimeLineID *tli);
 static void ensureCleanShutdown(const char *argv0);
@@ -403,13 +403,14 @@ main(int argc, char **argv)
 	updateControlFile(&ControlFile_new);
 
 	pg_log(PG_PROGRESS, "syncing target data directory\n");
-	syncTargetDirectory(argv[0]);
 
 	if (writerecoveryconf && connstr_source)
 	{
 		GenerateRecoveryConf(replication_slot);
 		WriteRecoveryConf();
 	}
+
+	syncTargetDirectory();
 
 	printf(_("Done!\n"));
 
@@ -644,54 +645,71 @@ updateControlFile(ControlFileData *ControlFile)
 /*
  * Sync target data directory to ensure that modifications are safely on disk.
  *
- * We do this once, for the whole data directory, for performance reasons.  At
- * the end of pg_rewind's run, the kernel is likely to already have flushed
- * most dirty buffers to disk. Additionally initdb -S uses a two-pass approach
- * (only initiating writeback in the first pass), which often reduces the
- * overall amount of IO noticeably.
+ * gpdb: We assume that all files are synchronized before rewinding and thus we
+ * just need to synchronize those affected files. This is a resonable
+ * assumption for gpdb since we've ensured that the db state is clean shutdown
+ * in pg_rewind by running single mode postgres if needed and also we do not
+ * copy an unsynchronized dababase without sync as the target base.
  */
 static void
-syncTargetDirectory(const char *argv0)
+syncTargetDirectory()
 {
-	int		ret;
-#define MAXCMDLEN (2 * MAXPGPATH)
-	char	exec_path[MAXPGPATH];
-	char	cmd[MAXCMDLEN];
-
-	/* locate initdb binary */
-	if ((ret = find_other_exec(argv0, "initdb",
-							   "initdb (Greenplum Database) " PG_VERSION "\n",
-							   exec_path)) < 0)
-	{
-		char        full_path[MAXPGPATH];
-
-		if (find_my_exec(argv0, full_path) < 0)
-			strlcpy(full_path, progname, sizeof(full_path));
-
-		if (ret == -1)
-			pg_fatal("The program \"initdb\" is needed by %s but was \n"
-					 "not found in the same directory as \"%s\".\n"
-					 "Check your installation.\n", progname, full_path);
-		else
-			pg_fatal("The program \"initdb\" was found by \"%s\"\n"
-					 "but was not the same version as %s.\n"
-					 "Check your installation.\n", full_path, progname);
-	}
-
-	/* only skip processing after ensuring presence of initdb */
 	if (dry_run)
 		return;
 
-	/* finally run initdb -S */
-	if (debug)
-		snprintf(cmd, MAXCMDLEN, "\"%s\" -D \"%s\" -S",
-				 exec_path, datadir_target);
-	else
-		snprintf(cmd, MAXCMDLEN, "\"%s\" -D \"%s\" -S > \"%s\"",
-				 exec_path, datadir_target, DEVNULL);
+	file_entry_t *entry;
+	int			  i;
 
-	if (system(cmd) != 0)
-		pg_fatal("sync of target directory failed\n");
+	if (chdir(datadir_target) < 0)
+	{
+		pg_log_error("could not change directory to \"%s\": %m", datadir_target);
+		exit(1);
+	}
+
+	for (i = 0; i < filemap->narray; i++)
+	{
+		entry = filemap->array[i];
+
+		if (entry->target_pages_to_overwrite.bitmapsize > 0)
+			fsync_fname(entry->path, false);
+		else
+		{
+			switch (entry->action)
+			{
+				case FILE_ACTION_COPY:
+				case FILE_ACTION_TRUNCATE:
+				case FILE_ACTION_COPY_TAIL:
+					fsync_fname(entry->path, false);
+					break;
+
+				case FILE_ACTION_CREATE:
+					fsync_fname(entry->path,
+								entry->source_type == FILE_TYPE_DIRECTORY);
+					/* FALLTHROUGH */
+				case FILE_ACTION_REMOVE:
+					/*
+					 * Fsync the parent directory if we either create or delete
+					 * files/directories in the parent directory. The parent
+					 * directory might be missing as expected, so fsync it could
+					 * fail but we ignore that error.
+					 */
+					fsync_parent_path(entry->path);
+					break;
+
+				case FILE_ACTION_NONE:
+					break;
+
+				default:
+					pg_fatal("no action decided for \"%s\"", entry->path);
+					break;
+			}
+		}
+	}
+
+	/* fsync some files that are (possibly) written by pg_rewind. */
+	fsync_fname("global/pg_control", false);
+	fsync_fname("backup_label", false);
+	fsync_fname("recovery.conf", false);
 }
 
 /*

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -710,6 +710,7 @@ syncTargetDirectory()
 	fsync_fname("global/pg_control", false);
 	fsync_fname("backup_label", false);
 	fsync_fname("recovery.conf", false);
+	fsync_fname(".", true); /* due to new file backup_label. */
 }
 
 /*

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -128,6 +128,7 @@ extern int	pg_flush_data(int fd, off_t offset, off_t amount);
 extern void fsync_fname(const char *fname, bool isdir);
 extern int	durable_rename(const char *oldfile, const char *newfile, int loglevel);
 extern int	durable_link_or_rename(const char *oldfile, const char *newfile, int loglevel);
+extern void SyncAllXLogFiles(void);
 extern void SyncDataDirectory(void);
 extern int data_sync_elevel(int elevel);
 

--- a/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
+++ b/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
@@ -43,6 +43,8 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid) FROM gp_segment_confi
 -- before unlink the file. This cased the crash recovery to PANIC as
 -- couldn't complete the stale fsync request registered by file
 -- truncate WAL record.
+-- Also this is a chance of simply testing SyncAllXLogFile() thats fsync wal
+-- files only during crash recovery.
 1: CHECKPOINT;
 CHECKPOINT
 1: BEGIN;

--- a/src/test/isolation2/sql/ao_same_trans_truncate_crash.sql
+++ b/src/test/isolation2/sql/ao_same_trans_truncate_crash.sql
@@ -24,6 +24,8 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
 -- before unlink the file. This cased the crash recovery to PANIC as
 -- couldn't complete the stale fsync request registered by file
 -- truncate WAL record.
+-- Also this is a chance of simply testing SyncAllXLogFile() thats fsync wal
+-- files only during crash recovery.
 1: CHECKPOINT;
 1: BEGIN;
 1: CREATE TABLE ao_same_trans_truncate(a int, b int) WITH (appendonly=true, orientation=column);


### PR DESCRIPTION
This is the gp6 version of https://github.com/greenplum-db/gpdb/pull/12065

The PR includes 5 patches. Three of them are backported patches. Other two patches are:
(one for pg_basebackup and another is for pg_rewind).
```
commit 764abaa2703e60d8c51511c6eadf648708728893
Author: Paul Guo <paulguo@gmail.com>
Date:   Thu May 27 11:38:49 2021 +0800

    Do target pgdata directory sync at the end of pg_basebackup.

    Previously we did not do that. Upstream added this later, for us this should be
    fine previously since we do fsync during startup finally, but now that we skip
    fsync for this scenario during startup, let's do fsync in pg_basebackup.
```
And
```
commit f6b7c50ee8d4391c2d23088c38bb685559cb09fc
Author: Paul Guo <paulguo@gmail.com>
Date:   Thu May 27 10:16:46 2021 +0800

    Backport fsync_fname() and fsync_parent_path() for frontend use.

```