### PR TITLE
pg_rewind: should do fsync after writing the recovery conf information.

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -459,13 +459,13 @@ main(int argc, char **argv)
 	ControlFile_new.state = DB_IN_ARCHIVE_RECOVERY;
 	update_controlfile(datadir_target, &ControlFile_new, do_sync);
 
-	if (showprogress)
-		pg_log_info("syncing target data directory");
-	syncTargetDirectory();
-
 	if (writerecoveryconf)
 		WriteRecoveryConfig(conn, datadir_target,
 							GenerateRecoveryConfig(conn, replication_slot));
+
+	if (showprogress)
+		pg_log_info("syncing target data directory");
+	syncTargetDirectory();
 
 	pg_log_info("Done!");
 


### PR DESCRIPTION
Not remember why I forgot to do that (I did do that in the PG patch).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
