### PR TITLE
uniform default/max -B options values across utils

### DIFF
--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -68,8 +68,8 @@ def parseargs():
     parser.add_option('-d', '--master-data-directory', dest='coordinator_data_directory',
                       help='The coordinator data directory for the system. If this option is not specified, \
                             the value is obtained from the $COORDINATOR_DATA_DIRECTORY environment variable.')
-    parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=16, metavar="<batch_size>",
-                      help='Max number of hosts to operate on in parallel. Valid values are 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
+    parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=gp.DEFAULT_COORDINATOR_NUM_WORKERS, metavar="<batch_size>",
+                      help='Max number of hosts to operate on in parallel. Valid values are 1-%d' % gp.MAX_COORDINATOR_NUM_WORKERS)
     parser.add_option('-b', '--segment-batch-size', dest='segment_batch_size', type='int', default=gp.DEFAULT_SEGHOST_NUM_WORKERS, metavar="<segment_batch_size>",
                       help='Max number of segments per host to operate on in parallel. Valid values are: 1-%d' % gp.MAX_SEGHOST_NUM_WORKERS)
     parser.add_option('-v', '--verbose', dest="verbose", action='store_true',
@@ -94,8 +94,8 @@ def parseargs():
         logger.error('Unknown argument %s' % args[0])
         parser.exit()
 
-    if options.batch_size < 1 or options.batch_size > gp.MAX_SEGHOST_NUM_WORKERS:
-        logger.error('Invalid value for argument -B. Value must be >= 1 and <= %d' % gp.MAX_SEGHOST_NUM_WORKERS)
+    if options.batch_size < 1 or options.batch_size > gp.MAX_COORDINATOR_NUM_WORKERS:
+        logger.error('Invalid value for argument -B. Value must be >= 1 and <= %d' % gp.MAX_COORDINATOR_NUM_WORKERS)
         parser.print_help()
         parser.exit()
 

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -534,10 +534,10 @@ class GpRecoverSegmentProgram:
             return res.fetchall()
 
     def run(self):
-        if self.__options.parallelDegree < 1 or self.__options.parallelDegree > 64:
+        if self.__options.parallelDegree < 1 or self.__options.parallelDegree > gp.MAX_COORDINATOR_NUM_WORKERS:
             raise ProgramArgumentValidationException(
                 "Invalid parallelDegree value provided with -B argument: %d" % self.__options.parallelDegree)
-        if self.__options.parallelPerHost < 1 or self.__options.parallelPerHost > 128:
+        if self.__options.parallelPerHost < 1 or self.__options.parallelPerHost > gp.MAX_SEGHOST_NUM_WORKERS:
             raise ProgramArgumentValidationException(
                 "Invalid parallelPerHost value provided with -b argument: %d" % self.__options.parallelPerHost)
 
@@ -749,12 +749,12 @@ class GpRecoverSegmentProgram:
                          dest="forceFullResynchronization",
                          metavar="<forceFullResynchronization>",
                          help="Force full segment resynchronization")
-        addTo.add_option("-B", None, type="int", default=16,
+        addTo.add_option("-B", None, type="int", default=gp.DEFAULT_COORDINATOR_NUM_WORKERS,
                          dest="parallelDegree",
                          metavar="<parallelDegree>",
                          help="Max number of hosts to operate on in parallel. Valid values are: 1-%d"
-                              % gp.MAX_SEGHOST_NUM_WORKERS)
-        addTo.add_option("-b", None, type="int", default=64,
+                              % gp.MAX_COORDINATOR_NUM_WORKERS)
+        addTo.add_option("-b", None, type="int", default=gp.DEFAULT_SEGHOST_NUM_WORKERS,
                          dest="parallelPerHost",
                          metavar="<parallelPerHost>",
                          help="Max number of segments per host to operate on in parallel. Valid values are: 1-%d"


### PR DESCRIPTION
Having different defaults/max  -B option values between utils created a bug. 
When one util calls another with -B value above the called util's limit, the operation would cause failure.
This change fixes that.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/uniform_utils_defaults)