### PR TITLE
6X backport: gpmovemirrors to remove tablespace directories on old host

### DIFF
--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -21,6 +21,7 @@ try:
     from gppylib import gparray, pgconf
     from gppylib.operations.deletesystem import validate_pgport
     from gppylib.userinput import *
+    from gppylib.operations.segment_tablespace_locations import get_tablespace_locations
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you '
              'have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -187,30 +188,6 @@ def check_for_dump_files(options):
     return gp.GpDirsExist.local('check for dump dirs', baseDir=options.master_data_dir, dirName="'*dump*'") \
            or gp.GpDirsExist.local('check for dump dirs', baseDir=options.master_data_dir, dirName="'*backups*'")
 
-def getTablespaceDirs():
-    ''' Create list of user-created tablespace locations for each host '''
-    tblspclocs = {}
-    gettblspcoids_sql = "select oid from pg_tablespace where spcname not in ('pg_default', 'pg_global')"
-    gettblspclocs_sql = "select c.hostname, t.tblspc_loc from gp_tablespace_location(%s) t, gp_segment_configuration c where t.gp_segment_id = c.content group by c.hostname, t.tblspc_loc"
-
-    # Get the tablespace oids
-    with dbconn.connect(dbconn.DbURL()) as conn:
-        tblspcoids = dbconn.execSQL(conn, gettblspcoids_sql).fetchall()
-
-    # Use the tablespace oids to get the tablespace locations
-    for row in tblspcoids:
-        tblspcoid = row[0]
-        with dbconn.connect(dbconn.DbURL()) as conn:
-            query_results = dbconn.execSQL(conn, gettblspclocs_sql % tblspcoid).fetchall()
-
-            for query_result in query_results:
-                if query_result[0] in tblspclocs:
-                    tblspclocs[query_result[0]].append(query_result[1])
-                else:
-                    tblspclocs[query_result[0]] = [query_result[1]]
-
-    return tblspclocs
-
 # -------------------------------------------------------------------------
 # delete_system() - deletes a GPDB system
 # -------------------------------------------------------------------------
@@ -230,9 +207,12 @@ def delete_cluster(options):
     dburl = dbconn.DbURL(port=options.pgport)
     try:
         array = gparray.GpArray.initFromCatalog(dburl, True)
-        tablespaceDirs = getTablespaceDirs()
     except Exception, ex:
         raise GpDeleteSystemException('Failed to get database configuration: %s' % ex.__str__())
+
+    #get tablespace locations of segments from all hosts
+    tablespace_locations = get_tablespace_locations(True, None)
+
     # get all segdbs
     segments = array.getDbList()
 
@@ -261,16 +241,15 @@ def delete_cluster(options):
         pool = base.WorkerPool(numWorkers=options.batch_size)
 
         try:
-            logger.info('Deleting tablespace directories...')
-            for segmentHost in tablespaceDirs:
-                for tablespaceDir in tablespaceDirs[segmentHost]:
-                    logger.debug('Queueing up command to remove %s:%s' % (segmentHost,
-                                                                          tablespaceDir))
-                    cmd = unix.RemoveDirectory('remove tablespace dir', tablespaceDir,
-                                               ctxt=base.REMOTE, remoteHost=segmentHost)
+            if tablespace_locations:
+                logger.info('Deleting tablespace directories...')
+                for host, tablespace_dir in tablespace_locations:
+                    logger.debug('Queueing up command to remove %s:%s' % (host, tablespace_dir))
+                    cmd = unix.RemoveDirectory('remove tablespace dir', tablespace_dir,
+                                               ctxt=base.REMOTE, remoteHost=host)
                     pool.addCommand(cmd)
 
-            logger.info('Waiting for worker threads to delete tablespace dirs...')
+                logger.info('Waiting for worker threads to delete tablespace dirs...')
         finally:
             pool.join()
             pool.haltWork()

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -25,6 +25,7 @@ try:
     from pygresql import pg
     from gppylib import gparray, gplog, pgconf, userinput, utils
     from gppylib.parseutils import line_reader, check_values, canonicalize_address
+    from gppylib.operations.segment_tablespace_locations import get_tablespace_locations
 
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -297,6 +298,7 @@ args = None
 pidfilepid = None  # pid of the process which has the lock
 locktorelease = None
 sml = None  # sml (simple main lock)
+mirror_tablespace_locations = {} #map of mirror and its tablespace locations
 
 logger = get_default_logger()
 
@@ -373,6 +375,10 @@ try:
     totalDirsToDelete = len(mirrorsToDelete)
     numberOfWorkers = min(totalDirsToDelete, options.batch_size)
 
+    """ Fetch tablespace locations before mirror move """
+    for mirror in mirrorsToDelete:
+        mirror_tablespace_locations[mirror.dataDirectory] = get_tablespace_locations(False, mirror.dataDirectory)
+
     """ Update pg_hba.conf on primary segments with new mirror information """
 
     if numberOfWorkers > 0:
@@ -439,11 +445,23 @@ try:
     cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
     cmd.run(validateAfter=True)
 
+    """ Reinitialize gparray after the new mirrors are in place. """
+    gpArrayInstance = GpArray.initFromCatalog(dburl, utility=True)
+    mirrorDirectories = set((seg.getSegmentHostName(),seg.getSegmentContentId()) for seg in gpArrayInstance.getDbList() if seg.isSegmentMirror())
+
     """ Delete old mirror directories. """
     if numberOfWorkers > 0:
         pool = WorkerPool(numWorkers=numberOfWorkers)
         for mirror in mirrorsToDelete:
-            logger.info("About to remove old mirror segment directory: " + mirror.dataDirectory)
+            logger.info("About to remove old mirror segment directories: " + mirror.dataDirectory)
+
+            if mirror_tablespace_locations[mirror.dataDirectory]:
+                for host, content, tablespace_dir in mirror_tablespace_locations[mirror.dataDirectory]:
+                    if (host, content) not in mirrorDirectories:
+                        cmd = RemoveDirectory("removing old mirror tablespace directory", tablespace_dir, ctxt=REMOTE,
+                                              remoteHost=mirror.address)
+                        pool.addCommand(cmd)
+
             cmd = RemoveDirectory("remove old mirror segment directories", mirror.dataDirectory, ctxt=REMOTE,
                                   remoteHost=mirror.address)
             pool.addCommand(cmd)

--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -7,7 +7,7 @@ PROGRAMS= initstandby.py test_utils_helper.py
 
 DATA= __init__.py buildMirrorSegments.py deletesystem.py detect_unreachable_hosts.py \
 	package.py rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
-	unix.py update_pg_hba_conf.py utils.py
+	unix.py update_pg_hba_conf.py utils.py segment_tablespace_locations.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(libdir)/python/gppylib/operations'

--- a/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from gppylib.db import dbconn
+
+# get tablespace locations
+def get_tablespace_locations(all_hosts, mirror_data_directory):
+    """
+    to get user defined tablespace locations for all hosts or a specific mirror data directory.
+    :param all_hosts: boolean type to indicate if tablespace locations should be fetched from all hosts.
+                      Only gpdeletesystem will call it with True
+    :param mirror_data_directory: string type to fetch tablespace locations for a specific mirror data directory.
+                      Only gpmovemirrors will call it with a specific data directory
+    :return: list of tablespace locations
+    """
+    tablespace_locations = []
+    oid_subq = """ (SELECT *
+                    FROM (
+                        SELECT oid FROM pg_tablespace
+                        WHERE spcname NOT IN ('pg_default', 'pg_global')
+                        ) AS _q1,
+                        LATERAL gp_tablespace_location(_q1.oid)
+                    ) AS t """
+
+    with dbconn.connect(dbconn.DbURL()) as conn:
+        if all_hosts:
+            tablespace_location_sql = """
+                SELECT c.hostname, t.tblspc_loc||'/'||c.dbid tblspc_loc
+                FROM {oid_subq}
+                    JOIN gp_segment_configuration AS c
+                    ON t.gp_segment_id = c.content
+                """ .format(oid_subq=oid_subq)
+        else:
+            tablespace_location_sql = """
+                SELECT c.hostname,c.content, t.tblspc_loc||'/'||c.dbid tblspc_loc
+                FROM {oid_subq}
+                    JOIN gp_segment_configuration AS c
+                    ON t.gp_segment_id = c.content
+                    AND c.role='m' AND c.datadir ='{mirror_data_directory}'
+                """ .format(oid_subq=oid_subq, mirror_data_directory=mirror_data_directory)
+        res = dbconn.execSQL(conn, tablespace_location_sql)
+        for r in res:
+            tablespace_locations.append(r)
+    return tablespace_locations

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from mock import Mock, patch
+from gppylib.operations.segment_tablespace_locations import get_tablespace_locations
+from test.unit.gp_unittest import GpTestCase
+
+
+class GetTablespaceDirTestCase(GpTestCase):
+    def setUp(self):
+        self.mock_query = Mock(return_value=[])
+        self.apply_patches([
+            patch('gppylib.operations.segment_tablespace_locations.dbconn.connect'),
+            patch('gppylib.operations.segment_tablespace_locations.dbconn.execSQL', self.mock_query)
+        ])
+
+    def tearDown(self):
+        super(GetTablespaceDirTestCase, self).tearDown()
+
+    def test_validate_empty_with_all_hosts_get_tablespace_locations(self):
+        self.assertEqual([], get_tablespace_locations(True, None))
+
+    def test_validate_empty_with_no_all_hosts_get_tablespace_locations(self):
+        mirror_data_directory = '/data/primary/seg1'
+        self.assertEqual([], get_tablespace_locations(False, mirror_data_directory))
+
+    def test_validate_data_with_all_hosts_get_tablespace_locations(self):
+        self.mock_query.side_effect =[[('sdw1', '/data/tblsp1')]]
+        expected = [('sdw1', '/data/tblsp1')]
+        self.assertEqual(expected, get_tablespace_locations(True, None))
+
+    def test_validate_data_with_mirror_data_directory_get_tablespace_locations(self):
+        self.mock_query.side_effect = [[('sdw1', 1, '/data/tblsp1')]]
+        expected = [('sdw1', 1, '/data/tblsp1')]
+        mirror_data_directory = '/data/tblsp1'
+        self.assertEqual(expected, get_tablespace_locations(False, mirror_data_directory))

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpdeletesystem.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpdeletesystem.py
@@ -49,10 +49,7 @@ class GpDeleteSystemTestCase(GpTestCase):
 
         self.assertTrue('Backup files exist' in context.exception)
 
-
-    @patch('gpdeletesystem.dbconn.DbURL', return_value=Mock())
-    @patch('gpdeletesystem.gparray.GpArray.initFromCatalog', return_value=Mock())
-    def test_delete_cluster_force_succeeds(self, dbURL, initFromCatalog):
+    def test_delete_cluster_force_failed_to_get_gparray(self):
         setattr(self.options, 'force', True)
         setattr(self.options, 'pgport', 5432)
         os.mkdir(os.path.join(self.tmpDir, 'backups'))

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -172,6 +172,10 @@ Feature: Tests for gpmovemirrors
           And a sample gpmovemirrors input file is created in "spread" configuration
          When the user runs "gpmovemirrors --input=/tmp/gpmovemirrors_input_spread"
          Then gpmovemirrors should return a return code of 0
+          And verify the tablespace directories on host "sdw2" for content "1" are deleted
+          And verify the tablespace directories on host "sdw1" for content "5" are deleted
+          And verify the tablespace directories on host "sdw3" for content "1" are valid
+          And verify the tablespace directories on host "sdw2" for content "5" are valid
           And verify the database has mirrors
           And all the segments are running
           And the segments are synchronized

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -1,4 +1,5 @@
 from os import path
+from gppylib.commands.base import REMOTE
 
 from behave import given, when, then
 from test.behave_utils.utils import *
@@ -452,3 +453,34 @@ def impl(context, mirror_config):
 
             fd.write(line_template % (old_address, old_port, old_directory, new_address, new_port, new_directory))
         fd.flush()
+
+@then('verify the tablespace directories on host "{host}" for content "{content}" are {status}')
+def impl(context, host, content, status):
+    if status not in ["deleted", "valid"]:
+        raise Exception('Unknown status.  Valid values are "deleted" and "valid"')
+    locations = []
+    existing_dirs =[]
+    dbid = -2
+    with dbconn.connect(dbconn.DbURL(dbname="postgres"), unsetSearchPath=False) as conn:
+        oids_query = "SELECT oid FROM pg_tablespace WHERE spcname NOT IN ('pg_default', 'pg_global')"
+        location_query = "SELECT t.tblspc_loc||'/'||c.dbid FROM gp_tablespace_location(%s) t JOIN gp_segment_configuration c ON t.gp_segment_id = c.content WHERE c.content = %s AND c.preferred_role = 'm'"
+
+        oids = [row[0] for row in dbconn.execSQL(conn, oids_query).fetchall()]
+        dbid = dbconn.execSQLForSingleton(conn, "SELECT dbid FROM gp_segment_configuration WHERE content = %s AND preferred_role = 'm'" % content)
+        for oid in oids:
+            locations.append(dbconn.execSQLForSingleton(conn, location_query % (oid, content)))
+
+    for location in locations:
+        cmd = Command(name="check tablespace dirs", cmdStr="find %s -name %s -type d -print 2> /dev/null ||true" % (location, dbid), ctxt=REMOTE, remoteHost=host)
+        cmd.run(validateAfter=True)
+        output = cmd.get_results().stdout.strip()
+        if output != '':
+            existing_dirs.append(output)
+
+    if status == "deleted":
+        if existing_dirs:
+            raise Exception("One or more directories have not been deleted:\n%s" % existing_dirs)
+    else:
+        if existing_dirs != locations:
+            missing_dirs = [d for d in locations if d not in existing_dirs]
+            raise Exception("One or more directories are not present on %s: %s" % (host, missing_dirs))


### PR DESCRIPTION
6X backport for [11831](https://github.com/greenplum-db/gpdb/pull/11831)

gpmovemirrors did not remove the mirror tablespace directories on old host after move to a new host. This commit will help in the cleanup of unused tablespace directories from old host

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6X_gpmovemirror_rm_old_tblspc_dir)