### PR TITLE
[6X Backport] Fix stale sequence reference causing duplicate nextval() (#12029)

### DIFF
--- a/src/test/regress/expected/sequence_gp.out
+++ b/src/test/regress/expected/sequence_gp.out
@@ -170,3 +170,29 @@ SELECT * FROM descending_sequence;
  descending_sequence | 9223372036854775796 | 9223372036854775806 |           -1 | 9223372036854775806 |         1 |           1 |      22 | f         | t
 (1 row)
 
+-- Test that we don't produce duplicate sequence values
+DROP SEQUENCE IF EXISTS check_no_duplicates;
+NOTICE:  sequence "check_no_duplicates" does not exist, skipping
+CREATE SEQUENCE check_no_duplicates CACHE 20;
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');
+ nextval 
+---------
+       1
+      21
+      41
+(3 rows)
+
+SELECT nextval('check_no_duplicates');
+ nextval 
+---------
+      61
+(1 row)
+
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');
+ nextval 
+---------
+       2
+      22
+      42
+(3 rows)
+

--- a/src/test/regress/sql/sequence_gp.sql
+++ b/src/test/regress/sql/sequence_gp.sql
@@ -63,3 +63,10 @@ CREATE TABLE descending_sequence_insert(a bigint, b bigint);
 INSERT INTO descending_sequence_insert SELECT i, nextval('descending_sequence') FROM generate_series(1, 10)i;
 SELECT * FROM descending_sequence_insert ORDER BY b DESC;
 SELECT * FROM descending_sequence;
+
+-- Test that we don't produce duplicate sequence values
+DROP SEQUENCE IF EXISTS check_no_duplicates;
+CREATE SEQUENCE check_no_duplicates CACHE 20;
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');
+SELECT nextval('check_no_duplicates');
+SELECT nextval('check_no_duplicates') FROM gp_dist_random('gp_id');


### PR DESCRIPTION
In the current sequence design, all sequence allocations originating
from dispatcher or executor ultimately flow through the dispatcher.
This led to a situation where it was possible to reference a `SeqTable`
object containing cached sequence numbers that belonged to a different
requestor.  This meant that it was possible to generate duplicate
sequence values.

Fix is to maintain separate sequence caches on dispatcher that
distinguishes between sequences allocated to dispatcher and those
allocated to executors. When the dispatcher sequence is mantained
separately, it is able to freely consume its own sequence numbers from
its cache without fear of duplicating values allocated to an executor.

(cherry picked from commit d8747002b9a0e7d73c377cb56539c08bc0b7c47f)

Notes:
In 6X this bug was somewhat hidden by the fact that CACHE default value is 1.
Only merge conflict is that in 6X had to explicitly call out `ctl.hash = tag_hash;`