### PR TITLE
Docs: Tablespaces note for primary-mirror pair

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
@@ -16,9 +16,9 @@
       from any database if you have appropriate privileges.</p>
     <note>Greenplum Database does not support different tablespace locations for a primary-mirror
       pair with the same content ID. It is only possible to configure different locations for
-      different content IDs. Modifying tablespace symbolic links under the directory
-        <codeph>pg_tblspc</codeph> for a primary-mirror pair so that they point to different file
-      locations will lead to erroneous behavior.</note>
+      different content IDs. Do not modify symbolic links under the <codeph>pg_tblspc</codeph>
+      directory so that primary-mirror pairs point to different file locations; this will lead to
+      erroneous behavior.</note>
   </body>
   <topic id="topic13" xml:lang="en">
     <title>Creating a Tablespace</title>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
@@ -16,8 +16,9 @@
       from any database if you have appropriate privileges.</p>
     <note>Greenplum Database does not support different tablespace locations for a primary-mirror
       pair with the same content ID. It is only possible to configure different locations for
-      different content IDs. Symbolic links pointing to different file locations for a
-      primary-mirror pair must not be used.</note>
+      different content IDs. Modifying tablespace symbolic links under the directory
+        <codeph>pg_tblspc</codeph> for a primary-mirror pair so they point to different file
+      locations will lead to erroneous behavior.</note>
   </body>
   <topic id="topic13" xml:lang="en">
     <title>Creating a Tablespace</title>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-tablespace.xml
@@ -14,6 +14,10 @@
       master, standby master, each primary segment, and each mirror segment. </p>
     <p>A tablespace is Greenplum Database system object (a global object), you can use a tablespace
       from any database if you have appropriate privileges.</p>
+    <note>Greenplum Database does not support different tablespace locations for a primary-mirror
+      pair with the same content ID. It is only possible to configure different locations for
+      different content IDs. Symbolic links pointing to different file locations for a
+      primary-mirror pair must not be used.</note>
   </body>
   <topic id="topic13" xml:lang="en">
     <title>Creating a Tablespace</title>

--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -93,6 +93,10 @@
             href="../admin_guide/workload_mgmt_resgroups.xml" format="dita" scope="peer">Using
             Resource Groups</xref> for information about enabling and configuring resource
           groups.</li>
+        <li>Filespaces are removed in Greenplum 6. When creating a tablespace, note that different
+          tablespace locations for a primary-mirror pair is now not supported. See <xref
+            href="../admin_guide/ddl/ddl-tablespace.xml" format="dita" scope="peer">Creating and
+            Managing Tablespaces</xref> for information about creating and configuring tablespaces. </li>
       </ul>
     </body>
   </topic>

--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -94,9 +94,10 @@
             Resource Groups</xref> for information about enabling and configuring resource
           groups.</li>
         <li>Filespaces are removed in Greenplum 6. When creating a tablespace, note that different
-          tablespace locations for a primary-mirror pair is now not supported. See <xref
-            href="../admin_guide/ddl/ddl-tablespace.xml" format="dita" scope="peer">Creating and
-            Managing Tablespaces</xref> for information about creating and configuring tablespaces. </li>
+          tablespace locations for a primary-mirror pair is no longer supported in Greenplum 6. See
+            <xref href="../admin_guide/ddl/ddl-tablespace.xml" format="dita" scope="peer">Creating
+            and Managing Tablespaces</xref> for information about creating and configuring
+          tablespaces. </li>
       </ul>
     </body>
   </topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
@@ -90,9 +90,9 @@
     </section>
     <note>Greenplum Database does not support different tablespace locations for a primary-mirror
       pair with the same content ID. It is only possible to configure different locations for
-      different content IDs. Modifying tablespace symbolic links under the directory
-        <codeph>pg_tblspc</codeph> for a primary-mirror pair so they point to different file
-      locations will lead to erroneous behavior.</note>
+      different content IDs. Do not modify symbolic links under the <codeph>pg_tblspc</codeph>
+      directory so that primary-mirror pairs point to different file locations; this will lead to
+      erroneous behavior.</note>
     <section id="section6">
       <title>Examples</title>
       <p>Create a new tablespace and specify the file system location for the master and all segment

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
@@ -88,6 +88,10 @@
         segment database IDs and host system file locations for the tablespace with OID
           <codeph>16385</codeph>.<codeblock>SELECT * FROM gp_tablespace_location(16385) </codeblock></p>
     </section>
+    <p>Greenplum Database does not support different tablespace locations for a primary-mirror pair
+      with the same content ID. It is only possible to configure different locations for different
+      content IDs. Symbolic links pointing to different file locations for a primary-mirror pair
+      must not be used.</p>
     <section id="section6">
       <title>Examples</title>
       <p>Create a new tablespace and specify the file system location for the master and all segment

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
@@ -82,7 +82,7 @@
       <p>The system catalog table <codeph>pg_tablespace</codeph> stores tablespace information. This
         command displays the tablespace OID values, names, and
         owner.<codeblock>SELECT oid, spcname, spcowner FROM pg_tablespace ;</codeblock></p>
-      <p>The Greenplum Databasse built-in function
+      <p>The Greenplum Database built-in function
             <codeph>gp_tablespace_location(<varname>tablespace_oid</varname>)</codeph> displays the
         tablespace host system file locations for all segment instances. This command lists the
         segment database IDs and host system file locations for the tablespace with OID
@@ -90,9 +90,9 @@
     </section>
     <note>Greenplum Database does not support different tablespace locations for a primary-mirror
       pair with the same content ID. It is only possible to configure different locations for
-      different content IDs. Modifying tablespace symbolic links under the directory pg_tblspc for a
-      primary-mirror pair so they point to different file locations will lead to erroneous
-      behavior.</note>
+      different content IDs. Modifying tablespace symbolic links under the directory
+        <codeph>pg_tblspc</codeph> for a primary-mirror pair so they point to different file
+      locations will lead to erroneous behavior.</note>
     <section id="section6">
       <title>Examples</title>
       <p>Create a new tablespace and specify the file system location for the master and all segment

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLESPACE.xml
@@ -82,16 +82,17 @@
       <p>The system catalog table <codeph>pg_tablespace</codeph> stores tablespace information. This
         command displays the tablespace OID values, names, and
         owner.<codeblock>SELECT oid, spcname, spcowner FROM pg_tablespace ;</codeblock></p>
-      <p>The Greenplum Database built-in function
+      <p>The Greenplum Databasse built-in function
             <codeph>gp_tablespace_location(<varname>tablespace_oid</varname>)</codeph> displays the
         tablespace host system file locations for all segment instances. This command lists the
         segment database IDs and host system file locations for the tablespace with OID
           <codeph>16385</codeph>.<codeblock>SELECT * FROM gp_tablespace_location(16385) </codeblock></p>
     </section>
-    <p>Greenplum Database does not support different tablespace locations for a primary-mirror pair
-      with the same content ID. It is only possible to configure different locations for different
-      content IDs. Symbolic links pointing to different file locations for a primary-mirror pair
-      must not be used.</p>
+    <note>Greenplum Database does not support different tablespace locations for a primary-mirror
+      pair with the same content ID. It is only possible to configure different locations for
+      different content IDs. Modifying tablespace symbolic links under the directory pg_tblspc for a
+      primary-mirror pair so they point to different file locations will lead to erroneous
+      behavior.</note>
     <section id="section6">
       <title>Examples</title>
       <p>Create a new tablespace and specify the file system location for the master and all segment

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -459,13 +459,13 @@ main(int argc, char **argv)
 	ControlFile_new.state = DB_IN_ARCHIVE_RECOVERY;
 	update_controlfile(datadir_target, &ControlFile_new, do_sync);
 
-	if (showprogress)
-		pg_log_info("syncing target data directory");
-	syncTargetDirectory();
-
 	if (writerecoveryconf)
 		WriteRecoveryConfig(conn, datadir_target,
 							GenerateRecoveryConfig(conn, replication_slot));
+
+	if (showprogress)
+		pg_log_info("syncing target data directory");
+	syncTargetDirectory();
 
 	pg_log_info("Done!");
 


### PR DESCRIPTION
Tablespaces in different locations are not supported for a primary-mirror pair. This is different from filespaces so it has caused some confusion among customers.
I have edited the following 2 sections to add a warning about it:

https://mireia-tablespace.sc2-04-pcf1-apps.oc.vmware.com/7-0/admin_guide/ddl/ddl-tablespace.html
https://mireia-tablespace.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/sql_commands/CREATE_TABLESPACE.html
https://mireia-tablespace.sc2-04-pcf1-apps.oc.vmware.com/7-0/install_guide/migrate.html

For the second link I didn't include it in a note element since there is a Notes section on that page. Let me know if this makes sense.

There is another pending PR to update the Release Notes for GPDB 6.0.
This PR should be merged to master and cherrypicked to 6.x.
