### PR TITLE
(6x only) Fix appendoptimized alias issue for appendonly.

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -7300,7 +7300,17 @@ def_list:	def_elem								{ $$ = list_make1($1); }
 
 def_elem:	ColLabel '=' def_arg
 				{
-					$$ = makeDefElem($1, (Node *) $3);
+					/*
+					 * appendoptimized is an alias for appendonly in order to
+					 * provide a reloption syntax which better reflects the
+					 * featureset of AO tables. It is implemented as a very
+					 * thin alias, the reloptions and messaging will still
+					 * say appendonly.
+					 */
+					if (strcmp($1, "appendoptimized") == 0)
+						$$ = makeDefElem("appendonly", (Node *) $3);
+					else
+						$$ = makeDefElem($1, (Node *) $3);
 				}
 			| ColLabel
 				{

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -50,6 +50,10 @@ CREATE TABLE tenk_ao14 (like tenk_heap) with (appendonly=true, appendoptimized=f
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
 
+CREATE TABLE t_ao_alias_31345(i integer) distributed randomly partition by range(i) (
+partition p100 start (1::integer) inclusive end (100::integer) inclusive  with (appendoptimized=true)  ,
+partition p101 start (101::integer) inclusive end (200::integer) inclusive);
+
 -- also make sure appendoptimized works in the gp_default_storage_options GUC
 SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row,appendoptimized=false';
 SET gp_default_storage_options = 'appendoptimized=true,blocksize=32768,compresstype=none,checksum=true,orientation=row';

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -54,6 +54,22 @@ CREATE TABLE t_ao_alias_31345(i integer) distributed randomly partition by range
 partition p100 start (1::integer) inclusive end (100::integer) inclusive  with (appendoptimized=true)  ,
 partition p101 start (101::integer) inclusive end (200::integer) inclusive);
 
+CREATE TABLE t_ao_alias_31345_partsupp (
+ps_partkey integer,
+ps_suppkey integer,
+ps_availqty integer,
+ps_supplycost decimal,
+ps_comment varchar(199)
+)
+partition by range (ps_suppkey)
+subpartition by range (ps_partkey)
+subpartition by range (ps_supplycost) subpartition template (start('1') end('1001') every(500))
+(
+partition p1 start('1') end('10001') every(5000)
+(subpartition sp1 start('1') end('200001') every(66666) with(appendoptimized=true)
+)
+);
+
 -- also make sure appendoptimized works in the gp_default_storage_options GUC
 SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row,appendoptimized=false';
 SET gp_default_storage_options = 'appendoptimized=true,blocksize=32768,compresstype=none,checksum=true,orientation=row';

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -70,6 +70,11 @@ CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
 ERROR:  invalid value for option "appendonly"
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
 ERROR:  parameter "appendonly" specified more than once
+CREATE TABLE t_ao_alias_31345(i integer) distributed randomly partition by range(i) (
+partition p100 start (1::integer) inclusive end (100::integer) inclusive  with (appendoptimized=true)  ,
+partition p101 start (101::integer) inclusive end (200::integer) inclusive);
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_1_prt_p100" for table "t_ao_alias_31345"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_1_prt_p101" for table "t_ao_alias_31345"
 -- also make sure appendoptimized works in the gp_default_storage_options GUC
 SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row,appendoptimized=false';
 ERROR:  parameter "appendonly" specified more than once

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -75,6 +75,49 @@ partition p100 start (1::integer) inclusive end (100::integer) inclusive  with (
 partition p101 start (101::integer) inclusive end (200::integer) inclusive);
 NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_1_prt_p100" for table "t_ao_alias_31345"
 NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_1_prt_p101" for table "t_ao_alias_31345"
+CREATE TABLE t_ao_alias_31345_partsupp (
+ps_partkey integer,
+ps_suppkey integer,
+ps_availqty integer,
+ps_supplycost decimal,
+ps_comment varchar(199)
+)
+partition by range (ps_suppkey)
+subpartition by range (ps_partkey)
+subpartition by range (ps_supplycost) subpartition template (start('1') end('1001') every(500))
+(
+partition p1 start('1') end('10001') every(5000)
+(subpartition sp1 start('1') end('200001') every(66666) with(appendoptimized=true)
+)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'ps_partkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1" for table "t_ao_alias_31345_partsupp"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_1_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_2_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_3" for table "t_ao_alias_31345_partsupp_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_3"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_3_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_3"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_4" for table "t_ao_alias_31345_partsupp_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_4"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_4_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_1_2_prt_sp1_4"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2" for table "t_ao_alias_31345_partsupp"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_1_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_1"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_2_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_3" for table "t_ao_alias_31345_partsupp_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_3"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_3_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_3"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_4" for table "t_ao_alias_31345_partsupp_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_1" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_4"
+NOTICE:  CREATE TABLE will create partition "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_4_3_prt_2" for table "t_ao_alias_31345_partsupp_1_prt_p1_2_2_prt_sp1_4"
 -- also make sure appendoptimized works in the gp_default_storage_options GUC
 SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=none,checksum=true,orientation=row,appendoptimized=false';
 ERROR:  parameter "appendonly" specified more than once


### PR DESCRIPTION
Commit b3b2797e adds an alias `appendoptimized ` for AO table, but forget to
modify the PartSpec related syntax. The commit b3b2797e exists in Greenplum 6,
we should fix this for PartSpec also.