### PR TITLE
Improve performance of DELETEs on randomly distributed tables in ORCA.

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
@@ -205,7 +205,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLDelete Columns="0,1" ActionCol="9" OidCol="0" CtidCol="2" SegmentIdCol="8" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.043052" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.043023" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -231,7 +231,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -252,9 +252,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RoutedDistributeMotion SegmentIdCol="8" InputSegments="0,1" OutputSegments="0,1">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -270,47 +270,26 @@
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="18"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.17027.1.1" TableName="rr">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RoutedDistributeMotion>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.17027.1.1" TableName="rr">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:DMLDelete>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Verify that deleting an element in a randomly distributed table doesn't execute a redistribute motion.
+    Test case:
+
+    create table t1 (a int) distributed randomly;
+    explain delete from t1;
+
+                                   QUERY PLAN
+    ----------------------------------------------------------------
+     Delete on t1  (cost=0.00..431.02 rows=1 width=1)
+       ->  Seq Scan on t1 t1_1  (cost=0.00..431.00 rows=1 width=14)
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (3 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16385.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1" CtidCol="2" SegmentIdCol="8">
+        <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t1" LockMode="3">
+          <dxl:Columns>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t1" LockMode="3">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:DMLDelete Columns="0" ActionCol="8" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.023458" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t1" LockMode="3">
+          <dxl:Columns>
+            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="ctid">
+              <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+              <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="ctid">
+                <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t1" LockMode="3">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:DMLDelete>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
@@ -1,0 +1,444 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Verify that redistribute random applies in this case.
+    
+    create table foo (a int) distributed randomly;
+    create table bar(a int);
+    explain delete from foo using bar where foo.a=bar.a;
+                                                     QUERY PLAN
+    -------------------------------------------------------------------------------------------------------------
+     Delete on foo  (cost=0.00..862.02 rows=1 width=1)
+       ->  Result  (cost=0.00..862.00 rows=1 width=18)
+             ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=14)
+                   ->  Hash Join  (cost=0.00..862.00 rows=1 width=14)
+                         Hash Cond: (foo_1.a = bar.a)
+                         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
+                               Hash Key: foo_1.a
+                               ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=14)
+                         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (11 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16417.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.16414.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.16414.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16417.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16417.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16414.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1" CtidCol="2" SegmentIdCol="8">
+        <dxl:TableDescriptor Mdid="0.16414.1.0" TableName="foo" LockMode="3">
+          <dxl:Columns>
+            <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalJoin JoinType="Inner">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.16414.1.0" TableName="foo" LockMode="3">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.16417.1.0" TableName="bar" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="17">
+      <dxl:DMLDelete Columns="0" ActionCol="16" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.023911" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="0.16414.1.0" TableName="foo" LockMode="3">
+          <dxl:Columns>
+            <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000473" Rows="1.000000" Width="18"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="ctid">
+              <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+              <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="ColRef_0016">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:RoutedDistributeMotion SegmentIdCol="7" InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000467" Rows="1.000000" Width="14"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="ctid">
+                <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000453" Rows="1.000000" Width="14"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="ctid">
+                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="14"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="ctid">
+                    <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                    <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="ctid">
+                      <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                      <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.16414.1.0" TableName="foo" LockMode="3">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="a">
+                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16417.1.0" TableName="bar" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:HashJoin>
+          </dxl:RoutedDistributeMotion>
+        </dxl:Result>
+      </dxl:DMLDelete>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SelfUpdate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelfUpdate.mdp
@@ -218,7 +218,7 @@ update t1 set b = c;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1,2" ActionCol="10" OidCol="11" CtidCol="3" SegmentIdCol="9" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.078255" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.078201" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -248,7 +248,7 @@ update t1 set b = c;
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000130" Rows="2.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="2.000000" Width="30"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -275,9 +275,9 @@ update t1 set b = c;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2" OutputSegments="0,1,2">
+          <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="2.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -299,11 +299,18 @@ update t1 set b = c;
                 <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Assert ErrorCode="23502">
+            <dxl:AssertConstraintList>
+              <dxl:AssertConstraint ErrorMessage="Not null constraint for column b of table t1 was violated">
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:AssertConstraint>
+            </dxl:AssertConstraintList>
+            <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -322,21 +329,12 @@ update t1 set b = c;
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                  <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+                  <dxl:DMLAction/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:AssertConstraintList>
-                <dxl:AssertConstraint ErrorMessage="Not null constraint for column b of table t1 was violated">
-                  <dxl:Not>
-                    <dxl:IsNull>
-                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:IsNull>
-                  </dxl:Not>
-                </dxl:AssertConstraint>
-              </dxl:AssertConstraintList>
-              <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -354,50 +352,25 @@ update t1 set b = c;
                   <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                    <dxl:DMLAction/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="22"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="c">
-                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="ctid">
-                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.47297780.1.1" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Split>
-            </dxl:Assert>
-          </dxl:RoutedDistributeMotion>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.47297780.1.1" TableName="t1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Split>
+          </dxl:Assert>
         </dxl:Result>
       </dxl:DMLUpdate>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
@@ -198,7 +198,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.101718" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.101649" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -224,7 +224,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -248,9 +248,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RoutedDistributeMotion SegmentIdCol="8" InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000129" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -266,14 +266,12 @@
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+                <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -282,19 +280,21 @@
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="ctid">
                   <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                   <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="18"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -302,9 +302,6 @@
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="1" Alias="b">
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="a">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="ctid">
                     <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -314,43 +311,22 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="18"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.17027.1.1" TableName="rr">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
-            </dxl:Split>
-          </dxl:RoutedDistributeMotion>
+                <dxl:TableDescriptor Mdid="0.17027.1.1" TableName="rr">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
+          </dxl:Split>
         </dxl:Result>
       </dxl:DMLUpdate>
     </dxl:Plan>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
@@ -44,9 +44,13 @@ protected:
 	// private copy ctor
 	CDistributionSpecRandom(const CDistributionSpecRandom &);
 
+	CColRef *m_gp_segment_id = {nullptr};
+
 public:
 	//ctor
 	CDistributionSpecRandom();
+
+	CDistributionSpecRandom(CColRef *gp_segment_id_);
 
 	// accessor
 	EDistributionType

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
@@ -332,7 +332,8 @@ public:
 	// compute distribution spec from the table descriptor
 	static CDistributionSpec *PdsCompute(CMemoryPool *mp,
 										 const CTableDescriptor *ptabdesc,
-										 CColRefArray *pdrgpcrOutput);
+										 CColRefArray *pdrgpcrOutput,
+										 CColRef *gp_segment_id);
 
 	// compute required sort order of the n-th child
 	virtual COrderSpec *PosRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
@@ -13,6 +13,8 @@
 
 #include "gpopt/base/CColRefSet.h"
 #include "gpopt/base/CColRefSetIter.h"
+#include "gpopt/base/CDistributionSpecReplicated.h"
+#include "gpopt/base/CDistributionSpecRouted.h"
 #include "gpopt/base/CDistributionSpecStrictRandom.h"
 #include "gpopt/base/COptCtxt.h"
 #include "gpopt/base/CUtils.h"
@@ -41,6 +43,17 @@ CDistributionSpecRandom::CDistributionSpecRandom()
 	}
 }
 
+CDistributionSpecRandom::CDistributionSpecRandom(CColRef *gp_segment_id_)
+	: m_gp_segment_id(gp_segment_id_)
+{
+	if (COptCtxt::PoctxtFromTLS()->FDMLQuery())
+	{
+		// set duplicate sensitive flag to enforce Hash-Distribution of
+		// Const Tables in DML queries
+		MarkDuplicateSensitive();
+	}
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CDistributionSpecRandom::Matches
@@ -52,15 +65,39 @@ CDistributionSpecRandom::CDistributionSpecRandom()
 BOOL
 CDistributionSpecRandom::Matches(const CDistributionSpec *pds) const
 {
-	if (Edt() != pds->Edt())
+	if (pds->Edt() == CDistributionSpec::EdtRouted)
+	{
+		// This follows a 2x2 decision matrix:
+		// If both gp_segment_ids are null, then it does not match
+		// If one gp_segment_id is null and the other is not, it doesn't match
+		// If both gp_segment_ids are not null, they match iff they are equal
+		const CDistributionSpecRouted *pdsRouted =
+			static_cast<const CDistributionSpecRouted *>(pds);
+		GPOS_ASSERT(pdsRouted != nullptr);
+
+		const BOOL localNull = m_gp_segment_id == nullptr;
+		const BOOL pdsNull = pdsRouted->Pcr() == nullptr;
+
+		if (localNull || pdsNull)
+		{
+			return false;
+		}
+		else
+		{
+			return m_gp_segment_id->Id() == pdsRouted->Pcr()->Id();
+		}
+	}
+	else if (pds->Edt() == CDistributionSpec::EdtRandom)
+	{
+		const CDistributionSpecRandom *pdsRandom =
+			static_cast<const CDistributionSpecRandom *>(pds);
+
+		return pdsRandom->IsDuplicateSensitive() == m_is_duplicate_sensitive;
+	}
+	else
 	{
 		return false;
 	}
-
-	const CDistributionSpecRandom *pdsRandom =
-		dynamic_cast<const CDistributionSpecRandom *>(pds);
-
-	return pdsRandom->IsDuplicateSensitive() == m_is_duplicate_sensitive;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDML.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDML.cpp
@@ -64,7 +64,8 @@ CPhysicalDML::CPhysicalDML(CMemoryPool *mp, CLogicalDML::EDMLOperator edmlop,
 		CLogicalDML::EdmlDelete == edmlop || CLogicalDML::EdmlUpdate == edmlop,
 		nullptr != pcrCtid && nullptr != pcrSegmentId);
 
-	m_pds = CPhysical::PdsCompute(m_mp, m_ptabdesc, pdrgpcrSource);
+	m_pds =
+		CPhysical::PdsCompute(m_mp, m_ptabdesc, pdrgpcrSource, pcrSegmentId);
 
 	if (CDistributionSpec::EdtHashed == m_pds->Edt() &&
 		ptabdesc->ConvertHashToRandom())

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
@@ -54,7 +54,8 @@ CPhysicalScan::CPhysicalScan(CMemoryPool *mp, const CName *pnameAlias,
 	}
 	else
 	{
-		m_pds = CPhysical::PdsCompute(m_mp, ptabdesc, pdrgpcrOutput);
+		m_pds = CPhysical::PdsCompute(m_mp, ptabdesc, pdrgpcrOutput,
+									  nullptr /* gp_segment_id */);
 	}
 	ComputeTableStats(m_mp);
 }

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -50,6 +50,8 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/InsertAssertSort.mdp",
 	"../data/dxl/minidump/UpdateRandomDistr.mdp",
 	"../data/dxl/minidump/DeleteRandomDistr.mdp",
+	"../data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp",
+	"../data/dxl/minidump/DeleteRandomlyDistributedTable.mdp",
 	"../data/dxl/minidump/InsertConstTuple.mdp",
 	"../data/dxl/minidump/InsertConstTupleVolatileFunction.mdp",
 	"../data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp",

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -1,4 +1,6 @@
 --  MPP-21536: Duplicated rows inserted when ORCA is turned on
+create schema bfv_dml;
+set search_path=bfv_dml;
 -- create test table
 create table m();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
@@ -292,3 +294,302 @@ select * from execinsert_test;
 (1 row)
 
 drop table execinsert_test;
+--
+-- Verify that DELETE properly redistributes in the case of joins
+--
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+explain delete from foo using bar where foo.a=bar.a;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=679.75..178739.85 rows=2471070 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=679.75..178739.85 rows=2471070 width=16)
+         ->  Hash Join  (cost=679.75..129318.45 rows=2471070 width=16)
+               Hash Cond: (foo.a = bar.a)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=14)
+                     Hash Key: foo.a
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=14)
+               ->  Hash  (cost=321.00..321.00 rows=28700 width=10)
+                     ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+delete from foo using bar where foo.a=bar.a;
+select * from foo;
+ a | b 
+---+---
+(0 rows)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into foo select generate_series(1, 10);
+insert into bar select generate_series(1, 10);
+explain delete from foo using bar where foo.a = bar.a returning foo.*;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=679.75..277582.65 rows=7413210 width=16)
+   ->  Delete on foo  (cost=679.75..178739.85 rows=2471070 width=16)
+         ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)  (cost=679.75..178739.85 rows=2471070 width=16)
+               ->  Hash Join  (cost=679.75..129318.45 rows=2471070 width=16)
+                     Hash Cond: (foo.a = bar.a)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..895.00 rows=28700 width=14)
+                           Hash Key: foo.a
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=14)
+                     ->  Hash  (cost=321.00..321.00 rows=28700 width=10)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+delete from foo using bar where foo.a = bar.a returning foo.*;
+ a  | b 
+----+---
+  1 |  
+  9 |  
+  7 |  
+ 10 |  
+  2 |  
+  3 |  
+  8 |  
+  5 |  
+  6 |  
+  4 |  
+(10 rows)
+
+select * from foo;
+ a | b 
+---+---
+(0 rows)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+explain delete from foo where foo.a=1;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Delete on foo  (cost=0.00..392.75 rows=29 width=10)
+   ->  Seq Scan on foo  (cost=0.00..392.75 rows=29 width=10)
+         Filter: (a = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+delete from foo where foo.a=1;
+drop table foo;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+explain delete from foo using bar where foo.a=bar.b;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=1253.75..179313.85 rows=2471070 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1253.75..179313.85 rows=2471070 width=16)
+         ->  Hash Join  (cost=1253.75..129892.45 rows=2471070 width=16)
+               Hash Cond: (foo.a = bar.b)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=14)
+                     Hash Key: foo.a
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=14)
+               ->  Hash  (cost=895.00..895.00 rows=28700 width=10)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..895.00 rows=28700 width=10)
+                           Hash Key: bar.b
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+delete from foo using bar where foo.a=bar.b;
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+explain delete from foo using foo foo_1 where foo_1.a=foo.a;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=1253.75..179313.85 rows=2471070 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1253.75..179313.85 rows=2471070 width=16)
+         ->  Hash Join  (cost=1253.75..129892.45 rows=2471070 width=16)
+               Hash Cond: (foo.a = foo_1.a)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=14)
+                     Hash Key: foo.a
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=14)
+               ->  Hash  (cost=895.00..895.00 rows=28700 width=10)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..895.00 rows=28700 width=10)
+                           Hash Key: foo_1.a
+                           ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+delete from foo using foo foo_1 where foo_1.a=foo.a;
+drop table foo;
+create table foo (a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+explain delete from foo;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Delete on foo  (cost=0.00..321.00 rows=28700 width=10)
+   ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+delete from foo;
+drop table foo;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+explain delete from foo using bar;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=10000000000.00..10030890236.75 rows=2471070000 width=16)
+   ->  Nested Loop  (cost=10000000000.00..10030890236.75 rows=2471070000 width=16)
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1469.00 rows=86100 width=6)
+               ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=6)
+         ->  Materialize  (cost=0.00..464.50 rows=28700 width=10)
+               ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+delete from foo using bar;
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int) distributed randomly;
+insert into bar select i, i from generate_series(1, 1000)i;
+insert into foo select i,i from generate_series(1, 10)i;
+analyze foo;
+analyze bar;
+set optimizer_enable_motion_redistribute=off;
+explain delete from foo using bar where foo.b=bar.b;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=1.29..6.56 rows=3 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.29..6.56 rows=3 width=16)
+         ->  Hash Join  (cost=1.29..6.50 rows=3 width=16)
+               Hash Cond: (bar.b = foo.b)
+               ->  Seq Scan on bar  (cost=0.00..4.33 rows=333 width=10)
+               ->  Hash  (cost=1.17..1.17 rows=10 width=14)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.17 rows=10 width=14)
+                           ->  Seq Scan on foo  (cost=0.00..1.03 rows=3 width=14)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+delete from foo using bar where foo.b=bar.b;
+drop table foo;
+drop table bar;
+reset optimizer_enable_motion_redistribute;
+create table foo (a int, b int) distributed randomly;
+create table bar (a int, b int) distributed randomly;
+insert into foo (a, b) values (1, 2);
+explain insert into bar select * from foo;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Insert on bar  (cost=0.00..321.00 rows=28700 width=8)
+   ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+insert into bar select * from foo;
+select * from bar;
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar (a int, b int) distributed randomly;
+insert into foo (a, b) values (1, 2);
+insert into bar (a, b) values (1, 2);
+explain update foo set a=4 from bar where foo.a=bar.a;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Update on foo  (cost=1253.75..179313.85 rows=2471070 width=24)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1253.75..179313.85 rows=2471070 width=24)
+         ->  Hash Join  (cost=1253.75..129892.45 rows=2471070 width=24)
+               Hash Cond: (foo.a = bar.a)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=18)
+                     Hash Key: foo.a
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=18)
+               ->  Hash  (cost=895.00..895.00 rows=28700 width=10)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..895.00 rows=28700 width=10)
+                           Hash Key: bar.a
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+update foo set a=4 from bar where foo.a=bar.a;
+select * from foo;
+ a | b 
+---+---
+ 4 | 2
+(1 row)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar (a int, b int) distributed randomly;
+create table jazz (a int, b int) distributed randomly;
+insert into foo (a, b) values (1, 2);
+insert into bar (a, b) values (1, 2);
+insert into jazz (a, b) values (1, 2);
+explain insert into foo select bar.a from bar, jazz where bar.a=jazz.a;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Insert on foo  (cost=1253.75..129892.45 rows=2471070 width=8)
+   ->  Hash Join  (cost=1253.75..129892.45 rows=2471070 width=8)
+         Hash Cond: (bar.a = jazz.a)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..895.00 rows=28700 width=4)
+               Hash Key: bar.a
+               ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+         ->  Hash  (cost=895.00..895.00 rows=28700 width=4)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=4)
+                     Hash Key: jazz.a
+                     ->  Seq Scan on jazz  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+insert into foo select bar.a from bar, jazz where bar.a=jazz.a;
+select * from foo;
+ a | b 
+---+---
+ 1 | 2
+ 1 |  
+(2 rows)
+
+drop table foo;
+drop table bar;
+drop table jazz;
+create table foo (a int) distributed randomly;
+create table bar (b int) distributed randomly;
+insert into foo select i from generate_series(1, 10)i;
+insert into bar select i from generate_series(1, 10)i;
+explain delete from foo using (select a from foo union all select b from bar) v;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=10000000000.00..10200932780.50 rows=6182460000 width=42)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10200932780.50 rows=6182460000 width=42)
+         ->  Nested Loop  (cost=10000000000.00..10077283580.50 rows=6182460000 width=42)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1639.00 rows=96300 width=10)
+                     ->  Seq Scan on foo  (cost=0.00..355.00 rows=32100 width=10)
+               ->  Materialize  (cost=0.00..1352.00 rows=64200 width=32)
+                     ->  Append  (cost=0.00..1031.00 rows=64200 width=32)
+                           ->  Seq Scan on foo foo_1  (cost=0.00..355.00 rows=32100 width=32)
+                           ->  Seq Scan on bar  (cost=0.00..355.00 rows=32100 width=32)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+delete from foo using (select a from foo union all select b from bar) v;
+select * from foo;
+ a 
+---
+(0 rows)
+
+drop table foo;
+drop table bar;

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -1,4 +1,6 @@
 --  MPP-21536: Duplicated rows inserted when ORCA is turned on
+create schema bfv_dml;
+set search_path=bfv_dml;
 -- create test table
 create table m();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
@@ -298,3 +300,294 @@ select * from execinsert_test;
 (1 row)
 
 drop table execinsert_test;
+--
+-- Verify that DELETE properly redistributes in the case of joins
+--
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+explain delete from foo using bar where foo.a=bar.a;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..862.03 rows=1 width=1)
+   ->  Result  (cost=0.00..862.00 rows=1 width=22)
+         ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=18)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
+                     Hash Cond: (foo_1.a = bar.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
+                           Hash Key: foo_1.a
+                           ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+delete from foo using bar where foo.a=bar.a;
+select * from foo;
+ a | b 
+---+---
+(0 rows)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into foo select generate_series(1, 10);
+insert into bar select generate_series(1, 10);
+explain delete from foo using bar where foo.a = bar.a returning foo.*;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=679.75..277582.65 rows=7413210 width=16)
+   ->  Delete on foo  (cost=679.75..178739.85 rows=2471070 width=16)
+         ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)  (cost=679.75..178739.85 rows=2471070 width=16)
+               ->  Hash Join  (cost=679.75..129318.45 rows=2471070 width=16)
+                     Hash Cond: (foo.a = bar.a)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..895.00 rows=28700 width=14)
+                           Hash Key: foo.a
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=14)
+                     ->  Hash  (cost=321.00..321.00 rows=28700 width=10)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=10)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+delete from foo using bar where foo.a = bar.a returning foo.*;
+ a  | b 
+----+---
+  1 |  
+  3 |  
+  4 |  
+  6 |  
+  9 |  
+ 10 |  
+  2 |  
+  5 |  
+  7 |  
+  8 |  
+(10 rows)
+
+select * from foo;
+ a | b 
+---+---
+(0 rows)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+explain delete from foo where foo.a=1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Delete on foo  (cost=0.00..431.03 rows=1 width=1)
+   ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         Filter: (a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+delete from foo where foo.a=1;
+drop table foo;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+explain delete from foo using bar where foo.a=bar.b;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..862.03 rows=1 width=1)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
+         Hash Cond: (foo_1.a = bar.b)
+         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+delete from foo using bar where foo.a=bar.b;
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+explain delete from foo using foo foo_1 where foo_1.a=foo.a;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..862.03 rows=1 width=1)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
+         Hash Cond: (foo_1.a = foo_2.a)
+         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+delete from foo using foo foo_1 where foo_1.a=foo.a;
+drop table foo;
+create table foo (a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+explain delete from foo;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Delete on foo  (cost=0.00..431.03 rows=1 width=1)
+   ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+delete from foo;
+drop table foo;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int) distributed randomly;
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+explain delete from foo using bar;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..1324032.10 rows=1 width=1)
+   ->  Nested Loop  (cost=0.00..1324032.07 rows=1 width=18)
+         Join Filter: true
+         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         ->  Materialize  (cost=0.00..431.00 rows=3 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
+                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+delete from foo using bar;
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar(a int, b int) distributed randomly;
+insert into bar select i, i from generate_series(1, 1000)i;
+insert into foo select i,i from generate_series(1, 10)i;
+analyze foo;
+analyze bar;
+set optimizer_enable_motion_redistribute=off;
+explain delete from foo using bar where foo.b=bar.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..862.56 rows=4 width=1)
+   ->  Hash Join  (cost=0.00..862.27 rows=10 width=18)
+         Hash Cond: (foo_1.b = bar.b)
+         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=10 width=18)
+         ->  Hash  (cost=431.08..431.08 rows=3000 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.08 rows=3000 width=4)
+                     ->  Seq Scan on bar  (cost=0.00..431.01 rows=334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+delete from foo using bar where foo.b=bar.b;
+drop table foo;
+drop table bar;
+reset optimizer_enable_motion_redistribute;
+create table foo (a int, b int) distributed randomly;
+create table bar (a int, b int) distributed randomly;
+insert into foo (a, b) values (1, 2);
+explain insert into bar select * from foo;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Insert on bar  (cost=0.00..431.02 rows=1 width=8)
+   ->  Result  (cost=0.00..0.00 rows=0 width=0)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+insert into bar select * from foo;
+select * from bar;
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar (a int, b int) distributed randomly;
+insert into foo (a, b) values (1, 2);
+insert into bar (a, b) values (1, 2);
+explain update foo set a=4 from bar where foo.a=bar.a;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Update on foo  (cost=0.00..862.07 rows=1 width=1)
+   ->  Result  (cost=0.00..862.00 rows=2 width=26)
+         ->  Split  (cost=0.00..862.00 rows=2 width=22)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
+                     Hash Cond: (foo_1.a = bar.a)
+                     ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+update foo set a=4 from bar where foo.a=bar.a;
+select * from foo;
+ a | b 
+---+---
+ 4 | 2
+(1 row)
+
+drop table foo;
+drop table bar;
+create table foo (a int, b int) distributed randomly;
+create table bar (a int, b int) distributed randomly;
+create table jazz (a int, b int) distributed randomly;
+insert into foo (a, b) values (1, 2);
+insert into bar (a, b) values (1, 2);
+insert into jazz (a, b) values (1, 2);
+explain insert into foo select bar.a from bar, jazz where bar.a=jazz.a;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Insert on foo  (cost=0.00..862.02 rows=1 width=4)
+   ->  Result  (cost=0.00..0.00 rows=0 width=0)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Cond: (bar.a = jazz.a)
+                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on jazz  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+insert into foo select bar.a from bar, jazz where bar.a=jazz.a;
+select * from foo;
+ a | b 
+---+---
+ 1 | 2
+ 1 |  
+(2 rows)
+
+drop table foo;
+drop table bar;
+drop table jazz;
+create table foo (a int) distributed randomly;
+create table bar (b int) distributed randomly;
+insert into foo select i from generate_series(1, 10)i;
+insert into bar select i from generate_series(1, 10)i;
+explain delete from foo using (select a from foo union all select b from bar) v;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..1765376.09 rows=1 width=1)
+   ->  Nested Loop  (cost=0.00..1765376.07 rows=1 width=14)
+         Join Filter: true
+         ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=1 width=14)
+         ->  Materialize  (cost=0.00..862.00 rows=3 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=3 width=1)
+                     ->  Append  (cost=0.00..862.00 rows=1 width=1)
+                           ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+delete from foo using (select a from foo union all select b from bar) v;
+select * from foo;
+ a 
+---
+(0 rows)
+
+drop table foo;
+drop table bar;

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1456,19 +1456,17 @@ explain delete from TabDel1 where TabDel1.a not in (select a from TabDel3); -- d
 (8 rows)
 
 explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- support this
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Delete on tabdel2  (cost=0.00..862.04 rows=1 width=1)
-   ->  Result  (cost=0.00..862.00 rows=1 width=22)
-         ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=18)
-               ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=18)
-                     Hash Cond: (tabdel2_1.a = tabdel4.a)
-                     ->  Seq Scan on tabdel2 tabdel2_1  (cost=0.00..431.00 rows=1 width=18)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on tabdel4  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(10 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Delete on tabdel2  (cost=0.00..862.03 rows=1 width=1)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=18)
+         Hash Cond: (tabdel2_1.a = tabdel4.a)
+         ->  Seq Scan on tabdel2 tabdel2_1  (cost=0.00..431.00 rows=1 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Seq Scan on tabdel4  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 delete from TabDel2 where TabDel2.a not in (select a from TabDel4); 
 select * from TabDel2;


### PR DESCRIPTION
Previously, we always added a redistribute motion on a DELETE on a randomly
distributed table. Now, we allow randomly distributed specs to match iff
gp_segment_id ColRef match.

Updated CDistributionSpecRandom::Matches to check whether two random distributions
have the same gp_segment_id and return true in that case. This commit re-derives
gp_segment_id through ptabdesc.

Added test cases to src/test/regress/sql/bfv_dml.sql and updates expected with
the new test cases.

```
create table foo (a int, b int) distributed randomly;
create table bar(a int, b int);
explain delete from foo where foo.a=1;
                            QUERY PLAN
------------------------------------------------------------------
 Delete on foo  (cost=0.00..431.03 rows=1 width=1)
   ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
         Filter: (a = 1)
 Optimizer: Pivotal Optimizer (GPORCA)
(4 rows)
```