### PR TITLE
Fix SortBy serialize/deserialize problem

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4823,7 +4823,6 @@ _outSortBy(StringInfo str, const SortBy *node)
 	WRITE_ENUM_FIELD(sortby_dir, SortByDir);
 	WRITE_ENUM_FIELD(sortby_nulls, SortByNulls);
 	WRITE_NODE_FIELD(useOp);
-	WRITE_NODE_FIELD(node);
 	WRITE_LOCATION_FIELD(location);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2206,10 +2206,10 @@ _readSortBy(void)
 {
 	READ_LOCALS(SortBy);
 
-	READ_INT_FIELD(sortby_dir);
-	READ_INT_FIELD(sortby_nulls);
-	READ_NODE_FIELD(useOp);
 	READ_NODE_FIELD(node);
+	READ_ENUM_FIELD(sortby_dir, SortByDir);
+	READ_ENUM_FIELD(sortby_nulls, SortByNulls);
+	READ_NODE_FIELD(useOp);
 	READ_LOCATION_FIELD(location);
 
 	READ_DONE();


### PR DESCRIPTION
_outSortBy and _readSortBy are mismatch obviously, adjust them to be
consistent.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
