### PR TITLE
Minor fix for partially grouped rel

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -7319,18 +7319,16 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 			{
 				Path	   *path = (Path *) lfirst(lc);
 				double		dNumGroups;
-				bool		is_sorted = true;
+				bool		is_sorted;
+
+				is_sorted = pathkeys_contained_in(root->group_pathkeys, path->pathkeys);
 
 				/*
-				 * Insert a Sort node, if required.  But there's no point in
+				 * Insert a Sort node, if required. But there's no point in
 				 * sorting anything but the cheapest path.
 				 */
-				if (!pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
-				{
-					if (path != partially_grouped_rel->cheapest_total_path)
-						continue;
-					is_sorted = false;
-				}
+				if (!is_sorted && path != partially_grouped_rel->cheapest_total_path)
+					continue;
 
 				path = cdb_prepare_path_for_sorted_agg(root,
 													   is_sorted,
@@ -7368,7 +7366,7 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 											 agg_final_costs,
 											 dNumGroups));
 				}
-						/* Group nodes are not used in GPDB */
+				/* Group nodes are not used in GPDB */
 #if 0
 				else
 					add_path(grouped_rel, (Path *)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -7319,14 +7319,19 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 			{
 				Path	   *path = (Path *) lfirst(lc);
 				double		dNumGroups;
-				bool		is_sorted = false;
+				bool		is_sorted = true;
 
-				if (pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
+				/*
+				 * Insert a Sort node, if required.  But there's no point in
+				 * sorting anything but the cheapest path.
+				 */
+				if (!pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
 				{
 					if (path != partially_grouped_rel->cheapest_total_path)
 						continue;
-					is_sorted = true;
+					is_sorted = false;
 				}
+
 				path = cdb_prepare_path_for_sorted_agg(root,
 													   is_sorted,
 													   grouped_rel,

--- a/src/test/regress/expected/partition_aggregate.out
+++ b/src/test/regress/expected/partition_aggregate.out
@@ -261,26 +261,25 @@ SELECT a, sum(b), avg(b), count(*) FROM pagg_tab GROUP BY 1 HAVING avg(d) < 15 O
          ->  Finalize GroupAggregate
                Group Key: pagg_tab_p1.a
                Filter: (avg(pagg_tab_p1.d) < '15'::numeric)
-               ->  Sort
+               ->  Merge Append
                      Sort Key: pagg_tab_p1.a
-                     ->  Append
-                           ->  Partial GroupAggregate
-                                 Group Key: pagg_tab_p1.a
-                                 ->  Sort
-                                       Sort Key: pagg_tab_p1.a
-                                       ->  Seq Scan on pagg_tab_p1
-                           ->  Partial GroupAggregate
-                                 Group Key: pagg_tab_p2.a
-                                 ->  Sort
-                                       Sort Key: pagg_tab_p2.a
-                                       ->  Seq Scan on pagg_tab_p2
-                           ->  Partial GroupAggregate
-                                 Group Key: pagg_tab_p3.a
-                                 ->  Sort
-                                       Sort Key: pagg_tab_p3.a
-                                       ->  Seq Scan on pagg_tab_p3
+                     ->  Partial GroupAggregate
+                           Group Key: pagg_tab_p1.a
+                           ->  Sort
+                                 Sort Key: pagg_tab_p1.a
+                                 ->  Seq Scan on pagg_tab_p1
+                     ->  Partial GroupAggregate
+                           Group Key: pagg_tab_p2.a
+                           ->  Sort
+                                 Sort Key: pagg_tab_p2.a
+                                 ->  Seq Scan on pagg_tab_p2
+                     ->  Partial GroupAggregate
+                           Group Key: pagg_tab_p3.a
+                           ->  Sort
+                                 Sort Key: pagg_tab_p3.a
+                                 ->  Seq Scan on pagg_tab_p3
  Optimizer: Postgres query optimizer
-(26 rows)
+(25 rows)
 
 SELECT a, sum(b), avg(b), count(*) FROM pagg_tab GROUP BY 1 HAVING avg(d) < 15 ORDER BY 1, 2, 3;
  a  | sum  |         avg         | count 
@@ -353,23 +352,34 @@ SELECT c FROM pagg_tab GROUP BY c ORDER BY 1;
 
 EXPLAIN (COSTS OFF)
 SELECT a FROM pagg_tab WHERE a < 3 GROUP BY a ORDER BY 1;
-                   QUERY PLAN                    
--------------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: pagg_tab_p1.a
-   ->  GroupAggregate
+   ->  Finalize GroupAggregate
          Group Key: pagg_tab_p1.a
-         ->  Sort
+         ->  Merge Append
                Sort Key: pagg_tab_p1.a
-               ->  Append
-                     ->  Seq Scan on pagg_tab_p1
-                           Filter: (a < 3)
-                     ->  Seq Scan on pagg_tab_p2
-                           Filter: (a < 3)
-                     ->  Seq Scan on pagg_tab_p3
-                           Filter: (a < 3)
+               ->  Partial GroupAggregate
+                     Group Key: pagg_tab_p1.a
+                     ->  Sort
+                           Sort Key: pagg_tab_p1.a
+                           ->  Seq Scan on pagg_tab_p1
+                                 Filter: (a < 3)
+               ->  Partial GroupAggregate
+                     Group Key: pagg_tab_p2.a
+                     ->  Sort
+                           Sort Key: pagg_tab_p2.a
+                           ->  Seq Scan on pagg_tab_p2
+                                 Filter: (a < 3)
+               ->  Partial GroupAggregate
+                     Group Key: pagg_tab_p3.a
+                     ->  Sort
+                           Sort Key: pagg_tab_p3.a
+                           ->  Seq Scan on pagg_tab_p3
+                                 Filter: (a < 3)
  Optimizer: Postgres query optimizer
-(14 rows)
+(25 rows)
 
 SELECT a FROM pagg_tab WHERE a < 3 GROUP BY a ORDER BY 1;
  a 


### PR DESCRIPTION
When considering finalizing a partially aggregated path in sorted way, if we
have to insert a sort node, we prefer to do so only for the cheapest path. This
keeps the same logic with PostgreSQL's.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
