### PR TITLE
COPY ON SEGMENT for distributed replicated tables

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1357,5 +1357,3 @@ COPY dist_rep_src TO '/tmp/dist_rep_src_<SEGID>.txt' ON SEGMENT;
 COPY dist_rep_dst FROM '/tmp/dist_rep_src_<SEGID>.txt' ON SEGMENT;
 -- Nothing should be copied
 SELECT * FROM dist_rep_dst;
-DROP TABLE dist_rep_src;
-DROP TABLE dist_rep_dst;

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1337,3 +1337,25 @@ COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest' ESCAPE 'OFF';
 COPY foo FROM PROGRAM '/usr/bin/env bash -c ''echo -E database in COPY FROM: $GP_DATABASE''' ESCAPE 'OFF';
 
 select * from foo;
+
+-- Test COPY FROM and TO on distributed replicated tables
+-- COPY on master should just work
+DROP TABLE IF EXISTS dist_rep_src;
+DROP TABLE IF EXISTS dist_rep_dst;
+CREATE TABLE dist_rep_src(a int,b char) distributed replicated;
+CREATE TABLE dist_rep_dst(a int,b char) distributed replicated;
+INSERT INTO dist_rep_src values(1,'1');
+INSERT INTO dist_rep_src values(2,'2');
+COPY dist_rep_src TO '/tmp/dist_rep_src.txt';
+COPY dist_rep_dst FROM '/tmp/dist_rep_src.txt';
+SELECT * FROM dist_rep_dst;
+
+TRUNCATE TABLE dist_rep_dst;
+-- COPY TO should work on segment
+COPY dist_rep_src TO '/tmp/dist_rep_src_<SEGID>.txt' ON SEGMENT;
+-- COPY FROM should fail on segment
+COPY dist_rep_dst FROM '/tmp/dist_rep_src_<SEGID>.txt' ON SEGMENT;
+-- Nothing should be copied
+SELECT * FROM dist_rep_dst;
+DROP TABLE dist_rep_src;
+DROP TABLE dist_rep_dst;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1694,5 +1694,3 @@ SELECT * FROM dist_rep_dst;
 ---+---
 (0 rows)
 
-DROP TABLE dist_rep_src;
-DROP TABLE dist_rep_dst;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1662,3 +1662,37 @@ select * from foo;
  database in COPY TO: funny copy"db'with\\quotes
 (3 rows)
 
+-- Test COPY FROM and TO on distributed replicated tables
+-- COPY on master should just work
+DROP TABLE IF EXISTS dist_rep_src;
+NOTICE:  table "dist_rep_src" does not exist, skipping
+DROP TABLE IF EXISTS dist_rep_dst;
+NOTICE:  table "dist_rep_dst" does not exist, skipping
+CREATE TABLE dist_rep_src(a int,b char) distributed replicated;
+CREATE TABLE dist_rep_dst(a int,b char) distributed replicated;
+INSERT INTO dist_rep_src values(1,'1');
+INSERT INTO dist_rep_src values(2,'2');
+COPY dist_rep_src TO '/tmp/dist_rep_src.txt';
+COPY dist_rep_dst FROM '/tmp/dist_rep_src.txt';
+SELECT * FROM dist_rep_dst;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+TRUNCATE TABLE dist_rep_dst;
+-- COPY TO should work on segment
+COPY dist_rep_src TO '/tmp/dist_rep_src_<SEGID>.txt' ON SEGMENT;
+-- COPY FROM should fail on segment
+COPY dist_rep_dst FROM '/tmp/dist_rep_src_<SEGID>.txt' ON SEGMENT;
+ERROR:  COPY FROM ON SEGMENT doesn't support distributed replicated table
+HINT:  Use COPY FROM statements instead.
+-- Nothing should be copied
+SELECT * FROM dist_rep_dst;
+ a | b 
+---+---
+(0 rows)
+
+DROP TABLE dist_rep_src;
+DROP TABLE dist_rep_dst;


### PR DESCRIPTION
Reports an error when COPY FROM ON SEGMENT is executed on a distributed
replicated table. The data cannot be guaranteed to be the same on all
the segments if that is allowed.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
