### PR TITLE
recoverseg/addmirrors: change -B/-b help description

### DIFF
--- a/gpMgmt/doc/gpaddmirrors_help
+++ b/gpMgmt/doc/gpaddmirrors_help
@@ -14,7 +14,8 @@ gpaddmirrors [-p <port_offset>] [-m <datadir_config_file> [-a]] [-s]
              [-l <logfile_directory>] [-v]
 
 gpaddmirrors -i <mirror_config_file> [-s] [-a] 
-             [-d <coordinator_data_directory>] [-B <parallel_processes>] 
+             [-d <coordinator_data_directory>]
+             [-B <batch_size>] [-b <segment_batch_size>]
              [-l <logfile_directory>] [-v]
 
 gpaddmirrors -o <output_sample_mirror_config> [-m <datadir_config_file>]
@@ -102,11 +103,19 @@ OPTIONS
  a configuration file with either -m or -i if this option is used.
 
 
--B <parallel_processes>
+-B <batch_size>
 
- The number of mirror setup processes to start in parallel. If 
- not specified, the utility will start up to 10 parallel processes 
- depending on how many mirror segment instances it needs to set up.
+The number of hosts to work on in parallel. If not specified, the
+utility will start working on up to 16 hosts in parallel.
+Valid values: 1-64
+
+
+-b <segment_batch_size>
+
+The number of segments per host to work on in parallel. If not
+specified, the utility will start working on up to 64 segments
+in parallel on each host it is working on.
+Valid values: 1-128
 
 
 -d <coordinator_data_directory>

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -9,7 +9,8 @@ Synopsis
 
 gprecoverseg [-p <new_recover_host>[,...]]
              |-i <recover_config_file> 
-             [-d <coordinator_data_directory>] [-B <parallel_processes>] 
+             [-d <coordinator_data_directory>]
+             [-B <batch_size>] [-b <segment_batch_size>]
              [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
 
 
@@ -109,11 +110,19 @@ OPTIONS
 Do not prompt the user for confirmation.
 
 
--B parallel_processes
+-B batch_size
 
-The number of segments to recover in parallel. If not specified, 
-the utility will start up to 16 parallel processes depending 
-on how many segment instances it needs to recover.
+The number of hosts to work on in parallel. If not specified,
+the utility will start working on up to 16 hosts in parallel.
+Valid values: 1-64
+
+
+-b segment_batch_size
+
+The number of segments per host to work on in parallel. If not
+specified, the utility will start recovering up to 64 segments
+in parallel on each host it is working on.
+Valid values: 1-128
 
 
 -d coordinator_data_directory


### PR DESCRIPTION
gprecoverseg and gpaddmirrors have changed behavior for -B/-b options.
This commit is to edit the help files to show that change.

gpmovemirrors/gprecoverseg changes: 695a73aa19, 25e463d7ae, 26e8a0bf6c, cb55a7e567
gpaddmirrors changes: 3a4067395d