### PR TITLE
6X: Coerce unknown-type literals to type cstring, but hide it

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -1411,8 +1411,8 @@ check_views_with_fabricated_unknown_casts()
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
 		pg_fatal("Your installation contains views having unknown\n"
-				 "casts. Drop the view or recreate the view with explicit \n"
-				 "unknown::text type casts before running the upgrade. Alternatively, drop the view \n"
+				 "casts. Drop the view or recreate the view without explicit \n"
+				 "unknown::cstring type casts before running the upgrade. Alternatively, drop the view \n"
 				 "before the upgrade and recreate the view after the upgrade. \n"
 				 "A list of views is in the file:\n"
 				 "\t%s\n\n", output_path);

--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -1412,8 +1412,7 @@ check_views_with_fabricated_unknown_casts()
 		pg_log(PG_REPORT, "fatal\n");
 		pg_fatal("Your installation contains views having unknown\n"
 				 "casts. Drop the view or recreate the view without explicit \n"
-				 "unknown::cstring type casts before running the upgrade. Alternatively, drop the view \n"
-				 "before the upgrade and recreate the view after the upgrade. \n"
+				 "unknown::cstring type casts before running the upgrade.\n"
 				 "A list of views is in the file:\n"
 				 "\t%s\n\n", output_path);
 	}

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -384,11 +384,11 @@ check_node_unknown_walker(Node *node, void *context)
 	{
 		FuncExpr *fe = (FuncExpr *) node;
 		/*
-		 * Check to see if the FuncExpr has an unknown::cstring cast.
+		 * Check to see if the FuncExpr has an unknown::cstring explicit cast.
 		 *
 		 * If it has no such cast yet, check its arguments.
 		 */
-		if ((fe->funcresulttype != CSTRINGOID) || !fe->args || (list_length(fe->args) != 1))
+		if ((fe->funcresulttype != CSTRINGOID) || !fe->args || (list_length(fe->args) != 1) || (fe->funcformat == COERCE_IMPLICIT_CAST))
 			return expression_tree_walker(node, check_node_unknown_walker, context);
 
 		Node *head = lfirst(((List *)fe->args)->head);

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -434,8 +434,14 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(outfunc));
 			Insist(OidIsValid(infunc));
 
-			/* do unknownout(Var) */
-			/* set it as an implicit cast to hide this Greenplum hack */
+			/*
+			 * do unknownout(Var)
+			 *
+			 * always supplying COERCE_IMPLICIT_CAST here, set it as an
+			 * implicit cast to hide this Greenplum hack, because the explicit
+			 * cast would be dumped but not able to be loaded, for like a cast
+			 * unknown::cstring::date
+			 */
 			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node),
 							  InvalidOid, InvalidOid, COERCE_IMPLICIT_CAST);
 			fe->location = location;

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -435,8 +435,9 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(infunc));
 
 			/* do unknownout(Var) */
-			fe = makeFuncExpr(outfunc, TEXTOID, list_make1(node),
-							  InvalidOid, InvalidOid, cformat);
+			/* set it as an implicit cast to hide this Greenplum hack */
+			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node),
+							  InvalidOid, InvalidOid, COERCE_IMPLICIT_CAST);
 			fe->location = location;
 
 			if (location >= 0 &&

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -136,7 +136,10 @@ SELECT pg_get_viewdef('view_with_array_op_expr');
   SELECT ('{1}'::integer[] = '{2}'::integer[]);
 (1 row)
 
--- Coerce unknown-type literals to type text
+-- Coerce unknown-type literals to type cstring implicitly
+-- we are checking to see if a cstring explicit cast is not erroneously
+-- generated when the view is created, a explicit one could not be
+-- loaded/created because it's against the Postgres policy.
 CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 WARNING:  column "field_unknown" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -147,7 +147,7 @@ CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 ---------------+------+-----------+---------+-------------
  field_unknown | date |           | plain   | 
 View definition:
- SELECT unknown_v1.field_unknown::text::date AS field_unknown
+ SELECT unknown_v1.field_unknown::date AS field_unknown
    FROM unknown_v1;
 
 SELECT * FROM unknown_v2;

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -159,5 +159,11 @@ SELECT * FROM unknown_v2;
  12-13-2020
 (1 row)
 
-DROP VIEW unknown_v2;
-DROP VIEW unknown_v1;
+-- Check unknown type data not parsed as other layouts
+CREATE TABLE ut1(c1 character varying(20), c2 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE VIEW uv1 AS SELECT 'test', c1 FROM ut1;
+WARNING:  column "?column?" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+INSERT INTO ut1 SELECT * FROM uv1;

--- a/src/test/regress/expected/gp_types.out
+++ b/src/test/regress/expected/gp_types.out
@@ -304,3 +304,13 @@ SELECT * FROM dml_timestamptz ORDER BY 1;
  4714-01-27 00:00:00-08
 (1 row)
 
+-- test unknown type casting
+with unknown as (
+        select '2021' as foo
+)
+select foo from unknown where foo = 2021.0;
+ foo  
+------
+ 2021
+(1 row)
+

--- a/src/test/regress/expected/gp_types.out
+++ b/src/test/regress/expected/gp_types.out
@@ -304,7 +304,7 @@ SELECT * FROM dml_timestamptz ORDER BY 1;
  4714-01-27 00:00:00-08
 (1 row)
 
--- test unknown type casting
+-- test unknown type implicit casting
 with unknown as (
         select '2021' as foo
 )

--- a/src/test/regress/expected/gp_types_optimizer.out
+++ b/src/test/regress/expected/gp_types_optimizer.out
@@ -304,3 +304,13 @@ SELECT * FROM dml_timestamptz ORDER BY 1;
  4714-01-27 00:00:00-08
 (1 row)
 
+-- test unknown type casting
+with unknown as (
+        select '2021' as foo
+)
+select foo from unknown where foo = 2021.0;
+ foo  
+------
+ 2021
+(1 row)
+

--- a/src/test/regress/expected/gp_types_optimizer.out
+++ b/src/test/regress/expected/gp_types_optimizer.out
@@ -304,7 +304,7 @@ SELECT * FROM dml_timestamptz ORDER BY 1;
  4714-01-27 00:00:00-08
 (1 row)
 
--- test unknown type casting
+-- test unknown type implicit casting
 with unknown as (
         select '2021' as foo
 )

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -527,6 +527,41 @@ DETAIL:  drop cascades to materialized view mvtest_mv_v
 drop cascades to materialized view mvtest_mv_v_2
 drop cascades to materialized view mvtest_mv_v_3
 drop cascades to materialized view mvtest_mv_v_4
+-- Check that unknown literals are converted to "text" in CREATE MATVIEW,
+-- so that we don't end up with unknown-type columns.
+CREATE MATERIALIZED VIEW mv_unspecified_types AS
+  SELECT 42 as i, 42.5 as num, 'foo' as u, 'foo'::unknown as u2, null as n;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WARNING:  column "u" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+WARNING:  column "u2" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+WARNING:  column "n" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+\d+ mv_unspecified_types
+           Materialized view "public.mv_unspecified_types"
+ Column |  Type   | Modifiers | Storage | Stats target | Description 
+--------+---------+-----------+---------+--------------+-------------
+ i      | integer |           | plain   |              | 
+ num    | numeric |           | main    |              | 
+ u      | unknown |           | plain   |              | 
+ u2     | unknown |           | plain   |              | 
+ n      | unknown |           | plain   |              | 
+View definition:
+ SELECT 42 AS i,
+    42.5 AS num,
+    'foo' AS u,
+    'foo' AS u2,
+    NULL::unknown AS n;
+Distributed by: (i)
+
+SELECT * FROM mv_unspecified_types;
+ i  | num  |  u  | u2  | n 
+----+------+-----+-----+---
+ 42 | 42.5 | foo | foo | 
+(1 row)
+
 -- make sure that create WITH NO DATA does not plan the query (bug #13907)
 create materialized view mvtest_error as select 1/0 as x;  -- fail
 ERROR:  division by zero

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -529,6 +529,40 @@ DETAIL:  drop cascades to materialized view mvtest_mv_v
 drop cascades to materialized view mvtest_mv_v_2
 drop cascades to materialized view mvtest_mv_v_3
 drop cascades to materialized view mvtest_mv_v_4
+-- Check that unknown literals are converted to "text" in CREATE MATVIEW,
+-- so that we don't end up with unknown-type columns.
+CREATE MATERIALIZED VIEW mv_unspecified_types AS
+  SELECT 42 as i, 42.5 as num, 'foo' as u, 'foo'::unknown as u2, null as n;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+WARNING:  column "u" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+WARNING:  column "u2" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+WARNING:  column "n" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+\d+ mv_unspecified_types
+           Materialized view "public.mv_unspecified_types"
+ Column |  Type   | Modifiers | Storage | Stats target | Description 
+--------+---------+-----------+---------+--------------+-------------
+ i      | integer |           | plain   |              | 
+ num    | numeric |           | main    |              | 
+ u      | unknown |           | plain   |              | 
+ u2     | unknown |           | plain   |              | 
+ n      | unknown |           | plain   |              | 
+View definition:
+ SELECT 42 AS i,
+    42.5 AS num,
+    'foo' AS u,
+    'foo' AS u2,
+    NULL::unknown AS n;
+Distributed randomly
+
+SELECT * FROM mv_unspecified_types;
+ i  | num  |  u  | u2  | n 
+----+------+-----+-----+---
+ 42 | 42.5 | foo | foo | 
+(1 row)
+
 -- make sure that create WITH NO DATA does not plan the query (bug #13907)
 create materialized view mvtest_error as select 1/0 as x;  -- fail
 ERROR:  division by zero

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -196,6 +196,39 @@ SELECT '' AS five, f1 AS "Correlated Field"
       |                3
 (5 rows)
 
+-- Unspecified-type literals in output columns should resolve as text
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1;
+ f1  | pg_typeof 
+-----+-----------
+ foo | text
+ foo | text
+ foo | text
+(3 rows)
+
+-- ... unless there's context to suggest differently
+explain verbose select '42' union all select '43';
+                   QUERY PLAN                   
+------------------------------------------------
+ Append  (cost=0.00..0.04 rows=1 width=32)
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         Output: '42'::text
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         Output: '43'::text
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain verbose select '42' union all select 43;
+                   QUERY PLAN                   
+------------------------------------------------
+ Append  (cost=0.00..0.04 rows=1 width=4)
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         Output: 42
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         Output: 43
+ Optimizer: Postgres query optimizer
+(6 rows)
+
 --
 -- Use some existing tables in the regression test
 --

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -196,6 +196,49 @@ SELECT '' AS five, f1 AS "Correlated Field"
       |                3
 (5 rows)
 
+-- Unspecified-type literals in output columns should resolve as text
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1;
+ f1  | pg_typeof 
+-----+-----------
+ foo | text
+ foo | text
+ foo | text
+(3 rows)
+
+-- ... unless there's context to suggest differently
+explain verbose select '42' union all select '43';
+                      QUERY PLAN                      
+------------------------------------------------------
+ Append  (cost=0.00..0.00 rows=1 width=8)
+   ->  Result  (cost=0.00..0.00 rows=1 width=8)
+         Output: '42'::text
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               Output: true
+   ->  Result  (cost=0.00..0.00 rows=1 width=8)
+         Output: '43'::text
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(11 rows)
+
+explain verbose select '42' union all select 43;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Append  (cost=0.00..0.00 rows=1 width=4)
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         Output: 42
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               Output: true
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         Output: 43
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(11 rows)
+
 --
 -- Use some existing tables in the regression test
 --

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -155,6 +155,18 @@ SELECT n, n IS OF (text) as is_text FROM t;
  foo bar bar bar bar bar | t
 (6 rows)
 
+-- In a perfect world, this would work and resolve the literal as int ...
+-- but for now, we have to be content with resolving to text too soon.
+WITH RECURSIVE t(n) AS (
+    SELECT '7'
+UNION ALL
+    SELECT n+1 FROM t WHERE n < 10
+)
+SELECT n, n IS OF (int) AS is_int FROM t;
+ERROR:  operator does not exist: text + integer
+LINE 4:     SELECT n+1 FROM t WHERE n < 10
+                    ^
+HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 --
 -- Some examples with a tree
 --

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -80,7 +80,10 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
 SELECT pg_get_viewdef('view_with_array_op_expr');
 
--- Coerce unknown-type literals to type text
+-- Coerce unknown-type literals to type cstring implicitly
+-- we are checking to see if a cstring explicit cast is not erroneously
+-- generated when the view is created, a explicit one could not be
+-- loaded/created because it's against the Postgres policy.
 CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 \d+ unknown_v2

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -88,5 +88,8 @@ CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 \d+ unknown_v2
 SELECT * FROM unknown_v2;
-DROP VIEW unknown_v2;
-DROP VIEW unknown_v1;
+
+-- Check unknown type data not parsed as other layouts
+CREATE TABLE ut1(c1 character varying(20), c2 text);
+CREATE VIEW uv1 AS SELECT 'test', c1 FROM ut1;
+INSERT INTO ut1 SELECT * FROM uv1;

--- a/src/test/regress/sql/gp_types.sql
+++ b/src/test/regress/sql/gp_types.sql
@@ -126,3 +126,9 @@ INSERT INTO dml_timestamptz VALUES ('4714-01-27 BC'::timestamptz);
 SELECT * FROM dml_timestamptz ORDER BY 1;
 UPDATE dml_timestamptz SET a = '4714-01-27 BC'::timestamptz;
 SELECT * FROM dml_timestamptz ORDER BY 1;
+
+-- test unknown type casting
+with unknown as (
+        select '2021' as foo
+)
+select foo from unknown where foo = 2021.0;

--- a/src/test/regress/sql/gp_types.sql
+++ b/src/test/regress/sql/gp_types.sql
@@ -127,7 +127,7 @@ SELECT * FROM dml_timestamptz ORDER BY 1;
 UPDATE dml_timestamptz SET a = '4714-01-27 BC'::timestamptz;
 SELECT * FROM dml_timestamptz ORDER BY 1;
 
--- test unknown type casting
+-- test unknown type implicit casting
 with unknown as (
         select '2021' as foo
 )

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -185,6 +185,13 @@ SELECT * FROM mvtest_mv_v_3;
 SELECT * FROM mvtest_mv_v_4;
 DROP TABLE mvtest_v CASCADE;
 
+-- Check that unknown literals are converted to "text" in CREATE MATVIEW,
+-- so that we don't end up with unknown-type columns.
+CREATE MATERIALIZED VIEW mv_unspecified_types AS
+  SELECT 42 as i, 42.5 as num, 'foo' as u, 'foo'::unknown as u2, null as n;
+\d+ mv_unspecified_types
+SELECT * FROM mv_unspecified_types;
+
 -- make sure that create WITH NO DATA does not plan the query (bug #13907)
 create materialized view mvtest_error as select 1/0 as x;  -- fail
 create materialized view mvtest_error as select 1/0 as x with no data;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -80,6 +80,16 @@ SELECT '' AS five, f1 AS "Correlated Field"
   WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
                      WHERE f3 IS NOT NULL);
 
+-- Unspecified-type literals in output columns should resolve as text
+
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1;
+
+-- ... unless there's context to suggest differently
+
+explain verbose select '42' union all select '43';
+explain verbose select '42' union all select 43;
+
 --
 -- Use some existing tables in the regression test
 --

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -82,6 +82,15 @@ UNION ALL
 )
 SELECT n, n IS OF (text) as is_text FROM t;
 
+-- In a perfect world, this would work and resolve the literal as int ...
+-- but for now, we have to be content with resolving to text too soon.
+WITH RECURSIVE t(n) AS (
+    SELECT '7'
+UNION ALL
+    SELECT n+1 FROM t WHERE n < 10
+)
+SELECT n, n IS OF (int) AS is_int FROM t;
+
 --
 -- Some examples with a tree
 --


### PR DESCRIPTION
Commit 951f817e9b4 "Coerce unknown-type literals to type text instead of
cstring" has an issue that it processed outfunc and infunc directly,
which made Greenplum have no chance to do an unknown-to-text-to-cstring
cast. It errors out, even panics, in some cases since the data type
don't match.

The better solution is still coercing unknown-type literals to type
cstring, but hiding it. Check out the test case to see what it fixes.