### PR TITLE
5X: Coerce unknown-type literals to type cstring, but hide it

### DIFF
--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -774,11 +774,11 @@ check_node_unknown_walker(Node *node, void *context)
 	{
 		FuncExpr *fe = (FuncExpr *) node;
 		/*
-		 * Check to see if the FuncExpr has an unknown::cstring cast.
+		 * Check to see if the FuncExpr has an unknown::cstring explicit cast.
 		 *
 		 * If it has no such cast yet, check its arguments.
 		 */
-		if ((fe->funcresulttype != CSTRINGOID) || !fe->args || (list_length(fe->args) != 1))
+		if ((fe->funcresulttype != CSTRINGOID) || !fe->args || (list_length(fe->args) != 1) || (fe->funcformat == COERCE_IMPLICIT_CAST))
 			return expression_tree_walker(node, check_node_unknown_walker, context);
 
 		Node *head = lfirst(((List *)fe->args)->head);

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -386,8 +386,14 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(outfunc));
 			Insist(OidIsValid(infunc));
 
-			/* do unknownout(Var) */
-			/* set it as an implicit cast to hide this Greenplum hack */
+			/*
+			 * do unknownout(Var)
+			 *
+			 * always supplying COERCE_IMPLICIT_CAST here, set it as an
+			 * implicit cast to hide this Greenplum hack, because the explicit
+			 * cast would be dumped but not able to be loaded, for like a cast
+			 * unknown::cstring::date
+			 */
 			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node), COERCE_IMPLICIT_CAST);
 			fe->location = location;
 

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -387,7 +387,8 @@ coerce_type(ParseState *pstate, Node *node,
 			Insist(OidIsValid(infunc));
 
 			/* do unknownout(Var) */
-			fe = makeFuncExpr(outfunc, TEXTOID, list_make1(node), cformat);
+			/* set it as an implicit cast to hide this Greenplum hack */
+			fe = makeFuncExpr(outfunc, CSTRINGOID, list_make1(node), COERCE_IMPLICIT_CAST);
 			fe->location = location;
 
 			if (location >= 0 &&

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -147,5 +147,3 @@ SELECT * FROM unknown_v2;
  12-13-2020
 (1 row)
 
-DROP VIEW unknown_v2;
-DROP VIEW unknown_v1;

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -147,3 +147,11 @@ SELECT * FROM unknown_v2;
  12-13-2020
 (1 row)
 
+-- Check unknown type data not parsed as other layouts
+CREATE TABLE ut1(c1 character varying(20), c2 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE VIEW uv1 AS SELECT 'test', c1 FROM ut1;
+WARNING:  column "?column?" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+INSERT INTO ut1 SELECT * FROM uv1;

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -135,7 +135,7 @@ CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 ---------------+------+-----------+---------+-------------
  field_unknown | date |           | plain   | 
 View definition:
- SELECT unknown_v1.field_unknown::text::date AS field_unknown
+ SELECT unknown_v1.field_unknown::date AS field_unknown
    FROM unknown_v1;
 
 SELECT * FROM unknown_v2;

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -124,7 +124,10 @@ SELECT pg_get_viewdef('view_with_array_op_expr');
  SELECT ('{1}'::integer[] = '{2}'::integer[]);
 (1 row)
 
--- Coerce unknown-type literals to type text
+-- Coerce unknown-type literals to type cstring implicitly
+-- we are checking to see if a cstring explicit cast is not erroneously
+-- generated when the view is created, a explicit one could not be
+-- loaded/created because it's against the Postgres policy.
 CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 WARNING:  column "field_unknown" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -198,6 +198,30 @@ SELECT '' AS five, f1 AS "Correlated Field"
       |                3
 (5 rows)
 
+-- Unspecified-type literals in output columns should resolve as text
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1;
+ f1  | pg_typeof 
+-----+-----------
+ foo | text
+ foo | text
+ foo | text
+(3 rows)
+
+select '42' union all select '43';
+ ?column? 
+----------
+ 42
+ 43
+(2 rows)
+
+select '42' union all select 43;
+ ?column? 
+----------
+       42
+       43
+(2 rows)
+
 --
 -- Use some existing tables in the regression test
 --

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -198,6 +198,30 @@ SELECT '' AS five, f1 AS "Correlated Field"
       |                3
 (5 rows)
 
+-- Unspecified-type literals in output columns should resolve as text
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1;
+ f1  | pg_typeof 
+-----+-----------
+ foo | text
+ foo | text
+ foo | text
+(3 rows)
+
+select '42' union all select '43';
+ ?column? 
+----------
+ 42
+ 43
+(2 rows)
+
+select '42' union all select 43;
+ ?column? 
+----------
+       42
+       43
+(2 rows)
+
 --
 -- Use some existing tables in the regression test
 --

--- a/src/test/regress/expected/text.out
+++ b/src/test/regress/expected/text.out
@@ -79,7 +79,7 @@ SELECT '(1,abc)'::text::usr_define_type;
  (1,abc)
 (1 row)
 
--- test unknown type casting
+-- test unknown type implicit casting
 with unknown as (
         select '2021' as foo
 )

--- a/src/test/regress/expected/text.out
+++ b/src/test/regress/expected/text.out
@@ -79,3 +79,13 @@ SELECT '(1,abc)'::text::usr_define_type;
  (1,abc)
 (1 row)
 
+-- test unknown type casting
+with unknown as (
+        select '2021' as foo
+)
+select foo from unknown where foo = 2021.0;
+ foo
+------
+ 2021
+(1 row)
+

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -93,6 +93,18 @@ SELECT n, n IS OF (text) as is_text FROM t;
  foo bar bar bar bar bar | t
 (6 rows)
 
+-- In a perfect world, this would work and resolve the literal as int ...
+-- but for now, we have to be content with resolving to text too soon.
+WITH RECURSIVE t(n) AS (
+    SELECT '7'
+UNION ALL
+    SELECT n+1 FROM t WHERE n < 10
+)
+SELECT n, n IS OF (int) AS is_int FROM t;
+ERROR:  operator does not exist: text + integer
+LINE 4:     SELECT n+1 FROM t WHERE n < 10
+                    ^
+HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 --
 -- Some examples with a tree
 --

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -77,5 +77,3 @@ CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 \d+ unknown_v2
 SELECT * FROM unknown_v2;
-DROP VIEW unknown_v2;
-DROP VIEW unknown_v1;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -77,3 +77,8 @@ CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 \d+ unknown_v2
 SELECT * FROM unknown_v2;
+
+-- Check unknown type data not parsed as other layouts
+CREATE TABLE ut1(c1 character varying(20), c2 text);
+CREATE VIEW uv1 AS SELECT 'test', c1 FROM ut1;
+INSERT INTO ut1 SELECT * FROM uv1;

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -69,7 +69,10 @@ DROP SCHEMA "schema_view\'.gp_dist_random" CASCADE;
 CREATE TEMP VIEW view_with_array_op_expr AS SELECT '{1}'::int[] = '{2}'::int[];
 SELECT pg_get_viewdef('view_with_array_op_expr');
 
--- Coerce unknown-type literals to type text
+-- Coerce unknown-type literals to type cstring implicitly
+-- we are checking to see if a cstring explicit cast is not erroneously
+-- generated when the view is created, a explicit one could not be
+-- loaded/created because it's against the Postgres policy.
 CREATE VIEW unknown_v1 AS SELECT '2020-12-13'::unknown AS field_unknown;
 CREATE VIEW unknown_v2 AS SELECT field_unknown::date FROM unknown_v1;
 \d+ unknown_v2

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -80,6 +80,14 @@ SELECT '' AS five, f1 AS "Correlated Field"
   WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
                      WHERE f3 IS NOT NULL) ORDER BY 2;
 
+-- Unspecified-type literals in output columns should resolve as text
+
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1;
+
+select '42' union all select '43';
+select '42' union all select 43;
+
 --
 -- Use some existing tables in the regression test
 --

--- a/src/test/regress/sql/text.sql
+++ b/src/test/regress/sql/text.sql
@@ -38,3 +38,9 @@ SELECT '{1,2}'::text::integer[];
 
 CREATE TYPE usr_define_type as (id int, name text);
 SELECT '(1,abc)'::text::usr_define_type;
+
+-- test unknown type casting
+with unknown as (
+        select '2021' as foo
+)
+select foo from unknown where foo = 2021.0;

--- a/src/test/regress/sql/text.sql
+++ b/src/test/regress/sql/text.sql
@@ -39,7 +39,7 @@ SELECT '{1,2}'::text::integer[];
 CREATE TYPE usr_define_type as (id int, name text);
 SELECT '(1,abc)'::text::usr_define_type;
 
--- test unknown type casting
+-- test unknown type implicit casting
 with unknown as (
         select '2021' as foo
 )

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -54,6 +54,15 @@ UNION ALL
 )
 SELECT n, n IS OF (text) as is_text FROM t;
 
+-- In a perfect world, this would work and resolve the literal as int ...
+-- but for now, we have to be content with resolving to text too soon.
+WITH RECURSIVE t(n) AS (
+    SELECT '7'
+UNION ALL
+    SELECT n+1 FROM t WHERE n < 10
+)
+SELECT n, n IS OF (int) AS is_int FROM t;
+
 --
 -- Some examples with a tree
 --


### PR DESCRIPTION
Commit 0cbadfa0242 "Coerce unknown-type literals to type text instead of
cstring" has an issue that it processed outfunc and infunc directly,
which made Greenplum have no chance to do an unknown-to-text-to-cstring
cast. It errors out, even panics, in some cases since the data type
don't match.

The better solution is still coercing unknown-type literals to type
cstring, but hiding it. Check out the test case to see what it fixes.
