### PR TITLE
(6x) set_append_path_locus should use max numsegments when break loop.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1344,10 +1344,17 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 	ListCell   *l;
 	CdbLocusType targetlocustype;
 	CdbPathLocus targetlocus;
-	int			numsegments;
+	int			 numsegments;
 	List	   *subpaths;
 	List	  **subpaths_out;
 	List	   *new_subpaths;
+
+	/*
+	 * Init max_numsegments to slient compiler.
+	 * This variable is only used when result
+	 * locus is partitioned.
+	 */
+	int			max_numsegments = -1;
 
 	if (IsA(pathnode, AppendPath))
 		subpaths_out = &((AppendPath *) pathnode)->subpaths;
@@ -1374,6 +1381,9 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 	 * figured out later. We treat also all partitioned types the same for now,
 	 * using Strewn to represent them all, and figure out later if we can mark
 	 * it hashed, or if have to leave it strewn.
+	 *
+	 * We will record the max number of segments of each subpath here for later
+	 * use.
 	 */
 	static const struct
 	{
@@ -1437,8 +1447,13 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 		if (l == list_head(subpaths))
 		{
 			targetlocustype = subtype;
+			max_numsegments = CdbPathLocus_NumSegments(subpath->locus);
 			continue;
 		}
+
+		max_numsegments = Max(max_numsegments,
+							  CdbPathLocus_NumSegments(subpath->locus));
+
 		for (i = 0; i < lengthof(append_locus_compatibility_table); i++)
 		{
 			if ((append_locus_compatibility_table[i].a == targetlocustype &&
@@ -1540,10 +1555,11 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 				 * subpaths have different distributed policy, mark it as random
 				 * distributed and set the numsegments to the maximum of all
 				 * subpaths to not missing any tuples.
+				 *
+				 * max_numsegments is computed in the first deduction loop,
+				 * even here we use projectdlocus, the numsegments never change.
 				 */
-				CdbPathLocus_MakeStrewn(&targetlocus,
-										Max(CdbPathLocus_NumSegments(targetlocus),
-											CdbPathLocus_NumSegments(projectedlocus)));
+				CdbPathLocus_MakeStrewn(&targetlocus, max_numsegments);
 				break;
 			}
 		}

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -567,6 +567,127 @@ explain (costs off) select * from t_hashdist cross join (select * from generate_
 (8 rows)
 
 reset optimizer;
+--
+-- Test append different numsegments tables work well
+-- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146
+--
+create table t1_12146 (a int, b int) distributed by (a);
+create table t2_12146 (a int, b int) distributed by (a);
+create table t3_12146 (a int, b int) distributed by (a);
+create table t4_12146 (a int, b int) distributed by (a);
+-- make t1_12146 and t2_12146 to partially-distributed
+set allow_system_table_mods = on;
+update gp_distribution_policy set numsegments = 2
+where localoid in ('t1_12146'::regclass::oid, 't2_12146'::regclass::oid);
+insert into t1_12146 select i,i from generate_series(1, 10000)i;
+insert into t2_12146 select i,i from generate_series(1, 10000)i;
+insert into t3_12146 select i,i from generate_series(1, 10)i;
+insert into t4_12146 select i,i from generate_series(1, 10)i;
+-- now set t1_12146 and t2_12146 randomly distributed;
+update gp_distribution_policy
+set distkey = '', distclass = ''
+where localoid in ('t1_12146'::regclass::oid, 't2_12146'::regclass::oid);
+analyze t1_12146;
+analyze t2_12146;
+analyze t3_12146;
+analyze t4_12146;
+explain select count(*)
+from
+(
+  (
+  -- t1 left join t3 to build broadcast t3 plan
+  -- so that the join's locus is t1's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t1_12146 left join t3_12146 on t1_12146.b = t3_12146.b
+  )
+  union all
+  (
+  -- t2 left join t4 to build broadcast t4 plan
+  -- so that the join's locus is t2's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t2_12146 left join t4_12146 on t2_12146.b = t4_12146.b
+  ) -- the first subplan's locus is not the same
+    -- because strewn locus always not the same
+  union all
+  (
+  -- this will be a full to full redist
+  select
+  *
+  from t3_12146 join t4_12146 on t3_12146.b = t4_12146.a
+  )
+) x;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=60000000988.25..60000000988.26 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=60000000988.19..60000000988.24 rows=1 width=8)
+         ->  Aggregate  (cost=60000000988.19..60000000988.20 rows=1 width=8)
+               ->  Subquery Scan on x  (cost=20000000003.65..60000000938.16 rows=6670 width=0)
+                     ->  Append  (cost=20000000003.65..60000000738.06 rows=6670 width=16)
+                           ->  Hash Left Join  (cost=20000000003.65..20000000265.65 rows=5000 width=16)
+                                 Hash Cond: (t1_12146.b = t3_12146.b)
+                                 ->  Seq Scan on t1_12146  (cost=10000000000.00..10000000112.00 rows=5000 width=8)
+                                 ->  Hash  (cost=10000000003.40..10000000003.40 rows=7 width=8)
+                                       ->  Broadcast Motion 3:2  (slice1; segments: 3)  (cost=10000000000.00..10000000003.40 rows=7 width=8)
+                                             ->  Seq Scan on t3_12146  (cost=10000000000.00..10000000003.10 rows=4 width=8)
+                           ->  Hash Left Join  (cost=20000000003.65..20000000265.65 rows=5000 width=16)
+                                 Hash Cond: (t2_12146.b = t4_12146.b)
+                                 ->  Seq Scan on t2_12146  (cost=10000000000.00..10000000112.00 rows=5000 width=8)
+                                 ->  Hash  (cost=10000000003.40..10000000003.40 rows=7 width=8)
+                                       ->  Broadcast Motion 3:2  (slice2; segments: 3)  (cost=10000000000.00..10000000003.40 rows=7 width=8)
+                                             ->  Seq Scan on t4_12146  (cost=10000000000.00..10000000003.10 rows=4 width=8)
+                           ->  Hash Join  (cost=20000000003.22..20000000006.66 rows=4 width=16)
+                                 Hash Cond: (t3_12146_1.b = t4_12146_1.a)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=10000000000.00..10000000003.30 rows=4 width=8)
+                                       Hash Key: t3_12146_1.b
+                                       ->  Seq Scan on t3_12146 t3_12146_1  (cost=10000000000.00..10000000003.10 rows=4 width=8)
+                                 ->  Hash  (cost=10000000003.10..10000000003.10 rows=4 width=8)
+                                       ->  Seq Scan on t4_12146 t4_12146_1  (cost=10000000000.00..10000000003.10 rows=4 width=8)
+ Optimizer: Postgres query optimizer
+(25 rows)
+
+select count(*)
+from
+(
+  (
+  -- t1 left join t3 to build broadcast t3 plan
+  -- so that the join's locus is t1's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t1_12146 left join t3_12146 on t1_12146.b = t3_12146.b
+  )
+  union all
+  (
+  -- t2 left join t4 to build broadcast t4 plan
+  -- so that the join's locus is t2's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t2_12146 left join t4_12146 on t2_12146.b = t4_12146.b
+  ) -- the first subplan's locus is not the same
+    -- because strewn locus always not the same
+  union all
+  (
+  -- this will be a full to full redist
+  select
+  *
+  from t3_12146 join t4_12146 on t3_12146.b = t4_12146.a
+  )
+) x;
+ count 
+-------
+ 20010
+(1 row)
+
+drop table t1_12146;
+drop table t2_12146;
+drop table t3_12146;
+drop table t4_12146;
+reset allow_system_table_mods;
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -318,6 +318,102 @@ explain (costs off) select * from t_hashdist cross join (select * from generate_
 
 reset optimizer;
 
+--
+-- Test append different numsegments tables work well
+-- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146
+--
+create table t1_12146 (a int, b int) distributed by (a);
+create table t2_12146 (a int, b int) distributed by (a);
+create table t3_12146 (a int, b int) distributed by (a);
+create table t4_12146 (a int, b int) distributed by (a);
+
+-- make t1_12146 and t2_12146 to partially-distributed
+set allow_system_table_mods = on;
+update gp_distribution_policy set numsegments = 2
+where localoid in ('t1_12146'::regclass::oid, 't2_12146'::regclass::oid);
+
+insert into t1_12146 select i,i from generate_series(1, 10000)i;
+insert into t2_12146 select i,i from generate_series(1, 10000)i;
+insert into t3_12146 select i,i from generate_series(1, 10)i;
+insert into t4_12146 select i,i from generate_series(1, 10)i;
+
+-- now set t1_12146 and t2_12146 randomly distributed;
+update gp_distribution_policy
+set distkey = '', distclass = ''
+where localoid in ('t1_12146'::regclass::oid, 't2_12146'::regclass::oid);
+
+analyze t1_12146;
+analyze t2_12146;
+analyze t3_12146;
+analyze t4_12146;
+
+explain select count(*)
+from
+(
+  (
+  -- t1 left join t3 to build broadcast t3 plan
+  -- so that the join's locus is t1's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t1_12146 left join t3_12146 on t1_12146.b = t3_12146.b
+  )
+  union all
+  (
+  -- t2 left join t4 to build broadcast t4 plan
+  -- so that the join's locus is t2's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t2_12146 left join t4_12146 on t2_12146.b = t4_12146.b
+  ) -- the first subplan's locus is not the same
+    -- because strewn locus always not the same
+  union all
+  (
+  -- this will be a full to full redist
+  select
+  *
+  from t3_12146 join t4_12146 on t3_12146.b = t4_12146.a
+  )
+) x;
+
+select count(*)
+from
+(
+  (
+  -- t1 left join t3 to build broadcast t3 plan
+  -- so that the join's locus is t1's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t1_12146 left join t3_12146 on t1_12146.b = t3_12146.b
+  )
+  union all
+  (
+  -- t2 left join t4 to build broadcast t4 plan
+  -- so that the join's locus is t2's locus:
+  -- strewn on 2segs
+  select
+  *
+  from t2_12146 left join t4_12146 on t2_12146.b = t4_12146.b
+  ) -- the first subplan's locus is not the same
+    -- because strewn locus always not the same
+  union all
+  (
+  -- this will be a full to full redist
+  select
+  *
+  from t3_12146 join t4_12146 on t3_12146.b = t4_12146.a
+  )
+) x;
+
+drop table t1_12146;
+drop table t2_12146;
+drop table t3_12146;
+drop table t4_12146;
+
+reset allow_system_table_mods;
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;


### PR DESCRIPTION
The function set_append_path_locus will deduce the append path's
locus in two steps:
  * first, loop all subpaths to deduce the final locus type
  * second, depends on the final locus type, choose next step,
    if final locus type is Strewn, then it will loop each subpaths
    to see if finaly is Strewn or can be Hashed. If any of the
    two subpaths' locus are different, we will set to Strewn with
    numsegments to be the max numsegments of all subpaths.

Previous code break out the loop and just set the numsegments to be
the max of the last two not all. This commit fixes this by recording
max numsegments in the first loop.

Fix Github Issue: https://github.com/greenplum-db/gpdb/issues/12146
