### PR TITLE
Avoid before_read_command fault usage where possible 

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -637,6 +637,12 @@ ReadCommand(StringInfo inBuf)
 {
 	int			result;
 
+	/*
+	 * XXX this fault location is reached in query executing backends as well
+	 * as many non-query executing processes such as FTS probe handler,
+	 * walsender, etc.  If a test intends to target a query executing backend
+	 * process, consider using "exec_simple_query_start" fault.
+	 */
 	SIMPLE_FAULT_INJECTOR("before_read_command");
 
 	if (whereToSendOutput == DestRemote)
@@ -1645,6 +1651,8 @@ exec_simple_query(const char *query_string)
 	bool		was_logged = false;
 	bool		use_implicit_block;
 	char		msec_str[32];
+
+	SIMPLE_FAULT_INJECTOR("exec_simple_query_start");
 
 	if (Gp_role != GP_ROLE_EXECUTE)
 		increment_command_count();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3951,8 +3951,10 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"dtx_phase2_retry_second", PGC_SUSET, GP_ARRAY_TUNING,
-			gettext_noop("Maximum number of timeout during two phase commit after which master PANICs."),
-			NULL,
+			gettext_noop("Maximum time for which coordinator tries to finish a prepared transaction"),
+			gettext_noop("The timer starts if finising a prepared transaction fails."
+						 " Coordinator keeps retrying the finish-prepared operation"
+						 " until this timeout (seconds)."),
 			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_S
 		},
 		&dtx_phase2_retry_second,

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -70,8 +70,8 @@ CHECKPOINT
  
 (1 row)
 
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -79,10 +79,11 @@ CHECKPOINT
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -45,11 +45,18 @@ select pg_reload_conf();
 -- broadcast failed before recovery. Master used to miss sending the
 -- COMMIT PREPARED across restart and instead abort the transaction
 -- after querying in-doubt prepared transactions from segments.
--- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault_infinite 
---------------------------
- Success:                 
+-- Inject fault to fail the COMMIT PREPARED on one segment.
+-- Temporarily disable retry finish prepared in this session, because
+-- we are not interested in testing the retry logic.  This makes it
+-- suffice to trigger the fault only once.  Otherwise, the fault may
+-- continue to trigger even after PANIC on coordinator, impacting
+-- finish prepared operation during crash recovery.
+1: SET dtx_phase2_retry_second = 0;
+SET
+1: SELECT gp_inject_fault('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();  <waiting ...>

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -296,13 +296,13 @@ ALTER
 
 -- trigger master panic and wait until master down before running any new query.
 17&: SELECT wait_till_master_shutsdown();  <waiting ...>
-18: SELECT gp_inject_fault('before_read_command', 'panic', 1);
+18: SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 18: SELECT 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -51,8 +51,8 @@ CHECKPOINT
 -------------------------------
  Success:                      
 (1 row)
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -60,10 +60,11 @@ CHECKPOINT
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -58,7 +58,7 @@ CREATE
  OK     
 (1 row)
 -- trigger master reset
-3: select gp_inject_fault('before_read_command', 'panic', 1);
+3: select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -66,11 +66,11 @@ CREATE
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 3: select 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -27,13 +27,13 @@
 1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'status', 1);
 1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'status', 1);
 
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
 

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -29,8 +29,14 @@ select pg_reload_conf();
 -- broadcast failed before recovery. Master used to miss sending the
 -- COMMIT PREPARED across restart and instead abort the transaction
 -- after querying in-doubt prepared transactions from segments.
--- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid)
+-- Inject fault to fail the COMMIT PREPARED on one segment.
+-- Temporarily disable retry finish prepared in this session, because
+-- we are not interested in testing the retry logic.  This makes it
+-- suffice to trigger the fault only once.  Otherwise, the fault may
+-- continue to trigger even after PANIC on coordinator, impacting
+-- finish prepared operation during crash recovery.
+1: SET dtx_phase2_retry_second = 0;
+1: SELECT gp_inject_fault('finish_prepared_start_of_function', 'error', dbid)
    from gp_segment_configuration where content=0 and role='p';
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -149,7 +149,7 @@ select pg_reload_conf();
 
 -- trigger master panic and wait until master down before running any new query.
 17&: SELECT wait_till_master_shutsdown();
-18: SELECT gp_inject_fault('before_read_command', 'panic', 1);
+18: SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 18: SELECT 1;
 16<:
 17<:

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -18,13 +18,13 @@
 
 -- wait till insert reaches intended point
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
 

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -27,12 +27,12 @@
 -- stop mirror
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=0 AND role = 'm';
 -- trigger master reset
-3: select gp_inject_fault('before_read_command', 'panic', 1);
+3: select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 3: select 1;
 


### PR DESCRIPTION
The `before_read_command` fault location is executed by not only regular backends but also special backends such as FTS probe backends, fault injection backends, walsender, etc.  Several tests made use of this fault to cause PANIC in QD, after executing a command.  This strategy caused intermittent failures in CI because the fault would trigger unexpectedly from other backends listed above.  This patch defines a new fault in `exec_simple_query()` that is guaranteed to be triggered
only by query executing backends.  This should resolve some of the intermittent failures in CI.

To be back-ported to 6X_STABLE.

Note: this confines the usage of `before_read_command` fault to only one test, that is `query_finish_pending`.  I was not able to refactor the test so as to avoid this usage.  Let's leave that one for another patch.