### PR TITLE
Migrate qp-gpdbdev image to GCR

### DIFF
--- a/concourse/tasks/build_with_orca.yml
+++ b/concourse/tasks/build_with_orca.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: pivotaldata/qp-gpdbdev
+    repository: gcr.io/data-orca/qp-gpdbdev
 inputs:
   - name: bin_orca
   - name: bin_xerces

--- a/concourse/tasks/diff_explain_results_with_baseline.yml
+++ b/concourse/tasks/diff_explain_results_with_baseline.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: pivotaldata/qp-gpdbdev
+    repository: gcr.io/data-orca/qp-gpdbdev
 inputs:
   - name: gpdb_main_src
   - name: explain_output

--- a/concourse/tasks/test_icg.yml
+++ b/concourse/tasks/test_icg.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: pivotaldata/qp-gpdbdev
+    repository: gcr.io/data-orca/qp-gpdbdev
 inputs:
   - name: gpdb_src
   - name: bin_orca

--- a/concourse/tasks/untar_build_with_orca.yml
+++ b/concourse/tasks/untar_build_with_orca.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: pivotaldata/qp-gpdbdev
+    repository: gcr.io/data-orca/qp-gpdbdev
 inputs:
   - name: gporca-commits-to-test
   - name: bin_orca


### PR DESCRIPTION
Pushed image to gcr.io/data-orca/qp-gpdbdev:latest.

    $ gcloud container images list --repository gcr.io/data-orca
    NAME
    gcr.io/data-orca/qp-gpdbdev

This commit updates the corresponding pipeline references.
