### PR TITLE
Fix gpload with header and reuse_tables bug.

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2133,9 +2133,15 @@ class gpload:
         for i, l in enumerate(self.locations):
             sql += " and pgext.urilocation[%s] = %s\n" % (i + 1, quote(l))
 
-        sql+= """and pgext.fmttype = %s
-                 and pgext.writable = false
-                 and pgext.fmtopts like %s """ % (quote('b') if formatType == 'custom' else quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip()) +"%"))
+        if formatType != 'custom':
+            sql+= """and pgext.fmttype = %s
+                     and pgext.writable = false
+                     and pgext.fmtopts like %s """ % (quote(formatType[0]), quote("%" + quote_unident(formatOpts.rstrip())))
+        # Custom formatter option ends with space ' '
+        else:
+            sql+= """and pgext.fmttype = %s
+                     and pgext.writable = false
+                     and pgext.fmtopts like %s """ % (quote('b'), quote("%" + quote_unident(formatOpts)))
 
         if limitStr:
             sql += "and pgext.rejectlimit = %s " % limitStr
@@ -2215,9 +2221,14 @@ class gpload:
         for i, l in enumerate(self.locations):
             sql += " and pgext.urilocation[%s] = %s\n" % (i + 1, quote(l))
 
-        sql+= """and pgext.fmttype = %s
-                 and pgext.writable = false
-                 and pgext.fmtopts like %s """ % (quote('b') if formatType == 'custom' else quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip()) +"%"))
+        if formatType != 'custom':
+            sql+= """and pgext.fmttype = %s
+                     and pgext.writable = false
+                     and pgext.fmtopts like %s """ % (quote(formatType[0]), quote("%" + quote_unident(formatOpts.rstrip())))
+        else:
+            sql+= """and pgext.fmttype = %s
+                     and pgext.writable = false
+                     and pgext.fmtopts like %s """ % (quote('b'), quote("%" + quote_unident(formatOpts)))
 
         if limitStr:
             sql += "and pgext.rejectlimit = %s " % limitStr

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_47.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_47.txt
@@ -1,0 +1,2 @@
+1,"row 1 - OK",file1
+2,"row 2 - OK",file1

--- a/gpMgmt/bin/gpload_test/gpload2/query47.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query47.ans
@@ -1,0 +1,18 @@
+2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
+2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_752a62e8_cda5_11eb_9402_000c29b81d26
+2021-06-15 14:46:48|INFO|running time: 0.08 seconds
+2021-06-15 14:46:48|INFO|rows Inserted          = 1
+2021-06-15 14:46:48|INFO|rows Updated           = 0
+2021-06-15 14:46:48|INFO|data formatting errors = 0
+2021-06-15 14:46:48|INFO|gpload succeeded
+2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
+2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7545772c_cda5_11eb_81e2_000c29b81d26
+2021-06-15 14:46:48|INFO|running time: 0.05 seconds
+2021-06-15 14:46:48|INFO|rows Inserted          = 2
+2021-06-15 14:46:48|INFO|rows Updated           = 0
+2021-06-15 14:46:48|INFO|data formatting errors = 0
+2021-06-15 14:46:48|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -23,6 +23,9 @@ DROP TABLE
 DROP TABLE IF EXISTS testSpecialChar;
 NOTICE:  table "testspecialchar" does not exist, skipping
 DROP TABLE
+DROP TABLE IF EXISTS testheaderreuse;
+NOTICE:  table "testheaderreuse" does not exist, skipping
+DROP TABLE
 reset client_min_messages;
 RESET
 CREATE TABLE texttable (
@@ -44,4 +47,9 @@ CREATE TABLE test.csvtable (
             DISTRIBUTED BY (year);
 CREATE TABLE
 create table testSpecialChar("Field1" bigint, "Field#2" text) distributed by ("Field1");
+CREATE TABLE
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;
 CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -12,6 +12,7 @@ DROP TABLE IF EXISTS csvtable;
 DROP TABLE IF EXISTS texttable1;
 DROP TABLE IF EXISTS test.csvtable;
 DROP TABLE IF EXISTS testSpecialChar;
+DROP TABLE IF EXISTS testheaderreuse;
 reset client_min_messages;
 CREATE TABLE texttable (
             s1 text, s2 text, s3 text, dt timestamp,
@@ -28,3 +29,7 @@ CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);
 create table testSpecialChar("Field1" bigint, "Field#2" text) distributed by ("Field1");
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;


### PR DESCRIPTION
If gpload loads one file with 'REUSE_TABLES' and 'HEADER' for the first time. Then loads another file with 'REUSE_TABLES' and without 'HEADER', the second loading will reuse the first external table which make the second loading miss the first line.

The reuse table procedure tries to get the existing external table and
compare the format option strings with sql 'like "%fmtopts%'. If the result
returns at least one table, it will reuse the existing external table. The
problem here is that format options are constructed in this order:
delimiter-> null -> escape -> quote(csv) -> [header] -> [fill_missing_field]
->[force_not_null] ->[force-quote] -> [newline]. The options in the square
brackets are optional, so the compare sql will not end with '%'.

This pr fix the incorrect reuse table by removing the last '%' from the sql
'like %formats%'.

So the format option "delimiter '|' null 'null' escape '\' header " will not
be matched with this new option "delimiter '|' null 'null' escape '\'".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
