### PR TITLE
Fix an assert failure caused by unwanted motion node

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6845,9 +6845,10 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				all_subplans_replicated = false;
 
 				/* Master-only table */
-				if (subplan->flow->flotype == FLOW_PARTITIONED ||
-					subplan->flow->flotype == FLOW_REPLICATED ||
-					(subplan->flow->flotype == FLOW_SINGLETON && subplan->flow->segindex != -1))
+				if (subplan->flow->locustype != CdbLocusType_General &&
+					(subplan->flow->flotype == FLOW_PARTITIONED ||
+					 subplan->flow->flotype == FLOW_REPLICATED ||
+					 (subplan->flow->flotype == FLOW_SINGLETON && subplan->flow->segindex != -1)))
 				{
 					/*
 					 * target table is master-only but flow is


### PR DESCRIPTION
This commit fixes issue #12161.
The generated plan is
```
                                                                       QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on sql_languages  (cost=0.66..0.67 rows=1 width=0)
   InitPlan 1 (returns $0)  (slice6)
     ->  Limit  (cost=0.58..0.66 rows=1 width=8)
           ->  Subquery Scan on gp_stat_replication  (cost=0.25..82.75 rows=1010 width=8)
                 ->  Append  (cost=0.25..72.65 rows=1010 width=320)
                       ->  Function Scan on gp_stat_get_master_replication r  (cost=0.25..12.75 rows=1000 width=288)
                       ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=15.75..49.90 rows=10 width=320)
                             ->  Hash Right Join  (cost=15.75..49.60 rows=4 width=320)
                                   Hash Cond: (r_1.gp_segment_id = e.gp_segment_id)
                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.25..30.25 rows=334 width=288)
                                         Hash Key: r_1.gp_segment_id
                                         ->  Function Scan on gp_stat_get_segment_replication r_1  (cost=0.25..10.25 rows=334 width=288)
                                   ->  Hash  (cost=15.38..15.38 rows=4 width=36)
                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1.33..15.38 rows=4 width=36)
                                               Hash Key: e.gp_segment_id
                                               ->  Hash Join  (cost=1.33..15.18 rows=4 width=36)
                                                     Hash Cond: (e.gp_segment_id = c.content)
                                                     ->  Function Scan on gp_stat_get_segment_replication_error e  (cost=0.25..10.25 rows=334 width=36)
                                                     ->  Hash  (cost=1.04..1.04 rows=1 width=2)
                                                           ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..1.04 rows=3 width=2)
                                                                 ->  Seq Scan on gp_segment_configuration c  (cost=0.00..1.00 rows=1 width=2)
                                                                       Filter: (role = 'm'::"char")
   ->  Gather Motion 1:1  (slice5; segments: 1)  (cost=0.00..0.01 rows=1 width=0)
         ->  Result  (cost=0.00..0.01 rows=1 width=0)
               One-Time Filter: false
 Optimizer: Postgres query optimizer
(26 rows)
```
The assert failure happens because the `estate->interconnect_context`
is cleaned up before executing the gather motion. But the last gather
motion is unwanted. The locus of the output tuples from the init-plan
is `CdbLocusType_General`. We should adjust the conditions to add a
motion.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
