### PR TITLE
gpcheckcat: allow running/skipping multiple tests

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -4,17 +4,20 @@ Usage: gpcheckcat [<option>] [dbname]
 
     -?
     -B parallel: number of worker threads
-    -g dir     : generate SQL to rectify catalog corruption, put it in dir
-    -p port    : DB port number
-    -P passwd  : DB password
-    -U uname   : DB User Name
-    -v         : verbose
-    -A         : all databases
-    -S option  : shared table options (none, only)
-    -O         : Online
-    -l         : list all tests
-    -R test    : run this particular test
-    -C catname : run cross consistency, FK and ACL tests for this catalog table
+    -g dir                   : generate SQL to rectify catalog corruption, put it in dir
+    -p port                  : DB port number
+    -P passwd                : DB password
+    -U uname                 : DB User Name
+    -v                       : verbose
+    -A                       : all databases
+    -S option                : shared table options (none, only)
+    -O                       : Online
+    -l                       : list all tests
+    -R test | 'test1, test2' : run this particular test(s) (quoted, comma seperated list for multiple tests)
+    -s test | 'test1, test2' : skip this particular test(s) (quoted, comma seperated list for multiple tests)
+    -C catname               : run cross consistency, FK and ACL tests for this catalog table
+
+    Test subset options are mutually exclusive, use only one of '-R', '-s', or '-C'.
 
 '''
 import datetime
@@ -118,6 +121,7 @@ class Global():
         self.opt['-O'] = False
 
         self.opt['-R'] = None
+        self.opt['-s'] = None
         self.opt['-C'] = None
         self.opt['-l'] = False
 
@@ -225,14 +229,14 @@ def getalldbs():
 def parseCommandLine():
     try:
         # A colon following the flag indicates an argument is expected
-        (options, args) = getopt.getopt(sys.argv[1:], '?p:P:U:B:vg:t:AOS:R:C:lE')
-    except Exception, e:
+        (options, args) = getopt.getopt(sys.argv[1:], '?p:P:U:B:vg:t:AOS:R:s:C:lE')
+    except Exception as e:
         usage('Error: ' + str(e))
 
     for (switch, val) in options:
         if switch == '-?':
             usage(0)
-        elif switch[1] in 'pBPUgSRC':
+        elif switch[1] in 'pBPUgSRCs':
             GV.opt[switch] = val
         elif switch[1] in 'vtAOlE':
             GV.opt[switch] = True
@@ -263,6 +267,9 @@ def parseCommandLine():
 
     if GV.opt['-R']:
         logger.debug('Run this test: %s' % GV.opt['-R'])
+
+    if GV.opt['-s']:
+        logger.debug('Skip these tests: %s' % GV.opt['-s'])
 
     if GV.opt['-C']:
         GV.opt['-C'] = GV.opt['-C'].lower()
@@ -3099,9 +3106,6 @@ def runCheckCatname(catalog_table_obj):
 #-------------------------------------------------------------------------------
 def runOneCheck(name):
 
-    if not all_checks.has_key(name):
-        logger.info("'%s' is not a valid test" % (name))
-        raise LookupError
     if GV.opt['-O'] and not all_checks[name]["online"]:
         logger.info("%s: Skip this test in online mode" % (name))
         return
@@ -3121,12 +3125,12 @@ def runOneCheck(name):
 
 
 #-------------------------------------------------------------------------------
-def runAllChecks():
+def runAllChecks(run_tests):
     '''
     perform catalog check for specified database
     '''
     for name in sorted(all_checks, key=lambda x: all_checks[x]["order"]):
-        if all_checks[name]["version"] >= GV.version:
+        if all_checks[name]["version"] >= GV.version and name in run_tests:
             runOneCheck(name)
 
     closeDbs()
@@ -4357,6 +4361,30 @@ def check_gpexpand():
         myprint(msg)
         sys.exit(1)
 
+def check_test_subset_parameter_count():
+    test_option_count = 0
+    if GV.opt['-R']:
+        test_option_count += 1
+    if GV.opt['-s']:
+        test_option_count += 1
+    if GV.opt['-C']:
+        test_option_count += 1
+    if test_option_count > 1:
+        myprint("Error: multiple test subset options are selected. Please pass only one of [-R, -s, -C] if necessary.\n")
+        setError(ERROR_NOREPAIR)
+        sys.exit(GV.retcode)
+    return
+
+def check_test_names_parsed(tests):
+    correct_tests = []
+    for t in tests:
+        if t not in all_checks:
+            myprint("'%s' is not a valid test" % t)
+        else:
+            correct_tests.append(t)
+    return correct_tests
+
+
 def main():
     parseCommandLine()
     if GV.opt['-l']:
@@ -4368,7 +4396,9 @@ def main():
         myprint("Error: only Greenplum database version >= 4.0 are supported\n")
         sys.exit(GV.retcode)
 
-    # gpcheckcat should check gpexpand runnning status
+    check_test_subset_parameter_count()
+
+    # gpcheckcat should check gpexpand running status
     check_gpexpand()
 
     GV.cfg = getGPConfiguration()
@@ -4405,15 +4435,7 @@ def main():
 
         drop_leaked_schemas(leaked_schema_dropper, dbname)
 
-        if GV.opt['-R']:
-            name = GV.opt['-R']
-            try:
-                runOneCheck(name)
-            except LookupError, e:
-                myprint("'%s' is not a valid test\n\n" % (name))
-                setError(ERROR_NOREPAIR)
-                sys.exit(GV.retcode)
-        elif GV.opt['-C']:
+        if GV.opt['-C']:
             namestr = GV.opt['-C']
             try:
                 catalog_table_obj = getCatObj(namestr)
@@ -4422,7 +4444,19 @@ def main():
                 setError(ERROR_NOREPAIR)
                 sys.exit(GV.retcode)
         else:
-            runAllChecks()
+            if GV.opt['-R']:
+                run_names = GV.opt['-R']
+                run_names_array = [x.strip() for x in run_names.split(",")]
+                run_tests = check_test_names_parsed(run_names_array)
+            elif GV.opt['-s']:
+                skip_names = GV.opt['-s']
+                skip_names_array = [x.strip() for x in skip_names.split(",")]
+                skip_tests = check_test_names_parsed(skip_names_array)
+                run_tests = [x for x in all_checks if x not in skip_tests]
+            else:
+                run_tests = all_checks.keys()
+
+            runAllChecks(run_tests)
 
         checkcatReport()
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -307,6 +307,87 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertIn('Relation schema: N/A', log_messages)
         self.assertIn('Relation name: N/A', log_messages)
 
+    @patch('gpcheckcat.GPCatalog', return_value=Mock())
+    @patch('sys.exit')
+    @patch('gpcheckcat.runAllChecks', return_value=Mock())
+    @patch('gpcheckcat.getversion', return_value="5.0")
+    def test_skip_one_test(self, mock_ver, mock_run, mock1, mock2):
+        primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
+        for i in range(1, 50):
+            primaries.append(dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=1, dbid=i, isprimary='t'))
+        self.db_connection.query.return_value.dictresult.return_value = primaries
+        self.subject.all_checks = {'test1': 'a', 'test2': 'b', 'test3': 'c'}
+
+        testargs = ['gpcheckcat', '-port 1', '-s test2']
+        with patch.object(sys, 'argv', testargs):
+            self.subject.main()
+        mock_run.assert_has_calls(call(['test1', 'test3']))
+
+    @patch('gpcheckcat.GPCatalog', return_value=Mock())
+    @patch('sys.exit')
+    @patch('gpcheckcat.runAllChecks', return_value=Mock())
+    @patch('gpcheckcat.getversion', return_value="5.0")
+    def test_skip_multiple_test(self, mock_ver, mock_run, mock1, mock2):
+        primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
+        for i in range(1, 50):
+            primaries.append(dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=1, dbid=i, isprimary='t'))
+        self.db_connection.query.return_value.dictresult.return_value = primaries
+        self.subject.all_checks = {'test1': 'a', 'test2': 'b', 'test3': 'c'}
+
+        testargs = ['gpcheckcat', '-port 1', '-s', "test1, test2"]
+        with patch.object(sys, 'argv', testargs):
+            self.subject.main()
+        mock_run.assert_has_calls(call(['test3']))
+
+    @patch('gpcheckcat.GPCatalog', return_value=Mock())
+    @patch('sys.exit')
+    @patch('gpcheckcat.runAllChecks', return_value=Mock())
+    @patch('gpcheckcat.getversion', return_value="5.0")
+    def test_skip_test_warning(self, mock_ver, mock_run, mock1, mock2):
+        primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
+        for i in range(1, 50):
+            primaries.append(dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=1, dbid=i, isprimary='t'))
+        self.db_connection.query.return_value.dictresult.return_value = primaries
+        self.subject.all_checks = {'test1': 'a', 'test2': 'b', 'test3': 'c'}
+
+        testargs = ['gpcheckcat', '-port 1', '-s', "test_invalid, test2"]
+        with patch.object(sys, 'argv', testargs):
+            self.subject.main()
+        mock_run.assert_has_calls(call(['test1', 'test3']))
+        expected_message = "'test_invalid' is not a valid test"
+        log_messages = [args[0][1] for args in self.subject.logger.log.call_args_list]
+        self.assertIn(expected_message, log_messages)
+
+    @patch('gpcheckcat.GPCatalog', return_value=Mock())
+    @patch('sys.exit')
+    @patch('gpcheckcat.runAllChecks', return_value=Mock())
+    @patch('gpcheckcat.getversion', return_value="5.0")
+    def test_run_multiple_test(self, mock_ver, mock_run, mock1, mock2):
+        primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
+        for i in range(1, 50):
+            primaries.append(dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=1, dbid=i, isprimary='t'))
+        self.db_connection.query.return_value.dictresult.return_value = primaries
+        self.subject.all_checks = {'test1': 'a', 'test2': 'b', 'test3': 'c'}
+
+        testargs = ['gpcheckcat', '-port 1', '-R', "test1, test2"]
+        with patch.object(sys, 'argv', testargs):
+            self.subject.main()
+        calls_to_check = [call(['test1', 'test2'])]
+        mock_run.assert_has_calls(calls_to_check)
+
+    @patch('sys.exit')
+    @patch('gpcheckcat.getversion', return_value="5.0")
+    def test_check_test_subset_parameter_count_fail(self, mock_ver, mock_exit):
+        GV = Global()
+        GV.opt['-R'] = 'test1'
+        GV.opt['-s'] = 'test2'
+        GV.opt['-C'] = None
+        GV.retcode = None
+        self.subject.GV = GV
+
+        self.subject.check_test_subset_parameter_count()
+        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
+
     ####################### PRIVATE METHODS #######################
 
     def _run_batch_size_experiment(self, num_primaries):
@@ -331,6 +412,9 @@ class GpCheckCatTestCase(GpTestCase):
                 self.num_batches += 1
                 self.num_joins = 0
                 self.num_starts = 0
+class Global():
+    def __init__(self):
+        self.opt = {}
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -499,16 +499,39 @@ Feature: gpcheckcat tests
           And the user runs "dropdb gpcheckcat_orphans"
           And the path "repair_dir" is removed from current working directory
 
-    Scenario: gpcheckcat should report vpinfo inconsistent error 
+    Scenario: gpcheckcat should report vpinfo inconsistent error
         Given database "vpinfo_inconsistent_db" is dropped and recreated
           And there is a "co" table "public.co_vpinfo" in "vpinfo_inconsistent_db" with data
          When the user runs "gpcheckcat vpinfo_inconsistent_db"
          Then gpcheckcat should return a return code of 0
          When an attribute of table "co_vpinfo" in database "vpinfo_inconsistent_db" is deleted on segment with content id "0"
          Then psql should return a return code of 0
-         When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db" 
+         When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db"
          Then gpcheckcat should print "Failed test\(s\) that are not reported here: aoseg_table" to stdout
           And the user runs "dropdb vpinfo_inconsistent_db"
+
+    Scenario: skip one check in gpcheckcat
+        Given database "all_good" is dropped and recreated
+        Then the user runs "gpcheckcat -s owner"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "owner" to stdout
+        And the user runs "dropdb all_good"
+
+    Scenario: skip multiple checks in gpcheckcat
+        Given database "all_good" is dropped and recreated
+        Then the user runs "gpcheckcat -s 'owner, acl'"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "owner" to stdout
+        And gpcheckcat should not print "acl" to stdout
+        And the user runs "dropdb all_good"
+
+    Scenario: run multiple checks in gpcheckcat
+        Given database "all_good" is dropped and recreated
+        Then the user runs "gpcheckcat -R 'foreign_key, distribution_policy'"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should print "foreign_key" to stdout
+        And gpcheckcat should print "distribution_policy" to stdout
+        And the user runs "dropdb all_good"
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster


### PR DESCRIPTION
gpcheckcat currently allows running only one test at a time or running
all tests. This change allows the user to select a subset of tests to
run or skip.
This introduces a -s option for skipping tests.

Co-authored-by: Orhan Kislal <okislal@vmware.com>

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6x_checkcat_add_skiptest)