### PR TITLE
Ensure materialize does not project in Orca

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13412,3 +13412,77 @@ select * from sqall_t1 where a not in (
 (0 rows)
 
 reset optimizer_join_order;
+-- Make sure materialize projects child's tlist, not what is requested
+create table material_test(first_id int, second_id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'first_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index material_test_idx on material_test using btree (second_id);
+create table material_test2(first_id int, second_id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'first_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into material_test select generate_series(1,10), generate_series(1,10);
+insert into material_test2 select generate_series(1,10), generate_series(1,10);
+insert into material_test select generate_series(1,100), generate_series(1,100);
+insert into material_test2 select generate_series(1,100), generate_series(1,100);
+analyze material_test;
+analyze material_test2;
+explain (verbose) with mat_w as (
+select first_id
+from material_test
+where second_id in (1,2,3,4)
+)
+select first_id
+from material_test2
+where first_id in (select first_id from mat_w)
+and first_id in (select first_id from mat_w);
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.36..5.01 rows=39 width=4)
+   Output: material_test2.first_id
+   ->  Seq Scan on orca.material_test2  (cost=0.36..5.01 rows=13 width=4)
+         Output: material_test2.first_id
+         Filter: ((hashed SubPlan 1) AND (hashed SubPlan 2))
+         SubPlan 1  (slice3; segments: 3)
+           ->  Materialize  (cost=4.69..4.94 rows=3 width=4)
+                 Output: share0_ref1.first_id
+                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=4.69..4.90 rows=3 width=4)
+                       Output: share0_ref1.first_id
+                       ->  Shared Scan (share slice:id 1:0)  (cost=4.69..4.90 rows=3 width=4)
+                             Output: share0_ref1.first_id
+                             ->  Materialize  (cost=0.00..4.69 rows=3 width=4)
+                                   Output: material_test.first_id
+                                   ->  Seq Scan on orca.material_test  (cost=0.00..4.65 rows=3 width=4)
+                                         Output: material_test.first_id
+                                         Filter: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
+         SubPlan 2  (slice3; segments: 3)
+           ->  Materialize  (cost=4.69..4.94 rows=3 width=4)
+                 Output: share0_ref2.first_id
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=4.69..4.90 rows=3 width=4)
+                       Output: share0_ref2.first_id
+                       ->  Shared Scan (share slice:id 2:0)  (cost=4.69..4.90 rows=3 width=4)
+                             Output: share0_ref2.first_id
+ Optimizer: Postgres query optimizer
+ Settings: enable_seqscan=on, optimizer=off
+(26 rows)
+
+with mat_w as (
+select first_id
+from material_test
+where second_id in (1,2,3,4)
+)
+select first_id
+from material_test2
+where first_id in (select first_id from mat_w)
+and first_id in (select first_id from mat_w);
+ first_id 
+----------
+        2
+        3
+        4
+        2
+        3
+        4
+        1
+        1
+(8 rows)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13667,3 +13667,82 @@ select * from sqall_t1 where a not in (
 (0 rows)
 
 reset optimizer_join_order;
+-- Make sure materialize projects child's tlist, not what is requested
+create table material_test(first_id int, second_id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'first_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index material_test_idx on material_test using btree (second_id);
+create table material_test2(first_id int, second_id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'first_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into material_test select generate_series(1,10), generate_series(1,10);
+insert into material_test2 select generate_series(1,10), generate_series(1,10);
+insert into material_test select generate_series(1,100), generate_series(1,100);
+insert into material_test2 select generate_series(1,100), generate_series(1,100);
+analyze material_test;
+analyze material_test2;
+explain (verbose) with mat_w as (
+select first_id
+from material_test
+where second_id in (1,2,3,4)
+)
+select first_id
+from material_test2
+where first_id in (select first_id from mat_w)
+and first_id in (select first_id from mat_w);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1680.99 rows=10 width=4)
+   Output: material_test2.first_id
+   ->  Sequence  (cost=0.00..1680.99 rows=4 width=4)
+         Output: material_test2.first_id
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..387.98 rows=4 width=1)
+               Output: share0_ref1.first_id
+               ->  Materialize  (cost=0.00..387.98 rows=4 width=1)
+                     Output: material_test.first_id, material_test.second_id
+                     ->  Bitmap Heap Scan on orca.material_test  (cost=0.00..387.98 rows=4 width=4)
+                           Output: material_test.first_id, material_test.second_id
+                           Recheck Cond: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
+                           ->  Bitmap Index Scan on material_test_idx  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
+         ->  Hash Semi Join  (cost=0.00..1293.01 rows=4 width=4)
+               Output: material_test2.first_id
+               Hash Cond: (material_test2.first_id = share0_ref2.first_id)
+               ->  Hash Semi Join  (cost=0.00..862.01 rows=4 width=4)
+                     Output: material_test2.first_id
+                     Hash Cond: (material_test2.first_id = share0_ref3.first_id)
+                     ->  Seq Scan on orca.material_test2  (cost=0.00..431.00 rows=37 width=4)
+                           Output: material_test2.first_id
+                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                           Output: share0_ref3.first_id
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=4)
+                                 Output: share0_ref3.first_id
+               ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                     Output: share0_ref2.first_id
+                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=4)
+                           Output: share0_ref2.first_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_seqscan=on, optimizer=on
+(31 rows)
+
+with mat_w as (
+select first_id
+from material_test
+where second_id in (1,2,3,4)
+)
+select first_id
+from material_test2
+where first_id in (select first_id from mat_w)
+and first_id in (select first_id from mat_w);
+ first_id 
+----------
+        2
+        3
+        4
+        2
+        3
+        4
+        1
+        1
+(8 rows)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2908,6 +2908,39 @@ select * from sqall_t1 where a not in (
 	    select b.a from sqall_t1 a left join sqall_t1 b on false);
 reset optimizer_join_order;
 
+-- Make sure materialize projects child's tlist, not what is requested
+create table material_test(first_id int, second_id int);
+create index material_test_idx on material_test using btree (second_id);
+create table material_test2(first_id int, second_id int);
+
+insert into material_test select generate_series(1,10), generate_series(1,10);
+insert into material_test2 select generate_series(1,10), generate_series(1,10);
+insert into material_test select generate_series(1,100), generate_series(1,100);
+insert into material_test2 select generate_series(1,100), generate_series(1,100);
+
+analyze material_test;
+analyze material_test2;
+
+explain (verbose) with mat_w as (
+select first_id
+from material_test
+where second_id in (1,2,3,4)
+)
+select first_id
+from material_test2
+where first_id in (select first_id from mat_w)
+and first_id in (select first_id from mat_w);
+
+with mat_w as (
+select first_id
+from material_test
+where second_id in (1,2,3,4)
+)
+select first_id
+from material_test2
+where first_id in (select first_id from mat_w)
+and first_id in (select first_id from mat_w);
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Materialize is not a projection node, and thus must use the target list
of its child. Previously, when generating a materialize node for a shared
scan producer, it used the requested columns from the parent, which
worked in most cases. However, in other cases, the requested columns did
not match the columns projected by the materialize's child, causing Orca to generate a
materialize node that projects. This caused a failure during execution
with 'Material operator does not support projection' due to a check at https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/executor/nodeMaterial.c#L360

Now, we ensure the materialize uses the child's target list, and let the shared scan project different columns if needed.