### PR TITLE
Use 'ss' command in absence of 'netstat' to find active tcp port

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -581,8 +581,18 @@ class Hostname(Command):
 class PgPortIsActive(Command):
     def __init__(self, name, port, file, ctxt=LOCAL, remoteHost=None):
         self.port = port
-        cmdStr = "%s -an 2>/dev/null | %s %s | %s '{print $NF}'" % \
-                 (findCmdInPath('netstat'), findCmdInPath('grep'), file, findCmdInPath('awk'))
+        try:
+            cmdStr = "%s -an 2>/dev/null | %s %s | %s '{print $NF}'" % \
+                     (findCmdInPath('netstat'), findCmdInPath('grep'), file, findCmdInPath('awk'))
+        except CommandNotFoundException:
+            try:
+                cmdStr = "%s -an 2>/dev/null | %s %s | %s '{print $5}'" % \
+                         (findCmdInPath('ss'), findCmdInPath('grep'), file, findCmdInPath('awk'))
+            except CommandNotFoundException as err:
+                logger.critical(
+                    "None of the utility netstat and ss are available in the system.")
+                raise
+
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     def contains_port(self):
@@ -593,8 +603,8 @@ class PgPortIsActive(Command):
 
         for r in rows:
             val = r.split('.')
-            netstatport = int(val[len(val) - 1])
-            if netstatport == self.port:
+            tcp_port = int(val[len(val) - 1])
+            if tcp_port == self.port:
                 return True
 
         return False

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
@@ -4,6 +4,7 @@ import pgdb
 
 from gppylib import gparray
 from gppylib.programs.clsSystemState import *
+from gppylib.commands.unix import CommandNotFoundException
 
 #
 # Creation helpers for gparray.Segment.
@@ -91,6 +92,24 @@ class ReplicationInfoTestCase(unittest.TestCase):
         cursor.fetchall.return_value = rows
         cursor.fetchone.side_effect = rows
         return cursor
+
+    def find_ss(cmd):
+        if cmd == 'ss':
+            return "echo 'u_str  LISTEN     0      128    /tmp/.s.PGSQL.6000 664041384'"
+        if cmd == 'grep':
+            return 'grep'
+        if cmd == 'awk':
+            return 'awk'
+        else:
+            raise CommandNotFoundException(cmd, '/usr/local/bin')
+
+    def dont_find_ss_netstat(cmd):
+        if cmd == 'grep':
+            return 'grep'
+        if cmd == 'awk':
+            return 'awk'
+        else:
+            raise CommandNotFoundException(cmd, '/usr/local/bin')
 
     def mock_pg_stat_replication(self, mock_query, rows):
         self._pg_rows['pg_stat_replication'] = rows
@@ -352,6 +371,27 @@ class ReplicationInfoTestCase(unittest.TestCase):
     def test_set_mirror_replication_values_complains_about_incorrect_kwargs(self):
         with self.assertRaises(TypeError):
             GpSystemStateProgram._set_mirror_replication_values(self.data, self.mirror, badarg=1)
+
+    # test the condition when netstat is not found but ss is found
+    @mock.patch('gppylib.commands.unix.findCmdInPath', mock.MagicMock(side_effect=find_ss))
+    def test_PgPortIsActive_no_netstat(self):
+        port = 6000
+        port_active = unix.PgPortIsActive.local('check netstat for postmaster port', "/tmp/.s.PGSQL.%d" % port,
+                                                        port)
+        self.assertTrue(port_active, "PgPortIsActive.local should be true")
+
+    # test the condition when netstat and ss are not found
+    @mock.patch('gppylib.commands.unix.findCmdInPath', mock.MagicMock(side_effect=dont_find_ss_netstat))
+    def test_PgPortIsActive_no_netstat_ss(self):
+        port = 6000
+        port_active = False
+        try:
+            port_active = unix.PgPortIsActive.local('check netstat for postmaster port', "/tmp/.s.PGSQL.%d" % port,
+                                                            port)
+        except CommandNotFoundException:
+            pass
+        self.assertFalse(port_active, "PgPortIsActive.local should be false")
+
 
 class GpStateDataTestCase(unittest.TestCase):
     def test_switchSegment_sets_current_segment_correctly(self):


### PR DESCRIPTION
`PgPortIsActive` would rely on `netstat` to find active tcp port. In many
modern Centos systems it has been replaced by `ss`. So now in absence of
`netstat` we use `ss`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
