### PR TITLE
[6X back patch]  Avoid before_read_command fault usage where possible 

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -621,6 +621,15 @@ ReadCommand(StringInfo inBuf)
 {
 	int			result;
 
+	/*
+	 * XXX Use of this fault is discouraged!  This fault location is reached
+	 * in query executing backends as well as many non-query executing
+	 * processes such as FTS probe handler, walsender, etc.  It is also found
+	 * to be triggered by the same SQL statement used to inject the fault,
+	 * causing difficult to analyse failures in CI.  If a test intends to
+	 * target a query executing backend process, consider using
+	 * "exec_simple_query_start" fault.
+	 */
 	SIMPLE_FAULT_INJECTOR("before_read_command");
 
 	if (whereToSendOutput == DestRemote)
@@ -1582,6 +1591,8 @@ exec_simple_query(const char *query_string)
 	bool		was_logged = false;
 	bool		isTopLevel;
 	char		msec_str[32];
+
+	SIMPLE_FAULT_INJECTOR("exec_simple_query_start");
 
 	if (Gp_role != GP_ROLE_EXECUTE)
 		increment_command_count();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4320,8 +4320,9 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"dtx_phase2_retry_count", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Maximum number of retries during two phase commit after which master PANICs."),
-			NULL,
+			gettext_noop("Maximum number of attempts to finish a prepared transaction."),
+			gettext_noop("The coordinator PANICs if a prepared transaction cannot be"
+						 " committed after this number of attempts."),
 			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&dtx_phase2_retry_count,

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -72,8 +72,8 @@ CHECKPOINT
  
 (1 row)
 
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -81,10 +81,11 @@ CHECKPOINT
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -50,11 +50,18 @@ CREATE
 -- after querying in-doubt prepared transactions from segments.
 1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE
--- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault_infinite 
---------------------------
- Success:                 
+-- Inject fault to fail the COMMIT PREPARED on one segment.
+-- Temporarily disable retry finish prepared in this session, because
+-- we are not interested in testing the retry logic.  This makes it
+-- suffice to trigger the fault only once.  Otherwise, the fault may
+-- continue to trigger even after PANIC on coordinator, impacting
+-- finish prepared operation during crash recovery.
+1: SET dtx_phase2_retry_count = 0;
+SET
+1: SELECT gp_inject_fault('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();  <waiting ...>

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -382,13 +382,13 @@ ALTER
 
 -- trigger master panic and wait until master down before running any new query.
 17&: SELECT wait_till_master_shutsdown();  <waiting ...>
-18: SELECT gp_inject_fault('before_read_command', 'panic', 1);
+18: SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 18: SELECT 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -53,8 +53,8 @@ CHECKPOINT
 -------------------------------
  Success:                      
 (1 row)
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -62,10 +62,11 @@ CHECKPOINT
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -61,7 +61,7 @@ CREATE
  OK     
 (1 row)
 -- trigger master reset
-3: select gp_inject_fault('before_read_command', 'panic', 1);
+3: select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -69,11 +69,11 @@ CREATE
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 3: select 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -28,13 +28,13 @@
 1:select gp_inject_fault('dtm_broadcast_commit_prepared', 'status', 1);
 1:select gp_inject_fault('transaction_abort_after_distributed_prepared', 'status', 1);
 
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
 

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -48,8 +48,14 @@ $$ LANGUAGE plpgsql;
 -- COMMIT PREPARED across restart and instead abort the transaction
 -- after querying in-doubt prepared transactions from segments.
 1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
--- Inject fault to fail the COMMIT PREPARED always on one segment, till fault is not reset
-1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid)
+-- Inject fault to fail the COMMIT PREPARED on one segment.
+-- Temporarily disable retry finish prepared in this session, because
+-- we are not interested in testing the retry logic.  This makes it
+-- suffice to trigger the fault only once.  Otherwise, the fault may
+-- continue to trigger even after PANIC on coordinator, impacting
+-- finish prepared operation during crash recovery.
+1: SET dtx_phase2_retry_count = 0;
+1: SELECT gp_inject_fault('finish_prepared_start_of_function', 'error', dbid)
    from gp_segment_configuration where content=0 and role='p';
 -- Start looping in background, till master panics and closes the session
 3&: SELECT wait_till_master_shutsdown();

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -213,7 +213,7 @@ $$ LANGUAGE plpgsql;
 
 -- trigger master panic and wait until master down before running any new query.
 17&: SELECT wait_till_master_shutsdown();
-18: SELECT gp_inject_fault('before_read_command', 'panic', 1);
+18: SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 18: SELECT 1;
 16<:
 17<:

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -19,13 +19,13 @@
 
 -- wait till insert reaches intended point
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
--- trigger crash
-1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- trigger crash on QD
+1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 1:select 1;
 

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -29,12 +29,12 @@ include: helpers/server_helpers.sql;
 -- stop mirror
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=0 AND role = 'm';
 -- trigger master reset
-3: select gp_inject_fault('before_read_command', 'panic', 1);
+3: select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
 -- verify master panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
--- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
--- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n//
 -- end_matchsubs
 3: select 1;
 


### PR DESCRIPTION
This is a back patch of PR #12153 from 7.  Cherry-pick was clean, this PR is only for visibility.

The before_read_command fault location is executed by not only regular backends but also special backends such as FTS probe backends, fault injection backends, walsender, etc.  Several tests made use of this fault to cause PANIC in QD, after executing a command.  This strategy caused intermittent failures in CI because the fault would trigger unexpectedly from other backends listed above.  This patch defines a new fault in `exec_simple_query()` that is guaranteed to be triggered only by query executing backends.  This should resolve some of the intermittent failures in CI.