### PR TITLE
[5X] Fix walker that detects deprecated tables

### DIFF
--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -816,10 +816,7 @@ view_references_deprecated_tables(PG_FUNCTION_ARGS)
 	if(rel->rd_rel->relkind == RELKIND_VIEW)
 	{
 		viewquery = get_view_query(rel);
-		found = query_tree_walker(viewquery,
-								  check_node_deprecated_tables_walker,
-								  NULL,
-								  QTW_EXAMINE_RTES);
+		found = check_node_deprecated_tables_walker((Node *) viewquery, NULL);
 	}
 	else
 		found = false;


### PR DESCRIPTION
This commit ensures that `check_node_deprecated_tables_walker` recurses into
all possible expressions that can contain range tables. Earlier, we only
dealt with CTEs, but not sublinks for instance. So the following view
would not have been detected:

```sql
CREATE VIEW dep_rel_sublink AS SELECT dbid FROM gp_segment_configuration
	WHERE 0 < ALL (SELECT fsedbid FROM pg_filespace_entry);
```

This commit also makes the walker implementation more canonical and
removes the pre-existing recursion logic for CTEs(which we now get for
free with `expression_tree_walker`). Some additional minor improvements
along the way.

Please refer to #12168, which introduces a similar walker to check for
deprecated columns.
