### PR TITLE
Create Partition ResultRel Hash table under the per query context

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4389,12 +4389,13 @@ targetid_get_partition(Oid targetid, EState *estate, bool openIndices)
 		ctl.keysize = sizeof(Oid);
 		ctl.entrysize = sizeof(*entry);
 		ctl.hash = oid_hash;
+		ctl.hcxt = estate->es_query_cxt;
 
 		parentInfo->ri_partition_hash =
 			hash_create("Partition Result Relation Hash",
 						10,
 						&ctl,
-						HASH_ELEM | HASH_FUNCTION);
+						HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 	}
 
 	entry = hash_search(parentInfo->ri_partition_hash,


### PR DESCRIPTION
Inside targetid_get_partition(), the parentInfo->ri_partition_hash named
"Partition Result Relation Hash" was created under the TopMemoryContext;
CloseResultRelInfo() only freezes it without calling hash_destroy().

Long running backend processes (e.g. pgpool connections) might leak a
large amount of memory into the partition result hash context, blowing
up vmem memory usage.

Fix this by creating the context under the estate->es_query_cxt.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
