### PR TITLE
Fix a resource queue lock issue

### DIFF
--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -560,17 +560,20 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 		return false;
 	}
 
+	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
+
 	/*
 	 * Double-check that we are actually holding a lock of the type we want to
 	 * Release.
 	 */
 	if (!(proclock->holdMask & LOCKBIT_ON(lockmode)) || proclock->nLocks <= 0)
 	{
-		LWLockRelease(partitionLock);
 		elog(DEBUG1, "Resource queue %d: proclock not held", locktag->locktag_field1);
 		RemoveLocalLock(locallock);
-		ResCleanUpLock(lock, proclock, hashcode, false);
 
+		ResCleanUpLock(lock, proclock, hashcode, false);
+		LWLockRelease(ResQueueLock);
+		LWLockRelease(partitionLock);
 		return false;
 	}
 
@@ -580,8 +583,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	MemSet(&portalTag, 0, sizeof(ResPortalTag));
 	portalTag.pid = MyProc->pid;
 	portalTag.portalId = resPortalId;
-
-	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
 	incrementSet = ResIncrementFind(&portalTag);
 	if (!incrementSet)


### PR DESCRIPTION
PR #10003 added an extra ResCleanUpLock() call into ResLockRelease().
However ResCleanUpLock() requires a HeldExclusive ResQueueLock, an
assertion failure would occur if this one ResCleanUpLock() called.

```

#0  0x00007f0ed3e3f337 in raise () from /lib64/libc.so.6
#1  0x00007f0ed3e40a28 in abort () from /lib64/libc.so.6
#2  0x00000000006c8aa9 in ExceptionalCondition (conditionName=0x13a6080 "!(LWLockHeldExclusiveByMe((&MainLWLockArray[38 + 4].lock)))", errorType=<optimized out>, fileName=<optimized out>, lineNumber=<optimized out>) at assert.c:66
#3  0x0000000000c7fb74 in ResCleanUpLock (lock=lock@entry=0x7f0eb93a3110, proclock=proclock@entry=0x7f0eb9aee010, hashcode=hashcode@entry=699557762, wakeupNeeded=wakeupNeeded@entry=0 '\000') at resqueue.c:978
#4  0x0000000000c7ff8b in ResLockRelease (locktag=locktag@entry=0x7fff8a5aa880, resPortalId=0) at resqueue.c:572
#5  0x0000000000c82fd2 in ResLockPortal (portal=portal@entry=0x7f2cd88, qDesc=qDesc@entry=0x803dd98) at resscheduler.c:701
#6  0x0000000000aec117 in PortalStart (portal=portal@entry=0x7f2cd88, params=params@entry=0x0, eflags=eflags@entry=0, snapshot=snapshot@entry=0x0, ddesc=ddesc@entry=0x0) at pquery.c:713
#7  0x0000000000ae7411 in exec_simple_query (query_string=0x7dff158 "SELECT 1") at postgres.c:1781
#8  0x0000000000ae9a38 in PostgresMain (argc=<optimized out>, argv=argv@entry=0x7e1e810, dbname=<optimized out>, username=<optimized out>) at postgres.c:5242
#9  0x0000000000a66f93 in BackendRun (port=0x7e142d0) at postmaster.c:4811
#10 BackendStartup (port=0x7e142d0) at postmaster.c:4468
#11 ServerLoop () at postmaster.c:1948
#12 0x0000000000a67f6d in PostmasterMain (argc=argc@entry=6, argv=argv@entry=0x7ddca20) at postmaster.c:1518
#13 0x00000000006f859a in main (argc=6, argv=0x7ddca20) at main.c:245
```

Fix this by adusting ResQueueLock acquire position.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
