### PR TITLE
6X: Update message of FTS double fault detected

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -1113,7 +1113,11 @@ processResponse(fts_context *context)
 				}
 				else
 				{
-					elog(WARNING, "FTS double fault detected (content=%d) "
+					/*
+					 * Only log here, will handle it later, having an "ERROR"
+					 * keyword here for customer convenience
+					 */
+					elog(WARNING, "ERROR: FTS double fault detected (content=%d) "
 						 "primary dbid=%d, mirror dbid=%d",
 						 primary->config->segindex, primary->config->dbid, mirror->config->dbid);
 					ftsInfo->state = FTS_RESPONSE_PROCESSED;
@@ -1130,7 +1134,11 @@ processResponse(fts_context *context)
 				ftsInfo->state = FTS_RESPONSE_PROCESSED;
 				break;
 			case FTS_PROMOTE_FAILED:
-				elog(WARNING, "FTS double fault detected (content=%d) "
+				/*
+				 * Only log here, will handle it later, having an "ERROR"
+				 * keyword here for customer convenience
+				 */
+				elog(WARNING, "ERROR: FTS double fault detected (content=%d) "
 					 "primary dbid=%d, mirror dbid=%d",
 					 primary->config->segindex, primary->config->dbid, mirror->config->dbid);
 				ftsInfo->state = FTS_RESPONSE_PROCESSED;


### PR DESCRIPTION
FTS's workflow prints the error message first and processes the error
later. It confuses some customers, especially the customer who monitors
the log in real-time.

Add an "ERROR" keyword for customer convenience, as we discussed.