### PR TITLE
Support implicit CoerceViaIO casts in Subplan test expressions in ORCA (6x)

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -742,41 +742,6 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	return (Expr *) subplan;
 }
 
-inline BOOL
-FDXLCastedId(CDXLNode *dxl_node)
-{
-	return EdxlopScalarCast == dxl_node->GetOperator()->GetDXLOperator() &&
-		   dxl_node->Arity() > 0 &&
-		   EdxlopScalarIdent == (*dxl_node)[0]->GetOperator()->GetDXLOperator();
-}
-
-inline CTranslatorDXLToScalar::STypeOidAndTypeModifier
-OidParamOidFromDXLIdentOrDXLCastIdent(CDXLNode *ident_or_cast_ident_node)
-{
-	GPOS_ASSERT(EdxlopScalarIdent ==
-					ident_or_cast_ident_node->GetOperator()->GetDXLOperator() ||
-				FDXLCastedId(ident_or_cast_ident_node));
-
-	CDXLScalarIdent *inner_ident;
-	if (EdxlopScalarIdent ==
-		ident_or_cast_ident_node->GetOperator()->GetDXLOperator())
-	{
-		inner_ident =
-			CDXLScalarIdent::Cast(ident_or_cast_ident_node->GetOperator());
-	}
-	else
-	{
-		inner_ident = CDXLScalarIdent::Cast(
-			(*ident_or_cast_ident_node)[0]->GetOperator());
-	}
-	Oid inner_type_oid = CMDIdGPDB::CastMdid(inner_ident->MdidType())->Oid();
-	INT type_modifier = inner_ident->TypeModifier();
-
-	CTranslatorDXLToScalar::STypeOidAndTypeModifier modifier = {inner_type_oid,
-																type_modifier};
-	return modifier;
-}
-
 //---------------------------------------------------------------------------
 //      @function:
 //              CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar
@@ -814,43 +779,17 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 	GPOS_ASSERT(2 == test_expr_node->Arity());
 	GPOS_ASSERT(ANY_SUBLINK == slink || ALL_SUBLINK == slink);
 
+	// Translate arguments
+	List *args = NULL;
+
 	CDXLNode *outer_child_node = (*test_expr_node)[0];
 	CDXLNode *inner_child_node = (*test_expr_node)[1];
 
-	if (EdxlopScalarIdent !=
-			inner_child_node->GetOperator()->GetDXLOperator() &&
-		!FDXLCastedId(inner_child_node))
-	{
-		// test expression is expected to be a comparison between an outer expression
-		// and a scalar identifier from subplan child
-		// ORCA currently only supports PARAMs on the inner side of the form id or cast(id)
-		// The outer side may be any non-param thing.
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-				   GPOS_WSZ_LIT("Unsupported subplan test expression"));
-	}
-
-	// extract type of inner column
-	CDXLScalarComp *scalar_cmp_dxl =
-		CDXLScalarComp::Cast(test_expr_node->GetOperator());
-
-	// create an OpExpr for subplan test expression
-	OpExpr *op_expr = MakeNode(OpExpr);
-	op_expr->opno = CMDIdGPDB::CastMdid(scalar_cmp_dxl->MDId())->Oid();
-	const IMDScalarOp *md_scalar_op =
-		m_md_accessor->RetrieveScOp(scalar_cmp_dxl->MDId());
-	op_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
-	op_expr->opresulttype =
-		CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeBool>()->MDId())
-			->Oid();
-	op_expr->opretset = false;
-
 	// translate outer expression (can be a deep scalar tree)
 	Expr *outer_arg_expr = TranslateDXLToScalar(outer_child_node, colid_var);
-
-	// add translated outer expression as first arg of OpExpr
-	List *args = NIL;
 	args = gpdb::LAppend(args, outer_arg_expr);
 
+	// translate inner expression (only certain forms supported)
 	// second arg must be an EXEC param which is replaced during query execution with subplan output
 	Param *param = MakeNode(Param);
 	param->paramkind = PARAM_EXEC;
@@ -858,31 +797,80 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 		(dynamic_cast<CMappingColIdVarPlStmt *>(colid_var))
 			->GetDXLToPlStmtContext();
 	param->paramid = dxl_to_plstmt_ctxt->GetNextParamId();
-	CTranslatorDXLToScalar::STypeOidAndTypeModifier oidAndTypeModifier =
-		OidParamOidFromDXLIdentOrDXLCastIdent(inner_child_node);
-	param->paramtype = oidAndTypeModifier.oid_type;
-	param->paramtypmod = oidAndTypeModifier.type_modifier;
 
-	// test expression is used for non-scalar subplan,
-	// second arg of test expression must be an EXEC param referring to subplan output,
-	// we add this param to subplan param ids before translating other params
-
-	*param_ids = gpdb::LAppendInt(*param_ids, param->paramid);
-
+	CDXLScalarIdent *inner_ident = NULL;
+	Expr *inner_expr = NULL;
 	if (EdxlopScalarIdent == inner_child_node->GetOperator()->GetDXLOperator())
 	{
-		args = gpdb::LAppend(args, param);
+		// Ident
+		inner_ident = CDXLScalarIdent::Cast(inner_child_node->GetOperator());
+		inner_expr = (Expr *) param;
 	}
-	else  // we have a cast
+	else if (EdxlopScalarCast ==
+				 inner_child_node->GetOperator()->GetDXLOperator() &&
+			 inner_child_node->Arity() > 0 &&
+			 EdxlopScalarIdent ==
+				 (*inner_child_node)[0]->GetOperator()->GetDXLOperator())
 	{
+		// Casted Ident
+		inner_ident =
+			CDXLScalarIdent::Cast((*inner_child_node)[0]->GetOperator());
 		CDXLScalarCast *scalar_cast =
 			CDXLScalarCast::Cast(inner_child_node->GetOperator());
-		Expr *pexprCastParam =
-			TranslateRelabelTypeOrFuncExprFromDXL(scalar_cast, (Expr *) param);
-		args = gpdb::LAppend(args, pexprCastParam);
+		inner_expr =
+			TranslateDXLScalarCastWithChildExpr(scalar_cast, (Expr *) param);
 	}
-	op_expr->args = args;
+	else if (EdxlopScalarCoerceViaIO ==
+				 inner_child_node->GetOperator()->GetDXLOperator() &&
+			 inner_child_node->Arity() > 0 &&
+			 EdxlopScalarIdent ==
+				 (*inner_child_node)[0]->GetOperator()->GetDXLOperator())
+	{
+		// CoerceViaIO over Ident
+		inner_ident =
+			CDXLScalarIdent::Cast((*inner_child_node)[0]->GetOperator());
+		CDXLScalarCoerceViaIO *coerce =
+			CDXLScalarCoerceViaIO::Cast(inner_child_node->GetOperator());
+		inner_expr =
+			TranslateDXLScalarCoerceViaIOWithChildExpr(coerce, (Expr *) param);
+	}
+	else
+	{
+		// ORCA currently only supports PARAMs on the inner side of the form id or cast(id)
+		// The outer side may be any non-param thing.
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
+				   GPOS_WSZ_LIT("Unsupported subplan test expression"));
+	}
+	GPOS_ASSERT(NULL != inner_ident);
+	GPOS_ASSERT(NULL != inner_expr);
 
+	// finalize inner expression
+	param->paramtype = CMDIdGPDB::CastMdid(inner_ident->MdidType())->Oid();
+	param->paramtypmod = inner_ident->TypeModifier();
+
+	// test expression is used for non-scalar subplan,
+	// second arg of test expression must be an EXEC param referring to subplan output
+	args = gpdb::LAppend(args, inner_expr);
+
+	// also, add this param to subplan param ids before translating other params
+	*param_ids = gpdb::LAppendInt(*param_ids, param->paramid);
+
+	// finally, create an OpExpr for subplan test expression
+	CDXLScalarComp *scalar_cmp_dxl =
+		CDXLScalarComp::Cast(test_expr_node->GetOperator());
+	const IMDScalarOp *md_scalar_op =
+		m_md_accessor->RetrieveScOp(scalar_cmp_dxl->MDId());
+
+	OpExpr *op_expr = MakeNode(OpExpr);
+	op_expr->opno = CMDIdGPDB::CastMdid(scalar_cmp_dxl->MDId())->Oid();
+	op_expr->opfuncid = CMDIdGPDB::CastMdid(md_scalar_op->FuncMdId())->Oid();
+	op_expr->opresulttype =
+		CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeBool>()->MDId())
+			->Oid();
+	op_expr->opcollid = gpdb::TypeCollation(op_expr->opresulttype);
+	op_expr->opretset = false;
+	op_expr->args = args;
+	op_expr->inputcollid = gpdb::ExprCollation((Node *) op_expr->args);
 	return (Expr *) op_expr;
 }
 
@@ -1199,7 +1187,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarNullIfToScalar(
 }
 
 Expr *
-CTranslatorDXLToScalar::TranslateRelabelTypeOrFuncExprFromDXL(
+CTranslatorDXLToScalar::TranslateDXLScalarCastWithChildExpr(
 	const CDXLScalarCast *scalar_cast, Expr *child_expr)
 {
 	if (IMDId::IsValid(scalar_cast->FuncMdId()))
@@ -1254,7 +1242,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarCastToScalar(
 
 	Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
-	return TranslateRelabelTypeOrFuncExprFromDXL(dxlop, child_expr);
+	return TranslateDXLScalarCastWithChildExpr(dxlop, child_expr);
 }
 
 
@@ -1291,6 +1279,24 @@ CTranslatorDXLToScalar::TranslateDXLScalarCoerceToDomainToScalar(
 	return (Expr *) coerce;
 }
 
+Expr *
+CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOWithChildExpr(
+	const CDXLScalarCoerceViaIO *dxl_coerce_via_io, Expr *child_expr)
+{
+	CoerceViaIO *coerce = MakeNode(CoerceViaIO);
+
+	coerce->resulttype =
+		CMDIdGPDB::CastMdid(dxl_coerce_via_io->GetResultTypeMdId())->Oid();
+	coerce->arg = child_expr;
+	coerce->location = dxl_coerce_via_io->GetLocation();
+	coerce->coerceformat =
+		(CoercionForm) dxl_coerce_via_io->GetDXLCoercionForm();
+	// GPDB_91_MERGE_FIXME: collation
+	coerce->resultcollid = gpdb::TypeCollation(coerce->resulttype);
+
+	return (Expr *) coerce;
+}
+
 //---------------------------------------------------------------------------
 //      @function:
 //              CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOToScalar
@@ -1311,16 +1317,8 @@ CTranslatorDXLToScalar::TranslateDXLScalarCoerceViaIOToScalar(
 	CDXLNode *child_dxl = (*scalar_coerce_node)[0];
 	Expr *child_expr = TranslateDXLToScalar(child_dxl, colid_var);
 
-	CoerceViaIO *coerce = MakeNode(CoerceViaIO);
-
-	coerce->resulttype = CMDIdGPDB::CastMdid(dxlop->GetResultTypeMdId())->Oid();
-	coerce->arg = child_expr;
-	coerce->location = dxlop->GetLocation();
-	coerce->coerceformat = (CoercionForm) dxlop->GetDXLCoercionForm();
-	// GPDB_91_MERGE_FIXME: collation
-	coerce->resultcollid = gpdb::TypeCollation(coerce->resulttype);
-
-	return (Expr *) coerce;
+	return (Expr *) TranslateDXLScalarCoerceViaIOWithChildExpr(dxlop,
+															   child_expr);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2654,6 +2654,12 @@ CTranslatorRelcacheToDXL::RetrieveCast(CMemoryPool *mp, IMDId *mdid)
 							true /*is_binary_coercible*/,
 							GPOS_NEW(mp) CMDIdGPDB(cast_fn_oid));
 			break;
+		case COERCION_PATH_COERCEVIAIO:
+			// uses IO functions from types, no function in the cast
+			GPOS_ASSERT(cast_fn_oid == 0);
+			return GPOS_NEW(mp) CMDCastGPDB(
+				mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible,
+				GPOS_NEW(mp) CMDIdGPDB(cast_fn_oid), IMDCast::EmdtCoerceViaIO);
 		default:
 			break;
 	}

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -3619,6 +3619,13 @@ CUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexpr,
 				parrayCoerceCast->Location()),
 			pexpr);
 	}
+	else if (pmdcast->GetMDPathType() == IMDCast::EmdtCoerceViaIO)
+	{
+		CScalarCoerceViaIO *op = GPOS_NEW(mp)
+			CScalarCoerceViaIO(mp, mdid_dest, default_type_modifier,
+							   COperator::EcfImplicitCast, -1 /* location */);
+		pexprCast = GPOS_NEW(mp) CExpression(mp, op, pexpr);
+	}
 	else
 	{
 		CScalarCast *popCast =

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDCast.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDCast.h
@@ -40,7 +40,8 @@ public:
 		EmdtNone,		 /* failed to find any coercion pathway */
 		EmdtFunc,		 /* apply the specified coercion function */
 		EmdtRelabelType, /* binary-compatible cast, no function */
-		EmdtArrayCoerce	 /* need an ArrayCoerceExpr node */
+		EmdtArrayCoerce, /* need an ArrayCoerceExpr node */
+		EmdtCoerceViaIO	 /* need a CoerceViaIO, no function */
 	};
 
 	// object type

--- a/src/backend/gporca/libnaucrates/src/md/CMDCastGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDCastGPDB.cpp
@@ -45,7 +45,8 @@ CMDCastGPDB::CMDCastGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 	GPOS_ASSERT(m_mdid->IsValid());
 	GPOS_ASSERT(m_mdid_src->IsValid());
 	GPOS_ASSERT(m_mdid_dest->IsValid());
-	GPOS_ASSERT_IMP(!is_binary_coercible, m_mdid_cast_func->IsValid());
+	GPOS_ASSERT_IMP(!is_binary_coercible && m_path_type != EmdtCoerceViaIO,
+					m_mdid_cast_func->IsValid());
 
 	m_dxl_str = CDXLUtils::SerializeMDObj(
 		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -231,8 +231,10 @@ private:
 	Const *ConvertDXLDatumToConstInt8(CDXLDatum *datum_dxl);
 	Const *ConvertDXLDatumToConstBool(CDXLDatum *datum_dxl);
 	Const *TranslateDXLDatumGenericToScalar(CDXLDatum *datum_dxl);
-	Expr *TranslateRelabelTypeOrFuncExprFromDXL(
-		const CDXLScalarCast *scalar_cast, Expr *pexprChild);
+	Expr *TranslateDXLScalarCastWithChildExpr(const CDXLScalarCast *scalar_cast,
+											  Expr *child_expr);
+	Expr *TranslateDXLScalarCoerceViaIOWithChildExpr(
+		const CDXLScalarCoerceViaIO *dxl_coerce_via_io, Expr *child_expr);
 
 	// private copy ctor
 	CTranslatorDXLToScalar(const CTranslatorDXLToScalar &);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13496,3 +13496,29 @@ and first_id in (select first_id from mat_w);
         1
 (8 rows)
 
+create table tt_varchar(
+	data character varying
+) distributed by (data);
+insert into tt_varchar values('test');
+create table tt_int(
+	id integer
+) distributed by (id);
+insert into tt_int values(1);
+set optimizer_enforce_subplans = 1;
+-- test collation in subplan testexpr
+select data from tt_varchar where data > any(select id::text from tt_int);
+ data 
+------
+ test
+(1 row)
+
+-- test implicit coerce via io
+CREATE CAST (integer AS text) WITH INOUT AS IMPLICIT;
+select data from tt_varchar where data > any(select id from tt_int);
+ data 
+------
+ test
+(1 row)
+
+DROP CAST (integer AS text);
+reset optimizer_enforce_subplans;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13759,3 +13759,29 @@ and first_id in (select first_id from mat_w);
         1
 (8 rows)
 
+create table tt_varchar(
+	data character varying
+) distributed by (data);
+insert into tt_varchar values('test');
+create table tt_int(
+	id integer
+) distributed by (id);
+insert into tt_int values(1);
+set optimizer_enforce_subplans = 1;
+-- test collation in subplan testexpr
+select data from tt_varchar where data > any(select id::text from tt_int);
+ data 
+------
+ test
+(1 row)
+
+-- test implicit coerce via io
+CREATE CAST (integer AS text) WITH INOUT AS IMPLICIT;
+select data from tt_varchar where data > any(select id from tt_int);
+ data 
+------
+ test
+(1 row)
+
+DROP CAST (integer AS text);
+reset optimizer_enforce_subplans;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2947,6 +2947,25 @@ from material_test2
 where first_id in (select first_id from mat_w)
 and first_id in (select first_id from mat_w);
 
+create table tt_varchar(
+	data character varying
+) distributed by (data);
+insert into tt_varchar values('test');
+create table tt_int(
+	id integer
+) distributed by (id);
+insert into tt_int values(1);
+
+set optimizer_enforce_subplans = 1;
+-- test collation in subplan testexpr
+select data from tt_varchar where data > any(select id::text from tt_int);
+-- test implicit coerce via io
+CREATE CAST (integer AS text) WITH INOUT AS IMPLICIT;
+select data from tt_varchar where data > any(select id from tt_int);
+
+DROP CAST (integer AS text);
+reset optimizer_enforce_subplans;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
ORCA already supported CoerceViaIO casts when they're explicit in the
query. This commit expands their usage for implicit casts and adds
handling for them in subplan test exprs during DXL to PlStmt
translation.

Also, refactor code in TranslateDXLSubplanTestExprToScalar(). This 
commit makes the code easier to extend for other cast types; and
sets inputcolid and opcollid in op_expr, which were previously left
unset causing an ERROR on execution.

Please review the two commits separately - that'll be easier.