### PR TITLE
gprecoverseg: show valid status for mirror with no pg_rewind

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -302,7 +302,7 @@ class GpMirrorListToBuild:
             self.__logger.info("Updating mirrors")
 
             if len(rewindInfo) != 0:
-                self.__logger.info("Running pg_rewind on required mirrors")
+                self.__logger.info("Running pg_rewind on failed segments")
                 rewindFailedSegments = self.run_pg_rewind(rewindInfo)
 
                 # Do not start mirrors that failed pg_rewind
@@ -447,6 +447,8 @@ class GpMirrorListToBuild:
                     cmd.run(validateAfter=True)
                     cmd.cmdStr = cmd_str
                     results = cmd.get_results().stdout.rstrip()
+                    if not results:
+                        results = "skipping pg_rewind on mirror as standby.signal is present"
                 except ExecutionError:
                     lines = cmd.get_results().stderr.splitlines()
                     if lines:


### PR DESCRIPTION
Mirrors with **standby.signal** file display empty status after pg_rewind
call during incremental recovery. pg_rewind is not required in this
scenario as per the existing design and replication needs to be handle by
WAL.  As empty status creates confusion at the user end, this commit will
introduce valid status "skipping pg_rewind on mirror as standby.signal is present".

It also changes existing recoverseg message from **Running pg_rewind on required mirrors**
to  **Running pg_rewind on failed segments**