### PR TITLE
Fix gpload with header and reuse_tables bug.

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2087,7 +2087,7 @@ class gpload:
 
         sql+= """and pgext.fmttype = %s
                  and pgext.writable = false
-                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip()) +"%"))
+                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip())))
 
         if limitStr:
             sql += "and pgext.rejectlimit = %s " % limitStr
@@ -2169,7 +2169,7 @@ class gpload:
 
         sql+= """and pgext.fmttype = %s
                  and pgext.writable = false
-                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip()) +"%"))
+                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip())))
 
         if limitStr:
             sql += "and pgext.rejectlimit = %s " % limitStr

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_43.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_43.txt
@@ -1,0 +1,2 @@
+1,"row 1 - OK",file1
+2,"row 2 - OK",file1

--- a/gpMgmt/bin/gpload_test/gpload2/init_file
+++ b/gpMgmt/bin/gpload_test/gpload2/init_file
@@ -16,7 +16,7 @@
 -- m/started gpfdist/
 -- s/started gpfdist -p \d* -P \d* -f .*/ports/
 -- m/gpfdist:/
--- s#gpfdist://\d*.\d*.\d*.\d*:\d*//\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*data_file.txt#LOCATION#
+-- s#gpfdist://\d*.\d*.\d*.\d*:\d*//(.*/)*data_file.txt#LOCATION#
 -- m/data_file.tbl/
 -- s/(").*data_file.tbl(")/data/
 -- m/cmdtime/

--- a/gpMgmt/bin/gpload_test/gpload2/query43.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query43.ans
@@ -1,0 +1,18 @@
+2021-06-22 17:00:02|INFO|gpload session started 2021-06-22 17:00:02
+2021-06-22 17:00:02|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-22 17:00:02|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-22 17:00:02|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3b05572e_d338_11eb_a04f_000c29b81d26
+2021-06-22 17:00:02|INFO|running time: 0.07 seconds
+2021-06-22 17:00:02|INFO|rows Inserted          = 1
+2021-06-22 17:00:02|INFO|rows Updated           = 0
+2021-06-22 17:00:02|INFO|data formatting errors = 0
+2021-06-22 17:00:02|INFO|gpload succeeded
+2021-06-22 17:00:02|INFO|gpload session started 2021-06-22 17:00:02
+2021-06-22 17:00:02|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-22 17:00:02|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-22 17:00:02|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3b1e43b0_d338_11eb_a5ee_000c29b81d26
+2021-06-22 17:00:02|INFO|running time: 0.06 seconds
+2021-06-22 17:00:02|INFO|rows Inserted          = 2
+2021-06-22 17:00:02|INFO|rows Updated           = 0
+2021-06-22 17:00:02|INFO|data formatting errors = 0
+2021-06-22 17:00:02|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -17,6 +17,9 @@ DROP TABLE
 DROP TABLE IF EXISTS testSpecialChar;
 NOTICE:  table "testspecialchar" does not exist, skipping
 DROP TABLE
+DROP TABLE IF EXISTS testheaderreuse;
+NOTICE:  table "testheaderreuse" does not exist, skipping
+DROP TABLE
 CREATE TABLE texttable (
             s1 text, s2 text, s3 text, dt timestamp,
             n1 smallint, n2 integer, n3 bigint, n4 decimal,
@@ -31,4 +34,9 @@ CREATE TABLE test.csvtable (
             DISTRIBUTED BY (year);
 CREATE TABLE
 CREATE TABLE testSpecialChar("Field1" bigint, "Field#2" text) DISTRIBUTED BY ("Field1");
+CREATE TABLE
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;
 CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -10,6 +10,7 @@ DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
 DROP TABLE IF EXISTS texttable;
 DROP TABLE IF EXISTS csvtable;
 DROP TABLE IF EXISTS testSpecialChar;
+DROP TABLE IF EXISTS testheaderreuse;
 
 CREATE TABLE texttable (
             s1 text, s2 text, s3 text, dt timestamp,
@@ -22,3 +23,7 @@ CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);
 CREATE TABLE testSpecialChar("Field1" bigint, "Field#2" text) DISTRIBUTED BY ("Field1");
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;


### PR DESCRIPTION
If gpload loads one file with 'REUSE_TABLES' and 'HEADER' for the first time.
Then loads another file with 'REUSE_TABLES' and without 'HEADER', the second
loading will reuse the first external table which make the second loading
miss the first line.

The reuse table procedure tries to get the existing external table and
compare the format option strings with sql 'like "%fmtopts%'. If the result
returns at least one table, it will reuse the existing external table. The
problem here is that format options are constructed in this order:
delimiter-> null -> escape -> quote(csv) -> [header] -> [fill_missing_field]
->[force_not_null] ->[force-quote] -> [newline]. The options in the square
brackets are optional, so the compare sql will not end with '%'.

This pr fix the incorrect reuse table by removing the last '%' from the sql
'like %formats%'.

So the format option "delimiter '|' null 'null' escape '\' header " will not
be matched with this new option "delimiter '|' null 'null' escape '\'".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
