### PR TITLE
Fix gpload with header and reuse_tables bug.

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2129,7 +2129,7 @@ class gpload:
 
         sql+= """and pgext.fmttype = %s
                  and pgext.writable = false
-                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip()) +"%"))
+                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip())))
 
         if limitStr:
             sql += "and pgext.rejectlimit = %s " % limitStr
@@ -2216,7 +2216,7 @@ class gpload:
 
         sql+= """and pgext.fmttype = %s
                  and pgext.writable = false
-                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip()) +"%"))
+                 and pgext.fmtopts like %s """ % (quote(formatType[0]),quote("%" + quote_unident(formatOpts.rstrip())))
 
         if limitStr:
             sql += "and pgext.rejectlimit = %s " % limitStr

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_config.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_config.py
@@ -146,3 +146,14 @@ def test_100_gpload_transform():
                       format='text',
                       table='prices',
                       mode='insert')
+
+@prepare_before_test_2(num=101)
+def test_101_gpload_test_port_range():
+    "101 gpload header reuse table MPP:31557"
+    copy_data('external_file_101.txt','data_file.txt')
+    write_config_file(input_port=None,port_range='[8082,8090]', mode='insert',reuse_tables='true',fast_match='false', file='data_file.txt',config='config/config_file1', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', header='true', truncate=True, match_columns=False)
+    write_config_file(input_port=None,port_range='[8082,8090]', mode='insert',reuse_tables='true',fast_match='false', file='data_file.txt',config='config/config_file2', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', truncate=True, match_columns=False)
+    f = open(mkpath('query101.sql'),'w')
+    f.write("\! gpload -f "+mkpath('config/config_file1')+ "\n")
+    f.write("\! gpload -f "+mkpath('config/config_file2')+ "\n")
+    f.close()

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_101.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_101.txt
@@ -1,0 +1,2 @@
+1,"row 1 - OK",file1
+2,"row 2 - OK",file1

--- a/gpMgmt/bin/gpload_test/gpload2/query101.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query101.ans
@@ -1,0 +1,20 @@
+NOTICE:  HEADER means that each one of the data files has a header row
+NOTICE:  HEADER means that each one of the data files has a header row
+2021-06-22 01:19:18|INFO|gpload session started 2021-06-22 01:19:18
+2021-06-22 01:19:18|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-22 01:19:18|INFO|started gpfdist -p 8082 -P 8090 -f "/home/zhaorui/workspace/greenplum_test/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-22 01:19:18|INFO|did not find an external table to reuse. creating ext_gpload_reusable_8a558d4a_d332_11eb_b595_000c29e26586
+2021-06-22 01:19:18|INFO|running time: 0.10 seconds
+2021-06-22 01:19:18|INFO|rows Inserted          = 1
+2021-06-22 01:19:18|INFO|rows Updated           = 0
+2021-06-22 01:19:18|INFO|data formatting errors = 0
+2021-06-22 01:19:18|INFO|gpload succeeded
+2021-06-22 01:19:18|INFO|gpload session started 2021-06-22 01:19:18
+2021-06-22 01:19:19|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-22 01:19:19|INFO|started gpfdist -p 8082 -P 8090 -f "/home/zhaorui/workspace/greenplum_test/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-22 01:19:19|INFO|did not find an external table to reuse. creating ext_gpload_reusable_8a7806ea_d332_11eb_a2b1_000c29e26586
+2021-06-22 01:19:19|INFO|running time: 0.11 seconds
+2021-06-22 01:19:19|INFO|rows Inserted          = 2
+2021-06-22 01:19:19|INFO|rows Updated           = 0
+2021-06-22 01:19:19|INFO|data formatting errors = 0
+2021-06-22 01:19:19|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query352.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query352.ans
@@ -1,7 +1,7 @@
 2021-01-04 15:10:26|INFO|gpload session started 2021-01-04 15:10:26
 2021-01-04 15:10:26|INFO|setting schema 'public' for table 'csvtable'
 2021-01-04 15:10:26|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
-2021-01-04 15:15:27|INFO|reusing external table ext_gpload_reusable_9eb1255c_4e5c_11eb_989a_000c299afcc5
+2021-06-22 01:01:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_0424961e_d330_11eb_b9c7_000c29e26586
 2021-01-04 15:10:26|INFO|running time: 0.07 seconds
 2021-01-04 15:10:26|INFO|rows Inserted          = 3
 2021-01-04 15:10:26|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -23,6 +23,8 @@ DROP TABLE IF EXISTS chinese表;
 DROP TABLE
 DROP TABLE IF EXISTS testtruncate;
 DROP TABLE
+DROP TABLE IF EXISTS testheaderreuse;
+DROP TABLE
 reset client_min_messages;
 RESET
 CREATE TABLE texttable (
@@ -56,5 +58,10 @@ CREATE TABLE testtruncate (
 CREATE TABLE
 INSERT INTO testtruncate VALUES('ttt','ttgt','shpits', '2011-06-01 12:30:30',16,732,834567,45.67,789.123,7.12345,156.456178);
 INSERT 0 1
-CREATE TABLE prices (itemnumber integer, price decimal ) DISTRIBUTED BY (itemnumber)
+CREATE TABLE prices (itemnumber integer, price decimal ) DISTRIBUTED BY (itemnumber);
+CREATE TABLE
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;
 CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -16,6 +16,7 @@ DROP TABLE IF EXISTS testSpecialChar;
 DROP TABLE IF EXISTS chinese表;
 DROP TABLE IF EXISTS testtruncate;
 DROP TABLE IF EXISTS prices;
+DROP TABLE IF EXISTS testheaderreuse;
 reset client_min_messages;
 CREATE TABLE texttable (
             s1 text, s2 text, s3 text, dt timestamp,
@@ -39,5 +40,8 @@ CREATE TABLE testtruncate (
             n1 smallint, n2 integer, n3 bigint, n4 decimal,
             n5 numeric, n6 real, n7 double precision) DISTRIBUTED BY (n1);
 INSERT INTO testtruncate VALUES('ttt','ttgt','shpits', '2011-06-01 12:30:30',16,732,834567,45.67,789.123,7.12345,156.456178);
-CREATE TABLE prices (itemnumber integer, price decimal ) DISTRIBUTED BY (itemnumber)
-
+CREATE TABLE prices (itemnumber integer, price decimal ) DISTRIBUTED BY (itemnumber);
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;


### PR DESCRIPTION
If gpload loads one file with 'REUSE_TABLES' and 'HEADER' for the first time.
Then loads another file with 'REUSE_TABLES' and without 'HEADER', the second
loading will reuse the first external table which make the second loading
miss the first line.

The reuse table procedure tries to get the existing external table and
compare the format option strings with sql 'like "%fmtopts%'. If the result
returns at least one table, it will reuse the existing external table. The
problem here is that format options are constructed in this order:
delimiter-> null -> escape -> quote(csv) -> [header] -> [fill_missing_field]
->[force_not_null] ->[force-quote] -> [newline]. The options in the square
brackets are optional, so the compare sql will not end with '%'.

This pr fix the incorrect reuse table by removing the last '%' from the sql
'like %formats%'.

So the format option "delimiter '|' null 'null' escape '\' header " will not
be matched with this new option "delimiter '|' null 'null' escape '\'".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
