### PR TITLE
[6X backport] gprecoverseg: show valid status for mirror with no pg_rewind

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -314,7 +314,7 @@ class GpMirrorListToBuild:
             self.__logger.info("Updating mirrors")
 
             if len(rewindInfo) != 0:
-                self.__logger.info("Running pg_rewind on required mirrors")
+                self.__logger.info("Running pg_rewind on failed segments")
                 rewindFailedSegments = self.run_pg_rewind(rewindInfo)
 
                 # Do not start mirrors that failed pg_rewind
@@ -459,6 +459,8 @@ class GpMirrorListToBuild:
                     cmd.run(validateAfter=True)
                     cmd.cmdStr = cmd_str
                     results = cmd.get_results().stdout.rstrip()
+                    if not results:
+                        results = "skipping pg_rewind on mirror as recovery.conf is present"
                 except ExecutionError:
                     lines = cmd.get_results().stderr.splitlines()
                     if lines:

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -78,7 +78,7 @@ Feature: gprecoverseg tests
         And user can start transactions
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running pg_rewind on required mirrors" to stdout
+        And gprecoverseg should print "Running pg_rewind on failed segments" to stdout
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
         When the user runs "gprecoverseg -ra"
@@ -138,7 +138,7 @@ Feature: gprecoverseg tests
         And we generate the postmaster.pid file with the background pid on "primary" segment
         And the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running pg_rewind on required mirrors" to stdout
+        And gprecoverseg should print "Running pg_rewind on failed segments" to stdout
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
         And the segments are synchronized
@@ -159,7 +159,7 @@ Feature: gprecoverseg tests
         When user can start transactions
         And we generate the postmaster.pid file with a non running pid on the same "primary" segment
         And the user runs "gprecoverseg -a"
-        And gprecoverseg should print "Running pg_rewind on required mirrors" to stdout
+        And gprecoverseg should print "Running pg_rewind on failed segments" to stdout
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
@@ -186,6 +186,20 @@ Feature: gprecoverseg tests
           And all the segments are running
           And the segments are synchronized
           And pg_isready reports all primaries are accepting connections
+
+    Scenario: gprecoverseg incremental recovery displays status for mirrors after pg_rewind call
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user stops all mirror processes
+        And user can start transactions
+        When the user runs "gprecoverseg -a -s"
+        And gprecoverseg should print "skipping pg_rewind on mirror as recovery.conf is present" to stdout
+        Then gprecoverseg should return a return code of 0
+        And gpAdminLogs directory has no "pg_rewind*" files
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
 
     @demo_cluster
     @concourse_cluster
@@ -272,7 +286,7 @@ Feature: gprecoverseg tests
         Then the saved "mirror" segment is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should not print "Running pg_rewind on required mirrors" to stdout
+        And gprecoverseg should not print "Running pg_rewind on failed segments" to stdout
         And all the segments are running
         And the segments are synchronized
 


### PR DESCRIPTION
**cherry-pick** [12198](https://github.com/greenplum-db/gpdb/pull/12198)

Mirrors with **recovery.conf** file display empty status after pg_rewind
call during incremental recovery. pg_rewind is not required in this
scenario as per the existing design and replication needs to be handle by
WAL. As empty status creates confusion at the user end, this commit will
introduce valid status **skipping pg_rewind on mirror as recovery.conf is present**

It also changes existing recoverseg message from **Running pg_rewind on required
mirrors** to **Running pg_rewind on failed segments**