### PR TITLE
[6X backport] Check errno as early as possible

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1423,6 +1423,7 @@ SetupTCPInterconnect(EState *estate)
 		int			highsock = -1;
 		uint64		timeout_ms = 20 * 60 * 1000;
 		int			outgoing_fail_count = 0;
+		int			select_errno;
 
 		iteration++;
 
@@ -1650,6 +1651,7 @@ SetupTCPInterconnect(EState *estate)
 
 		ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 		n = select(highsock + 1, (fd_set *) &rset, (fd_set *) &wset, (fd_set *) &eset, &timeout);
+		select_errno = errno;
 		ML_CHECK_FOR_INTERRUPTS(interconnect_context->teardownActive);
 		if (Gp_role == GP_ROLE_DISPATCH)
 			checkForCancelFromQD(interconnect_context);
@@ -1666,7 +1668,6 @@ SetupTCPInterconnect(EState *estate)
 			{
 				int			elevel = (n == expectedTotalIncoming + expectedTotalOutgoing)
 				? DEBUG1 : LOG;
-				int			errnoSave = errno;
 
 				initStringInfo(&logbuf);
 				if (n > 0)
@@ -1682,17 +1683,18 @@ SetupTCPInterconnect(EState *estate)
 										elapsed_ms, logbuf.data)));
 				pfree(logbuf.data);
 				MemSet(&logbuf, 0, sizeof(logbuf));
-				errno = errnoSave;
 			}
 		}
 
+		/* An error other than EINTR is not acceptable */
 		if (n < 0)
 		{
-			if (errno == EINTR)
+			if (select_errno == EINTR)
 				continue;
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-					 errmsg("interconnect error: %s: %m", "select")));
+					 errmsg("interconnect error in select: %s",
+							strerror(select_errno))));
 		}
 
 		/*


### PR DESCRIPTION
Previously, the result of `select()` system call and `errno` set by it was checked after performing several function calls, including checking for interrupts and `checkForCancelFromQD`.  That made it very likely for `errno` to change, losing the original value that was set by the `select()`.

This patch fixes it so that the `errno` is checked immediately after the system call.  This should address intermittent failures in CI with error message like this:

```
    "ERROR","58M01","interconnect error: select: Success"
```

This patch would have made the following CI failure easier to diagnose: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE_without_asserts/jobs/icw_planner_ictcp_centos6/builds/991

