### PR TITLE
Fix an two-phase transaction may be committed in master but rollbacked in segments

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1486,6 +1486,7 @@ insertingDistributedCommitted(void)
 void
 insertedDistributedCommitted(void)
 {
+	SIMPLE_FAULT_INJECTOR("start_insertedDistributedCommitted");
 	ereport(DTM_DEBUG5,
 			(errmsg("entering insertedDistributedCommitted"),
 			TM_ERRDETAIL));

--- a/src/test/isolation2/expected/checkpoint_dtx_info.out
+++ b/src/test/isolation2/expected/checkpoint_dtx_info.out
@@ -1,23 +1,31 @@
--- Currently `MyTmGxact->includeInCkpt = true` and `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)`
--- is already protected by delayChkpt, so these are an atomic operation from the outside perspective.
--- But getDtxCheckPointInfo() may see the middle state because getDtxCheckPointInfo() is called
--- before GetVirtualXIDsDelayingChkpt(). We have fixed it and add this testcase.
--- This testcase will fail if getDtxCheckPointInfo() is called before GetVirtualXIDsDelayingChkpt().
-
--- We accurately control the progress of COMMIT executed in session 1 and of CHECKPOINT executed
--- in the checkpointer process, so that events occur in the following specific order:
+-- Scenario to test, CHECKPOINT getting distributed transaction
+-- information between COMMIT processing time window
+-- `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)` and
+-- insertedDistributedCommitted(). `delayChkpt` protects this
+-- case. There used to bug in placement of getDtxCheckPointInfo() in
+-- checkpoint code causing, transaction to be committed on coordinator
+-- and aborted on segments. Test case is meant to validate
+-- getDtxCheckPointInfo() gets called after
+-- GetVirtualXIDsDelayingChkpt().
 --
--- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted.
--- 2. checkpointer: Start a new CHECKPOINT and the CHECKPOINT is blocked at `checkpoint`.
--- 3. checkpointer: CHECKPOINT is resumed and executes to before_wait_VirtualXIDsDelayingChkpt.
--- 4. session 1: COMMIT is resumed and executes to after_xlog_xact_distributed_commit
--- 5. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg and cause a panic.
+-- Test controls the progress of COMMIT executed in session 1 and of
+-- CHECKPOINT executed in the checkpointer process, with high-level
+-- flow:
 --
--- if getDtxCheckPointInfo() is invoked before GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo()
--- will not contain the distributed transaction in session1 whose state is DTX_STATE_INSERTED_COMMITTED.
--- Therefore, after crash recovery, the 2PC transaction that has been committed in master will be
--- considered by the master as an orphaned prepared transaction and will be rollbacked at segments.
--- So the SELECT executed by session3 will fail because the twopcbug table only exists on the master.
+-- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted
+-- 2. checkpointer: Start a CHECKPOINT and wait to reach before_wait_VirtualXIDsDelayingChkpt
+-- 3. session 1: COMMIT is resumed
+-- 4. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg to finally introduce panic and perform crash recovery
+--
+-- Bug existed when getDtxCheckPointInfo() was invoked before
+-- GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo() will not
+-- contain the distributed transaction in session1 whose state is
+-- DTX_STATE_INSERTED_COMMITTED.  Therefore, after crash recovery, the
+-- 2PC transaction that has been committed on coordinator will be
+-- considered as orphaned prepared transaction hence is aborted at
+-- segments. As a result the SELECT executed by session3 used to fail
+-- because the twopcbug table only existed on the coordinator.
+--
 1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
@@ -28,37 +36,28 @@ BEGIN
 1: create table twopcbug(i int, j int);
 CREATE
 1&: commit;  <waiting ...>
-2: select gp_inject_fault_infinite('checkpoint', 'suspend', 1);
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-33&: checkpoint;  <waiting ...>
-2: select gp_wait_until_triggered_fault('checkpoint', 1, 1);
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
-2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
 2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
-2: select gp_inject_fault_infinite('checkpoint', 'resume', 1);
+33&: checkpoint;  <waiting ...>
+2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
+-- wait to make sure we don't resume commit processing before this
+-- step in checkpoint
 2: select gp_wait_until_triggered_fault('before_wait_VirtualXIDsDelayingChkpt', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
+-- reason for this inifinite wait is just to avoid test flake. Without
+-- this joining step "1<" may see "COMMIT" sometimes or "server closed
+-- the connection unexpectedly" otherwise. With this its always
+-- "server closed the connection unexpectedly".
 2: select gp_inject_fault_infinite('after_xlog_xact_distributed_commit', 'infinite_loop', 1);
  gp_inject_fault_infinite 
 --------------------------
@@ -77,7 +76,7 @@ server closed the connection unexpectedly
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- wait until master is up for querying.
+-- wait until coordinator is up for querying.
 3: select 1;
  ?column? 
 ----------
@@ -88,4 +87,3 @@ server closed the connection unexpectedly
 -------
  0     
 (1 row)
-

--- a/src/test/isolation2/expected/checkpoint_dtx_info.out
+++ b/src/test/isolation2/expected/checkpoint_dtx_info.out
@@ -1,0 +1,72 @@
+-- See https://github.com/greenplum-db/gpdb/issues/12199 for more details
+1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: begin;
+BEGIN
+1: create table twopcbug(i int, j int);
+CREATE
+1&: commit;  <waiting ...>
+2: select gp_inject_fault_infinite('checkpoint', 'suspend', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+33&: checkpoint;  <waiting ...>
+2: select gp_wait_until_triggered_fault('checkpoint', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('checkpoint', 'resume', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_wait_until_triggered_fault('before_wait_VirtualXIDsDelayingChkpt', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+2: select gp_inject_fault_infinite('after_xlog_xact_distributed_commit', 'infinite_loop', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'resume', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+33<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- wait until master is up for querying.
+3: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+3: select count(1) from twopcbug;
+ count 
+-------
+ 0     
+(1 row)
+

--- a/src/test/isolation2/expected/checkpoint_dtx_info.out
+++ b/src/test/isolation2/expected/checkpoint_dtx_info.out
@@ -1,4 +1,23 @@
--- See https://github.com/greenplum-db/gpdb/issues/12199 for more details
+-- Currently `MyTmGxact->includeInCkpt = true` and `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)`
+-- is already protected by delayChkpt, so these are an atomic operation from the outside perspective.
+-- But getDtxCheckPointInfo() may see the middle state because getDtxCheckPointInfo() is called
+-- before GetVirtualXIDsDelayingChkpt(). We have fixed it and add this testcase.
+-- This testcase will fail if getDtxCheckPointInfo() is called before GetVirtualXIDsDelayingChkpt().
+
+-- We accurately control the progress of COMMIT executed in session 1 and of CHECKPOINT executed
+-- in the checkpointer process, so that events occur in the following specific order:
+--
+-- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted.
+-- 2. checkpointer: Start a new CHECKPOINT and the CHECKPOINT is blocked at `checkpoint`.
+-- 3. checkpointer: CHECKPOINT is resumed and executes to before_wait_VirtualXIDsDelayingChkpt.
+-- 4. session 1: COMMIT is resumed and executes to after_xlog_xact_distributed_commit
+-- 5. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg and cause a panic.
+--
+-- if getDtxCheckPointInfo() is invoked before GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo()
+-- will not contain the distributed transaction in session1 whose state is DTX_STATE_INSERTED_COMMITTED.
+-- Therefore, after crash recovery, the 2PC transaction that has been committed in master will be
+-- considered by the master as an orphaned prepared transaction and will be rollbacked at segments.
+-- So the SELECT executed by session3 will fail because the twopcbug table only exists on the master.
 1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,6 +1,7 @@
 # test if gxid is valid or not on the cluster before running the tests
 test: check_gxid
 
+test: checkpoint_dtx_info
 test: autovacuum-analyze
 test: lockmodes
 test: pg_rewind_fail_missing_xlog

--- a/src/test/isolation2/sql/checkpoint_dtx_info.sql
+++ b/src/test/isolation2/sql/checkpoint_dtx_info.sql
@@ -1,39 +1,49 @@
--- Currently `MyTmGxact->includeInCkpt = true` and `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)`
--- is already protected by delayChkpt, so these are an atomic operation from the outside perspective.
--- But getDtxCheckPointInfo() may see the middle state because getDtxCheckPointInfo() is called
--- before GetVirtualXIDsDelayingChkpt(). We have fixed it and add this testcase.
--- This testcase will fail if getDtxCheckPointInfo() is called before GetVirtualXIDsDelayingChkpt().
-
--- We accurately control the progress of COMMIT executed in session 1 and of CHECKPOINT executed
--- in the checkpointer process, so that events occur in the following specific order:
+-- Scenario to test, CHECKPOINT getting distributed transaction
+-- information between COMMIT processing time window
+-- `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)` and
+-- insertedDistributedCommitted(). `delayChkpt` protects this
+-- case. There used to bug in placement of getDtxCheckPointInfo() in
+-- checkpoint code causing, transaction to be committed on coordinator
+-- and aborted on segments. Test case is meant to validate
+-- getDtxCheckPointInfo() gets called after
+-- GetVirtualXIDsDelayingChkpt().
 --
--- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted.
--- 2. checkpointer: Start a new CHECKPOINT and the CHECKPOINT is blocked at `checkpoint`.
--- 3. checkpointer: CHECKPOINT is resumed and executes to before_wait_VirtualXIDsDelayingChkpt.
--- 4. session 1: COMMIT is resumed and executes to after_xlog_xact_distributed_commit
--- 5. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg and cause a panic.
+-- Test controls the progress of COMMIT executed in session 1 and of
+-- CHECKPOINT executed in the checkpointer process, with high-level
+-- flow:
 --
--- if getDtxCheckPointInfo() is invoked before GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo()
--- will not contain the distributed transaction in session1 whose state is DTX_STATE_INSERTED_COMMITTED.
--- Therefore, after crash recovery, the 2PC transaction that has been committed in master will be
--- considered by the master as an orphaned prepared transaction and will be rollbacked at segments.
--- So the SELECT executed by session3 will fail because the twopcbug table only exists on the master.
+-- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted
+-- 2. checkpointer: Start a CHECKPOINT and wait to reach before_wait_VirtualXIDsDelayingChkpt
+-- 3. session 1: COMMIT is resumed
+-- 4. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg to finally introduce panic and perform crash recovery
+--
+-- Bug existed when getDtxCheckPointInfo() was invoked before
+-- GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo() will not
+-- contain the distributed transaction in session1 whose state is
+-- DTX_STATE_INSERTED_COMMITTED.  Therefore, after crash recovery, the
+-- 2PC transaction that has been committed on coordinator will be
+-- considered as orphaned prepared transaction hence is aborted at
+-- segments. As a result the SELECT executed by session3 used to fail
+-- because the twopcbug table only existed on the coordinator.
+--
 1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
 1: begin;
 1: create table twopcbug(i int, j int);
 1&: commit;
-2: select gp_inject_fault_infinite('checkpoint', 'suspend', 1);
-33&: checkpoint;
-2: select gp_wait_until_triggered_fault('checkpoint', 1, 1);
-2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
 2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
-2: select gp_inject_fault_infinite('checkpoint', 'resume', 1);
+33&: checkpoint;
+2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
+-- wait to make sure we don't resume commit processing before this
+-- step in checkpoint
 2: select gp_wait_until_triggered_fault('before_wait_VirtualXIDsDelayingChkpt', 1, 1);
+-- reason for this inifinite wait is just to avoid test flake. Without
+-- this joining step "1<" may see "COMMIT" sometimes or "server closed
+-- the connection unexpectedly" otherwise. With this its always
+-- "server closed the connection unexpectedly".
 2: select gp_inject_fault_infinite('after_xlog_xact_distributed_commit', 'infinite_loop', 1);
 2: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'resume', 1);
 1<:
 33<:
--- wait until master is up for querying.
+-- wait until coordinator is up for querying.
 3: select 1;
 3: select count(1) from twopcbug;
-

--- a/src/test/isolation2/sql/checkpoint_dtx_info.sql
+++ b/src/test/isolation2/sql/checkpoint_dtx_info.sql
@@ -1,0 +1,39 @@
+-- Currently `MyTmGxact->includeInCkpt = true` and `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)`
+-- is already protected by delayChkpt, so these are an atomic operation from the outside perspective.
+-- But getDtxCheckPointInfo() may see the middle state because getDtxCheckPointInfo() is called
+-- before GetVirtualXIDsDelayingChkpt(). We have fixed it and add this testcase.
+-- This testcase will fail if getDtxCheckPointInfo() is called before GetVirtualXIDsDelayingChkpt().
+
+-- We accurately control the progress of COMMIT executed in session 1 and of CHECKPOINT executed
+-- in the checkpointer process, so that events occur in the following specific order:
+--
+-- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted.
+-- 2. checkpointer: Start a new CHECKPOINT and the CHECKPOINT is blocked at `checkpoint`.
+-- 3. checkpointer: CHECKPOINT is resumed and executes to before_wait_VirtualXIDsDelayingChkpt.
+-- 4. session 1: COMMIT is resumed and executes to after_xlog_xact_distributed_commit
+-- 5. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg and cause a panic.
+--
+-- if getDtxCheckPointInfo() is invoked before GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo()
+-- will not contain the distributed transaction in session1 whose state is DTX_STATE_INSERTED_COMMITTED.
+-- Therefore, after crash recovery, the 2PC transaction that has been committed in master will be
+-- considered by the master as an orphaned prepared transaction and will be rollbacked at segments.
+-- So the SELECT executed by session3 will fail because the twopcbug table only exists on the master.
+1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
+1: begin;
+1: create table twopcbug(i int, j int);
+1&: commit;
+2: select gp_inject_fault_infinite('checkpoint', 'suspend', 1);
+33&: checkpoint;
+2: select gp_wait_until_triggered_fault('checkpoint', 1, 1);
+2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
+2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
+2: select gp_inject_fault_infinite('checkpoint', 'resume', 1);
+2: select gp_wait_until_triggered_fault('before_wait_VirtualXIDsDelayingChkpt', 1, 1);
+2: select gp_inject_fault_infinite('after_xlog_xact_distributed_commit', 'infinite_loop', 1);
+2: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'resume', 1);
+1<:
+33<:
+-- wait until master is up for querying.
+3: select 1;
+3: select count(1) from twopcbug;
+


### PR DESCRIPTION
Fix #12199 