### PR TITLE
Use socket to validate TCP port

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -5,6 +5,7 @@
 """
 Set of Classes for executing unix commands.
 """
+import errno
 import os
 import platform
 import psutil
@@ -590,7 +591,7 @@ class PgPortIsActive():
             result = False
         except OSError as e:
             if e.errno == errno.EADDRINUSE:
-                logger.error("Port %s already in use" % self.port)
+                pass
             else:
                 raise
         sock.close()

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -581,35 +581,27 @@ class Hostname(Command):
 class PgPortIsActive(Command):
     def __init__(self, name, port, file, ctxt=LOCAL, remoteHost=None):
         self.port = port
-        cmdStr = "%s -an 2>/dev/null | %s %s | %s '{print $NF}'" % \
-                 (findCmdInPath('netstat'), findCmdInPath('grep'), file, findCmdInPath('awk'))
-        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
-    def contains_port(self):
-        rows = self.results.stdout.strip().split()
-
-        if len(rows) == 0:
-            return False
-
-        for r in rows:
-            val = r.split('.')
-            netstatport = int(val[len(val) - 1])
-            if netstatport == self.port:
-                return True
-
-        return False
+    def contains_port(self, remoteHost="127.0.0.1"):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = True
+        try:
+            sock.bind((remoteHost, self.port))
+            result = False
+        except:
+            pass
+        sock.close()
+        return result
 
     @staticmethod
     def local(name, file, port):
         cmd = PgPortIsActive(name, port, file)
-        cmd.run(validateAfter=True)
         return cmd.contains_port()
 
     @staticmethod
     def remote(name, file, port, remoteHost):
         cmd = PgPortIsActive(name, port, file, ctxt=REMOTE, remoteHost=remoteHost)
-        cmd.run(validateAfter=True)
-        return cmd.contains_port()
+        return cmd.contains_port(remoteHost)
 
 
 # --------------chmod ----------------------

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -588,8 +588,11 @@ class PgPortIsActive():
         try:
             sock.bind((remoteHost, self.port))
             result = False
-        except:
-            logger.error("Port %s already in use" % self.port)
+        except OSError as e:
+            if e.errno == errno.EADDRINUSE:
+                logger.error("Port %s already in use" % self.port)
+            else:
+                raise
         sock.close()
         return result
 

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -578,30 +578,30 @@ class Hostname(Command):
 
 
 # --------------tcp port is active -----------------------
-class PgPortIsActive(Command):
+class PgPortIsActive():
     def __init__(self, name, port, file, ctxt=LOCAL, remoteHost=None):
         self.port = port
 
-    def contains_port(self, remoteHost="127.0.0.1"):
+    def port_in_use(self, remoteHost="127.0.0.1"):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         result = True
         try:
             sock.bind((remoteHost, self.port))
             result = False
         except:
-            pass
+            logger.error("Port %s already in use" % self.port)
         sock.close()
         return result
 
     @staticmethod
     def local(name, file, port):
         cmd = PgPortIsActive(name, port, file)
-        return cmd.contains_port()
+        return cmd.port_in_use()
 
     @staticmethod
     def remote(name, file, port, remoteHost):
         cmd = PgPortIsActive(name, port, file, ctxt=REMOTE, remoteHost=remoteHost)
-        return cmd.contains_port(remoteHost)
+        return cmd.port_in_use(remoteHost)
 
 
 # --------------chmod ----------------------

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -593,7 +593,8 @@ class PgPortIsActive():
             if e.errno == errno.EADDRINUSE:
                 pass
             else:
-                raise
+                logger.critical('Unexpected socket bound error %d', e.errno)
+                pass
         sock.close()
         return result
 


### PR DESCRIPTION
Earlier we used netstat to validate PGPORT, Trying to avoid netstat/ss with socket calls

Co-authored-by: Sumit Basu Mallick sumitbm@rediffmail.com
Co-authored-by: Hari Krishna pobbati.hari@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
