### PR TITLE
The postgresql.auto.conf should copy from segment

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -861,6 +861,14 @@ class SegmentTemplate:
             remoteHost=self.srcSegHostname)
         cpCmd.run(validateAfter=True)
 
+        self.logger.info('Copying postgresql.auto.conf from existing segment into template')
+        cmdName = 'gpexpand copying postgresql.auto.conf to %s:%s/postgresql.auto.conf' \
+                  % (self.srcSegHostname, self.srcSegDataDir)
+        cpCmd = Scp(name=cmdName, srcFile=self.srcSegDataDir + '/postgresql.auto.conf',
+            dstFile=self.tempDir, dstHost=localHostname, ctxt=REMOTE,
+            remoteHost=self.srcSegHostname)
+        cpCmd.run(validateAfter=True)
+
         self.logger.info('Copying pg_hba.conf from existing segment into template')
         cmdName = 'gpexpand copy pg_hba.conf to %s:%s/pg_hba.conf' \
                   % (self.srcSegHostname, self.srcSegDataDir)

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -529,3 +529,21 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "public.test_matview" is 4
         And distribution information from table "public.test_matview" and "public.test_matview_base" in "gptest" are the same
+
+    @gpexpand_verify_autoconf_from_qe
+    Scenario: Verify should succeed when expand partition table
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "1" primaries only
+        And database "gptest" exists
+        And the user change enable_mergejoin to on only on qd by alter system on gptest
+        And the user restart the whole cluster
+        And enable_mergejoin is on on qd and off on all qes
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 1 new segments
+        Then enable_mergejoin is on on qd and off on all qes

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2337,6 +2337,32 @@ def impl(context, command, target):
     if target not in contents:
         raise Exception("cannot find %s in %s" % (target, filename))
 
+
+@given('the user change enable_mergejoin to on only on qd by alter system on gptest')
+def impl(context):
+    host, port = get_primary_segment_host_port_for_content('-1')
+    query = "alter system set enable_mergejoin to on"
+    psql_cmd = "PGDATABASE=\'%s\' psql -h %s -p %s -c \"%s\"; " % (
+        "gptest", host, port, query)
+    Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
+
+@given('the user restart the whole cluster')
+def impl(context):
+    cmd = "gpstop -rai"
+    Command(name='Running Remote command: %s' % cmd, cmdStr=cmd).run(validateAfter=True)
+
+@given('enable_mergejoin is on on qd and off on all qes')
+@then('enable_mergejoin is on on qd and off on all qes')
+def impl(context):
+    cmd = "gpconfig -s enable_mergejoin"
+    c = Command(name='Running Remote command: %s' % cmd, cmdStr=cmd)
+    c.run(validateAfter=True)
+    out = c.get_stdout()
+    if ("Master  value: on" not in out or
+        "Segment value: off" not in out):
+        raise Exception('Guc enable_mergejoin value is not correct')
+
+
 @given('verify that a role "{role_name}" exists in database "{dbname}"')
 @then('verify that a role "{role_name}" exists in database "{dbname}"')
 def impl(context, role_name, dbname):


### PR DESCRIPTION
For command ALTER SYSTEM, will modify the config file postgresql.auto.conf, while execute gpexpand, copy this file from master is not correct.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
