### PR TITLE
Cleanup workfile_mgr isolation2 test

### DIFF
--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -77,10 +77,6 @@ extern int	max_safe_fds;
 extern File PathNameOpenFile(const char *fileName, int fileFlags);
 extern File PathNameOpenFilePerm(const char *fileName, int fileFlags, mode_t fileMode);
 
-extern File OpenNamedTemporaryFile(const char *fileName,
-								   bool create,
-								   bool delOnClose,
-								   bool interXact);
 extern File OpenTemporaryFile(bool interXact, const char *filePrefix);
 extern void FileClose(File file);
 extern int	FilePrefetch(File file, off_t offset, int amount, uint32 wait_event_info);

--- a/src/test/isolation2/input/workfile_mgr_test.source
+++ b/src/test/isolation2/input/workfile_mgr_test.source
@@ -29,6 +29,32 @@ RETURNS TABLE(segid int4, prefix text, size int8, operation text, slice int4, se
 AS '$libdir/gp_workfile_mgr', 'gp_workfile_mgr_cache_entries'
 LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 
+-- Wait for at the most 1 min for backends to remove transient
+-- workfile sets as part of exit processing and then report long lived
+-- workfile sets.
+create or replace function report_workfile_entries()
+returns table(segid int4, prefix text, size int8, operation text, slice int4, numfiles int4) as $$
+declare
+    iterations int; /* in func */
+    cnt int; /* in func */
+begin
+    iterations := 120; /* wait at the most 1 min */
+    select count(*) into cnt from gp_workfile_mgr_cache_entries() w
+    where w.prefix not like 'long_live_workset%'; /* in func */
+
+    while (iterations > 0) and (cnt > 0)
+    loop
+        select count(*) into cnt from gp_workfile_mgr_cache_entries() w
+        where w.prefix not like 'long_live_workset%'; /* in func */
+        perform pg_sleep(0.5); /* sleep for half a second */
+	iterations := iterations - 1; /* in func */
+    end loop; /* in func */
+    return query select w.segid, w.prefix, w.size, w.operation, w.slice, w.numfiles
+                 from gp_workfile_mgr_cache_entries() w; /* in func */
+end; /* in func */
+$$
+language plpgsql volatile execute on all segments;
+
 -- start_ignore
 !\retcode gpconfig -c gp_workfile_max_entries -v 32 --skipvalidation;
 !\retcode gpstop -ari;
@@ -83,4 +109,10 @@ LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 
 -- for workset lives across transaction, e.g. with hold cursor, proc exit will cleanup the workset
 3q:
-4: select segid, prefix, size, operation, slice, numfiles from gp_workfile_mgr_cache_entries() order by (segid, prefix);
+
+-- The "q:" step does not wait for the backend process to exit.  So
+-- wait at the most 1 min so that only the long lived sessions are
+-- reported.  If we don't wait thte test sometimes fails because
+-- "inter_xact_workset" entries show up in the output of
+-- gp_workfile_mgr_cache_entries().
+4: select * from report_workfile_entries();

--- a/src/test/isolation2/input/workfile_mgr_test.source
+++ b/src/test/isolation2/input/workfile_mgr_test.source
@@ -40,8 +40,6 @@ LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 1: CREATE TABLESPACE work_file_test_ts LOCATION '@testtablespace@/workfile_mgr';
 
 1: select gp_workfile_mgr_test('atomic_test', 0);
-1: select gp_workfile_mgr_test('fd_tests', 0);
-1: select gp_workfile_mgr_test('fd_large_file_test', 0);
 
 -- test will fail when the workset exceeds gp_workfile_max_entries, the workset will be released at the end of transaction.
 1: select gp_workfile_mgr_test('workfile_fill_sharedcache', 0);

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -16,6 +16,13 @@ CREATE
 CREATE FUNCTION gp_workfile_mgr_cache_entries() RETURNS TABLE(segid int4, prefix text, size int8, operation text, slice int4, sessionid int4, commandid int4, numfiles int4) AS '$libdir/gp_workfile_mgr', 'gp_workfile_mgr_cache_entries' LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 CREATE
 
+-- Wait for at the most 1 min for backends to remove transient
+-- workfile sets as part of exit processing and then report long lived
+-- workfile sets.
+create or replace function report_workfile_entries() returns table(segid int4, prefix text, size int8, operation text, slice int4, numfiles int4) as $$ declare iterations int; /* in func */ cnt int; /* in func */ begin iterations := 120; /* wait at the most 1 min */ select count(*) into cnt from gp_workfile_mgr_cache_entries() w where w.prefix not like 'long_live_workset%'; /* in func */ 
+while (iterations > 0) and (cnt > 0) loop select count(*) into cnt from gp_workfile_mgr_cache_entries() w where w.prefix not like 'long_live_workset%'; /* in func */ perform pg_sleep(0.5); /* sleep for half a second */ iterations := iterations - 1; /* in func */ end loop; /* in func */ return query select w.segid, w.prefix, w.size, w.operation, w.slice, w.numfiles from gp_workfile_mgr_cache_entries() w; /* in func */ end; /* in func */ $$ language plpgsql volatile execute on all segments;
+CREATE
+
 -- start_ignore
 !\retcode gpconfig -c gp_workfile_max_entries -v 32 --skipvalidation;
 -- start_ignore
@@ -282,7 +289,13 @@ ABORT
 
 -- for workset lives across transaction, e.g. with hold cursor, proc exit will cleanup the workset
 3q: ... <quitting>
-4: select segid, prefix, size, operation, slice, numfiles from gp_workfile_mgr_cache_entries() order by (segid, prefix);
+
+-- The "q:" step does not wait for the backend process to exit.  So
+-- wait at the most 1 min so that only the long lived sessions are
+-- reported.  If we don't wait thte test sometimes fails because
+-- "inter_xact_workset" entries show up in the output of
+-- gp_workfile_mgr_cache_entries().
+4: select * from report_workfile_entries();
  segid | prefix              | size | operation         | slice | numfiles 
 -------+---------------------+------+-------------------+-------+----------
  0     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -72,22 +72,6 @@ CREATE
  f                    
  f                    
 (4 rows)
-1: select gp_workfile_mgr_test('fd_tests', 0);
- gp_workfile_mgr_test 
-----------------------
- t                    
- t                    
- t                    
- t                    
-(4 rows)
-1: select gp_workfile_mgr_test('fd_large_file_test', 0);
- gp_workfile_mgr_test 
-----------------------
- t                    
- t                    
- t                    
- t                    
-(4 rows)
 
 -- test will fail when the workset exceeds gp_workfile_max_entries, the workset will be released at the end of transaction.
 1: select gp_workfile_mgr_test('workfile_fill_sharedcache', 0);

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -704,13 +704,6 @@ workfile_fill_sharedcache(void)
 			success = false;
 			break;
 		}
-		if (crt_entry >= gp_workfile_max_entries - 2)
-		{
-			/* Pause between adding extra ones so we can test from other sessions */
-			elog(LOG, "Added %d entries out of %d, pausing for 30 seconds before proceeding", crt_entry + 1, n_entries);
-			sleep(30);
-		}
-
 	}
 
 	unit_test_result(success);


### PR DESCRIPTION
Please see individual commit messages for details.  This patch removes `OpenNamedTemporaryFile()` interface that was used only by workfile_mgr test.  The workfile_mgr_test.c still contains several merge fixmes and disabled code, but this PR is one step forward.