### PR TITLE
Exclude columns which has attstattarget=0 for analyzing stats merge

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1180,7 +1180,7 @@ get_rel_oids(Oid relid, VacuumStmt *vacstmt, int stmttype)
 					for (int i = 1; i <= attr_cnt; i++)
 					{
 						Form_pg_attribute attr = onerel->rd_att->attrs[i-1];
-						if (attr->attisdropped)
+						if (attr->attisdropped || attr->attstattarget == 0)
 							continue;
 						va_root_attnums = lappend_int(va_root_attnums, i);
 					}

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1968,3 +1968,34 @@ select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
          0 |        1
 (1 row)
 
+-- Test merging of stats after the last partition is analyzed. Merging should
+-- be done for root without taking a sample from root if one of the column
+-- statistics collection is turned off
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c gp_hyperloglog_estimator) PARTITION BY RANGE (b) (START (1) END (3) EVERY (1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+SET gp_autostats_mode=none;
+ALTER TABLE foo ALTER COLUMN c SET STATISTICS 0;
+INSERT INTO foo SELECT i,i%2+1, NULL FROM generate_series(1,100)i;
+ANALYZE VERBOSE foo_1_prt_1;
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(44747, 400, 'f');
+ANALYZE VERBOSE foo_1_prt_2;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(44755, 400, 'f');
+INFO:  analyzing "public.foo" inheritance tree
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+  tablename  | attname | null_frac | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
+-------------+---------+-----------+------------+------------------+-------------------+------------------
+ foo         | a       |         0 |         -1 |                  |                   | {1,26,50,74,100}
+ foo_1_prt_1 | a       |         0 |         -1 |                  |                   | {2,26,50,74,100}
+ foo_1_prt_2 | a       |         0 |         -1 |                  |                   | {1,25,49,73,99}
+ foo         | b       |         0 |          2 | {1,2}            | {0.5,0.5}         | 
+ foo_1_prt_1 | b       |         0 |          1 | {1}              | {1}               | 
+ foo_1_prt_2 | b       |         0 |          1 | {2}              | {1}               | 
+(6 rows)
+
+RESET gp_autostats_mode;

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -811,3 +811,15 @@ analyze verbose rootpartition foo;
 -- ensure relpages is correctly set after analyzing
 analyze foo_1_prt_2;
 select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
+-- Test merging of stats after the last partition is analyzed. Merging should
+-- be done for root without taking a sample from root if one of the column
+-- statistics collection is turned off
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c gp_hyperloglog_estimator) PARTITION BY RANGE (b) (START (1) END (3) EVERY (1));
+SET gp_autostats_mode=none;
+ALTER TABLE foo ALTER COLUMN c SET STATISTICS 0;
+INSERT INTO foo SELECT i,i%2+1, NULL FROM generate_series(1,100)i;
+ANALYZE VERBOSE foo_1_prt_1;
+ANALYZE VERBOSE foo_1_prt_2;
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+RESET gp_autostats_mode;


### PR DESCRIPTION
If for a column attstattarget is set to 0, it should not be considered
while evaluating if the stats could be merged for the root. The user has
specifically disabled stats collection on that column, so leaf stats
merge should proceed based on the other columns.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
