### PR TITLE
Exclude columns which has attstattarget=0 for analyzing stats merge

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1174,7 +1174,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 			Form_pg_attribute att = TupleDescAttr(tupdesc, i);
 			char       *attname;
 
-			if (att->attisdropped)
+			if (att->attisdropped || att->attstattarget == 0)
 				continue;
 
 			attname = pstrdup(NameStr(att->attname));

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1993,3 +1993,32 @@ INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229792, 400, 'f')
 INFO:  analyzing "public.foo_1_prt_1"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(229789, 400, 'f');
 reset optimizer_analyze_root_partition;
+-- Test merging of stats after the last partition is analyzed. Merging should
+-- be done for root without taking a sample from root if one of the column
+-- statistics collection is turned off
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c gp_hyperloglog_estimator) PARTITION BY RANGE (b) (START (1) END (3) EVERY (1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET gp_autostats_mode=none;
+ALTER TABLE foo ALTER COLUMN c SET STATISTICS 0;
+INSERT INTO foo SELECT i,i%2+1, NULL FROM generate_series(1,100)i;
+ANALYZE VERBOSE foo_1_prt_1;
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(24965, 400, 'f');
+ANALYZE VERBOSE foo_1_prt_2;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(24971, 400, 'f');
+INFO:  analyzing "public.foo" inheritance tree
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+  tablename  | attname | null_frac | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
+-------------+---------+-----------+------------+------------------+-------------------+------------------
+ foo         | a       |         0 |         -1 |                  |                   | {1,26,50,74,100}
+ foo_1_prt_1 | a       |         0 |         -1 |                  |                   | {2,26,50,74,100}
+ foo_1_prt_2 | a       |         0 |         -1 |                  |                   | {1,25,49,73,99}
+ foo         | b       |         0 |          2 | {1,2}            | {0.5,0.5}         | 
+ foo_1_prt_1 | b       |         0 |          1 | {1}              | {1}               | 
+ foo_1_prt_2 | b       |         0 |          1 | {2}              | {1}               | 
+(6 rows)
+
+RESET gp_autostats_mode;

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -2004,3 +2004,30 @@ INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230132, 400, 'f')
 INFO:  analyzing "public.foo_1_prt_1"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(230129, 400, 'f');
 reset optimizer_analyze_root_partition;
+-- Test merging of stats after the last partition is analyzed. Merging should
+-- be done for root without taking a sample from root if one of the column
+-- statistics collection is turned off
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int, b int, c gp_hyperloglog_estimator) PARTITION BY RANGE (b) (START (1) END (3) EVERY (1));
+SET gp_autostats_mode=none;
+ALTER TABLE foo ALTER COLUMN c SET STATISTICS 0;
+INSERT INTO foo SELECT i,i%2+1, NULL FROM generate_series(1,100)i;
+ANALYZE VERBOSE foo_1_prt_1;
+INFO:  analyzing "public.foo_1_prt_1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows()
+ANALYZE VERBOSE foo_1_prt_2;
+INFO:  analyzing "public.foo_1_prt_2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows()
+INFO:  analyzing "public.foo" inheritance tree
+SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename like 'foo%' ORDER BY attname,tablename;
+  tablename  | attname | null_frac | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
+-------------+---------+-----------+------------+------------------+-------------------+------------------
+ foo         | a       |         0 |         -1 |                  |                   | {1,26,50,74,100}
+ foo_1_prt_1 | a       |         0 |         -1 |                  |                   | {2,26,50,74,100}
+ foo_1_prt_2 | a       |         0 |         -1 |                  |                   | {1,25,49,73,99}
+ foo         | b       |         0 |          2 | {1,2}            | {0.5,0.5}         | 
+ foo_1_prt_1 | b       |         0 |          1 | {1}              | {1}               | 
+ foo_1_prt_2 | b       |         0 |          1 | {2}              | {1}               | 
+(6 rows)
+
+RESET gp_autostats_mode;


### PR DESCRIPTION
If for a column attstattarget is set to 0, it should not be considered
while evaluating if the stats could be merged for the root. The user has
specifically disabled stats collection on that column, so leaf stats
merge should proceed based on the other columns.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
