### PR TITLE
Typo fix in logging message of UpperBoundNDVs module

### DIFF
--- a/src/backend/gporca/libnaucrates/src/statistics/CUpperBoundNDVs.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CUpperBoundNDVs.cpp
@@ -108,7 +108,7 @@ CUpperBoundNDVs::OsPrint(IOstream &os) const
 {
 	os << "{" << std::endl;
 	m_column_refset->OsPrint(os);
-	os << " Upper Bound of NDVs" << UpperBoundNDVs() << std::endl;
+	os << " Upper Bound of NDVs " << UpperBoundNDVs() << std::endl;
 	os << "}" << std::endl;
 
 	return os;


### PR DESCRIPTION
This patch adds space between title text and UpperBoundNDVs value in logging message so these entries don't stick together in output.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
