### PR TITLE
[6X]Correct CTAS plan for general & segmentGeneral path with volatiole functions

### DIFF
--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -566,6 +566,103 @@ explain (costs off) select * from t_hashdist cross join (select * from generate_
  Optimizer: Postgres query optimizer
 (8 rows)
 
+-- CTAS on general locus into replicated table
+create temp SEQUENCE test_seq;
+explain (costs off) create table t_rep as select nextval('test_seq') from (select generate_series(1,10)) t1 distributed replicated;
+                 QUERY PLAN                  
+---------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t1
+         ->  Result
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+create table t_rep1 as select nextval('test_seq') from (select generate_series(1,10)) t1 distributed replicated;
+select count(*) from gp_dist_random('t_rep1');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct nextval) from gp_dist_random('t_rep1');
+ count 
+-------
+    10
+(1 row)
+
+-- CTAS on general locus into replicated table with HAVING
+explain (costs off) create table t_rep as select i from generate_series(5,15) as i group by i having i < nextval('test_seq') distributed replicated;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  HashAggregate
+         Group Key: i
+         Filter: (i < nextval('test_seq'::regclass))
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+create table t_rep2 as select i from generate_series(5,15) as i group by i having i < nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep2');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct i) from gp_dist_random('t_rep2');
+ count 
+-------
+    10
+(1 row)
+
+-- CTAS on general locus into replicated table with GROUP BY
+explain (costs off) create table t_rep as select i > nextval('test_seq') from generate_series(5,15) as i group by i > nextval('test_seq') distributed replicated;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  HashAggregate
+         Group Key: (i > nextval('test_seq'::regclass))
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+create table t_rep3 as select i > nextval('test_seq') as a from generate_series(5,15) as i group by i > nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep3');
+ count 
+-------
+     3
+(1 row)
+
+select count(distinct a) from gp_dist_random('t_rep3');
+ count 
+-------
+     1
+(1 row)
+
+-- CTAS on replicated table into replicated table
+create table rep_tbl as select t1 from generate_series(1,10) t1 distributed replicated;
+explain (costs off) create table t_rep as select nextval('test_seq') from rep_tbl distributed replicated;
+                 QUERY PLAN                  
+---------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  Seq Scan on rep_tbl
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+create table t_rep4 as select nextval('test_seq') from rep_tbl distributed replicated;
+select count(*) from gp_dist_random('t_rep4');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct nextval) from gp_dist_random('t_rep4');
+ count 
+-------
+    10
+(1 row)
+
+drop table rep_tbl, t_rep1, t_rep2, t_rep3, t_rep4;
 reset optimizer;
 --
 -- Test append different numsegments tables work well

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -316,6 +316,33 @@ explain (costs off) select * from t_hashdist cross join (select a, count(1) as s
 -- limit
 explain (costs off) select * from t_hashdist cross join (select * from generate_series(1, 10) limit 1) x;
 
+-- CTAS on general locus into replicated table
+create temp SEQUENCE test_seq;
+explain (costs off) create table t_rep as select nextval('test_seq') from (select generate_series(1,10)) t1 distributed replicated;
+create table t_rep1 as select nextval('test_seq') from (select generate_series(1,10)) t1 distributed replicated;
+select count(*) from gp_dist_random('t_rep1');
+select count(distinct nextval) from gp_dist_random('t_rep1');
+
+-- CTAS on general locus into replicated table with HAVING
+explain (costs off) create table t_rep as select i from generate_series(5,15) as i group by i having i < nextval('test_seq') distributed replicated;
+create table t_rep2 as select i from generate_series(5,15) as i group by i having i < nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep2');
+select count(distinct i) from gp_dist_random('t_rep2');
+
+-- CTAS on general locus into replicated table with GROUP BY
+explain (costs off) create table t_rep as select i > nextval('test_seq') from generate_series(5,15) as i group by i > nextval('test_seq') distributed replicated;
+create table t_rep3 as select i > nextval('test_seq') as a from generate_series(5,15) as i group by i > nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep3');
+select count(distinct a) from gp_dist_random('t_rep3');
+
+-- CTAS on replicated table into replicated table
+create table rep_tbl as select t1 from generate_series(1,10) t1 distributed replicated;
+explain (costs off) create table t_rep as select nextval('test_seq') from rep_tbl distributed replicated;
+create table t_rep4 as select nextval('test_seq') from rep_tbl distributed replicated;
+select count(*) from gp_dist_random('t_rep4');
+select count(distinct nextval) from gp_dist_random('t_rep4');
+
+drop table rep_tbl, t_rep1, t_rep2, t_rep3, t_rep4;
 reset optimizer;
 
 --


### PR DESCRIPTION
For CTAS plans, general and segmentGeneral locus implies that if the corresponding
slice is executed in many different segments should provide the same result
data set. If the segmentGeneral and general locus path contain volatile
functions they lose the property and cannot be treated as *general.
So adjust the plan in apply_motion when the query is used in CTAS.
This is the continued fix base on https://github.com/greenplum-db/gpdb/pull/10418.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
