### PR TITLE
init holdTillEndXact and add asserts

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1310,14 +1310,10 @@ SetupLockInTable(LockMethod lockMethodTable, PGPROC *proc,
 	 * false for LOCKTAG_RELATION_EXTEND no matter if it is a new lock or
 	 * an existing lock
 	 */
-	if(locktag->locktag_type == LOCKTAG_TRANSACTION)
-	{
-		Assert(lock->holdTillEndXact);
-	}
-	else if(locktag->locktag_type == LOCKTAG_RELATION_EXTEND)
-	{
-		Assert(!(lock->holdTillEndXact));
-	}
+	AssertImply(locktag->locktag_type == LOCKTAG_TRANSACTION,
+				lock->holdTillEndXact);
+	AssertImply(locktag->locktag_type == LOCKTAG_RELATION_EXTEND,
+				!(lock->holdTillEndXact));
 
 	/*
 	 * Create the hash key for the proclock table.

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1291,7 +1291,9 @@ SetupLockInTable(LockMethod lockMethodTable, PGPROC *proc,
 		lock->nGranted = 0;
 		MemSet(lock->requested, 0, sizeof(int) * MAX_LOCKMODES);
 		MemSet(lock->granted, 0, sizeof(int) * MAX_LOCKMODES);
-		// By default, holdTillEndXact is true only for LOCKTAG_TRANSACTION
+		/*
+		 * By default, holdTillEndXact is true only for LOCKTAG_TRANSACTION
+		 */
 		lock->holdTillEndXact = locktag->locktag_type == LOCKTAG_TRANSACTION;
 		LOCK_PRINT("LockAcquire: new", lock, lockmode);
 	}
@@ -1303,9 +1305,11 @@ SetupLockInTable(LockMethod lockMethodTable, PGPROC *proc,
 		Assert(lock->nGranted <= lock->nRequested);
 	}
 
-	// holdTillEndXact must be true for LOCKTAG_TRANSACTION and
-	// false for LOCKTAG_RELATION_EXTEND no matter if it is a new lock or
-	// an existing lock
+	/*
+	 * holdTillEndXact must be true for LOCKTAG_TRANSACTION and
+	 * false for LOCKTAG_RELATION_EXTEND no matter if it is a new lock or
+	 * an existing lock
+	 */
 	if(locktag->locktag_type == LOCKTAG_TRANSACTION)
 	{
 		Assert(lock->holdTillEndXact);
@@ -2304,22 +2308,24 @@ LockRelease(const LOCKTAG *locktag, LOCKMODE lockmode, bool sessionLock)
 		return false;
 	}
 
-	// There are 3 possibilities for holdTillEndXact:
-	// 1. must be true for LOCKTAG_TRANSACTION
-	// 2. might be true or false for LOCKTAG_RELATION
-	// 3. must be false for others
+	/*
+	 * There are 3 possibilities for holdTillEndXact:
+	 * 1. must be true for LOCKTAG_TRANSACTION
+	 * 2. might be true or false for LOCKTAG_RELATION
+	 * 3. must be false for others
+	 */
 	if(locktag->locktag_type == LOCKTAG_TRANSACTION)
 	{
-		// must be true
+		/* must be true */
 		Assert(lock->holdTillEndXact);
 	}
 	else if(locktag->locktag_type == LOCKTAG_RELATION)
 	{
-		// might be true or false, no assert
+		/* might be true or false, no assert */
 	}
 	else
 	{
-		// must be false for others
+		/* must be false for others */
 		Assert(!(lock->holdTillEndXact));
 	}
 

--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -63,9 +63,6 @@ lockIsHoldTillEndXact(LockInstanceData *lock)
 	if (lock->holdTillEndXact)
 		return true;
 
-	if (tag->locktag_type == LOCKTAG_TRANSACTION)
-		return true;
-
 	/* FIXME: other types */
 
 	return false;


### PR DESCRIPTION
The fix is from github issue 11923, which is about some incorrect behavior due to that holdTillEndXact is not initialized:
https://github.com/greenplum-db/gpdb/issues/11923

Basically the change includes:

1. Setting holdTillEndXact to false in the initialization block.
2. Adding an assert to check if holdTillEndXact is false when a lock with type LOCKTAG_RELATION_EXTEND is released.

No extra test case was added, because the change is related to all actions requiring a lock, which have been covered by existing tests.
