### PR TITLE
[5X] Fix issue of releasing lock in resource queue

### DIFF
--- a/src/backend/storage/ipc/shmqueue.c
+++ b/src/backend/storage/ipc/shmqueue.c
@@ -88,6 +88,9 @@ SHMQueueDelete(SHM_QUEUE *queue)
 	nextElem->prev = (queue)->prev;
 
 	(queue)->prev = (queue)->next = INVALID_OFFSET;
+
+	Assert(prevElem->next != INVALID_OFFSET);
+	Assert(nextElem->prev != INVALID_OFFSET);
 }
 
 /*

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -560,10 +560,12 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	 */
 	if (!(proclock->holdMask & LOCKBIT_ON(lockmode)) || proclock->nLocks <= 0)
 	{
-		LWLockRelease(partitionLock);
 		elog(DEBUG1, "Resource queue %d: proclock not held", locktag->locktag_field1);
 		RemoveLocalLock(locallock);
+
 		ResCleanUpLock(lock, proclock, hashcode, false);
+		LWLockRelease(ResQueueLock);
+		LWLockRelease(partitionLock);
 
 		return false;
 	}

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -554,6 +554,8 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 		return false;
 	}
 
+	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
+
 	/*
 	 * Double-check that we are actually holding a lock of the type we want to
 	 * Release.
@@ -576,8 +578,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	MemSet(&portalTag, 0, sizeof(ResPortalTag));
 	portalTag.pid = MyProc->pid;
 	portalTag.portalId = resPortalId;
-
-	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
 	incrementSet = ResIncrementFind(&portalTag);
 	if (!incrementSet)


### PR DESCRIPTION
There is a code path of releasing lock in resource queue which is
not completely protected by partition lock. The issue may cause
damaged lock table.
The fix is to move the code into the scope of partition lock, and
add some asserts.