### PR TITLE
Acquire proper locks when releasing resource queue locks from lock table

### DIFF
--- a/src/backend/postmaster/autostats.c
+++ b/src/backend/postmaster/autostats.c
@@ -29,6 +29,7 @@
 #include "postmaster/autostats.h"
 #include "utils/acl.h"
 #include "miscadmin.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
@@ -265,6 +266,8 @@ auto_stats(AutoStatsCmdType cmdType, Oid relationOid, uint64 ntuples, bool inFun
 	Assert(relationOid != InvalidOid);
 	Assert(cmdType >= 0 && cmdType <= AUTOSTATS_CMDTYPE_SENTINEL);		/* it is a valid command
 																		 * as per auto-stats */
+
+	SIMPLE_FAULT_INJECTOR(BeforeAutoStats);
 
 	GpAutoStatsModeValue actual_gp_autostats_mode;
 

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -836,6 +836,11 @@ DescribeLockTag(StringInfo buf, const LOCKTAG *tag)
 							 tag->locktag_field2,
 							 tag->locktag_field1);
 			break;
+		case LOCKTAG_RESOURCE_QUEUE:
+			appendStringInfo(buf,
+							 _("resource queue %u"),
+							 tag->locktag_field1);
+			break;
 		case LOCKTAG_TRANSACTION:
 			appendStringInfo(buf,
 							 _("transaction %u"),

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -377,6 +377,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in AbortTransaction after ProcArrayEndTransaction */
 	_("cdbdisp_finish_command"),
 		/* inject fault in cdbdisp_finishCommand */
+	_("before_auto_stats"),
+		/* inject fault in auto_stats before running autostats logic */
 	_("not recognized"),
 };
 

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -554,16 +554,20 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 		return false;
 	}
 
+	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
+
 	/*
 	 * Double-check that we are actually holding a lock of the type we want to
 	 * Release.
 	 */
 	if (!(proclock->holdMask & LOCKBIT_ON(lockmode)) || proclock->nLocks <= 0)
 	{
-		LWLockRelease(partitionLock);
 		elog(DEBUG1, "Resource queue %d: proclock not held", locktag->locktag_field1);
 		RemoveLocalLock(locallock);
+
 		ResCleanUpLock(lock, proclock, hashcode, false);
+		LWLockRelease(ResQueueLock);
+		LWLockRelease(partitionLock);
 
 		return false;
 	}
@@ -574,8 +578,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	MemSet(&portalTag, 0, sizeof(ResPortalTag));
 	portalTag.pid = MyProc->pid;
 	portalTag.portalId = resPortalId;
-
-	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
 	incrementSet = ResIncrementFind(&portalTag);
 	if (!incrementSet)

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -562,7 +562,7 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	 */
 	if (!(proclock->holdMask & LOCKBIT_ON(lockmode)) || proclock->nLocks <= 0)
 	{
-		elog(DEBUG1, "Resource queue %d: proclock not held", locktag->locktag_field1);
+		elog(LOG, "ResLockRelease: Resource queue %d: proclock not held", locktag->locktag_field1);
 		RemoveLocalLock(locallock);
 
 		ResCleanUpLock(lock, proclock, hashcode, false);
@@ -982,10 +982,24 @@ ResCleanUpLock(LOCK *lock, PROCLOCK *proclock, uint32 hashcode, bool wakeupNeede
 		uint32		proclock_hashcode;
 
 		if (proclock->lockLink.next != INVALID_OFFSET)
-			SHMQueueDelete(&proclock->lockLink);
+		{
+			SHM_QUEUE  *queue = &proclock->lockLink;
+			SHM_QUEUE  *nextElem = (SHM_QUEUE *) MAKE_PTR((queue)->next);
+			SHM_QUEUE  *prevElem = (SHM_QUEUE *) MAKE_PTR((queue)->prev);
+			SHMQueueDelete(queue);
+			if (prevElem->next == INVALID_OFFSET || nextElem->prev == INVALID_OFFSET)
+				elog(PANIC, "corruption of lock table encountered");
+		}
 
 		if (proclock->procLink.next != INVALID_OFFSET)
-			SHMQueueDelete(&proclock->procLink);
+		{
+			SHM_QUEUE  *queue = &proclock->procLink;
+			SHM_QUEUE  *nextElem = (SHM_QUEUE *) MAKE_PTR((queue)->next);
+			SHM_QUEUE  *prevElem = (SHM_QUEUE *) MAKE_PTR((queue)->prev);
+			SHMQueueDelete(queue);
+			if (prevElem->next == INVALID_OFFSET || nextElem->prev == INVALID_OFFSET)
+				elog(PANIC, "corruption of lock table encountered");
+		}
 
 		proclock_hashcode = ProcLockHashCode(&proclock->tag, hashcode);
 		hash_search_with_hash_value(LockMethodProcLockHash, (void *) &(proclock->tag),

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -257,6 +257,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	CdbDispFinishCommand,
 
+	BeforeAutoStats,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/resource_queue_deadlock.out
+++ b/src/test/isolation2/expected/resource_queue_deadlock.out
@@ -1,0 +1,85 @@
+-- This test is used to test if waiting on a resource queue lock will
+-- trigger a local deadlock detection and properly clean up.
+
+0: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- We need gp_autostats_mode to be ON_NO_STATS in this test.
+0: SHOW gp_autostats_mode;
+gp_autostats_mode
+-----------------
+ON_NO_STATS
+(1 row)
+
+-- Create a resource queue where only 1 query can run at a time and
+-- new queries must wait. The role attached to the resource queue must
+-- be a nonsuperuser.
+0: CREATE RESOURCE QUEUE rq_deadlock_test WITH (active_statements = 1);
+CREATE
+0: CREATE ROLE role_deadlock_test RESOURCE QUEUE rq_deadlock_test;
+CREATE
+
+-- Inject suspend fault right before auto_stats() starts doing its thing
+0: SELECT gp_inject_fault_new('before_auto_stats', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+0&: SELECT gp_wait_until_triggered_fault('before_auto_stats', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';  <waiting ...>
+
+-- The INSERT will block when it hits the injected suspend fault. The
+-- INSERT will also hold the ExclusiveLock on the resource queue while
+-- blocking.
+1: SET ROLE role_deadlock_test;
+SET
+1: CREATE TABLE t_deadlock_test(c1 int);
+CREATE
+1&: INSERT INTO t_deadlock_test VALUES (1);  <waiting ...>
+
+-- The ANALYZE will acquire ShareUpdateExclusiveLock on
+-- the t_deadlock_test table.
+2: SET ROLE role_deadlock_test;
+SET
+2: BEGIN;
+BEGIN
+2: ANALYZE t_deadlock_test;
+ANALYZE
+
+-- Unblock session 1's INSERT which will move forward with the
+-- autostats logic. Session 1 will try to acquire
+-- ShareUpdateExclusiveLock on the t_deadlock_test table but will
+-- block waiting for session 2 to release the lock.
+0<:  <... completed>
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+0: SELECT gp_inject_fault_new('before_auto_stats', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+
+-- The SELECT will try to acquire ExclusiveLock on the resource
+-- queue. This will cause a deadlock because session 1 is waiting for
+-- session 2's ShareUpdateExclusiveLock while session 2 will now be
+-- waiting for session 1's ExclusiveLock. Deadlock detection will
+-- catch the issue and error out session 2.
+2: SELECT * FROM t_deadlock_test;
+ERROR:  deadlock detected
+DETAIL:  Process 26804 waits for ExclusiveLock on resource queue 57544; blocked by process 26795.
+Process 26795 waits for ShareUpdateExclusiveLock on relation 57546 of database 57503; blocked by process 26804.
+
+-- Finish up the two sessions.
+2: ROLLBACK;
+ROLLBACK
+1<:  <... completed>
+INSERT 1
+
+-- Clean up the test
+0: DROP TABLE t_deadlock_test;
+DROP
+0: DROP ROLE role_deadlock_test;
+DROP
+0: DROP RESOURCE QUEUE rq_deadlock_test;
+DROP

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -12,4 +12,13 @@ s/\s+\(entry db(.*)+\spid=\d+\)//
 # ignore OID and file/line number diffs for invalid toast indexes
 m/^ERROR:  no valid index found for toast relation/
 s/with Oid \d+ \(.*\)/with Oid OID/
+
+# For resource queue deadlock
+m/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./
+s/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./DETAIL:  Process PID waits for ExclusiveLock on resource queue OID; blocked by process PID./
+
+# For resource queue deadlock
+m/^Process \d+ waits for ShareUpdateExclusiveLock on relation \d+ of database \d+; blocked by process \d+./
+s/^Process \d+ waits for ShareUpdateExclusiveLock on relation \d+ of database \d+; blocked by process \d+./Process PID waits for ShareUpdateExclusiveLock on relation OID of database OID; blocked by process PID./
+
 -- end_matchsubs

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -25,6 +25,9 @@ test: dynamic_index_scan
 test: select_for_update
 test: eval_record
 
+# Test deadlock situation when waiting on a resource queue lock
+test: resource_queue_deadlock
+
 # Tests on Append-Optimized tables (row-oriented).
 test: uao/alter_while_vacuum_row
 test: uao/alter_while_vacuum2_row

--- a/src/test/isolation2/sql/resource_queue_deadlock.sql
+++ b/src/test/isolation2/sql/resource_queue_deadlock.sql
@@ -1,0 +1,53 @@
+-- This test is used to test if waiting on a resource queue lock will
+-- trigger a local deadlock detection and properly clean up.
+
+0: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- We need gp_autostats_mode to be ON_NO_STATS in this test.
+0: SHOW gp_autostats_mode;
+
+-- Create a resource queue where only 1 query can run at a time and
+-- new queries must wait. The role attached to the resource queue must
+-- be a nonsuperuser.
+0: CREATE RESOURCE QUEUE rq_deadlock_test WITH (active_statements = 1);
+0: CREATE ROLE role_deadlock_test RESOURCE QUEUE rq_deadlock_test;
+
+-- Inject suspend fault right before auto_stats() starts doing its thing
+0: SELECT gp_inject_fault_new('before_auto_stats', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+0&: SELECT gp_wait_until_triggered_fault('before_auto_stats', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+
+-- The INSERT will block when it hits the injected suspend fault. The
+-- INSERT will also hold the ExclusiveLock on the resource queue while
+-- blocking.
+1: SET ROLE role_deadlock_test;
+1: CREATE TABLE t_deadlock_test(c1 int);
+1&: INSERT INTO t_deadlock_test VALUES (1);
+
+-- The ANALYZE will acquire ShareUpdateExclusiveLock on
+-- the t_deadlock_test table.
+2: SET ROLE role_deadlock_test;
+2: BEGIN;
+2: ANALYZE t_deadlock_test;
+
+-- Unblock session 1's INSERT which will move forward with the
+-- autostats logic. Session 1 will try to acquire
+-- ShareUpdateExclusiveLock on the t_deadlock_test table but will
+-- block waiting for session 2 to release the lock.
+0<:
+0: SELECT gp_inject_fault_new('before_auto_stats', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+
+-- The SELECT will try to acquire ExclusiveLock on the resource
+-- queue. This will cause a deadlock because session 1 is waiting for
+-- session 2's ShareUpdateExclusiveLock while session 2 will now be
+-- waiting for session 1's ExclusiveLock. Deadlock detection will
+-- catch the issue and error out session 2.
+2: SELECT * FROM t_deadlock_test;
+
+-- Finish up the two sessions.
+2: ROLLBACK;
+1<:
+
+-- Clean up the test
+0: DROP TABLE t_deadlock_test;
+0: DROP ROLE role_deadlock_test;
+0: DROP RESOURCE QUEUE rq_deadlock_test;


### PR DESCRIPTION
When process tries to release the resource queue lock after deadlock
error, the process was not properly holding the partitionLock and
ResQueueLock. This could lead to shared memory corruption (when
another process goes to release its resource queue locks) and later
cause segmentation faults. Fix the issue by making sure we hold both
locks before touching the shared memory queue. We also introduce a
validation check to PANIC when corruption of the lock table is
encountered.

This commit contains code inspired from Github user dh-cloud's PR:
https://github.com/greenplum-db/gpdb/pull/12185

This commit also contains test code inspired from Github user
dreamedcheng's PR:
https://github.com/greenplum-db/gpdb/pull/9652

Co-authored-by: dh-cloud <60729713+dh-cloud@users.noreply.github.com>
Co-authored-by: wuchengwen <wcw190496@alibaba-inc.com>
Co-authored-by: Yao Wang <wayao@vmware.com>
Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Kate Dontsova <edontsova@pivotal.io>