### PR TITLE
Check if subpath can do motion.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -140,6 +140,11 @@ cdbpath_create_motion_path(PlannerInfo *root,
 		if (CdbPathLocus_IsSingleQE(subpath->locus))
 		{
 			/*
+			 * If the subpath requires parameters, we cannot generate Motion atop of it.
+			 */
+			if (!bms_is_empty(PATH_REQ_OUTER(subpath)))
+				return NULL;
+			/*
 			 * Create CdbMotionPath node to indicate that the slice must be
 			 * dispatched to a singleton gang running on the entry db.  We
 			 * merely use this node to note that the path has 'Entry' locus;
@@ -170,6 +175,11 @@ cdbpath_create_motion_path(PlannerInfo *root,
 
 		if (CdbPathLocus_IsSegmentGeneral(subpath->locus))
 		{
+			/*
+			 * If the subpath requires parameters, we cannot generate Motion atop of it.
+			 */
+			if (!bms_is_empty(PATH_REQ_OUTER(subpath)))
+				return NULL;
 			/*
 			 * Data is only available on segments, to distingush it with
 			 * CdbLocusType_General, adding a motion to indicated this
@@ -304,6 +314,11 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	/* Does subpath produce same multiset of rows on every qExec of its gang? */
 	else if (CdbPathLocus_IsReplicated(subpath->locus))
 	{
+		/*
+		 * If the subpath requires parameters, we cannot generate Motion atop of it.
+		 */
+		if (!bms_is_empty(PATH_REQ_OUTER(subpath)))
+			return NULL;
 		/* No-op if replicated-->replicated. */
 		if (CdbPathLocus_IsReplicated(locus))
 		{
@@ -364,6 +379,12 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	 * data. other nodes pull. We relieve motion deadlocks by adding
 	 * materialize nodes on top of motion nodes
 	 */
+
+	/*
+	 * If the subpath requires parameters, we cannot generate Motion atop of it.
+	 */
+	if (!bms_is_empty(PATH_REQ_OUTER(subpath)))
+		return NULL;
 
 	/* Create CdbMotionPath node. */
 	pathnode = makeNode(CdbMotionPath);

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -380,12 +380,6 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	 * materialize nodes on top of motion nodes
 	 */
 
-	/*
-	 * If the subpath requires parameters, we cannot generate Motion atop of it.
-	 */
-	if (!bms_is_empty(PATH_REQ_OUTER(subpath)))
-		return NULL;
-
 	/* Create CdbMotionPath node. */
 	pathnode = makeNode(CdbMotionPath);
 	pathnode->path.pathtype = T_Motion;

--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -2154,7 +2154,7 @@ select max(c1) from pg_class left join t_5628 on true;
 (1 row)
 
 --
--- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault
+-- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault; see issue #12228
 --
 create table test_tz(tz interval) distributed replicated;
 insert into test_tz

--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -2153,10 +2153,49 @@ select max(c1) from pg_class left join t_5628 on true;
    2
 (1 row)
 
+--
+-- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault
+--
+create table test_tz(tz interval) distributed replicated;
+insert into test_tz
+select i * '1 hour'::interval
+from generate_series(0,23) i;
+create index test_tz_idx on test_tz(tz);
+set optimizer=off;
+set enable_hashjoin=off;
+set enable_seqscan=off;
+EXPLAIN (costs off)
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Nested Loop
+   Join Filter: (tst.tz = pg_timezone_names.utc_offset)
+   ->  Function Scan on pg_timezone_names
+         Filter: (name = 'UTC'::text)
+   ->  Materialize
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Index Only Scan using test_tz_idx on test_tz tst
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+ name | tz  
+------+-----
+ UTC  | @ 0
+(1 row)
+
+reset optimizer;
+reset enable_hashjoin;
+reset enable_seqscan;
 drop schema rpt_joins cascade;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table j1_tbl
 drop cascades to table j2_tbl
 drop cascades to table rpt_joins.t1
 drop cascades to table rpt_joins.t2
 drop cascades to table rpt_joins.t3
+drop cascades to table test_tz

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -451,7 +451,7 @@ explain (costs off) select max(c1) from pg_class left join t_5628 on true;
 select max(c1) from pg_class left join t_5628 on true;
 
 --
--- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault
+-- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault; see issue #12228
 --
 create table test_tz(tz interval) distributed replicated;
 insert into test_tz

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -450,4 +450,30 @@ insert into t_5628 values (1,1), (2,2);
 explain (costs off) select max(c1) from pg_class left join t_5628 on true;
 select max(c1) from pg_class left join t_5628 on true;
 
+--
+-- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault
+--
+create table test_tz(tz interval) distributed replicated;
+insert into test_tz
+select i * '1 hour'::interval
+from generate_series(0,23) i;
+create index test_tz_idx on test_tz(tz);
+
+set optimizer=off;
+set enable_hashjoin=off;
+set enable_seqscan=off;
+
+EXPLAIN (costs off)
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+
+reset optimizer;
+reset enable_hashjoin;
+reset enable_seqscan;
+
 drop schema rpt_joins cascade;


### PR DESCRIPTION
`cdbpath_create_motion_path` function doesn't check subpath's params Relids. When Path contains index scan with quals it leads to segfault.
Fix adds a few additional checks of can motion node be generated atop of subpath. Additional regression test included.
Related to issue #[12228](https://github.com/greenplum-db/gpdb/issues/12228). Partial backport of 9cc1da6 (#[10012](https://github.com/greenplum-db/gpdb/issues/10012)).
