### PR TITLE
Add GUC optimizer_enable_cte_predicate_pushdown for GPORCA

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -184,6 +184,11 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT("Enable CTE inlining.")},
 
+	{EopttraceEnableCTEPredicatePushdown,
+	 &optimizer_enable_cte_predicate_pushdown,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT("Enable predicate push down to CTE producer.")},
+
 	{EopttraceEnableConstantExpressionEvaluation,
 	 &optimizer_enable_constant_expression_evaluation,
 	 false,	 // m_negate_param

--- a/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
@@ -72,7 +72,10 @@ CQueryContext::CQueryContext(CMemoryPool *mp, CExpression *pexpr,
 	SetSystemCols(mp);
 
 	// collect CTE predicates and add them to CTE producer expressions
-	CExpressionPreprocessor::AddPredsToCTEProducers(mp, m_pexpr);
+	if (GPOS_FTRACE(EopttraceEnableCTEPredicatePushdown))
+	{
+		CExpressionPreprocessor::AddPredsToCTEProducers(mp, m_pexpr);
+	}
 
 	CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -210,6 +210,9 @@ enum EOptTraceFlag
 	// Use legacy (cdbhash) opfamilies for compatibility
 	EopttraceUseLegacyOpfamilies = 103039,
 
+	// Enable predicate push down to CTE producer.
+	EopttraceEnableCTEPredicatePushdown = 103040,
+
 	///////////////////////////////////////////////////////
 	///////////////////// statistics flags ////////////////
 	//////////////////////////////////////////////////////

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -375,6 +375,7 @@ bool		optimizer_multilevel_partitioning;
 bool 		optimizer_parallel_union;
 bool		optimizer_array_constraints;
 bool		optimizer_cte_inlining;
+bool		optimizer_enable_cte_predicate_pushdown;
 bool		optimizer_enable_space_pruning;
 bool		optimizer_enable_associativity;
 bool		optimizer_enable_eageragg;
@@ -2422,6 +2423,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_cte_inlining,
 		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_cte_predicate_pushdown", PGC_USERSET, DEVELOPER_OPTIONS,
+		 gettext_noop("Enable predicate push down to CTE producer"),
+		 NULL,
+		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_cte_predicate_pushdown,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -560,6 +560,7 @@ extern bool optimizer_multilevel_partitioning;
 extern bool optimizer_parallel_union;
 extern bool optimizer_array_constraints;
 extern bool optimizer_cte_inlining;
+extern bool optimizer_enable_cte_predicate_pushdown;
 extern bool optimizer_enable_space_pruning;
 extern bool optimizer_enable_associativity;
 extern bool optimizer_enable_range_predicate_dpe;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -352,6 +352,7 @@
 		"optimizer_cost_model",
 		"optimizer_cost_threshold",
 		"optimizer_cte_inlining",
+		"optimizer_enable_cte_predicate_pushdown",
 		"optimizer_damping_factor_filter",
 		"optimizer_damping_factor_groupby",
 		"optimizer_damping_factor_join",


### PR DESCRIPTION
Add GUC for pushing down predicate from CTE consumer to CTE producer,
default is true.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
