### PR TITLE
[6X backport] Workfile mgr test cleanup

### DIFF
--- a/src/test/isolation2/input/workfile_mgr_test.source
+++ b/src/test/isolation2/input/workfile_mgr_test.source
@@ -29,6 +29,32 @@ RETURNS TABLE(segid int4, prefix text, size int8, operation text, slice int4, se
 AS '$libdir/gp_workfile_mgr', 'gp_workfile_mgr_cache_entries'
 LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 
+-- Wait for at the most 1 min for backends to remove transient
+-- workfile sets as part of exit processing and then report long lived
+-- workfile sets.
+create or replace function report_workfile_entries()
+returns table(segid int4, prefix text, size int8, operation text, slice int4, numfiles int4) as $$
+declare
+    iterations int; /* in func */
+    cnt int; /* in func */
+begin
+    iterations := 120; /* wait at the most 1 min */
+    select count(*) into cnt from gp_workfile_mgr_cache_entries() w
+    where w.prefix not like 'long_live_workset%'; /* in func */
+
+    while (iterations > 0) and (cnt > 0)
+    loop
+        select count(*) into cnt from gp_workfile_mgr_cache_entries() w
+        where w.prefix not like 'long_live_workset%'; /* in func */
+        perform pg_sleep(0.5); /* sleep for half a second */
+	iterations := iterations - 1; /* in func */
+    end loop; /* in func */
+    return query select w.segid, w.prefix, w.size, w.operation, w.slice, w.numfiles
+                 from gp_workfile_mgr_cache_entries() w; /* in func */
+end; /* in func */
+$$
+language plpgsql volatile execute on all segments;
+
 -- start_ignore
 !\retcode gpconfig -c gp_workfile_max_entries -v 32 --skipvalidation;
 !\retcode gpstop -ari;
@@ -78,6 +104,10 @@ LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 
 -- for workset lives across transaction, e.g. with hold cursor, proc exit will cleanup the workset
 3q:
--- sleep a while in case the session 3 slow exit cause the inter_xact_workset workfile_set not cleaned
-4: select * from pg_sleep(1);
-4: select segid, prefix, size, operation, slice, numfiles from gp_workfile_mgr_cache_entries() order by (segid, prefix);
+
+-- The "q:" step does not wait for the backend process to exit.  So
+-- wait at the most 1 min so that only the long lived sessions are
+-- reported.  If we don't wait thte test sometimes fails because
+-- "inter_xact_workset" entries show up in the output of
+-- gp_workfile_mgr_cache_entries().
+4: select * from report_workfile_entries();

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -16,6 +16,13 @@ CREATE
 CREATE FUNCTION gp_workfile_mgr_cache_entries() RETURNS TABLE(segid int4, prefix text, size int8, operation text, slice int4, sessionid int4, commandid int4, numfiles int4) AS '$libdir/gp_workfile_mgr', 'gp_workfile_mgr_cache_entries' LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
 CREATE
 
+-- Wait for at the most 1 min for backends to remove transient
+-- workfile sets as part of exit processing and then report long lived
+-- workfile sets.
+create or replace function report_workfile_entries() returns table(segid int4, prefix text, size int8, operation text, slice int4, numfiles int4) as $$ declare iterations int; /* in func */ cnt int; /* in func */ begin iterations := 120; /* wait at the most 1 min */ select count(*) into cnt from gp_workfile_mgr_cache_entries() w where w.prefix not like 'long_live_workset%'; /* in func */ 
+while (iterations > 0) and (cnt > 0) loop select count(*) into cnt from gp_workfile_mgr_cache_entries() w where w.prefix not like 'long_live_workset%'; /* in func */ perform pg_sleep(0.5); /* sleep for half a second */ iterations := iterations - 1; /* in func */ end loop; /* in func */ return query select w.segid, w.prefix, w.size, w.operation, w.slice, w.numfiles from gp_workfile_mgr_cache_entries() w; /* in func */ end; /* in func */ $$ language plpgsql volatile execute on all segments;
+CREATE
+
 -- start_ignore
 !\retcode gpconfig -c gp_workfile_max_entries -v 32 --skipvalidation;
 -- start_ignore
@@ -280,13 +287,13 @@ ABORT
 
 -- for workset lives across transaction, e.g. with hold cursor, proc exit will cleanup the workset
 3q: ... <quitting>
--- sleep a while in case the session 3 slow exit cause the inter_xact_workset workfile_set not cleaned
-4: select * from pg_sleep(1);
- pg_sleep 
-----------
-          
-(1 row)
-4: select segid, prefix, size, operation, slice, numfiles from gp_workfile_mgr_cache_entries() order by (segid, prefix);
+
+-- The "q:" step does not wait for the backend process to exit.  So
+-- wait at the most 1 min so that only the long lived sessions are
+-- reported.  If we don't wait thte test sometimes fails because
+-- "inter_xact_workset" entries show up in the output of
+-- gp_workfile_mgr_cache_entries().
+4: select * from report_workfile_entries();
  segid | prefix              | size | operation         | slice | numfiles 
 -------+---------------------+------+-------------------+-------+----------
  0     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -781,13 +781,6 @@ workfile_fill_sharedcache(void)
 			success = false;
 			break;
 		}
-		if (crt_entry >= gp_workfile_max_entries - 2)
-		{
-			/* Pause between adding extra ones so we can test from other sessions */
-			elog(LOG, "Added %d entries out of %d, pausing for 30 seconds before proceeding", crt_entry + 1, n_entries);
-			sleep(30);
-		}
-
 	}
 
 	unit_test_result(success);


### PR DESCRIPTION
This is a backport of two commits from PR #12213 from 7X.

```
    Wait until backend process exits in workfile_mgr isolation2 test
    
    The test was sufferring from "q:" problem described in
    https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/A2JUpJ0NrEA/m/3S6rmd2zBAAJ
    
    This patch implements Ashwin's suggestion on that thread by
    introducing retry logic.
```
and
```
    Remove pointless sleep from legacy workfile_mgr_test
    
    It reduces the test runtime by 1 minute.  It must have been a remnant
    of an old refactor.  I couldn't find a justification for it in last
    few years worth of commit history.
```