### PR TITLE
Disable tls1.0 and tls1.1 protocol for gpfdist for security reasons.

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -4033,6 +4033,8 @@ static SSL_CTX *initialize_ctx(void)
 	/* Create our context*/
 	ctx = SSL_CTX_new(SSLv23_server_method());
 
+	/* Disable old protocol versions */
+	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
 	/* Generate random seed */
 	if ( RAND_poll() == 0 )
 		gfatal(NULL,"Can't generate random seed for SSL");

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -78,15 +78,30 @@ INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
 -- test disable tls1.0 and tls1.1
 CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
-execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 --tls-max 1.0 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 --tls-max 1.0 >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
 on SEGMENT 0
 FORMAT 'text';
 CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
-execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 --tls-max 1.1 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 --tls-max 1.1 >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
 on SEGMENT 0
 FORMAT 'text';
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
-execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 --tls-max 1.2 >/dev/null 2>&1;ret=$?;if [ $ret -ne 35 ];then echo "success";else echo $ret;fi'
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 --tls-max 1.2 >/dev/null 2>&1;ret=$?;
+if [ $ret -ne 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
 on SEGMENT 0
 FORMAT 'text';
 select * from curl_with_tls10;

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -76,6 +76,26 @@ LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
+-- test disable tls1.0 and tls1.1
+CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 --tls-max 1.0 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+on SEGMENT 0
+FORMAT 'text';
+CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 --tls-max 1.1 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+on SEGMENT 0
+FORMAT 'text';
+CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 --tls-max 1.2 >/dev/null 2>&1;ret=$?;if [ $ret -ne 35 ];then echo "success";else echo $ret;fi'
+on SEGMENT 0
+FORMAT 'text';
+select * from curl_with_tls10;
+select * from curl_with_tls11;
+select * from curl_with_tls12;
+drop external table if exists curl_with_tls10;
+drop external table if exists curl_with_tls11;
+drop external table if exists curl_with_tls12;
+-- end test disable tls1.0 and tls1.1
 
 -- gpfdist_ssl case 2
 DROP TABLE IF EXISTS tbl_on_heap2;

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -72,6 +72,41 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
  ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (3 rows)
 
+-- test disable tls1.0 and tls1.1
+CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 --tls-max 1.0 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+on SEGMENT 0
+FORMAT 'text';
+CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 --tls-max 1.1 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+on SEGMENT 0
+FORMAT 'text';
+CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 --tls-max 1.2 >/dev/null 2>&1;ret=$?;if [ $ret -ne 35 ];then echo "success";else echo $ret;fi'
+on SEGMENT 0
+FORMAT 'text';
+select * from curl_with_tls10;
+    x    
+---------
+ success
+(1 row)
+
+select * from curl_with_tls11;
+    x    
+---------
+ success
+(1 row)
+
+select * from curl_with_tls12;
+    x    
+---------
+ success
+(1 row)
+
+drop external table if exists curl_with_tls10;
+drop external table if exists curl_with_tls11;
+drop external table if exists curl_with_tls12;
+-- end test disable tls1.0 and tls1.1
 -- gpfdist_ssl case 2
 DROP TABLE IF EXISTS tbl_on_heap2;
 NOTICE:  table "tbl_on_heap2" does not exist, skipping

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -74,15 +74,30 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 
 -- test disable tls1.0 and tls1.1
 CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
-execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 --tls-max 1.0 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 --tls-max 1.0 >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
 on SEGMENT 0
 FORMAT 'text';
 CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
-execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 --tls-max 1.1 >/dev/null 2>&1;ret=$?;if [ $ret -eq 35 ];then echo "success";else echo $ret;fi'
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 --tls-max 1.1 >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
 on SEGMENT 0
 FORMAT 'text';
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
-execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 --tls-max 1.2 >/dev/null 2>&1;ret=$?;if [ $ret -ne 35 ];then echo "success";else echo $ret;fi'
+execute E'curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 --tls-max 1.2 >/dev/null 2>&1;ret=$?;
+if [ $ret -ne 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
 on SEGMENT 0
 FORMAT 'text';
 select * from curl_with_tls10;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
