### PR TITLE
Delete TLS_RSA_WITH_AES_128_CBC_SHA for gpdb5 clients.

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -113,7 +113,6 @@ typedef struct
  *
  *  SSL Params
  *	extssl_protocol  CURL_SSLVERSION_TLSv1 				
- *  extssl_cipher 	 TLS_RSA_WITH_AES_128_CBC_SHA
  *  extssl_verifycert 	1
  *  extssl_verifyhost 	2
  *  extssl_no_verifycert 	0
@@ -127,7 +126,6 @@ typedef struct
  */
 
 const static int extssl_protocol  = CURL_SSLVERSION_TLSv1;
-const char* extssl_cipher = "AES128-SHA";
 const static int extssl_verifycert = 1;
 const static int extssl_verifyhost = 2;
 const static int extssl_no_verifycert = 0;
@@ -1346,9 +1344,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		/* set host verification */
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSL_VERIFYHOST,
 				(long)(verify_gpfdists_cert ? extssl_verifyhost : extssl_no_verifyhost));
-
-		/* set ciphersuite */
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSL_CIPHER_LIST, extssl_cipher);
 
 		/* set protocol */
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLVERSION, extssl_protocol);


### PR DESCRIPTION
In order to make the gpdb5 client able to connect to gpdb6 gpfdist
server using ssl, we have to delete the old cipher
TLS_RSA_WITH_AES_128_CBC_SHA. In this way, gpdb5 client can choose
 a compatible protocol with latest version of gpfdist and also be
able to connect with version 5 gpfdist(using tls1.0 protocol).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
