### PR TITLE
(6x only) Fix unlock leaf partitions.

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -380,18 +380,13 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	{
 		LOCKMODE lockmode;
 		if (lockUpgraded)
-		{
 			lockmode = ExclusiveLock;
-		}
 		else if (pstate->p_is_insert && gp_enable_global_deadlock_detector)
-		{
 			lockmode = NoLock;
-		}
 		else
-		{
 			lockmode = RowExclusiveLock;
-		}
-		find_all_inheritors(relid, lockmode, NULL);
+
+		(void) find_all_inheritors(relid, lockmode, NULL);
 	}
 
 	/*

--- a/src/test/isolation2/expected/cached_plan.out
+++ b/src/test/isolation2/expected/cached_plan.out
@@ -1,0 +1,48 @@
+-- Commit 99fbc8ea9 introduces a invalid pointer reference
+-- bug and we do not have test case cover that code path.
+-- This case is to make sure unlock logic of cached plan works
+-- well.
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+create table sales_row_99fbc8 (id int, date date, amt decimal(10,2)) distributed by (id) partition by range (date) ( start (date '2008-01-01') inclusive end (date '2009-01-01') exclusive every (interval '1 month') );
+CREATE
+
+-- a plan without any params will always be cached and used
+1: prepare cached_plan_99fbc8 as insert into sales_row_99fbc8 values (1, '2008-01-01'::date);
+PREPARE
+
+select gp_inject_fault('wait_for_cached_plan_invalid', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1&: execute cached_plan_99fbc8;  <waiting ...>
+
+select gp_wait_until_triggered_fault('wait_for_cached_plan_invalid', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- in a new session, drop the table, and this should
+-- invalidate the cached plan that already locked previously.
+2: vacuum full sales_row_99fbc8;
+VACUUM
+
+-- let the session 1 continue, make sure it does not coredump
+select gp_inject_fault('wait_for_cached_plan_invalid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+EXECUTE 1
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop table sales_row_99fbc8;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,5 +1,5 @@
 test: setup
-
+test: cached_plan
 test: lockmodes
 # Put test prepare_limit near to test lockmodes since both of them reboot the
 # cluster during testing. Usually the 2nd reboot should be faster.

--- a/src/test/isolation2/sql/cached_plan.sql
+++ b/src/test/isolation2/sql/cached_plan.sql
@@ -1,0 +1,35 @@
+-- Commit 99fbc8ea9 introduces a invalid pointer reference
+-- bug and we do not have test case cover that code path.
+-- This case is to make sure unlock logic of cached plan works
+-- well.
+
+create extension if not exists gp_inject_fault;
+
+create table sales_row_99fbc8 (id int, date date, amt decimal(10,2))
+distributed by (id)
+partition by range (date)
+( start (date '2008-01-01') inclusive
+end (date '2009-01-01') exclusive
+every (interval '1 month') );
+
+-- a plan without any params will always be cached and used
+1: prepare cached_plan_99fbc8 as insert into sales_row_99fbc8 values (1, '2008-01-01'::date);
+
+select gp_inject_fault('wait_for_cached_plan_invalid', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+1&: execute cached_plan_99fbc8;
+
+select gp_wait_until_triggered_fault('wait_for_cached_plan_invalid', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- in a new session, drop the table, and this should
+-- invalidate the cached plan that already locked previously.
+2: vacuum full sales_row_99fbc8;
+
+-- let the session 1 continue, make sure it does not coredump
+select gp_inject_fault('wait_for_cached_plan_invalid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+1<:
+1q:
+2q:
+
+drop table sales_row_99fbc8;


### PR DESCRIPTION
Previous commit 99fbc8ea9496 does not init ListCell correctly,
it may lead to coredump. Actually prod 6X pipeline find it.
Besides, function `find_all_inheritors` will also return the
parent Oid, so we should skip it in the foreach loop.

This commit fixes the above issue.

--------------------

I find this in https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE/jobs/icw_planner_icproxy_centos6/builds/392 and https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE_without_asserts/jobs/icw_gporca_centos7/builds/1005

The bug (mistake) is so obvious that we do not find it when reviewing and most of the pipeline is OK. This really surprises me.

The coredump's backtrace is:

```
#0  0x00007fc9768a26ab in raise () from /lib64/libpthread.so.0
#1  0x0000000000c9eeb0 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<value optimized out>, postgres_signal_arg=<value optimized out>) at elog.c:5548
#2  <signal handler called>
#3  ScanQueryForLocks (parsetree=<value optimized out>, acquire=<value optimized out>) at plancache.c:1718
#4  0x0000000000c6ca27 in RevalidateCachedQuery (plansource=<value optimized out>, intoClause=<value optimized out>) at plancache.c:1614
#5  0x0000000000c6d030 in GetCachedPlan (plansource=<value optimized out>, boundParams=<value optimized out>, useResOwner=<value optimized out>, intoClause=<value optimized out>) at plancache.c:578
#6  0x000000000096b596 in _SPI_execute_plan (plan=<value optimized out>, paramLI=<value optimized out>, snapshot=<value optimized out>, crosscheck_snapshot=<value optimized out>, read_only=<value optimized out>, fire_triggers=<value optimized out>, tcount=Could not find the frame base for "_SPI_execute_plan".
) at spi.c:2198
#7  0x000000000096c1a8 in SPI_execute_plan_with_paramlist (plan=<value optimized out>, params=<value optimized out>, read_only=<value optimized out>, tcount=<value optimized out>) at spi.c:499
#8  0x00007fc95efccc00 in exec_stmt_execsql (estate=<value optimized out>, stmt=<value optimized out>) at pl_exec.c:3334
#9  0x00007fc95efd01ef in exec_stmts (estate=<value optimized out>, stmts=<value optimized out>) at pl_exec.c:1467
#10 0x00007fc95efd0e67 in exec_stmts (estate=<value optimized out>, stmts=<value optimized out>) at pl_exec.c:1742
#11 0x00007fc95efd2f46 in exec_stmt_block (estate=<value optimized out>, block=<value optimized out>) at pl_exec.c:1304
#12 0x00007fc95efd3305 in plpgsql_exec_function (func=<value optimized out>, fcinfo=<value optimized out>, simple_eval_estate=<value optimized out>) at pl_exec.c:348
#13 0x00007fc95efc3bb1 in plpgsql_call_handler (fcinfo=0x7ca8650) at pl_handler.c:253
#14 0x00000000009307ce in ExecEvalFunc (fcache=<value optimized out>, econtext=<value optimized out>, isNull=<value optimized out>, isDone=<value optimized out>) at execQual.c:2161
```

The full dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_fix_pipelie_fail