### PR TITLE
(5x only) Copy string to avoid using dangling string pointers in PLy_get_spi_error_data

### DIFF
--- a/src/pl/plpython/plpython.c
+++ b/src/pl/plpython/plpython.c
@@ -5079,21 +5079,27 @@ PLy_get_spi_error_data(PyObject *exc, int* sqlerrcode, char **detail, char **hin
 
 	if (!PyArg_ParseTuple(spidata, "izzzi", sqlerrcode, detail, hint, query, position))
 	{
-		ereport(LOG, (errcode(*sqlerrcode),
+		*detail = NULL;
+		*hint = NULL;
+		*query = NULL;
+		ereport(LOG, (errcode(ERRCODE_INTERNAL_ERROR),
 					  errmsg("PyArg_ParseTuple(): failed to get error details")));
 	}
-	/*
-	 * Currently, it's safe to access these pointers.
-	 * Copy these error details to avoid using dangling memory pointers.
-	 * The returned strings may be freed by python that will cause invalid pointer
-	 * reference, i.e. segment fault.
-	 */
-	if (*detail)
-		*detail = pstrdup(*detail);
-	if (*hint)
-		*hint = pstrdup(*hint);
-	if (*query)
-		*query = pstrdup(*query);
+	else
+	{
+		/*
+		 * Currently, it's safe to access these pointers.
+		 * Copy these error details to avoid using dangling memory pointers.
+		 * The returned strings may be freed by python that will cause invalid pointer
+		 * reference, i.e. segment fault.
+		 */
+		if (*detail)
+			*detail = pstrdup(*detail);
+		if (*hint)
+			*hint = pstrdup(*hint);
+		if (*query)
+			*query = pstrdup(*query);
+	}
 
 cleanup:
 	PyErr_Clear();


### PR DESCRIPTION
In function `PLy_get_spi_error_data()`, it calls PyArg_ParseTuple(),
which is a function in python library. Some pointers may be set even if
PyArg_ParseTuple() fails. It should be fine for the update pointers to
use as long as the allocated memories are still valid. However,
the allocated memory becomes invalid in some way. Using the pointers,
like `query` may cause a PANIC.
This commit workaround to not use the poiners that may point to some
invalid memories.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
