### PR TITLE
gpcheckcat failing with "inconsistent_pg_extension"

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1518,7 +1518,10 @@ def checkTableInconsistentEntry(cat):
     pkey = cat.getPrimaryKey()
     coordinator = cat.isCoordinatorOnly()
     isShared = cat.isShared()
-    columns = cat.getTableColumns(with_acl=False)
+    if catname != 'pg_extension':
+        columns = cat.getTableColumns(with_acl=False)
+    else:
+        columns = cat.getTableColumns(with_acl=False, excluding=['extconfig', 'extcondition'])
     coltypes = cat.getTableColtypes()
 
     # Skip coordinator only tables

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -300,6 +300,13 @@ Feature: gpcheckcat tests
         And the user runs "dropdb fkey2_db"
         And the path "gpcheckcat.repair.*" is removed from current working directory
 
+    Scenario: gpcheckcat should report no inconsistency of pg_extension between Master and Segements
+        Given database "pgextension_db" is dropped and recreated
+        And the user runs sql "set allow_system_table_mods=true;update pg_extension set extconfig='{2130}', extcondition='{2130}';" in "pgextension_db" on first primary segment
+        Then the user runs "gpcheckcat -R inconsistent pgextension_db"
+        Then gpcheckcat should return a return code of 0
+        And the user runs "dropdb gpextension_db"
+
     Scenario: gpcheckcat should generate repair scripts when -g, -R, and -E options are provided
         Given database "extra_gr_db" is dropped and recreated
         And the path "repair_dir" is removed from current working directory


### PR DESCRIPTION
After loading PostGIS, pg_extension of MASTER has values in extconfig and extcondition columns
while in segments those cols are empty.
Fix: Exclude extconfig and extcondition columns from pg_extension table while executing query from pgcheckcat

Co-authored-by:Sambitesh Dash <sdash@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
