### PR TITLE
Added note to PXF migration from GPDB 5

### DIFF
--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -14,6 +14,7 @@ The PXF Greenplum Database 5 to 6 migration procedure has two parts. You perform
 
 Before migrating PXF from Greenplum 5 to Greenplum 6, ensure that you can:
 
+- Identify your OS Version. Greenplum Database 6 does not support running PXF on CentOS 6.x or RHEL 6.x due to a limitation with the version of `cURL`. See [Known Issues and Limitations](https://gpdb.docs.pivotal.io/latest/relnotes/release-notes.html) for more details.
 - Identify the version number of your Greenplum 5 installation. If it is older than 5.21.2, upgrade to a newer 5.x version.
 - Identify the version of PXF running in the Greenplum 5 cluster.
 - Identify the location of your PXF installation:


### PR DESCRIPTION
PXF is not compatible with GPDB 6 if running on RHEL/CentOS 6.x due to cURL version incompatibilities. This was listed on the Known Issues and Limitations section of the GPDB Release Notes but might not be enough.
Added it as well to the PXF upgrade guidelines when upgrading GPDB from 5.x. 
Let me know if it would make sense to add it to any other section.
Preview:
https://mireia-pxf-rhel.sc2-04-pcf1-apps.oc.vmware.com/7-0/pxf/migrate_5to6.html
