### PR TITLE
Unix socket permissions

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -5896,7 +5896,7 @@
               <entry colname="col1">numeric UNIX file permission mode (as accepted by the
                   <i>chmod</i> or <i>umask</i> commands)</entry>
               <entry colname="col2">0600</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+              <entry colname="col3">local<p>system</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -327,6 +327,9 @@
               <xref href="#listen_addresses"/>
             </li>
             <li>
+              <xref href="#log_file_mode"/>
+            </li>
+            <li>
               <xref href="#log_planner_stats"/>
             </li>
             <li>
@@ -5869,6 +5872,37 @@
       </table>
     </body>
   </topic>
+  <topic id="log_file_mode">
+    <title>log_file_mode</title>
+    <body>
+      <p>On Unix systems this parameter sets the permissions for log files when
+          <codeph>logging_collector</codeph> is enabled. The parameter value is expected to be a
+        numeric mode specified in the format accepted by the <codeph>chmod</codeph> and
+          <codeph>umask</codeph> system calls.</p>
+      <table id="table_s4d_hfj_2qb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">numeric UNIX file permission mode (as accepted by the
+                  <i>chmod</i> or <i>umask</i> commands)</entry>
+              <entry colname="col2">0600</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="log_hostname">
     <title>log_hostname</title>
     <body>
@@ -9285,7 +9319,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
             <row>
               <entry colname="col1">numeric UNIX file permission mode (as accepted by the
                   <i>chmod</i> or <i>umask</i> commands)</entry>
-              <entry colname="col2">511</entry>
+              <entry colname="col2">0777</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -9227,7 +9227,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
           <tbody>
             <row>
               <entry colname="col1">directory path</entry>
-              <entry colname="col2">unset</entry>
+              <entry colname="col2">0777</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -718,6 +718,10 @@
                   >log_error_verbosity</xref>
               </p>
               <p>
+                <xref href="guc-list.xml#log_file_mode" type="section"
+                  >log_file_mode</xref>
+              </p>
+              <p>
                 <xref href="guc-list.xml#log_min_duration_statement" type="section"
                   >log_min_duration_statement</xref>
               </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -188,6 +188,7 @@
             <topicref href="guc-list.xml#log_duration"/>
             <topicref href="guc-list.xml#log_error_verbosity"/>
             <topicref href="guc-list.xml#log_executor_stats"/>
+            <topicref href="guc-list.xml#log_file_mode"/>
             <topicref href="guc-list.xml#log_hostname"/>
             <topicref href="guc-list.xml#log_min_duration_statement"/>
             <topicref href="guc-list.xml#log_min_error_statement"/>


### PR DESCRIPTION
- Modified default value of GUC unix_socket_permissions to 0777
- Added GUC log_file_mode
- Did not add data_directory_mode since I cannot see it available on a Greenplum test environment.
Can you please confirm that the values under Set Classifications column for log_file_mode are correct?
Test site:  https://mireia-gucs.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/config_params/guc-list.html

Needs to be added to 6.17 as well
