### PR TITLE
DOCS: No single quotes around string GUCs for gpconfig -c

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpconfig.xml
@@ -25,6 +25,8 @@
           <codeph>max_connections</codeph> require a different setting on the coordinator than what is
         used for the segments. If you want to set or unset a global or coordinator only parameter, use
         the <codeph>--masteronly</codeph> option.</p>
+      <note>For configuration parameters of vartype <codeph>string</codeph>, you may not pass values
+        enclosed in single quotes to <codeph>gpconfig -c</codeph>.</note>
       <p><codeph>gpconfig</codeph> can only be used to manage certain parameters. For example, you
         cannot use it to set parameters such as <codeph>port</codeph>, which is required to be
         distinct for every segment instance. Use the <codeph>-l</codeph> (list) option to see a


### PR DESCRIPTION
As of 6.x, users cannot pass in to gpconfig -c values enclosed in single quotes for GUCs of vartype string. 
