### PR TITLE
[Backport to 6X] Fix transaction may be committed on coordinator, aborted on segments

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8798,32 +8798,6 @@ CreateCheckPoint(int flags)
 	TRACE_POSTGRESQL_CHECKPOINT_START(flags);
 
 	/*
-	 * When the crash happens, we need to handle the transactions that have
-	 * already inserted 'commit' record and haven't inserted 'forget' record.
-	 *
-	 * If the 'commit' record is logically before the checkpoint REDO pointer,
-	 * we save the transactions in checkpoint record, and these transactions
-	 * will be load into shared memory and mark as 'crash committed' during
-	 * redo checkpoint.
-	 * If the 'commit' record is logically after the checkpoint REDO pointer,
-	 * the transactions will be added to shared memory and mark as 'crash
-	 * committed' during redo xact.
-	 * All these transactions will be stored in the shutdown checkpoint record
-	 * after recovery, and they will be finally recovered in recoverTM().
-	 *
-	 * So if it's a shutdown checkpoint here, we should include all 'crash
-	 * committed' transactions, and if it's a normal checkpoint should include
-	 * all transactions whose 'commit' record is logically before checkpoint
-	 * REDO pointer.
-	 *
-	 * We don't hold the WALInsertLock, so there's a time window that allows
-	 * transactions insert 'commit' record and/or 'forget' record after
-	 * checkpoint REDO pointer. That's fine, resend 'commit prepared' to already
-	 * finished transactions is handled.
-	 */
-	getDtxCheckPointInfo(&dtxCheckPointInfo, &dtxCheckPointInfoSize);
-
-	/*
 	 * Get the other info we need for the checkpoint record.
 	 */
 	LWLockAcquire(XidGenLock, LW_SHARED);
@@ -8865,6 +8839,8 @@ CreateCheckPoint(int flags)
 	 */
 	END_CRIT_SECTION();
 
+	SIMPLE_FAULT_INJECTOR("before_wait_VirtualXIDsDelayingChkpt");
+
 	/*
 	 * In some cases there are groups of actions that must all occur on one
 	 * side or the other of a checkpoint record. Before flushing the
@@ -8903,6 +8879,39 @@ CreateCheckPoint(int flags)
 		} while (HaveVirtualXIDsDelayingChkpt(vxids, nvxids));
 	}
 	pfree(vxids);
+
+	/*
+	 * When the crash happens, we need to handle the transactions that have
+	 * already inserted 'commit' record and haven't inserted 'forget' record.
+	 *
+	 * If the 'commit' record is logically before the checkpoint REDO pointer,
+	 * we save the transactions in checkpoint record, and these transactions
+	 * will be load into shared memory and mark as 'crash committed' during
+	 * redo checkpoint.
+	 * If the 'commit' record is logically after the checkpoint REDO pointer,
+	 * the transactions will be added to shared memory and mark as 'crash
+	 * committed' during redo xact.
+	 * All these transactions will be stored in the shutdown checkpoint record
+	 * after recovery, and they will be finally recovered in recoverTM().
+	 *
+	 * So if it's a shutdown checkpoint here, we should include all 'crash
+	 * committed' transactions, and if it's a normal checkpoint should include
+	 * all transactions whose 'commit' record is logically before checkpoint
+	 * REDO pointer.
+	 *
+	 * We don't hold the WALInsertLock, so there's a time window that allows
+	 * transactions insert 'commit' record and/or 'forget' record after
+	 * checkpoint REDO pointer. That's fine, resend 'commit prepared' to already
+	 * finished transactions is handled.
+	 *
+	 * Currently `MyTmGxact->includeInCkpt = true` and `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)`
+	 * is already protected by delayChkpt, so these are an atomic operation
+	 * from the outside perspective. getDtxCheckPointInfo() should be called
+	 * after HaveVirtualXIDsDelayingChkpt() otherwise some distributed transactions
+	 * with a state of DTX_STATE_INSERTED_COMMITTED may not be included in the
+	 * checkpoint record.
+	 */
+	getDtxCheckPointInfo(&dtxCheckPointInfo, &dtxCheckPointInfoSize);
 
 	CheckPointGuts(checkPoint.redo, flags);
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1562,6 +1562,7 @@ insertingDistributedCommitted(void)
 void
 insertedDistributedCommitted(void)
 {
+	SIMPLE_FAULT_INJECTOR("start_insertedDistributedCommitted");
 	ereportif(Debug_print_full_dtm, LOG,
 			  (errmsg("entering insertedDistributedCommitted"),
 				  TM_ERRDETAIL));

--- a/src/test/isolation2/expected/checkpoint_dtx_info.out
+++ b/src/test/isolation2/expected/checkpoint_dtx_info.out
@@ -1,0 +1,89 @@
+-- Scenario to test, CHECKPOINT getting distributed transaction
+-- information between COMMIT processing time window
+-- `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)` and
+-- insertedDistributedCommitted(). `delayChkpt` protects this
+-- case. There used to bug in placement of getDtxCheckPointInfo() in
+-- checkpoint code causing, transaction to be committed on coordinator
+-- and aborted on segments. Test case is meant to validate
+-- getDtxCheckPointInfo() gets called after
+-- GetVirtualXIDsDelayingChkpt().
+--
+-- Test controls the progress of COMMIT executed in session 1 and of
+-- CHECKPOINT executed in the checkpointer process, with high-level
+-- flow:
+--
+-- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted
+-- 2. checkpointer: Start a CHECKPOINT and wait to reach before_wait_VirtualXIDsDelayingChkpt
+-- 3. session 1: COMMIT is resumed
+-- 4. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg to finally introduce panic and perform crash recovery
+--
+-- Bug existed when getDtxCheckPointInfo() was invoked before
+-- GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo() will not
+-- contain the distributed transaction in session1 whose state is
+-- DTX_STATE_INSERTED_COMMITTED.  Therefore, after crash recovery, the
+-- 2PC transaction that has been committed on coordinator will be
+-- considered as orphaned prepared transaction hence is aborted at
+-- segments. As a result the SELECT executed by session3 used to fail
+-- because the twopcbug table only existed on the coordinator.
+--
+1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: begin;
+BEGIN
+1: create table twopcbug(i int, j int);
+CREATE
+1&: commit;  <waiting ...>
+2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+33&: checkpoint;  <waiting ...>
+2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- wait to make sure we don't resume commit processing before this
+-- step in checkpoint
+2: select gp_wait_until_triggered_fault('before_wait_VirtualXIDsDelayingChkpt', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- reason for this inifinite wait is just to avoid test flake. Without
+-- this joining step "1<" may see "COMMIT" sometimes or "server closed
+-- the connection unexpectedly" otherwise. With this its always
+-- "server closed the connection unexpectedly".
+2: select gp_inject_fault_infinite('after_xlog_xact_distributed_commit', 'infinite_loop', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'resume', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+33<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- wait until coordinator is up for querying.
+3: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+3: select count(1) from twopcbug;
+ count 
+-------
+ 0     
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,5 +1,6 @@
 test: setup
 test: cached_plan
+test: checkpoint_dtx_info
 test: lockmodes
 # Put test prepare_limit near to test lockmodes since both of them reboot the
 # cluster during testing. Usually the 2nd reboot should be faster.

--- a/src/test/isolation2/sql/checkpoint_dtx_info.sql
+++ b/src/test/isolation2/sql/checkpoint_dtx_info.sql
@@ -1,0 +1,49 @@
+-- Scenario to test, CHECKPOINT getting distributed transaction
+-- information between COMMIT processing time window
+-- `XLogInsert(RM_XACT_ID, XLOG_XACT_DISTRIBUTED_COMMIT)` and
+-- insertedDistributedCommitted(). `delayChkpt` protects this
+-- case. There used to bug in placement of getDtxCheckPointInfo() in
+-- checkpoint code causing, transaction to be committed on coordinator
+-- and aborted on segments. Test case is meant to validate
+-- getDtxCheckPointInfo() gets called after
+-- GetVirtualXIDsDelayingChkpt().
+--
+-- Test controls the progress of COMMIT executed in session 1 and of
+-- CHECKPOINT executed in the checkpointer process, with high-level
+-- flow:
+--
+-- 1. session 1: COMMIT is blocked at start_insertedDistributedCommitted
+-- 2. checkpointer: Start a CHECKPOINT and wait to reach before_wait_VirtualXIDsDelayingChkpt
+-- 3. session 1: COMMIT is resumed
+-- 4. checkpointer: CHECKPOINT is resumed and executes to keep_log_seg to finally introduce panic and perform crash recovery
+--
+-- Bug existed when getDtxCheckPointInfo() was invoked before
+-- GetVirtualXIDsDelayingChkpt(), getDtxCheckPointInfo() will not
+-- contain the distributed transaction in session1 whose state is
+-- DTX_STATE_INSERTED_COMMITTED.  Therefore, after crash recovery, the
+-- 2PC transaction that has been committed on coordinator will be
+-- considered as orphaned prepared transaction hence is aborted at
+-- segments. As a result the SELECT executed by session3 used to fail
+-- because the twopcbug table only existed on the coordinator.
+--
+1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
+1: begin;
+1: create table twopcbug(i int, j int);
+1&: commit;
+2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
+33&: checkpoint;
+2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
+-- wait to make sure we don't resume commit processing before this
+-- step in checkpoint
+2: select gp_wait_until_triggered_fault('before_wait_VirtualXIDsDelayingChkpt', 1, 1);
+-- reason for this inifinite wait is just to avoid test flake. Without
+-- this joining step "1<" may see "COMMIT" sometimes or "server closed
+-- the connection unexpectedly" otherwise. With this its always
+-- "server closed the connection unexpectedly".
+2: select gp_inject_fault_infinite('after_xlog_xact_distributed_commit', 'infinite_loop', 1);
+2: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'resume', 1);
+1<:
+33<:
+-- wait until coordinator is up for querying.
+3: select 1;
+3: select count(1) from twopcbug;


### PR DESCRIPTION
WAL insert and in-memory state change for XLOG_XACT_DISTRIBUTED_COMMIT
is protected by delayChkpt. This makes the operation atomic from
checkpoint perspective. Hence, getDtxCheckPointInfo() is expected to
be called only after GetVirtualXIDsDelayingChkpt() to ensure no middle
state is seen.

Before this fix, getDtxCheckPointInfo() was called before
GetVirtualXIDsDelayingChkpt(), resulted in situation where WAL insert
for XLOG_XACT_DISTRIBUTED_COMMIT was performed but in-memory state was
not changed. If CHECKPOINT happened during this time window,
checkpoint record missed to transaction in
DTX_STATE_INSERTED_COMMITTED state. When recovering from this
checkpoint record, the coordinator will think that these distributed
transactions are orphaned and will execute `rollback prepared`.

So we move getDtxCheckPointInfo() below GetVirtualXIDsDelayingChkpt(),
and getDtxCheckPointInfo() will not see the middle state.

Reviewed-by: Paul Guo <pguo@pivotal.io>
Reviewed-by: Asim R P <pasim@vmware.com>
Reviewed-by: Ashwin Agrawal <aashwin@vmware.com>
(cherry picked from commit ac34cd1eb5e081fed9a101f25961462df76287e9)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
