### PR TITLE
Fix isolation2 test framework for MacOS using Python 3.8+

### DIFF
--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -696,6 +696,11 @@ if __name__ == "__main__":
                       help="connect to database DBNAME", metavar="DBNAME")
     (options, args) = parser.parse_args()
 
+    # Explicitly set multiprocessing start method to 'fork' (Unix
+    # default) to make isolation2 work with python3.8+ on MacOS.
+    if sys.version_info >= (3, 8) and sys.platform == "darwin":
+        multiprocessing.set_start_method('fork')
+
     executor = SQLIsolationExecutor(dbname=options.dbname)
 
     executor.process_isolation_file(sys.stdin, sys.stdout)


### PR DESCRIPTION
When running isolation2 tests on MacOS using Python 3.8+, all tests
fail with the following error:
```
FAILED: cannot pickle '_io.TextIOWrapper' object
```

This is due to a change introduced in Python 3.8 where the
multiprocessing start method default was changed from 'fork' to
'spawn' for MacOS. To avoid a lengthy refactor, simply just set the
method to 'fork' (the Unix default) when running isolation2 tests on
MacOS with Python 3.8+.

Python3 Documentation:
https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
