### PR TITLE
[6X]Remove unnecessary calls for add_to_flat_tlist_junk function

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -527,15 +527,6 @@ create_scan_plan(PlannerInfo *root, Path *best_path)
 										   : NULL,
 										   plan);
 
-	/**
-	 * If plan has a flow node, ensure all entries of hashExpr
-	 * are in the targetlist.
-	 */
-	if (plan->flow && plan->flow->hashExprs)
-	{
-		plan->targetlist = add_to_flat_tlist_junk(plan->targetlist, plan->flow->hashExprs, true /* resjunk */ );
-	}
-
 	/*
 	 * If there are any pseudoconstant clauses attached to this node, insert a
 	 * gating Result node that evaluates the pseudoconstants as one-time
@@ -816,15 +807,6 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 			best_path->path.parent ? best_path->path.parent->relids
 					: NULL,
 					  plan);
-
-	/**
-	 * If plan has a flow node, ensure all entries of hashExpr
-	 * are in the targetlist.
-	 */
-	if (plan->flow && plan->flow->hashExprs)
-	{
-		plan->targetlist = add_to_flat_tlist_junk(plan->targetlist, plan->flow->hashExprs, true /* resjunk */ );
-	}
 
 	/*
 	 * We may set prefetch_joinqual to true if there is

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -2033,6 +2033,72 @@ select from t2_ncols union select * from t2_ncols;
 ERROR:  each UNION query must have the same number of columns
 LINE 1: select from t2_ncols union select * from t2_ncols;
                                           ^
+-- Issue https://github.com/greenplum-db/gpdb/issues/12031, extra junk tagrget entry added
+-- on the Subquery Scan node when we compare the hashExprs and the targetlist of the scan plan.
+-- And if it appears under the Append node, with Motion node on top of the Subquery Scan node,
+-- it'll cause the mismatch of the target lists for these nodes, generate wrong result.
+-- The plan looks like:
+-- Motion
+-- --> Append
+-- -----> Subplan1
+-- -----> Subplan2
+-- So remove the unnecessary call of `add_to_flat_tlist_junk` in `create_scan_plan` and `create_join_plan`.
+CREATE TABLE junkt1 (model character varying(16), last_build_date timestamp) DISTRIBUTED BY (model);
+-- Note the model in junkt1 and junkt2 has different varying value, this cause add junk
+-- target entry before
+CREATE TABLE junkt2(model character varying(12), last_build_date timestamp) DISTRIBUTED BY (model);
+create table junkt3 (model2 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'model2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into junkt3 values ('WF2598042001');
+insert into junkt1 values('WF2598042001','2020/3/6 3:43:08 PM');
+set optimizer = off;
+explain (costs off, verbose) select b.model2, f.model, f.last_build_date::date + case when f.model~'^.F.+$' then interval '5year' else interval '1year' end <= '2021-07-08'
+	from junkt3 b
+	join junkt1 f on f.model = b.model2
+union all
+select b.model2, f.model, f.last_build_date::date + interval '1year' <= '2021-07-08'
+	from junkt3 b
+	join junkt2 f on f.model = b.model2;
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: b.model2, f.model, ((((f.last_build_date)::date + CASE WHEN ((f.model)::text ~ '^.F.+$'::text) THEN '@ 5 years'::interval ELSE '@ 1 year'::interval END) <= 'Thu Jul 08 00:00:00 2021'::timestamp without time zone))
+   ->  Append
+         ->  Hash Join
+               Output: b.model2, f.model, (((f.last_build_date)::date + CASE WHEN ((f.model)::text ~ '^.F.+$'::text) THEN '@ 5 years'::interval ELSE '@ 1 year'::interval END) <= 'Thu Jul 08 00:00:00 2021'::timestamp without time zone)
+               Hash Cond: (b.model2 = (f.model)::text)
+               ->  Seq Scan on public.junkt3 b
+                     Output: b.model2
+               ->  Hash
+                     Output: f.model, f.last_build_date
+                     ->  Seq Scan on public.junkt1 f
+                           Output: f.model, f.last_build_date
+         ->  Hash Join
+               Output: b_1.model2, f_1.model, (((f_1.last_build_date)::date + '@ 1 year'::interval) <= 'Thu Jul 08 00:00:00 2021'::timestamp without time zone)
+               Hash Cond: ((f_1.model)::text = b_1.model2)
+               ->  Seq Scan on public.junkt2 f_1
+                     Output: f_1.model, f_1.last_build_date
+               ->  Hash
+                     Output: b_1.model2
+                     ->  Seq Scan on public.junkt3 b_1
+                           Output: b_1.model2
+ Optimizer: Postgres query optimizer
+(22 rows)
+
+select b.model2, f.model, f.last_build_date::date + case when f.model~'^.F.+$' then interval '5year' else interval '1year' end <= '2021-07-08'
+	from junkt3 b
+	join junkt1 f on f.model = b.model2
+union all
+select b.model2, f.model, f.last_build_date::date + interval '1year' <= '2021-07-08'
+	from junkt3 b
+	join junkt2 f on f.model = b.model2;
+    model2    |    model     | ?column? 
+--------------+--------------+----------
+ WF2598042001 | WF2598042001 | f
+(1 row)
+
+reset optimizer;
 --
 -- Clean up
 --
@@ -2042,3 +2108,6 @@ DROP TABLE IF EXISTS T_random CASCADE;
 DROP VIEW IF EXISTS v1_ncols CASCADE;
 DROP TABLE IF EXISTS t1_ncols CASCADE;
 DROP TABLE IF EXISTS t2_ncols CASCADE;
+DROP TABLE IF EXISTS junkt1 CASCADE;
+DROP TABLE IF EXISTS junkt2 CASCADE;
+DROP TABLE IF EXISTS junkt3 CASCADE;


### PR DESCRIPTION
Most of the calls of `add_to_flat_tlist_junk` seem not necessary,
since if there are no sub plans in the hashExpr, it means all the
elements must come from the target list, then there's no need to
check the target list again and add it back from hashExpr to the
target list.

Normally add extra junk target entry is ok, but for issue:
https://github.com/greenplum-db/gpdb/issues/12031.
When the node which add junk target entry is under Append node and
with Motion on top of it, the targetlist of these nodes are not same,
this will cause the Motion node recognizes tuple with wrong target
entries, and lead to wrong results.
The plan looks like:
Motion
--> Append
-----> Subplan1
-----> Subplan2

Co-authored-by: bbbearxyz <mzj1996@mail.ustc.edu.cn>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
