### PR TITLE
Oid bitmapset retire in pg_stat

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -438,7 +438,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 	struct pollfd	*pollRead;
 	bool		io_errors = false;
 	StringInfoData io_err_msg;
-	Bitmapset	   *oidMap = NULL;
+	List           *oidList = NULL;
 	int				nest_level;
 
 	initStringInfo(&io_err_msg);
@@ -564,7 +564,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 					first_error = cdbdisp_get_PQerror(res);
 			}
 
-			pgstat_combine_one_qe_result(&oidMap, res, nest_level, q->segindex);
+			pgstat_combine_one_qe_result(&oidList, res, nest_level, q->segindex);
 
 			if (q->conn->wrote_xlog)
 			{

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -438,7 +438,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 	struct pollfd	*pollRead;
 	bool		io_errors = false;
 	StringInfoData io_err_msg;
-	List           *oidList = NULL;
+	List           *oidList = NIL;
 	int				nest_level;
 
 	initStringInfo(&io_err_msg);

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4769,7 +4769,7 @@ pgstat_combine_from_qe(CdbDispatchResults *results, int writerSliceIndex)
 	CdbDispatchResult	   *dispatchResult;
 	CdbDispatchResult	   *resultEnd;
 	struct pg_result	   *pgresult;
-	List                   *oidList = NULL;
+	List                   *oidList = NIL;
 	int						nest_level;
 
 	if (!pgstat_track_counts)

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4668,7 +4668,7 @@ pgstat_send_qd_tabstats(void)
  * segindex - the QE segment index for the current pgresult, for logging purpose
  */
 void
-pgstat_combine_one_qe_result(Bitmapset **oidMap, struct pg_result *pgresult,
+pgstat_combine_one_qe_result(List **oidList, struct pg_result *pgresult,
 							 int nest_level, int32 segindex)
 {
 	int						arrayLen;
@@ -4704,7 +4704,7 @@ pgstat_combine_one_qe_result(Bitmapset **oidMap, struct pg_result *pgresult,
 			pgstat_info->trans->nest_level != nest_level)
 			add_tabstat_xact_level(pgstat_info, nest_level);
 		trans = pgstat_info->trans;
-		if (bms_is_member(records[i].table_stat.t_id, *oidMap))
+		if (list_member_oid(*oidList, records[i].table_stat.t_id))
 		{
 			/*
 			 * Same table pgstat from different QE;
@@ -4726,7 +4726,7 @@ pgstat_combine_one_qe_result(Bitmapset **oidMap, struct pg_result *pgresult,
 			 * it already contians the previous count collected from previous
 			 * statement.
 			 */
-			*oidMap = bms_add_member(*oidMap, records[i].table_stat.t_id);
+			*oidList = lappend_oid(*oidList, records[i].table_stat.t_id);
 			trans->tuples_inserted = records[i].table_stat.tuples_inserted;
 			trans->tuples_updated = records[i].table_stat.tuples_updated;
 			trans->tuples_deleted = records[i].table_stat.tuples_deleted;
@@ -4769,7 +4769,7 @@ pgstat_combine_from_qe(CdbDispatchResults *results, int writerSliceIndex)
 	CdbDispatchResult	   *dispatchResult;
 	CdbDispatchResult	   *resultEnd;
 	struct pg_result	   *pgresult;
-	Bitmapset			   *oidMap = NULL;
+	List                   *oidList = NULL;
 	int						nest_level;
 
 	if (!pgstat_track_counts)
@@ -4785,7 +4785,7 @@ pgstat_combine_from_qe(CdbDispatchResults *results, int writerSliceIndex)
 		if (pgresult && !dispatchResult->errcode && pgresult->extraslen > 0 &&
 			pgresult->extraType == PGExtraTypeTableStats)
 		{
-			pgstat_combine_one_qe_result(&oidMap, pgresult, nest_level,
+			pgstat_combine_one_qe_result(&oidList, pgresult, nest_level,
 										 dispatchResult->segdbDesc->segindex);
 		}
 	}

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -1602,7 +1602,7 @@ extern void pgstat_send_bgwriter(void);
 struct CdbDispatchResults;
 struct pg_result;
 extern void pgstat_send_qd_tabstats(void);								/* GPDB */
-extern void pgstat_combine_one_qe_result(Bitmapset **oidMap,			/* GPDB */
+extern void pgstat_combine_one_qe_result(List **oidList,           /* GPDB */
 										 struct pg_result *pgresult,
 										 int nest_level,
 										 int32 segindex);


### PR DESCRIPTION
For the bitmapset, it requires a signed integer as its value, but
for Oid, it is an unsigned integer. Therefore, if we meet an oid value
big enough, the overflow issue is triggered. Using a list instead of bitmapset
to record distinct oid value in function `pgstat_combine_one_qe_result`.

Fix issue: #12270
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
