### PR TITLE
correct plan for CTAS with volatile functions.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -79,6 +79,7 @@
 #include "cdb/cdbmutate.h"
 #include "cdb/cdbutil.h"
 #include "optimizer/tlist.h"
+#include "optimizer/optimizer.h" /* for contain_volatile_functions() */
 
 /*
  * decorate_subplans_with_motions_context holds state for the recursive
@@ -499,7 +500,9 @@ cdbllize_adjust_top_path(PlannerInfo *root, Path *best_path, PlanSlice *topslice
 
 		query->intoPolicy = targetPolicy;
 
-		if (GpPolicyIsReplicated(targetPolicy))
+		if (GpPolicyIsReplicated(targetPolicy) &&
+			!contain_volatile_functions((Node*) query->targetList) &&
+			!contain_volatile_functions((Node*) query->havingQual))
 		{
 			CdbPathLocus replicatedLocus;
 

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2342,7 +2342,8 @@ create_motion_path_for_insert(PlannerInfo *root, GpPolicy *policy,
 	{
 		/* try to optimize insert with no motion introduced into */
 		if (optimizer_replicated_table_insert &&
-			!contain_volatile_functions((Node *)subpath->pathtarget->exprs))
+			!contain_volatile_functions((Node *)subpath->pathtarget->exprs) &&
+			!contain_volatile_functions((Node *)root->parse->havingQual))
 		{
 			/*
 			 * CdbLocusType_SegmentGeneral is only used by replicated table

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -562,6 +562,107 @@ explain (costs off) select * from t_hashdist cross join (select * from generate_
  Optimizer: Postgres query optimizer
 (7 rows)
 
+-- CTAS on general locus into replicated table
+create temp SEQUENCE test_seq;
+explain (costs off) create table t_rep as select nextval('test_seq') from (select generate_series(1, 10)) t1 distributed replicated;
+                 QUERY PLAN                  
+---------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t1
+         ->  ProjectSet
+               ->  Result
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+create table t_rep1 as select nextval('test_seq') from (select generate_series(1, 10)) t1 distributed replicated;
+select count(*) from gp_dist_random('t_rep1');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct nextval) from gp_dist_random('t_rep1');
+ count 
+-------
+    10
+(1 row)
+
+drop table t_rep1;
+-- CTAS on general locus into replicated table with HAVING
+explain (costs off) create table t_rep as select i from generate_series(5, 15) as i group by i having i < nextval('test_seq') distributed replicated;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  HashAggregate
+         Group Key: i
+         Filter: (i < nextval('test_seq'::regclass))
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+create table t_rep2 as select i from generate_series(5, 15) as i group by i having i < nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep2');
+ count 
+-------
+    33
+(1 row)
+
+select count(distinct i) from gp_dist_random('t_rep2');
+ count 
+-------
+    11
+(1 row)
+
+drop table t_rep2;
+-- CTAS on general locus into replicated table with GROUP BY
+explain (costs off) create table t_rep as select i > nextval('test_seq') from generate_series(5, 15) as i group by i > nextval('test_seq') distributed replicated;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  HashAggregate
+         Group Key: (i > nextval('test_seq'::regclass))
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+create table t_rep3 as select i > nextval('test_seq') as a from generate_series(5, 15) as i group by i > nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep3');
+ count 
+-------
+     3
+(1 row)
+
+select count(distinct a) from gp_dist_random('t_rep3');
+ count 
+-------
+     1
+(1 row)
+
+drop table t_rep3;
+-- CTAS on replicated table into replicated table
+create table rep_tbl as select t1 from generate_series(1, 10) t1 distributed replicated;
+explain (costs off) create table t_rep as select nextval('test_seq') from rep_tbl distributed replicated;
+                 QUERY PLAN                  
+---------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  Seq Scan on rep_tbl
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+create table t_rep4 as select nextval('test_seq') from rep_tbl distributed replicated;
+select count(*) from gp_dist_random('t_rep4');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct nextval) from gp_dist_random('t_rep4');
+ count 
+-------
+    10
+(1 row)
+
+drop table rep_tbl, t_rep4;
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -569,6 +569,117 @@ explain (costs off) select * from t_hashdist cross join (select * from generate_
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
+-- CTAS on general locus into replicated table
+create temp SEQUENCE test_seq;
+explain (costs off) create table t_rep as select nextval('test_seq') from (select generate_series(1, 10)) t1 distributed replicated;
+              QUERY PLAN               
+---------------------------------------
+ Result
+   ->  Broadcast Motion 1:3  (slice1)
+         ->  Result
+               ->  ProjectSet
+                     ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+create table t_rep1 as select nextval('test_seq') from (select generate_series(1, 10)) t1 distributed replicated;
+select count(*) from gp_dist_random('t_rep1');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct nextval) from gp_dist_random('t_rep1');
+ count 
+-------
+    10
+(1 row)
+
+drop table t_rep1;
+-- CTAS on general locus into replicated table with HAVING
+explain (costs off) create table t_rep as select i from generate_series(5, 15) as i group by i having i < nextval('test_seq') distributed replicated;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Result
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+         ->  Result
+               Filter: (generate_series < nextval('test_seq'::regclass))
+               ->  HashAggregate
+                     Group Key: generate_series
+                     ->  Result
+                           ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+create table t_rep2 as select i from generate_series(5, 15) as i group by i having i < nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep2');
+ count 
+-------
+    33
+(1 row)
+
+select count(distinct i) from gp_dist_random('t_rep2');
+ count 
+-------
+    11
+(1 row)
+
+drop table t_rep2;
+-- CTAS on general locus into replicated table with GROUP BY
+explain (costs off) create table t_rep as select i > nextval('test_seq') from generate_series(5, 15) as i group by i > nextval('test_seq') distributed replicated;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Result
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+         ->  GroupAggregate
+               Group Key: ((generate_series > nextval('test_seq'::regclass)))
+               ->  Sort
+                     Sort Key: ((generate_series > nextval('test_seq'::regclass)))
+                     ->  Redistribute Motion 1:3  (slice2)
+                           Hash Key: ((generate_series > nextval('test_seq'::regclass)))
+                           ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+create table t_rep3 as select i > nextval('test_seq') as a from generate_series(5, 15) as i group by i > nextval('test_seq') distributed replicated;
+select count(*) from gp_dist_random('t_rep3');
+ count 
+-------
+     3
+(1 row)
+
+select count(distinct a) from gp_dist_random('t_rep3');
+ count 
+-------
+     1
+(1 row)
+
+drop table t_rep3;
+-- CTAS on replicated table into replicated table
+create table rep_tbl as select t1 from generate_series(1, 10) t1 distributed replicated;
+explain (costs off) create table t_rep as select nextval('test_seq') from rep_tbl distributed replicated;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Result
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Seq Scan on rep_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+create table t_rep4 as select nextval('test_seq') from rep_tbl distributed replicated;
+select count(*) from gp_dist_random('t_rep4');
+ count 
+-------
+    30
+(1 row)
+
+select count(distinct nextval) from gp_dist_random('t_rep4');
+ count 
+-------
+    10
+(1 row)
+
+drop table rep_tbl, t_rep4;
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -934,19 +934,39 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- CTAS
+explain (costs off) create table rpt_ctas as select random() from generate_series(1, 10) distributed replicated;
+                 QUERY PLAN                  
+---------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  Function Scan on generate_series
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Broadcast Motion 1:3  (slice1; segments: 1)
+   ->  HashAggregate
+         Group Key: a
+         Filter: ((sum(a))::double precision > random())
+         ->  Function Scan on generate_series a
+ Optimizer: Postgres query optimizer
+(6 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) update t_replicate_volatile set a = 1 from t_hashdist x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) delete from t_replicate_volatile where a < random();
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) delete from t_replicate_volatile using t_replicate_volatile x where t_replicate_volatile.a + x.b < random();
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) update t_replicate_volatile set a = random();
-ERROR:  could not devise a plan. (cdbpath.c:2440)
+ERROR:  could not devise a plan. (cdbpath.c:2441)
 -- limit
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit random();
                                    QUERY PLAN                                    

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -920,19 +920,41 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
+-- CTAS
+explain (costs off) create table rpt_ctas as select random() from generate_series(1, 10) distributed replicated;
+QUERY PLAN
+___________
+ Result
+   ->  Broadcast Motion 1:3  (slice1)
+         ->  Function Scan on generate_series
+GP_IGNORE:(4 rows)
+
+explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
+QUERY PLAN
+___________
+ Result
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+         ->  Result
+               Filter: (((sum(generate_series)))::double precision > random())
+               ->  HashAggregate
+                     Group Key: generate_series
+                     ->  Result
+                           ->  Function Scan on generate_series
+GP_IGNORE:(9 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) update t_replicate_volatile set a = 1 from t_hashdist x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) delete from t_replicate_volatile where a < random();
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) delete from t_replicate_volatile using t_replicate_volatile x where t_replicate_volatile.a + x.b < random();
-ERROR:  could not devise a plan (cdbpath.c:2577)
+ERROR:  could not devise a plan (cdbpath.c:2578)
 explain (costs off) update t_replicate_volatile set a = random();
-ERROR:  could not devise a plan. (cdbpath.c:2440)
+ERROR:  could not devise a plan. (cdbpath.c:2441)
 -- limit
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit random();
                                    QUERY PLAN                                    

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -416,6 +416,11 @@ explain (costs off) insert into t_replicate_volatile select random(), a, a from 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
+
+-- CTAS
+explain (costs off) create table rpt_ctas as select random() from generate_series(1, 10) distributed replicated;
+explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;


### PR DESCRIPTION
follow up #10418.

CTAS has an additional code path that will add a replicated locus on the top of the current node.
but the code path lacks some volatile function check, which will produce an incorrect plan. The incorrect
plan will execute the volatile function more times than expected.


```
-- the old plan
> explain (costs off) create table rpt_ctas as select random() from generate_series(1, 10) distributed replicated;
+-------------------------------------+
| QUERY PLAN                          |
|-------------------------------------|
| Function Scan on generate_series    |
| Optimizer: Postgres query optimizer |
+-------------------------------------+

> explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
+---------------------------------------------------+
| QUERY PLAN                                        |
|---------------------------------------------------|
| HashAggregate                                     |
|   Group Key: a                                    |
|   Filter: ((sum(a))::double precision > random()) |
|   ->  Function Scan on generate_series a          |
| Optimizer: Postgres query optimizer               |
+---------------------------------------------------+

-- the new plan
> explain (costs off) create table rpt_ctas as select random() from generate_series(1, 10) distributed replicated;
+---------------------------------------------+
| QUERY PLAN                                  |
|---------------------------------------------|
| Broadcast Motion 1:3  (slice1; segments: 1) |
|   ->  Function Scan on generate_series      |
| Optimizer: Postgres query optimizer         |
+---------------------------------------------+

> explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
+---------------------------------------------------------+
| QUERY PLAN                                              |
|---------------------------------------------------------|
| Broadcast Motion 1:3  (slice1; segments: 1)             |
|   ->  HashAggregate                                     |
|         Group Key: a                                    |
|         Filter: ((sum(a))::double precision > random()) |
|         ->  Function Scan on generate_series a          |
| Optimizer: Postgres query optimizer                     |
+---------------------------------------------------------+
```

ORCA looks like not have this special optimization for replicated tables. in this case, ORCA's plan is correct.

related issues: #9737 #10419

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
