### PR TITLE
Don't generate predicate which can't be pushed below CTE

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CTE-DontInferPredicateOnComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-DontInferPredicateOnComputedColumns.mdp
@@ -1,0 +1,829 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+	CREATE TABLE badestimate1(a int, b int, c int);
+	INSERT INTO badestimate1 SELECT 1,  i+100, 1 FROM generate_series(1,10000)i;
+	ANALYZE badestimate1;
+	EXPLAIN WITH CTE AS (SELECT c::int8, b  FROM badestimate1) 
+	SELECT 1 FROM CTE WHERE c <> 1 OR c = 1 AND b <> 101;
+	                                       QUERY PLAN
+	-----------------------------------------------------------------------------------------
+	 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.35 rows=3908 width=4)
+	   ->  Result  (cost=0.00..431.29 rows=1303 width=4)
+	         ->  Result  (cost=0.00..431.29 rows=1303 width=1)
+	               Filter: ((((c)::bigint) <> 1) OR ((((c)::bigint) = 1) AND (b <> 101)))
+	               ->  Result  (cost=0.00..431.15 rows=2084 width=12)
+	                     ->  Seq Scan on badestimate1  (cost=0.00..431.08 rows=3334 width=8)
+	 Optimizer: Pivotal Optimizer (GPORCA)
+  ]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.72841.1.0" Name="badestimate1" Rows="10000.000000" RelPages="14" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.72841.1.0" Name="badestimate1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.416.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.474.1.0"/>
+        <dxl:Commutator Mdid="0.15.1.0"/>
+        <dxl:InverseOp Mdid="0.417.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.417.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.475.1.0"/>
+        <dxl:Commutator Mdid="0.36.1.0"/>
+        <dxl:InverseOp Mdid="0.416.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.419.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.477.1.0"/>
+        <dxl:Commutator Mdid="0.37.1.0"/>
+        <dxl:InverseOp Mdid="0.420.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.418.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.476.1.0"/>
+        <dxl:Commutator Mdid="0.76.1.0"/>
+        <dxl:InverseOp Mdid="0.430.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:MDScalarComparison Mdid="4.20.1.0;23.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.20.1.0" RightType="0.23.1.0" OperatorMdid="0.416.1.0"/>
+      <dxl:MDScalarComparison Mdid="4.20.1.0;23.1.0;4" Name="&gt;" ComparisonType="GT" LeftType="0.20.1.0" RightType="0.23.1.0" OperatorMdid="0.419.1.0"/>
+      <dxl:MDScalarComparison Mdid="4.20.1.0;23.1.0;2" Name="&lt;" ComparisonType="LT" LeftType="0.20.1.0" RightType="0.23.1.0" OperatorMdid="0.418.1.0"/>
+      <dxl:ColumnStatistics Mdid="1.72841.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.72841.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBFunc Mdid="0.481.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.72841.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.23.1.0;20.1.0" Name="int8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.20.1.0" CastFuncId="0.481.1.0" CoercePathType="1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="14" ColName="?column?" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList>
+        <dxl:LogicalCTEProducer CTEId="1" Columns="11,2">
+          <dxl:LogicalProject>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="c">
+                <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                  <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.72841.1.0" TableName="badestimate1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalProject>
+        </dxl:LogicalCTEProducer>
+      </dxl:CTEList>
+      <dxl:LogicalCTEAnchor CTEId="1">
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="14" Alias="?column?">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalSelect>
+            <dxl:Or>
+              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.417.1.0">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:Comparison>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
+                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                  <dxl:Ident ColId="13" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="101"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Or>
+            <dxl:LogicalCTEConsumer CTEId="1" Columns="12,13"/>
+          </dxl:LogicalSelect>
+        </dxl:LogicalProject>
+      </dxl:LogicalCTEAnchor>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.352173" Rows="3907.875000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="22" Alias="?column?">
+            <dxl:Ident ColId="22" ColName="?column?" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.293920" Rows="3907.875000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="22" Alias="?column?">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.288709" Rows="3907.875000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.417.1.0">
+                  <dxl:Ident ColId="11" ColName="c" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
+                    <dxl:Ident ColId="11" ColName="c" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                    <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="101"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:OneTimeFilter/>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.151604" Rows="6251.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="11" Alias="c">
+                  <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                    <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:Cast>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="b">
+                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.077000" Rows="10000.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="12" Alias="b">
+                    <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="14" Alias="c">
+                    <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.72841.1.0" TableName="badestimate1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="13" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
+          </dxl:Result>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionFactorizer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionFactorizer.h
@@ -153,8 +153,8 @@ private:
 
 	//	returns the set of columns produced by the scalar children of the given
 	//	expression
-	static CColRefSet *PcrsColumnsProducedByChildren(CMemoryPool *mp,
-													 CExpression *pexpr);
+	static CColRefSet *PcrsColumnsProducedByChildrenOrCTEConsumers(
+		CMemoryPool *mp, CExpression *pexpr);
 
 	// compute disjunctive pre-filters that can be pushed to the column creators
 	static CExpression *PexprExtractInferredFiltersFromDisj(

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
@@ -99,6 +99,12 @@ public:
 		return m_pexprInlined;
 	}
 
+	CColRefSet *
+	PcrsOutput()
+	{
+		return m_pcrsOutput;
+	}
+
 	// operator specific hash function
 	ULONG HashValue() const override;
 

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionFactorizer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionFactorizer.cpp
@@ -25,6 +25,7 @@
 #include "gpopt/exception.h"
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/operators/CExpressionUtils.h"
+#include "gpopt/operators/CLogicalCTEConsumer.h"
 #include "gpopt/operators/CPredicateUtils.h"
 #include "naucrates/md/IMDFunction.h"
 #include "naucrates/md/IMDScalarOp.h"
@@ -522,7 +523,8 @@ CExpressionFactorizer::PdrgPdrgpexprDisjunctArrayForColumn(
 void
 CExpressionFactorizer::StoreBaseOpToColumnExpr(
 	CMemoryPool *mp, CExpression *pexpr, SourceToArrayPosMap *psrc2array,
-	ColumnToArrayPosMap *pcol2array, const CColRefSet *pcrsProducedByChildren,
+	ColumnToArrayPosMap *pcol2array,
+	const CColRefSet *pcrsProducedByChildrenOrCTEConsumers,
 	BOOL fAllowNewSources, ULONG ulPosition)
 {
 	ULONG ulOpSourceId;
@@ -542,8 +544,8 @@ CExpressionFactorizer::StoreBaseOpToColumnExpr(
 	else
 	{
 		GPOS_ASSERT(nullptr != pcrComputed);
-		if (nullptr != pcrsProducedByChildren &&
-			pcrsProducedByChildren->FMember(pcrComputed))
+		if (nullptr != pcrsProducedByChildrenOrCTEConsumers &&
+			pcrsProducedByChildrenOrCTEConsumers->FMember(pcrComputed))
 		{
 			// do not create filters for columns produced by the scalar tree of
 			// a logical operator immediately under the current logical operator
@@ -667,12 +669,13 @@ CExpressionFactorizer::AddInferredFiltersFromArray(
 //
 //	@doc:
 //		Returns the set of columns produced by the scalar trees of the given expression's
-//		children
+//		children or CTE consumers because one can't push down predicates below
+//		computed columns of the CTE, thus we don't need to generate predicates on them
 //
 //---------------------------------------------------------------------------
 CColRefSet *
-CExpressionFactorizer::PcrsColumnsProducedByChildren(CMemoryPool *mp,
-													 CExpression *pexpr)
+CExpressionFactorizer::PcrsColumnsProducedByChildrenOrCTEConsumers(
+	CMemoryPool *mp, CExpression *pexpr)
 {
 	GPOS_ASSERT(nullptr != pexpr);
 	const ULONG arity = pexpr->Arity();
@@ -691,6 +694,14 @@ CExpressionFactorizer::PcrsColumnsProducedByChildren(CMemoryPool *mp,
 					pexprGrandChild->DeriveDefinedColumns();
 				pcrs->Include(pcrsChildDefined);
 			}
+		}
+
+		if (pexprChild->Pop()->Eopid() == COperator::EopLogicalCTEConsumer)
+		{
+			CLogicalCTEConsumer *popConsumer =
+				CLogicalCTEConsumer::PopConvert(pexprChild->Pop());
+			CColRefSet *pcrsOutputCTE = popConsumer->PcrsOutput();
+			pcrs->Include(pcrsOutputCTE);
 		}
 	}
 
@@ -727,12 +738,13 @@ CExpressionFactorizer::PexprExtractInferredFiltersFromDisj(
 	// create a similar map for computed columns
 	ColumnToArrayPosMap *pcol2array = GPOS_NEW(mp) ColumnToArrayPosMap(mp);
 
-	CColRefSet *pcrsProducedByChildren = nullptr;
+	CColRefSet *pcrsProducedByChildrenOrCTEConsumers = nullptr;
 	if (COperator::EopLogicalSelect ==
 		pexprLowestLogicalAncestor->Pop()->Eopid())
 	{
-		pcrsProducedByChildren =
-			PcrsColumnsProducedByChildren(mp, pexprLowestLogicalAncestor);
+		pcrsProducedByChildrenOrCTEConsumers =
+			PcrsColumnsProducedByChildrenOrCTEConsumers(
+				mp, pexprLowestLogicalAncestor);
 	}
 
 	for (ULONG ul = 0; ul < arity; ul++)
@@ -745,7 +757,8 @@ CExpressionFactorizer::PexprExtractInferredFiltersFromDisj(
 			for (ULONG ulAnd = 0; ulAnd < ulAndArity; ++ulAnd)
 			{
 				StoreBaseOpToColumnExpr(mp, (*pexprCurrent)[ulAnd], psrc2array,
-										pcol2array, pcrsProducedByChildren,
+										pcol2array,
+										pcrsProducedByChildrenOrCTEConsumers,
 										fFirst,	 // fAllowNewSources
 										ul);
 			}
@@ -753,7 +766,7 @@ CExpressionFactorizer::PexprExtractInferredFiltersFromDisj(
 		else
 		{
 			StoreBaseOpToColumnExpr(mp, pexprCurrent, psrc2array, pcol2array,
-									pcrsProducedByChildren,
+									pcrsProducedByChildrenOrCTEConsumers,
 									fFirst /*fAllowNewSources*/, ul);
 		}
 
@@ -761,7 +774,7 @@ CExpressionFactorizer::PexprExtractInferredFiltersFromDisj(
 		{
 			psrc2array->Release();
 			pcol2array->Release();
-			CRefCount::SafeRelease(pcrsProducedByChildren);
+			CRefCount::SafeRelease(pcrsProducedByChildrenOrCTEConsumers);
 			pexpr->AddRef();
 			return pexpr;
 		}
@@ -771,7 +784,7 @@ CExpressionFactorizer::PexprExtractInferredFiltersFromDisj(
 		PexprAddInferredFilters(mp, pexpr, psrc2array, pcol2array);
 	psrc2array->Release();
 	pcol2array->Release();
-	CRefCount::SafeRelease(pcrsProducedByChildren);
+	CRefCount::SafeRelease(pcrsProducedByChildrenOrCTEConsumers);
 	CExpression *pexprDeduped =
 		CExpressionUtils::PexprDedupChildren(mp, pexprWithPrefilters);
 	pexprWithPrefilters->Release();

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CCTETest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CCTETest.cpp
@@ -58,7 +58,8 @@ const CHAR *rgszCTEFileNames[] = {
 	"../data/dxl/minidump/CTEinlining.mdp",
 	"../data/dxl/minidump/CTE-ValuesScan-ProjList.mdp",
 	"../data/dxl/minidump/CTEWithMergedGroup.mdp",
-	"../data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp"};
+	"../data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp",
+	"../data/dxl/minidump/CTE-DontInferPredicateOnComputedColumns.mdp"};
 
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Inferred predicates generated on the computed columns of the CTE using
disjunctive filters can't be pushed down below the CTE Consumer.
1) In case if cte inlining is disabled, in CNormalizer::PushThru if the
   logical node has no child which is the case for CLogicalCTEConsumer,
   no push thru occurs.
   Example:
```
   +--CLogicalSelect   origin: [Grp:12, GrpExpr:0]
      |--CLogicalCTEConsumer (0), Columns: ["c" (11), "b" (12)]   origin: [Grp:0, GrpExpr:0]
      +--CScalarBoolOp (EboolopAnd)   origin: [Grp:11, GrpExpr:0]
         |--CScalarBoolOp (EboolopOr)   origin: [Grp:9, GrpExpr:0]
         |  |--CScalarCmp (<>)   origin: [Grp:3, GrpExpr:0]
         |  |  |--CScalarIdent "c" (11)   origin: [Grp:1, GrpExpr:0]
         |  |  +--CScalarConst (1)   origin: [Grp:2, GrpExpr:0]
         |  +--CScalarBoolOp (EboolopAnd)   origin: [Grp:8, GrpExpr:0]
         |     |--CScalarCmp (=)   origin: [Grp:4, GrpExpr:0]
         |     |  |--CScalarIdent "c" (11)   origin: [Grp:1, GrpExpr:0]
         |     |  +--CScalarConst (1)   origin: [Grp:2, GrpExpr:0]
         |     +--CScalarCmp (<>)   origin: [Grp:7, GrpExpr:0]
         |        |--CScalarIdent "b" (12)   origin: [Grp:5, GrpExpr:0]
         |        +--CScalarConst (101)   origin: [Grp:6, GrpExpr:0]
         +--CScalarBoolOp (EboolopOr)   origin: [Grp:10, GrpExpr:0]
            |--CScalarCmp (<>)   origin: [Grp:3, GrpExpr:0]
            |  |--CScalarIdent "c" (11)   origin: [Grp:1, GrpExpr:0]
            |  +--CScalarConst (1)   origin: [Grp:2, GrpExpr:0]
            +--CScalarCmp (=)   origin: [Grp:4, GrpExpr:0]
               |--CScalarIdent "c" (11)   origin: [Grp:1, GrpExpr:0]
               +--CScalarConst (1)   origin: [Grp:2, GrpExpr:0]
```
   In this case, CLogicalCTEConsumer has 0 childs, so any inferred
   predicate can be pushed below it.

2) Even if cte inlining is enabled, in ORCA we always place a result
   node on top of the base colum producing node to derive the computed
   column.
   Example:
```
   +--CLogicalSelect
      |--CLogicalProject
      |  |--CLogicalGet "badestimate1" ("badestimate1"), Columns: ["a" (13), "b" (12), "c" (14), "ctid" (15), "xmin" (16), "cmin" (17), "xmax" (18), "cmax" (19), "tableoid" (20), "gp_segment_id" (21)] Key sets: {[3,9]}
      |  +--CScalarProjectList
      |     +--CScalarProjectElement "c" (11)
      |        +--CScalarCast
      |           +--CScalarIdent "c" (14)
      +--CScalarBoolOp (EboolopAnd)
         |--CScalarBoolOp (EboolopOr)
         |  |--CScalarCmp (<>)
         |  |  |--CScalarIdent "c" (11)
         |  |  +--CScalarConst (1)
         |  +--CScalarBoolOp (EboolopAnd)
         |     |--CScalarCmp (=)
         |     |  |--CScalarIdent "c" (11)
         |     |  +--CScalarConst (1)
         |     +--CScalarCmp (<>)
         |        |--CScalarIdent "b" (12)
         |        +--CScalarConst (101)
         +--CScalarBoolOp (EboolopOr)
            |--CScalarCmp (<>)
            |  |--CScalarIdent "c" (11)
            |  +--CScalarConst (1)
            +--CScalarCmp (=)
               |--CScalarIdent "c" (11)
               +--CScalarConst (1)
   In this case the Colref 11 is generated using a CLogicaProject, and
   since it a computed column the filter can't be pushed any further for
   the inlined CTE.
```
Generating additional predicates appears to be not useful in these cases
and due to the additional predicates we also underestimate the rows
produced after the filters.

In the below example: the inferred pedicate `((c::bigint) <> 1 OR (c::bigint) = 1)`
from the disjunctive filters is unnecessary and reduces the cardinality
```
EXPLAIN WITH  CTE AS
 (SELECT c::int8, b  FROM badestimate1)
SELECT 1 FROM CTE WHERE c <> 1 OR (c = 1 AND b <> 101);
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.13 rows=2 width=4)
   ->  Result  (cost=0.00..431.13 rows=1 width=4)
         ->  Result  (cost=0.00..431.13 rows=1 width=1)
               Filter: ((c::bigint) <> 1 OR ((c::bigint) = 1 AND b <> 101)) AND ((c::bigint) <> 1 OR (c::bigint) = 1)
               ->  Result  (cost=0.00..431.13 rows=1 width=12)
                     ->  Table Scan on badestimate1  (cost=0.00..431.08 rows=3334 width=8)
 Optimizer status: PQO version 3.116.0
```
After fix: The unnecessary predicate `((c::bigint) <> 1 OR (c::bigint) =
1)` will not be there.

This commit does the following:
1) Identifies the output columns of CTEConsumers
2) If there are predicates on the computed columns, and these are the
   output colums of CTE, predicates are not inferred using the
   disjunctive filters.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
