### PR TITLE
Update distribution spec for inner child of left outer index NL join to handle random distributions

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
@@ -33,6 +33,10 @@ public:
 	// dtor
 	~CPhysicalLeftOuterIndexNLJoin() override;
 
+	CEnfdProp::EPropEnforcingType EpetDistribution(
+		CExpressionHandle &exprhdl,
+		const CEnfdDistribution *ped) const override;
+
 	// ident accessors
 	EOperatorId
 	Eopid() const override

--- a/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
@@ -2092,9 +2092,21 @@ CEngine::FCheckEnfdProps(CMemoryPool *mp, CGroupExpression *pgexpr,
 	BOOL fOrderReqd = !GPOS_FTRACE(EopttraceDisableSort) &&
 					  !prpp->Peo()->PosRequired()->IsEmpty();
 
+	// CPhysicalLeftOuterIndexNLJoin requires the inner child to be any
+	// distribution but random. The OR makes an exception in this case.
+	// This should be generalized when more physical operators require
+	// this pattern. We need an explicit check for CPhysicalLeftOuterIndexNLJoin
+	// when there are no motions, therefore we need to handle this exceptional
+	// case here.
+	//
+	// Similar exceptions should be OR'd into fDistirbutionReqdException to
+	// force checking EpetDistribution on the physical operation
+	BOOL fDistributionReqdException =
+		popPhysical->Eopid() == COperator::EopPhysicalLeftOuterIndexNLJoin;
 	BOOL fDistributionReqd =
-		!GPOS_FTRACE(EopttraceDisableMotions) &&
-		(CDistributionSpec::EdtAny != prpp->Ped()->PdsRequired()->Edt());
+		(!GPOS_FTRACE(EopttraceDisableMotions) &&
+		 (CDistributionSpec::EdtAny != prpp->Ped()->PdsRequired()->Edt())) ||
+		fDistributionReqdException;
 
 	BOOL fRewindabilityReqd = !GPOS_FTRACE(EopttraceDisableSpool) &&
 							  (prpp->Per()->PrsRequired()->IsCheckRequired());

--- a/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
@@ -2099,14 +2099,14 @@ CEngine::FCheckEnfdProps(CMemoryPool *mp, CGroupExpression *pgexpr,
 	// when there are no motions, therefore we need to handle this exceptional
 	// case here.
 	//
-	// Similar exceptions should be OR'd into fDistirbutionReqdException to
+	// Similar exceptions should be OR'd into fDistributionReqdException to
 	// force checking EpetDistribution on the physical operation
 	BOOL fDistributionReqdException =
 		popPhysical->Eopid() == COperator::EopPhysicalLeftOuterIndexNLJoin;
 	BOOL fDistributionReqd =
-		(!GPOS_FTRACE(EopttraceDisableMotions) &&
-		 (CDistributionSpec::EdtAny != prpp->Ped()->PdsRequired()->Edt())) ||
-		fDistributionReqdException;
+		!GPOS_FTRACE(EopttraceDisableMotions) &&
+		((CDistributionSpec::EdtAny != prpp->Ped()->PdsRequired()->Edt()) ||
+		 fDistributionReqdException);
 
 	BOOL fRewindabilityReqd = !GPOS_FTRACE(EopttraceDisableSpool) &&
 							  (prpp->Per()->PrsRequired()->IsCheckRequired());

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
@@ -54,8 +54,7 @@ CPhysicalLeftOuterIndexNLJoin::Matches(COperator *pop) const
 
 CEnfdProp::EPropEnforcingType
 CPhysicalLeftOuterIndexNLJoin::EpetDistribution(
-	CExpressionHandle &exprhdl,			 // exprhdl
-	const CEnfdDistribution *ped) const	 // ped
+	CExpressionHandle &exprhdl, const CEnfdDistribution *ped) const
 {
 	GPOS_ASSERT(nullptr != ped);
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
@@ -52,6 +52,29 @@ CPhysicalLeftOuterIndexNLJoin::Matches(COperator *pop) const
 	return false;
 }
 
+CEnfdProp::EPropEnforcingType
+CPhysicalLeftOuterIndexNLJoin::EpetDistribution(
+	CExpressionHandle &exprhdl,			 // exprhdl
+	const CEnfdDistribution *ped) const	 // ped
+{
+	GPOS_ASSERT(nullptr != ped);
+
+	// outer index nested loop join cannot have the inner child be random
+	if (exprhdl.Pdpplan(1)->Pds()->Edt() == CDistributionSpec::EdtRandom)
+	{
+		return CEnfdProp::EpetProhibited;
+	}
+
+	// get distribution delivered by the physical node
+	CDistributionSpec *pds = CDrvdPropPlan::Pdpplan(exprhdl.Pdp())->Pds();
+	if (ped->FCompatible(pds))
+	{
+		// required distribution is already provided
+		return CEnfdProp::EpetUnnecessary;
+	}
+
+	return CEnfdProp::EpetRequired;
+}
 
 CDistributionSpec *
 CPhysicalLeftOuterIndexNLJoin::PdsRequired(
@@ -83,6 +106,11 @@ CPhysicalLeftOuterIndexNLJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		// inner (index-scan side) is requested for Any distribution,
 		// we allow outer references on the inner child of the join since it needs
 		// to refer to columns in join's outer child
+		//
+		// this distribution is intentionally invalid so we can reject invalid
+		// plans in EpetDistribution. there is a special case in CEnfdDistribution
+		// where fDistributionReqd is false if the distribution spec is any *or* the
+		// Eopid is CPhysicalLeftOuterIndexNLJoin (this case)
 		return GPOS_NEW(mp) CEnfdDistribution(
 			GPOS_NEW(mp)
 				CDistributionSpecAny(this->Eopid(), true /*fAllowOuterRefs*/),
@@ -143,15 +171,12 @@ CPhysicalLeftOuterIndexNLJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		return GPOS_NEW(mp) CEnfdDistribution(pdshashed, dmatch);
 	}
 
-	// shouldn't come here!
-	GPOS_RAISE(
-		gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
-		GPOS_WSZ_LIT("Left outer index nestloop join broadcasting outer side"));
 	// otherwise, require outer child to be replicated
+	// this will end up generating an invalid plan, but we reject it in EpetDistribution
 	return GPOS_NEW(mp) CEnfdDistribution(
 		GPOS_NEW(mp)
-			CDistributionSpecReplicated(CDistributionSpec::EdtStrictReplicated),
-		dmatch);
+			CDistributionSpecReplicated(CDistributionSpec::EdtReplicated),
+		CEnfdDistribution::EDistributionMatching::EdmSatisfy);
 }
 
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13692,3 +13692,160 @@ select data from tt_varchar where data > any(select id from tt_int);
 
 DROP CAST (integer AS text);
 reset optimizer_enforce_subplans;
+create table left_outer_index_nl_foo (a integer, b integer, c integer) distributed randomly;
+create table left_outer_index_nl_bar (a integer, b integer, c integer) distributed randomly;
+create index left_outer_index_nl_bar_idx on left_outer_index_nl_bar using btree (b);
+insert into left_outer_index_nl_foo select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar select i, i, i from generate_series(2, 6)i;
+analyze left_outer_index_nl_foo;
+analyze left_outer_index_nl_bar;
+set optimizer_enable_hashjoin=off;
+set enable_nestloop=on;
+set enable_hashjoin=off;
+--- verify that the inner half of a left outer nested loop join is non-randomly distributed
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.52 rows=4 width=16)
+   ->  Nested Loop Left Join  (cost=0.00..2.47 rows=1 width=16)
+         Join Filter: (r.b = l.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.04 rows=1 width=12)
+               Hash Key: r.b
+               ->  Seq Scan on left_outer_index_nl_foo r  (cost=0.00..1.01 rows=1 width=12)
+         ->  Materialize  (cost=0.00..1.06 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=2 width=8)
+                     Hash Key: l.b
+                     ->  Seq Scan on left_outer_index_nl_bar l  (cost=0.00..1.02 rows=2 width=8)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 1 | 1 | 1 |  
+ 3 | 3 | 3 | 3
+ 2 | 2 | 2 | 2
+ 4 | 4 | 4 | 4
+(4 rows)
+
+create table left_outer_index_nl_foo_hash (a integer, b integer, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table left_outer_index_nl_bar_hash (a integer, b integer, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index left_outer_index_nl_bar_hash_idx on left_outer_index_nl_bar_hash using btree (b);
+insert into left_outer_index_nl_foo_hash select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar_hash select i, i, i from generate_series(2, 6)i;
+analyze left_outer_index_nl_foo_hash;
+analyze left_outer_index_nl_bar_hash;
+--- verify that the inner half of a left outer nested loop join is non-randomly distributed
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.52 rows=4 width=14)
+   ->  Nested Loop Left Join  (cost=0.00..2.47 rows=1 width=14)
+         Join Filter: (r.b = l.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.04 rows=1 width=10)
+               Hash Key: r.b
+               ->  Seq Scan on left_outer_index_nl_foo_hash r  (cost=0.00..1.01 rows=1 width=10)
+         ->  Materialize  (cost=0.00..1.06 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=2 width=8)
+                     Hash Key: l.b
+                     ->  Seq Scan on left_outer_index_nl_bar l  (cost=0.00..1.02 rows=2 width=8)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+ 1 | 1 | 1 |  
+(4 rows)
+
+--- verify that a motion is introduced such that joins on each segment are internal to that segment (distributed by join key)
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.52 rows=4 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..2.47 rows=1 width=12)
+         Join Filter: (r.b = l.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.04 rows=1 width=10)
+               Hash Key: r.b
+               ->  Seq Scan on left_outer_index_nl_foo_hash r  (cost=0.00..1.01 rows=1 width=10)
+         ->  Materialize  (cost=0.00..1.06 rows=2 width=6)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=2 width=6)
+                     Hash Key: l.b
+                     ->  Seq Scan on left_outer_index_nl_bar_hash l  (cost=0.00..1.02 rows=2 width=6)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 1 | 1 | 1 | 
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+(4 rows)
+
+create table left_outer_index_nl_foo_repl (a integer, b integer, c integer) distributed replicated;
+create table left_outer_index_nl_bar_repl (a integer, b integer, c integer) distributed replicated;
+create index left_outer_index_nl_bar_repl_idx on left_outer_index_nl_bar_repl using btree (b);
+insert into left_outer_index_nl_foo_repl select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar_repl select i, i, i from generate_series(2, 6)i;
+analyze left_outer_index_nl_foo_repl;
+analyze left_outer_index_nl_bar_repl;
+--- replicated on both sides shouldn't require a motion
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_repl l on r.b=l.b;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=2.40..2.40 rows=4 width=16)
+   ->  Nested Loop Left Join  (cost=0.00..2.40 rows=4 width=16)
+         Join Filter: (r.b = l.b)
+         ->  Seq Scan on left_outer_index_nl_foo_repl r  (cost=0.00..1.04 rows=4 width=12)
+         ->  Materialize  (cost=0.00..1.07 rows=5 width=8)
+               ->  Seq Scan on left_outer_index_nl_bar_repl l  (cost=0.00..1.05 rows=5 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_repl l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 1 | 1 | 1 |  
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+(4 rows)
+
+--- outer side replicated, inner side hashed can have interesting cases (gather + join on one segment of inner side and redistribute + join + gather are both valid)
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.57 rows=4 width=14)
+   ->  Nested Loop Left Join  (cost=0.00..2.52 rows=1 width=14)
+         Join Filter: (r.b = l.b)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..1.09 rows=1 width=12)
+               Hash Key: r.b
+               ->  Seq Scan on left_outer_index_nl_foo_repl r  (cost=0.00..1.04 rows=4 width=12)
+         ->  Materialize  (cost=0.00..1.06 rows=2 width=6)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=2 width=6)
+                     Hash Key: l.b
+                     ->  Seq Scan on left_outer_index_nl_bar_hash l  (cost=0.00..1.02 rows=2 width=6)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+ 1 | 1 | 1 | 
+(4 rows)
+
+reset optimizer_enable_hashjoin;
+reset enable_nestloop;
+reset enable_hashjoin;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14069,3 +14069,148 @@ select data from tt_varchar where data > any(select id from tt_int);
 
 DROP CAST (integer AS text);
 reset optimizer_enforce_subplans;
+create table left_outer_index_nl_foo (a integer, b integer, c integer) distributed randomly;
+create table left_outer_index_nl_bar (a integer, b integer, c integer) distributed randomly;
+create index left_outer_index_nl_bar_idx on left_outer_index_nl_bar using btree (b);
+insert into left_outer_index_nl_foo select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar select i, i, i from generate_series(2, 6)i;
+analyze left_outer_index_nl_foo;
+analyze left_outer_index_nl_bar;
+set optimizer_enable_hashjoin=off;
+set enable_nestloop=on;
+set enable_hashjoin=off;
+--- verify that the inner half of a left outer nested loop join is non-randomly distributed
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.80 rows=7 width=16)
+   ->  Nested Loop Left Join  (cost=0.00..1324033.80 rows=3 width=16)
+         Join Filter: (left_outer_index_nl_foo.b = left_outer_index_nl_bar.b)
+         ->  Seq Scan on left_outer_index_nl_foo  (cost=0.00..431.00 rows=2 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=5 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+                     ->  Seq Scan on left_outer_index_nl_bar  (cost=0.00..431.00 rows=2 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 4 | 4 | 4 | 4
+ 1 | 1 | 1 |  
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+(4 rows)
+
+create table left_outer_index_nl_foo_hash (a integer, b integer, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table left_outer_index_nl_bar_hash (a integer, b integer, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index left_outer_index_nl_bar_hash_idx on left_outer_index_nl_bar_hash using btree (b);
+insert into left_outer_index_nl_foo_hash select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar_hash select i, i, i from generate_series(2, 6)i;
+analyze left_outer_index_nl_foo_hash;
+analyze left_outer_index_nl_bar_hash;
+--- verify that the inner half of a left outer nested loop join is non-randomly distributed
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.77 rows=7 width=14)
+   ->  Nested Loop Left Join  (cost=0.00..1324033.77 rows=3 width=14)
+         Join Filter: (left_outer_index_nl_foo_hash.b = left_outer_index_nl_bar.b)
+         ->  Seq Scan on left_outer_index_nl_foo_hash  (cost=0.00..431.00 rows=2 width=10)
+         ->  Materialize  (cost=0.00..431.00 rows=5 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+                     ->  Seq Scan on left_outer_index_nl_bar  (cost=0.00..431.00 rows=2 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+ 1 | 1 | 1 |  
+(4 rows)
+
+--- verify that a motion is introduced such that joins on each segment are internal to that segment (distributed by join key)
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.54 rows=7 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..1324033.54 rows=3 width=12)
+         Join Filter: (left_outer_index_nl_foo_hash.b = left_outer_index_nl_bar_hash.b)
+         ->  Seq Scan on left_outer_index_nl_foo_hash  (cost=0.00..431.00 rows=2 width=10)
+         ->  Materialize  (cost=0.00..431.00 rows=5 width=6)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=6)
+                     ->  Seq Scan on left_outer_index_nl_bar_hash  (cost=0.00..431.00 rows=2 width=6)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 1 | 1 | 1 | 
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+(4 rows)
+
+create table left_outer_index_nl_foo_repl (a integer, b integer, c integer) distributed replicated;
+create table left_outer_index_nl_bar_repl (a integer, b integer, c integer) distributed replicated;
+create index left_outer_index_nl_bar_repl_idx on left_outer_index_nl_bar_repl using btree (b);
+insert into left_outer_index_nl_foo_repl select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar_repl select i, i, i from generate_series(2, 6)i;
+analyze left_outer_index_nl_foo_repl;
+analyze left_outer_index_nl_bar_repl;
+--- replicated on both sides shouldn't require a motion
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_repl l on r.b=l.b;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..455.00 rows=7 width=16)
+   ->  Nested Loop Left Join  (cost=0.00..455.00 rows=21 width=16)
+         Join Filter: true
+         ->  Seq Scan on left_outer_index_nl_foo_repl  (cost=0.00..431.00 rows=12 width=12)
+         ->  Index Scan using left_outer_index_nl_bar_repl_idx on left_outer_index_nl_bar_repl  (cost=0.00..24.00 rows=3 width=4)
+               Index Cond: (b = left_outer_index_nl_foo_repl.b)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_repl l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 1 | 1 | 1 |  
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+(4 rows)
+
+--- outer side replicated, inner side hashed can have interesting cases (gather + join on one segment of inner side and redistribute + join + gather are both valid)
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1324035.41 rows=7 width=14)
+   ->  Nested Loop Left Join  (cost=0.00..1324035.41 rows=21 width=14)
+         Join Filter: (left_outer_index_nl_foo_repl.b = left_outer_index_nl_bar_hash.b)
+         ->  Seq Scan on left_outer_index_nl_foo_repl  (cost=0.00..431.00 rows=12 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=15 width=6)
+               ->  Broadcast Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=15 width=6)
+                     ->  Seq Scan on left_outer_index_nl_bar_hash  (cost=0.00..431.00 rows=2 width=6)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+ a | b | c | c 
+---+---+---+---
+ 1 | 1 | 1 | 
+ 2 | 2 | 2 | 2
+ 3 | 3 | 3 | 3
+ 4 | 4 | 4 | 4
+(4 rows)
+
+reset optimizer_enable_hashjoin;
+reset enable_nestloop;
+reset enable_hashjoin;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3268,3 +3268,62 @@ reset optimizer_enforce_subplans;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore
+
+create table left_outer_index_nl_foo (a integer, b integer, c integer) distributed randomly;
+create table left_outer_index_nl_bar (a integer, b integer, c integer) distributed randomly;
+create index left_outer_index_nl_bar_idx on left_outer_index_nl_bar using btree (b);
+
+insert into left_outer_index_nl_foo select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar select i, i, i from generate_series(2, 6)i;
+
+analyze left_outer_index_nl_foo;
+analyze left_outer_index_nl_bar;
+
+set optimizer_enable_hashjoin=off;
+set enable_nestloop=on;
+set enable_hashjoin=off;
+
+--- verify that the inner half of a left outer nested loop join is non-randomly distributed
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
+
+create table left_outer_index_nl_foo_hash (a integer, b integer, c text);
+create table left_outer_index_nl_bar_hash (a integer, b integer, c text);
+create index left_outer_index_nl_bar_hash_idx on left_outer_index_nl_bar_hash using btree (b);
+
+insert into left_outer_index_nl_foo_hash select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar_hash select i, i, i from generate_series(2, 6)i;
+
+analyze left_outer_index_nl_foo_hash;
+analyze left_outer_index_nl_bar_hash;
+
+--- verify that the inner half of a left outer nested loop join is non-randomly distributed
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
+
+--- verify that a motion is introduced such that joins on each segment are internal to that segment (distributed by join key)
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+
+create table left_outer_index_nl_foo_repl (a integer, b integer, c integer) distributed replicated;
+create table left_outer_index_nl_bar_repl (a integer, b integer, c integer) distributed replicated;
+create index left_outer_index_nl_bar_repl_idx on left_outer_index_nl_bar_repl using btree (b);
+
+insert into left_outer_index_nl_foo_repl select i, i, i from generate_series(1, 4)i;
+insert into left_outer_index_nl_bar_repl select i, i, i from generate_series(2, 6)i;
+
+analyze left_outer_index_nl_foo_repl;
+analyze left_outer_index_nl_bar_repl;
+
+--- replicated on both sides shouldn't require a motion
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_repl l on r.b=l.b;
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_repl l on r.b=l.b;
+
+--- outer side replicated, inner side hashed can have interesting cases (gather + join on one segment of inner side and redistribute + join + gather are both valid)
+explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
+
+reset optimizer_enable_hashjoin;
+reset enable_nestloop;
+reset enable_hashjoin;
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3265,10 +3265,6 @@ select data from tt_varchar where data > any(select id from tt_int);
 DROP CAST (integer AS text);
 reset optimizer_enforce_subplans;
 
--- start_ignore
-DROP SCHEMA orca CASCADE;
--- end_ignore
-
 create table left_outer_index_nl_foo (a integer, b integer, c integer) distributed randomly;
 create table left_outer_index_nl_bar (a integer, b integer, c integer) distributed randomly;
 create index left_outer_index_nl_bar_idx on left_outer_index_nl_bar using btree (b);
@@ -3327,3 +3323,6 @@ reset optimizer_enable_hashjoin;
 reset enable_nestloop;
 reset enable_hashjoin;
 
+-- start_ignore
+DROP SCHEMA orca CASCADE;
+-- end_ignore


### PR DESCRIPTION
Previously, CPhysicalLeftOuterIndexNLJoin requested any distribution on the
inner child, and threw an exception (and fell back to planner) if the inner
table was randomly distributed to prevent incorrect results.  This commit adds
CPhysicalLeftOuterIndexNLJoin::EpetDistribution to prohibit certain plans so we
do not reach an invalid state (i.e. reject random distributions on the inner
child without creating a new distribution spec entirely).

This commit adds a specific case where `EpetDistribution` is called if we are
using `CPhysicalLeftOuterIndexNLJoin` (normally, an operation with
`CDistributionSpecAny` will not have `EpetDistribution` called, so we made an
exception specifc to this operation) and adds test cases to `gporca` to verify the
behavior is correct. This commit also adds missing test cases for hashed and
replicated tables with left outer index nested loop joins.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
