### PR TITLE
Fixing PR #12238.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -437,6 +437,8 @@ bring_to_singleQE(PlannerInfo *root, RelOptInfo *rel, List *outer_quals)
 											  NIL, // DESTROY pathkeys
 											  false,
 											  target_locus);
+			if (!path)
+				elog(ERROR, "Can't create valid motion for relation's path.");
 
 			path = (Path *) create_material_path(root, rel, path);
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1581,6 +1581,8 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 		else
 		{
 			subpath = cdbpath_create_motion_path(root, subpath, subpath->pathkeys, false, targetlocus);
+			if (!subpath)
+				elog(ERROR, "Can't create valid motion for Append node.");
 		}
 
 		pathnode->sameslice_relids = bms_union(pathnode->sameslice_relids, subpath->sameslice_relids);


### PR DESCRIPTION
Removing unnecessary check for replicated locus type. Adding missed blank lines. Mentioning broken regression test.

PR #12238 [contains](https://github.com/arenadata/gpdb/blob/dc74b6bc0ce6fa459300763e5b1ed90046be2a3b/src/backend/cdb/cdbpath.c#L320) unnecessary `if` condition which was included by mistake. This statement can return NULL, which in rare cases can filter the optimal plan.