### PR TITLE
Added reference to restart database

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/diskquota.xml
+++ b/gpdb-doc/dita/ref_guide/modules/diskquota.xml
@@ -116,9 +116,8 @@ $ gpstop -ar</codeblock></li>
         (in seconds) the table sizes are recalculated. The smaller the <codeph>naptime</codeph>
         value, the less delay in detecting changes in disk usage. This example sets the
           <codeph>naptime</codeph> to ten seconds.
-        <codeblock>$ gpconfig -c diskquota.naptime -v 10</codeblock></section>
-      <section>Note that you will need to restart the database in order for this parameter
-        configuration changes to take effect.</section>
+        <codeblock>$ gpconfig -c diskquota.naptime -v 10
+$ gpstop -ar</codeblock></section>
       <section>
         <title>Configuring diskquota Shared Memory</title>
         <p>The <codeph>diskquota</codeph> module uses shared memory to save the denylist and to save

--- a/gpdb-doc/dita/ref_guide/modules/diskquota.xml
+++ b/gpdb-doc/dita/ref_guide/modules/diskquota.xml
@@ -117,6 +117,8 @@ $ gpstop -ar</codeblock></li>
         value, the less delay in detecting changes in disk usage. This example sets the
           <codeph>naptime</codeph> to ten seconds.
         <codeblock>$ gpconfig -c diskquota.naptime -v 10</codeblock></section>
+      <section>Note that you will need to restart the database in order for this parameter
+        configuration changes to take effect.</section>
       <section>
         <title>Configuring diskquota Shared Memory</title>
         <p>The <codeph>diskquota</codeph> module uses shared memory to save the denylist and to save
@@ -136,7 +138,7 @@ $ gpstop -ar</codeblock></li>
           This example changes the active table shared memory to
           2MiB:<codeblock>$ gpconfig -c diskquota.max_active_tables -v '2MiB'</codeblock></p>
         <p>Shared memory is allocated when Greenplum Database starts up, so a server restart is
-          required after you change the value of the  <codeph>diskquota.max_active_tables</codeph>
+          required after you change the value of the <codeph>diskquota.max_active_tables</codeph>
           parameter.</p>
       </section>
     </body>


### PR DESCRIPTION
When editing the configuration parameter diskquota.naptime, database restart is required. Added a reference to indicate this.