### PR TITLE
Vacuum should read fresh version of pg_class for update

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1562,6 +1562,13 @@ vac_update_relstats_from_list(List *updated_stats)
 	 */
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
+	/*
+	 * To read latest version of pg_class tuple below, as it was most likely
+	 * updated earlier within same command by earlier call to
+	 * vac_update_relstats().
+	 */
+	CommandCounterIncrement();
+
 	foreach (lc, updated_stats)
 	{
 		VPgClassStats *stats = (VPgClassStats *) lfirst(lc);

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -358,3 +358,51 @@ DROP TABLE vac_acl_heap;
 DROP TABLE vac_acl_ao;
 DROP TABLE vac_acl_aocs;
 DROP ROLE non_super_user_vacuum;
+-- Test to validate VACUUM FREEZE correctly updates pg_class
+CREATE TABLE vacuum_test_heap_table AS
+SELECT generate_series(1, 10) distributed BY (generate_series);
+DELETE FROM vacuum_test_heap_table;
+-- just to bump transaction id
+CREATE TEMP TABLE t1(a int) ON COMMIT DROP distributed BY (a);
+CREATE TEMP TABLE t1(a int) ON COMMIT DROP distributed BY (a);
+SELECT gp_segment_id,
+       relname, reltuples, relpages,
+       age(relfrozenxid)
+FROM pg_class
+WHERE relname = 'vacuum_test_heap_table'
+UNION ALL
+SELECT gp_segment_id,
+       relname, reltuples, relpages,
+       age(relfrozenxid)
+FROM gp_dist_random('pg_class')
+WHERE relname = 'vacuum_test_heap_table'
+ORDER BY gp_segment_id;
+ gp_segment_id |        relname         | reltuples | relpages | age 
+---------------+------------------------+-----------+----------+-----
+            -1 | vacuum_test_heap_table |        10 |        3 |   3
+             0 | vacuum_test_heap_table |         0 |        0 |   4
+             1 | vacuum_test_heap_table |         0 |        0 |   4
+             2 | vacuum_test_heap_table |         0 |        0 |   4
+(4 rows)
+
+VACUUM FREEZE vacuum_test_heap_table;
+SELECT gp_segment_id,
+       relname, reltuples, relpages,
+       age(relfrozenxid)
+FROM pg_class
+WHERE relname = 'vacuum_test_heap_table'
+UNION ALL
+SELECT gp_segment_id,
+       relname, reltuples, relpages,
+       age(relfrozenxid)
+FROM gp_dist_random('pg_class')
+WHERE relname = 'vacuum_test_heap_table'
+ORDER BY gp_segment_id;
+ gp_segment_id |        relname         | reltuples | relpages | age 
+---------------+------------------------+-----------+----------+-----
+            -1 | vacuum_test_heap_table |         0 |        1 |   1
+             0 | vacuum_test_heap_table |         0 |        1 |   0
+             1 | vacuum_test_heap_table |         0 |        1 |   0
+             2 | vacuum_test_heap_table |         0 |        1 |   0
+(4 rows)
+


### PR DESCRIPTION
For GPDB on coordinator, vac_update_relstats() gets called
twice. First in regular flow of vacuum via lazy_vacuum_rel() and next
time after receiving values for reltuples and relpages from segments
via vac_update_relstats_from_list() → vac_update_relstats(). Without
CommandCounterIncrement() added as part of this commit, second call to
vac_update_relstats() reads stale value of row from pg_class and hence
overwrites the effect (mostly update to relfrozenxid) performed by
first calls update.

Added test to showcase and validate the behavior.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
