### PR TITLE
Use the address for WAL-replication in gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -660,7 +660,7 @@ class SegmentTemplate:
         try:
             masterSeg = self.gparray.master
             cmd = PgBaseBackup(pgdata=self.tempDir,
-                               host=masterSeg.getSegmentHostName(),
+                               host=masterSeg.getSegmentAddress(),
                                port=str(masterSeg.getSegmentPort()),
                                recovery_mode=False,
                                target_gp_dbid=dummyDBID)


### PR DESCRIPTION
The address for WAL-replication should be the primary's `address`
in gp_segment_configuration.

This PR is a sub-fix of another PR(https://github.com/greenplum-db/gpdb/pull/12208).
The major intent is to make this change minimal for review and merge
it soon.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
