### PR TITLE
Fix Readme for Mac OS

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -69,6 +69,7 @@ sudo chown $USER:admin /usr/local/gpdb
 cat >> ~/.bashrc << EOF
 ulimit -n 65536 65536  # Increases the number of open files
 export PGHOST="$(hostname)"
+export LC_CTYPE="en_US.UTF-8"
 EOF
 
 cat << EOF


### PR DESCRIPTION
Without setting the correct LC_CTYPE, demo cluster creation fails in Master

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
