### PR TITLE
Handle squelching LockRows node

### DIFF
--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -647,6 +647,7 @@ ExecSquelchNode(PlanState *node)
 		case T_BitmapOrState:
 		case T_DynamicBitmapHeapScanState:
 		case T_LimitState:
+		case T_LockRowsState:
 		case T_NestLoopState:
 		case T_MergeJoinState:
 		case T_RepeatState:

--- a/src/test/regress/expected/qp_executor.out
+++ b/src/test/regress/expected/qp_executor.out
@@ -27,6 +27,16 @@ select * from cf_executor_test order by a limit 1 for share;
  1
 (1 row)
 
+select oid from pg_class order by oid limit 0 for update;
+ oid 
+-----
+(0 rows)
+
+select oid from pg_class order by oid limit 0 for share;
+ oid 
+-----
+(0 rows)
+
 --returning clause
 insert into cf_executor_test values (1) returning *;
  a 

--- a/src/test/regress/sql/qp_executor.sql
+++ b/src/test/regress/sql/qp_executor.sql
@@ -12,6 +12,9 @@ select count(*) from cf_executor_test;
 select * from cf_executor_test order by a limit 1 for update;
 select * from cf_executor_test order by a limit 1 for share;
 
+select oid from pg_class order by oid limit 0 for update;
+select oid from pg_class order by oid limit 0 for share;
+
 --returning clause
 insert into cf_executor_test values (1) returning *;
 


### PR DESCRIPTION
For LockRows node, we do not need special handling, just recurse to its
children.

Fixes issue #12111

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
