### PR TITLE
skip gpload test in centos6

### DIFF
--- a/gpMgmt/bin/gpload_test/Makefile
+++ b/gpMgmt/bin/gpload_test/Makefile
@@ -22,7 +22,7 @@ GPTest.pm:
 ifeq "$(findstring ubuntu, $(TEST_OS))" "ubuntu"
 installcheck: gpdiff.pl gpstringsubs.pl
 	@echo "skip gpload test for ubuntu"
-else ifeq "$(findstring CentOS release 6., $(OS))" "centos6"
+else ifeq "$(findstring CentOS release 6., $(OS))" "CentOS release 6."
 installcheck: gpdiff.pl gpstringsubs.pl
 	@echo "skip gpload test for centos6"
 else


### PR DESCRIPTION
this pr fix pipeline fail in #12301
modify gpload test Makefile, recognize the system os, skip gpload test if in centos6 and ubuntu

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
