### PR TITLE
[6X]Correct var mapping for 3 stage agg with group by expression

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -3815,7 +3815,7 @@ deconstruct_agg_info(MppGroupContext *ctx)
 	 *---------------------------------------------------------------------
 	 */
 	ctx->dqa_offsets = palloc(sizeof(int) * (1 + ctx->numDistinctCols));
-	ctx->dqa_offsets[0] = ctx->numGroupCols;
+	ctx->dqa_offsets[0] = list_length(ctx->grps_tlist);
 	for (i = 0; i < ctx->numDistinctCols; i++)
 	{
 		ctx->dqa_offsets[i + 1] = ctx->dqa_offsets[i]
@@ -4163,7 +4163,7 @@ split_aggref(Aggref *aggref, MppGroupContext *ctx)
 			Aggref	   *dqa_aggref;
 			TargetEntry *firstarg = (TargetEntry *) linitial(aggref->args);
 
-			arg_var = makeVar(ctx->final_varno, ctx->numGroupCols + 1,
+			arg_var = makeVar(ctx->final_varno, list_length(ctx->grps_tlist) + 1,
 							  exprType((Node *) firstarg->expr),
 							  exprTypmod((Node *) firstarg->expr),
 							  exprCollation((Node *) firstarg->expr),
@@ -4263,7 +4263,7 @@ split_aggref(Aggref *aggref, MppGroupContext *ctx)
 			ctx->prefs_tlist = lappend(ctx->prefs_tlist, prelim_tle);
 
 			args = makeVar(ctx->final_varno,
-						   ctx->numGroupCols
+						   list_length(ctx->grps_tlist)
 						   + (ctx->use_dqa_pruning ? 1 : 0)
 						   + attrno,
 						   transtype,

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -465,3 +465,179 @@ SELECT v1.B
  2
 (2 rows)
 
+-- Test 3 stage aggregate with an expression contains subplan as the group key
+create table agg_a (id int, a int, b int, c numeric(10, 0));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table agg_b (id int, a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into agg_a values (1, 1, 1, 100);
+insert into agg_b values (1, 1, 1, 1);
+-- The below issue is planner only.
+-- The subplan in the group key expression and the type cast "bb.v::text" under select
+-- will cause the vars(b.a, b.b) showed in the expression appear in first agg's target list.
+-- And grps_tlist for MppGroupContext will contains these vars with the group expression,
+-- but normal case only contains group expression in grps_tlist.
+-- We used to sure that there could only be one target entry(the expression here) in grps_tlist
+-- for a group, but current case also contains b.a and b.b.
+-- When we build the 3 stage agg and try to split the Aggref and find or add target list into
+-- different Aggref stages with function `split_aggref`, it'll match to wrong Vars in
+-- `AGGSTAGE_INTERMEDIATE` and `AGGSTAGE_FINAL` stage.
+-- For the below query, it used to do the avg on b.b for the `AGGSTAGE_INTERMEDIATE` and
+-- `AGGSTAGE_FINAL` stage and cause a crash since the type expected here should be numeric, but
+-- get a int value when executing numeric_avg_deserialize.
+set enable_groupagg = false;
+set optimizer_enable_groupagg = false; -- to force orca generate same plan
+explain (costs off, verbose)
+SELECT bb.v::text, count(distinct a.a), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Output: ((CASE WHEN (b.a >= (SubPlan 1)) THEN b.a ELSE b.b END)::text), (count(a.a)), (pg_catalog.avg((pg_catalog.avg((avg(a.c)))))), (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END)
+   ->  HashAggregate
+         Output: (CASE WHEN (b.a >= (SubPlan 1)) THEN b.a ELSE b.b END)::text, count(a.a), pg_catalog.avg((pg_catalog.avg((avg(a.c))))), (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END)
+         Group Key: (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END)
+         ->  HashAggregate
+               Output: (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END), b.a, b.b, a.a, pg_catalog.avg((avg(a.c)))
+               Group Key: (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END), b.a
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END), b.a, b.b, a.a, (avg(a.c))
+                     Hash Key: (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END)
+                     ->  HashAggregate
+                           Output: (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END), b.a, b.b, a.a, avg(a.c)
+                           Group Key: CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END, a.a
+                           ->  Hash Join
+                                 Output: b.a, b.b, a.a, a.c, CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END
+                                 Hash Cond: (a.a = b.b)
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                       Output: a.a, a.c, a.id
+                                       Hash Key: a.a
+                                       ->  Seq Scan on public.agg_a a
+                                             Output: a.a, a.c, a.id
+                                 ->  Hash
+                                       Output: b.a, b.b, b.id
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                             Output: b.a, b.b, b.id
+                                             Hash Key: b.b
+                                             ->  Seq Scan on public.agg_b b
+                                                   Output: b.a, b.b, b.id
+                                 SubPlan 2  (slice3; segments: 1)
+                                   ->  Result
+                                         Output: (b.b - 2)
+         SubPlan 1  (slice4; segments: 1)
+           ->  Result
+                 Output: (b.b - 2)
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg=off
+(37 rows)
+
+SELECT bb.v::text, count(distinct a.a), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+ v | count |         avg          
+---+-------+----------------------
+ 1 |     1 | 100.0000000000000000
+(1 row)
+
+-- with multi dqa
+explain (costs off, verbose)
+SELECT bb.v::text, count(distinct a.a), count(distinct a.b), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+                                                                                                                 QUERY PLAN                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)
+   Output: ((CASE WHEN (share0_ref2.a >= (SubPlan 1)) THEN share0_ref2.a ELSE share0_ref2.b END)::text), (count(share0_ref2.a_1)), (count(share0_ref1.b_1)), (pg_catalog.avg((pg_catalog.avg((avg(share0_ref2.c)))))), share0_ref2.col_6
+   ->  Hash Join
+         Output: (CASE WHEN (share0_ref2.a >= (SubPlan 1)) THEN share0_ref2.a ELSE share0_ref2.b END)::text, (count(share0_ref2.a_1)), (count(share0_ref1.b_1)), (pg_catalog.avg((pg_catalog.avg((avg(share0_ref2.c)))))), share0_ref2.col_6
+         Hash Cond: (NOT (share0_ref2.col_6 IS DISTINCT FROM share0_ref1.col_6))
+         ->  HashAggregate
+               Output: share0_ref2.col_6, share0_ref2.a, share0_ref2.b, count(share0_ref2.a_1), pg_catalog.avg((pg_catalog.avg((avg(share0_ref2.c)))))
+               Group Key: share0_ref2.col_6
+               ->  HashAggregate
+                     Output: share0_ref2.col_6, share0_ref2.a, share0_ref2.b, share0_ref2.a_1, pg_catalog.avg((avg(share0_ref2.c)))
+                     Group Key: share0_ref2.col_6, share0_ref2.a
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Output: share0_ref2.col_6, share0_ref2.a, share0_ref2.b, share0_ref2.a_1, (avg(share0_ref2.c))
+                           Hash Key: share0_ref2.col_6
+                           ->  HashAggregate
+                                 Output: share0_ref2.col_6, share0_ref2.a, share0_ref2.b, share0_ref2.a_1, avg(share0_ref2.c)
+                                 Group Key: share0_ref2.col_6, share0_ref2.a_1
+                                 ->  Shared Scan (share slice:id 1:0)
+                                       Output: share0_ref2.a, share0_ref2.b, share0_ref2.a_1, share0_ref2.b_1, share0_ref2.c, share0_ref2.col_6
+         ->  Hash
+               Output: share0_ref1.col_6, share0_ref1.a, share0_ref1.b, (count(share0_ref1.b_1))
+               ->  HashAggregate
+                     Output: share0_ref1.col_6, share0_ref1.a, share0_ref1.b, count(share0_ref1.b_1)
+                     Group Key: share0_ref1.col_6
+                     ->  HashAggregate
+                           Output: share0_ref1.col_6, share0_ref1.a, share0_ref1.b, share0_ref1.b_1
+                           Group Key: share0_ref1.col_6, share0_ref1.a
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 Output: share0_ref1.col_6, share0_ref1.a, share0_ref1.b, share0_ref1.b_1
+                                 Hash Key: share0_ref1.col_6
+                                 ->  HashAggregate
+                                       Output: share0_ref1.col_6, share0_ref1.a, share0_ref1.b, share0_ref1.b_1
+                                       Group Key: share0_ref1.col_6, share0_ref1.b_1
+                                       ->  Shared Scan (share slice:id 4:0)
+                                             Output: share0_ref1.a, share0_ref1.b, share0_ref1.a_1, share0_ref1.b_1, share0_ref1.c, share0_ref1.col_6
+                                             ->  Materialize
+                                                   Output: b.a, b.b, a.a, a.b, a.c, (CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END)
+                                                   ->  Hash Join
+                                                         Output: b.a, b.b, a.a, a.b, a.c, CASE WHEN (b.a >= (SubPlan 2)) THEN b.a ELSE b.b END
+                                                         Hash Cond: (a.a = b.b)
+                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                               Output: a.a, a.b, a.c, a.id
+                                                               Hash Key: a.a
+                                                               ->  Seq Scan on public.agg_a a
+                                                                     Output: a.a, a.b, a.c, a.id
+                                                         ->  Hash
+                                                               Output: b.a, b.b, b.id
+                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                                                     Output: b.a, b.b, b.id
+                                                                     Hash Key: b.b
+                                                                     ->  Seq Scan on public.agg_b b
+                                                                           Output: b.a, b.b, b.id
+                                                         SubPlan 2  (slice4; segments: 1)
+                                                           ->  Result
+                                                                 Output: (b.b - 2)
+         SubPlan 1  (slice5; segments: 1)
+           ->  Result
+                 Output: (share0_ref2.b - 2)
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg=off
+(60 rows)
+
+SELECT bb.v::text, count(distinct a.a), count(distinct a.b), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+ v | count | count |         avg          
+---+-------+-------+----------------------
+ 1 |     1 |     1 | 100.0000000000000000
+(1 row)
+
+reset optimizer_enable_groupagg;
+reset enable_groupagg;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -182,3 +182,65 @@ SELECT v1.B
   v1.B, v1.C
   HAVING ( v1.B= ( SELECT v2.B FROM multiagg_expr_group_view v2 WHERE v1.C = v2.C));
 
+-- Test 3 stage aggregate with an expression contains subplan as the group key
+create table agg_a (id int, a int, b int, c numeric(10, 0));
+create table agg_b (id int, a int, b int, c int);
+insert into agg_a values (1, 1, 1, 100);
+insert into agg_b values (1, 1, 1, 1);
+
+-- The below issue is planner only.
+-- The subplan in the group key expression and the type cast "bb.v::text" under select
+-- will cause the vars(b.a, b.b) showed in the expression appear in first agg's target list.
+-- And grps_tlist for MppGroupContext will contains these vars with the group expression,
+-- but normal case only contains group expression in grps_tlist.
+-- We used to sure that there could only be one target entry(the expression here) in grps_tlist
+-- for a group, but current case also contains b.a and b.b.
+-- When we build the 3 stage agg and try to split the Aggref and find or add target list into
+-- different Aggref stages with function `split_aggref`, it'll match to wrong Vars in
+-- `AGGSTAGE_INTERMEDIATE` and `AGGSTAGE_FINAL` stage.
+-- For the below query, it used to do the avg on b.b for the `AGGSTAGE_INTERMEDIATE` and
+-- `AGGSTAGE_FINAL` stage and cause a crash since the type expected here should be numeric, but
+-- get a int value when executing numeric_avg_deserialize.
+
+set enable_groupagg = false;
+set optimizer_enable_groupagg = false; -- to force orca generate same plan
+explain (costs off, verbose)
+SELECT bb.v::text, count(distinct a.a), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+
+SELECT bb.v::text, count(distinct a.a), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+
+-- with multi dqa
+explain (costs off, verbose)
+SELECT bb.v::text, count(distinct a.a), count(distinct a.b), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+
+SELECT bb.v::text, count(distinct a.a), count(distinct a.b), avg(a.c)	-- note the type cast
+FROM agg_a a
+Join ( SELECT b.b,
+			(CASE WHEN b.a >= (SELECT b.b - 2)		-- note the subplan here
+				THEN b.a ELSE b.b END) as v
+		FROM agg_b b) as bb
+ON a.a = bb.b
+GROUP BY bb.v;
+reset optimizer_enable_groupagg;
+reset enable_groupagg;


### PR DESCRIPTION
grps_tlist for MppGroupContext may contains extra vars with the
group expression in some cases, for example subplan in group expression.
But for normal case it only contains group expression in grps_tlist.
We used to sure that there could only be one target entry in grps_tlist
for a group.
When we build the 3 stage agg and try to split the Aggref and find or
add target list into different Aggref stages with function `split_aggref`,
it'll match to wrong Vars in `AGGSTAGE_INTERMEDIATE` and `AGGSTAGE_FINAL`
stage.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
