### PR TITLE
Fix 6x pipeline fail

### DIFF
--- a/gpMgmt/bin/gpload_test/Makefile
+++ b/gpMgmt/bin/gpload_test/Makefile
@@ -25,6 +25,9 @@ installcheck: gpdiff.pl gpstringsubs.pl
 else ifeq "$(findstring CentOS release 6., $(OS))" "CentOS release 6."
 installcheck: gpdiff.pl gpstringsubs.pl
 	@echo "skip gpload test for centos6"
+else ifeq "$(findstring Red Hat Enterprise Linux Server, $(OS))" "Red Hat Enterprise Linux Server"
+installcheck: gpdiff.pl gpstringsubs.pl
+	@echo "skip gpload test for Red Hat"
 else
 installcheck: gpdiff.pl gpstringsubs.pl
 	@cd gpload && ./TEST.py

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -259,7 +259,7 @@ def write_config_file(version='1.0.0.1', database='reuse_gptest', user=os.enviro
     if quote:
         f.write("\n    - QUOTE: "+quote)
     if header:
-        f.write("\n    - HEADER: "+header)
+        f.write("\n    - HEADER: "+str(header))
     if transform:
         f.write("\n    - TRANSFORM: "+transform)
     if transform_config:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -400,17 +400,17 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
     gphome = os.environ['GPHOME']
     if os.path.exists(suitePath + "/init_file"):
         (ok, out) = run(gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
-                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file --gp_init_file=%s/init_file '
+                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file --gp_init_file=%s/init_file '
                               '%s %s > %s 2>&1' % (LMYD, suitePath, f1, f2, dfile))
 
     else:
         if os.path.exists(myinitfile):
             (ok, out) = run(gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
-                                  ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file --gp_init_file=%s '
+                                  ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file --gp_init_file=%s '
                                   '%s %s > %s 2>&1' % (LMYD, myinitfile, f1, f2, dfile))
         else:
             (ok, out) = run( gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
-                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file '
+                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s/global_init_file '
                               '%s %s > %s 2>&1' % ( LMYD, f1, f2, dfile ) )
 
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_legacy.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_legacy.py
@@ -372,8 +372,6 @@ def test_38_gpload_without_preload():
     copy_data('external_file_04.txt','data_file.txt')
     write_config_file(mode='insert',reuse_tables=True,fast_match=False,file='data_file.txt',error_table="err_table",error_limit=1000,preload=False)
 
-# gpload5 does not support fill_missing_fields
-'''
 @pytest.mark.order(39)
 @prepare_before_test(num=39)
 def test_39_gpload_fill_missing_fields():
@@ -382,21 +380,6 @@ def test_39_gpload_fill_missing_fields():
     runfile(file)
     copy_data('external_file_04.txt','data_file.txt')
     write_config_file(mode='insert',reuse_tables=False,fast_match=False,file='data_file.txt',table='texttable1', error_limit=1000, fill_missing_fields=True)
-'''
-
-@pytest.mark.order(39)
-@prepare_before_test(num=39)
-def test_39_gpload_header():
-    "39 gpload header reuse table MPP:31557"
-    file = mkpath('setup.sql')
-    runfile(file)
-    copy_data('external_file_47.txt','data_file.txt')
-    write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',config='config/config_file1', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', header=True, truncate=True, match_columns=False)
-    write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',config='config/config_file2', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', truncate=True, match_columns=False)
-    f = open(mkpath('query39.sql'),'w')
-    f.write("\! gpload -f "+mkpath('config/config_file1')+ " -d reuse_gptest\n")
-    f.write("\! gpload -f "+mkpath('config/config_file2')+ " -d reuse_gptest\n")
-    f.close()
 
 @pytest.mark.order(40)
 @prepare_before_test(num=40)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_legacy.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_legacy.py
@@ -383,6 +383,21 @@ def test_39_gpload_fill_missing_fields():
     copy_data('external_file_04.txt','data_file.txt')
     write_config_file(mode='insert',reuse_tables=False,fast_match=False,file='data_file.txt',table='texttable1', error_limit=1000, fill_missing_fields=True)
 '''
+
+@pytest.mark.order(39)
+@prepare_before_test(num=39)
+def test_39_gpload_header():
+    "39 gpload header reuse table MPP:31557"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_47.txt','data_file.txt')
+    write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',config='config/config_file1', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', header=True, truncate=True, match_columns=False)
+    write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',config='config/config_file2', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', truncate=True, match_columns=False)
+    f = open(mkpath('query39.sql'),'w')
+    f.write("\! gpload -f "+mkpath('config/config_file1')+ " -d reuse_gptest\n")
+    f.write("\! gpload -f "+mkpath('config/config_file2')+ " -d reuse_gptest\n")
+    f.close()
+
 @pytest.mark.order(40)
 @prepare_before_test(num=40)
 def test_40_gpload_merge_mode_with_multi_pk():

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_options.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_options.py
@@ -11,6 +11,22 @@ def test_301_gpload_yaml_with_header():
     copy_data('external_file_301.txt','data_file.txt')
     write_config_file(config='config/config_file',format='text',file='data_file.txt',table='texttable', header='true')
 
+@pytest.mark.order(302)
+@prepare_before_test(num=302)
+def test_302_gpload_header():
+    "302 gpload header reuse table MPP:31557"
+    '''
+    file = mkpath('setup.sql')
+    runfile(file)
+    '''
+    copy_data('external_file_47.txt','data_file.txt')
+    write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',config='config/config_file1', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', header=True, truncate=True, match_columns=False)
+    write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',config='config/config_file2', table='testheaderreuse', delimiter="','", format='csv', quote="'\x22'", encoding='LATIN1', log_errors=True, error_limit='1000', truncate=True, match_columns=False)
+    f = open(mkpath('query302.sql'),'w')
+    f.write("\! gpload -f "+mkpath('config/config_file1')+ " -d reuse_gptest\n")
+    f.write("\! gpload -f "+mkpath('config/config_file2')+ " -d reuse_gptest\n")
+    f.close()
+
 @pytest.mark.order(310)
 @prepare_before_test(num=310, times=1)
 def test_310_gpload_yaml_with_error_limit_0():

--- a/gpMgmt/bin/gpload_test/gpload2/query302.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query302.ans
@@ -1,0 +1,18 @@
+2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
+2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_752a62e8_cda5_11eb_9402_000c29b81d26
+2021-06-15 14:46:48|INFO|running time: 0.08 seconds
+2021-06-15 14:46:48|INFO|rows Inserted          = 1
+2021-06-15 14:46:48|INFO|rows Updated           = 0
+2021-06-15 14:46:48|INFO|data formatting errors = 0
+2021-06-15 14:46:48|INFO|gpload succeeded
+2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
+2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7545772c_cda5_11eb_81e2_000c29b81d26
+2021-06-15 14:46:48|INFO|running time: 0.05 seconds
+2021-06-15 14:46:48|INFO|rows Inserted          = 2
+2021-06-15 14:46:48|INFO|rows Updated           = 0
+2021-06-15 14:46:48|INFO|data formatting errors = 0
+2021-06-15 14:46:48|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query39.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query39.ans
@@ -1,18 +1,16 @@
-2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
-2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
-2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_752a62e8_cda5_11eb_9402_000c29b81d26
-2021-06-15 14:46:48|INFO|running time: 0.08 seconds
-2021-06-15 14:46:48|INFO|rows Inserted          = 1
-2021-06-15 14:46:48|INFO|rows Updated           = 0
-2021-06-15 14:46:48|INFO|data formatting errors = 0
-2021-06-15 14:46:48|INFO|gpload succeeded
-2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
-2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
-2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7545772c_cda5_11eb_81e2_000c29b81d26
-2021-06-15 14:46:48|INFO|running time: 0.05 seconds
-2021-06-15 14:46:48|INFO|rows Inserted          = 2
-2021-06-15 14:46:48|INFO|rows Updated           = 0
-2021-06-15 14:46:48|INFO|data formatting errors = 0
-2021-06-15 14:46:48|INFO|gpload succeeded
+2020-06-02 14:55:41|INFO|gpload session started 2020-06-02 14:55:41
+2020-06-02 14:55:46|INFO|setting schema 'public' for table 'texttable1'
+2020-06-02 14:55:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-06-02 14:55:46|INFO|running time: 5.27 seconds
+2020-06-02 14:55:51|INFO|rows Inserted          = 16
+2020-06-02 14:55:51|INFO|rows Updated           = 0
+2020-06-02 14:55:51|INFO|data formatting errors = 0
+2020-06-02 14:55:51|INFO|gpload succeeded
+2020-06-02 14:55:51|INFO|gpload session started 2020-06-02 14:55:51
+2020-06-02 14:55:56|INFO|setting schema 'public' for table 'texttable1'
+2020-06-02 14:55:56|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-06-02 14:55:56|INFO|running time: 5.09 seconds
+2020-06-02 14:56:01|INFO|rows Inserted          = 16
+2020-06-02 14:56:01|INFO|rows Updated           = 0
+2020-06-02 14:56:01|INFO|data formatting errors = 0
+2020-06-02 14:56:01|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query39.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query39.ans
@@ -1,16 +1,18 @@
-2020-06-02 14:55:41|INFO|gpload session started 2020-06-02 14:55:41
-2020-06-02 14:55:46|INFO|setting schema 'public' for table 'texttable1'
-2020-06-02 14:55:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2020-06-02 14:55:46|INFO|running time: 5.27 seconds
-2020-06-02 14:55:51|INFO|rows Inserted          = 16
-2020-06-02 14:55:51|INFO|rows Updated           = 0
-2020-06-02 14:55:51|INFO|data formatting errors = 0
-2020-06-02 14:55:51|INFO|gpload succeeded
-2020-06-02 14:55:51|INFO|gpload session started 2020-06-02 14:55:51
-2020-06-02 14:55:56|INFO|setting schema 'public' for table 'texttable1'
-2020-06-02 14:55:56|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2020-06-02 14:55:56|INFO|running time: 5.09 seconds
-2020-06-02 14:56:01|INFO|rows Inserted          = 16
-2020-06-02 14:56:01|INFO|rows Updated           = 0
-2020-06-02 14:56:01|INFO|data formatting errors = 0
-2020-06-02 14:56:01|INFO|gpload succeeded
+2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
+2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_752a62e8_cda5_11eb_9402_000c29b81d26
+2021-06-15 14:46:48|INFO|running time: 0.08 seconds
+2021-06-15 14:46:48|INFO|rows Inserted          = 1
+2021-06-15 14:46:48|INFO|rows Updated           = 0
+2021-06-15 14:46:48|INFO|data formatting errors = 0
+2021-06-15 14:46:48|INFO|gpload succeeded
+2021-06-15 14:46:48|INFO|gpload session started 2021-06-15 14:46:48
+2021-06-15 14:46:48|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-06-15 14:46:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/zhaorui/workspace/6_greenplum/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-06-15 14:46:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7545772c_cda5_11eb_81e2_000c29b81d26
+2021-06-15 14:46:48|INFO|running time: 0.05 seconds
+2021-06-15 14:46:48|INFO|rows Inserted          = 2
+2021-06-15 14:46:48|INFO|rows Updated           = 0
+2021-06-15 14:46:48|INFO|data formatting errors = 0
+2021-06-15 14:46:48|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -8,7 +8,7 @@ CREATE SCHEMA
 set client_min_messages='warning';
 SET
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
-DROP FOREIGN TABLE
+DROP EXTERNAL TABLE
 DROP TABLE IF EXISTS texttable;
 DROP TABLE
 DROP TABLE IF EXISTS csvtable;
@@ -23,8 +23,7 @@ DROP TABLE IF EXISTS chinese表;
 DROP TABLE
 DROP TABLE IF EXISTS testtruncate;
 DROP TABLE
-DROP TABLE IF EXISTS testheaderreuse;
-NOTICE:  table "testheaderreuse" does not exist, skipping
+DROP TABLE IF EXISTS prices;
 DROP TABLE
 reset client_min_messages;
 RESET

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -19,6 +19,8 @@ DROP TABLE IF EXISTS texttable1;
 DROP TABLE
 DROP TABLE IF EXISTS testSpecialChar;
 DROP TABLE
+DROP TABLE IF EXISTS testheaderreuse;
+DROP TABLE
 DROP TABLE IF EXISTS chinese表;
 DROP TABLE
 DROP TABLE IF EXISTS testtruncate;
@@ -46,6 +48,11 @@ CREATE TABLE test.csvtable (
             DISTRIBUTED BY (year);
 CREATE TABLE
 create table testSpecialChar("Field1" bigint, "Field#2" text) distributed by ("Field1");
+CREATE TABLE
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;
 CREATE TABLE
 CREATE TABLE  chinese表 ( 列1 text, "列#2" int, lie3 timestamp, 列four decimal ) DISTRIBUTED BY ("列#2");
 CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -13,6 +13,7 @@ DROP TABLE IF EXISTS csvtable;
 DROP TABLE IF EXISTS test.csvtable;
 DROP TABLE IF EXISTS texttable1;
 DROP TABLE IF EXISTS testSpecialChar;
+DROP TABLE IF EXISTS testheaderreuse;
 DROP TABLE IF EXISTS chinese表;
 DROP TABLE IF EXISTS testtruncate;
 DROP TABLE IF EXISTS prices;
@@ -32,6 +33,10 @@ CREATE TABLE test.csvtable (
 	    year int, make text, model text, decription text, price decimal)
             DISTRIBUTED BY (year);
 create table testSpecialChar("Field1" bigint, "Field#2" text) distributed by ("Field1");
+CREATE TABLE testheaderreuse (
+            field1            integer not null,
+            field2            text,
+            field3            text) DISTRIBUTED randomly;
 CREATE TABLE  chinese表 ( 列1 text, "列#2" int, lie3 timestamp, 列four decimal ) DISTRIBUTED BY ("列#2");
 CREATE TABLE texttable2(s1 text, s2 text) DISTRIBUTED BY (s1);
 CREATE TABLE testtruncate (


### PR DESCRIPTION
1. skip gpload test in Red Hat for gpdb6-oracle7-test task
    judge the os in gpload test Makefile, if os is red hat, than skip gpload test

2. add test case 39
    case 39 is added by Zhaorui in pr #12166 (case number is 47 in his pr), and missed when refactor gpload test

3. delete 'ignore drop' command when compare ans and out files
    drop information is ignored when comparing ans and out files in local test. While in remote test it is not ignored. So we delete the ignore command in local test to make the ans files same in local and remote tests.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
