### PR TITLE
Fix the misuse of hostname and address in gp_segment_configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -208,7 +208,8 @@ before_install:
 
 before_script:
     - ssh-keygen -t "rsa" -f ~/.ssh/id_rsa -N ""
-    - ssh-keyscan $(hostname) >> ~/.ssh/known_hosts
+    - ssh-keyscan $(hostname) $(python -c 'import socket;print(socket.gethostbyname(socket.gethostname()))') >> ~/.ssh/known_hosts
+    - ssh-keyscan localhost 127.0.0.1 >> ~/.ssh/known_hosts
     - cp ~/.ssh/{id_rsa.pub,authorized_keys}
     - ccache --zero-stats
 

--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -30,7 +30,7 @@ ssh_keyscan_for_user() {
   {
     ssh-keyscan localhost
     ssh-keyscan 0.0.0.0
-    ssh-keyscan `hostname`
+    ssh-keyscan `hostname` $(python -c 'import socket;print(socket.gethostbyname(socket.gethostname()))')
   } >> "${home_dir}/.ssh/known_hosts"
 }
 

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -250,7 +250,8 @@ MIRROR_DIRS_LIST=${MIRROR_DIRS_LIST#* }
 # Host configuration
 #*****************************************************************************************
 
-LOCALHOST=`hostname`
+LOCALHOST=$(python -c 'import socket;print(socket.gethostbyname(socket.gethostname()))')
+COORDINATOR_HOSTNAME=`hostname`
 echo $LOCALHOST > hostfile
 
 #*****************************************************************************************
@@ -283,7 +284,7 @@ cat >> $CLUSTER_CONFIG <<-EOF
 	declare -a DATA_DIRECTORY=(${PRIMARY_DIRS_LIST})
 	
 	# Name of host on which to setup the QD
-	COORDINATOR_HOSTNAME=$LOCALHOST
+	COORDINATOR_HOSTNAME=$COORDINATOR_HOSTNAME
 	
 	# Name of directory on that host in which to setup the QD
 	COORDINATOR_DIRECTORY=$QDDIR

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -660,7 +660,7 @@ class SegmentTemplate:
         try:
             coordinatorSeg = self.gparray.coordinator
             cmd = PgBaseBackup(pgdata=self.tempDir,
-                               host=coordinatorSeg.getSegmentHostName(),
+                               host=coordinatorSeg.getSegmentAddress(),
                                port=str(coordinatorSeg.getSegmentPort()),
                                recovery_mode=False,
                                target_gp_dbid=dummyDBID)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -827,7 +827,7 @@ class SegmentTemplate:
         # Map primary and mirror hostnames to expanded segment's contentid
         m = defaultdict(lambda: [])
         for seg in self.gparray.getExpansionSegDbList():
-            m[seg.getSegmentContentId()].append(seg.getSegmentHostName())
+            m[seg.getSegmentContentId()].append(seg.getSegmentAddress())
 
         # Now update the primary's hba config with the corresponding primary
         # and mirror information

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -113,8 +113,8 @@ def parseargs():
 
     # Standby initialization options section
     optgrp = OptionGroup(parser, 'Standby initialization options')
-    optgrp.add_option('-s', '--standby-host', type='string', dest='standby_host',
-                      help='hostname of system to create standby coordinator on')
+    optgrp.add_option('-s', '--standby-address', '--standby-host', type='string', dest='standby_address',
+                      help='address of system to create standby coordinator on')
     optgrp.add_option('-P', '--standby-port', type='int', dest='standby_port',
                       help='port of system to create standby coordinator on')
     optgrp.add_option('-S', '--standby-datadir', type='string', dest='standby_datadir',
@@ -139,6 +139,10 @@ def parseargs():
     # Parse the command line arguments
     (options, args) = parser.parse_args()
 
+# We only accept the standby address, the hostname is resolved below,
+# Keeping standby_hostname here is for convenience and consistency.
+    setattr(options, 'standby_hostname', 'localhost')
+
     if options.help:
         parser.print_help()
         parser.exit(0, None)
@@ -152,7 +156,7 @@ def parseargs():
         parser.exit(2, None)
 
     # -s and -n are exclusive
-    if options.standby_host and options.no_update:
+    if options.standby_address and options.no_update:
         logger.error('Options -s and -n cannot be specified together.')
         parser.exit(2, None)
 
@@ -162,27 +166,36 @@ def parseargs():
         parser.exit(2, None)
 
     # -s and -r are exclusive
-    if options.standby_host and options.remove:
+    if options.standby_address and options.remove:
         logger.error('Options -s and -r cannot be specified together.')
         parser.exit(2, None)
 
     # we either need to delete or create or start
-    if not options.remove and not options.standby_host and not options.no_update:
+    if not options.remove and not options.standby_address and not options.no_update:
         logger.error('No action provided in the options.')
         parser.print_help()
         parser.exit(2, None)
 
     # check that new standby host is up
-    if options.standby_host:
+    if options.standby_address:
         try:
-            gp.Ping.local('check new standby up', options.standby_host)
+            resolve_hostname(options)
         except:
-            logger.error('Unable to ping new standby host %s' % options.standby_host)
+            logger.error('Unable to resolve new standby host %s' % options.standby_address)
             parser.exit(2, None)
 
     return options, args
-   
-   
+
+def resolve_hostname(options):
+    cmd = unix.Hostname('lookup hostname', ctxt=base.REMOTE, remoteHost=options.standby_address)
+    cmd.run(validateAfter=True)
+    hostname = cmd.get_hostname()
+    if not hostname:
+        raise Exception("can't resolve address to hostname: '%s' => '%s'" %
+                        (options.standby_address, options.standby_hostname))
+
+    options.standby_hostname = hostname
+
 #-------------------------------------------------------------------------
 def print_summary(options, array, standby_datadir, unreachable_hosts=[]):
     """Display summary of gpinitstandby operations."""
@@ -202,9 +215,13 @@ def print_summary(options, array, standby_datadir, unreachable_hosts=[]):
     if options.remove:
         logger.info('Greenplum standby coordinator hostname       = %s' \
                         % array.standbyCoordinator.getSegmentHostName())
+        logger.info('Greenplum standby coordinator address        = %s' \
+                        % array.standbyCoordinator.getSegmentAddress())
     else:
         logger.info('Greenplum standby coordinator hostname       = %s' \
-                        % options.standby_host)
+                        % options.standby_hostname)
+        logger.info('Greenplum standby coordinator address        = %s' \
+                        % options.standby_address)
 
     if array.standbyCoordinator:
         standby_port = array.standbyCoordinator.getSegmentPort()
@@ -399,7 +416,7 @@ def create_standby(options):
         # initialize a standby.
         try:
             logger.info('Syncing Greenplum Database extensions to standby')
-            SyncPackages(options.standby_host).run()
+            SyncPackages(options.standby_hostname).run()
         except Exception as e:
             logger.warning('Syncing of Greenplum Database extensions has failed.')
             logger.warning('Please run gppkg --clean after successful standby initialization.')
@@ -413,7 +430,7 @@ def create_standby(options):
         logger.info('Updating pg_hba.conf file...')
         update_pg_hba_conf(options, array)
         logger.debug('Updating pg_hba.conf file on segments...')
-        update_pg_hba_conf_on_segments(array, options.standby_host, options.hba_hostnames, unreachable_hosts)
+        update_pg_hba_conf_on_segments(array, options.standby_hostname, options.hba_hostnames, unreachable_hosts)
         logger.info('pg_hba.conf files updated successfully.')
 
         copy_coordinator_datadir_to_standby(options, array, standby_datadir)
@@ -506,10 +523,10 @@ def update_pg_hba_conf(options, array):
     try:
         coordinator_data_dir = array.coordinator.getSegmentDataDirectory()
         pg_hba_path = os.path.join(coordinator_data_dir, 'pg_hba.conf')
-        standby_ips = gp.IfAddrs.list_addrs(options.standby_host)
+        standby_ips = gp.IfAddrs.list_addrs(options.standby_hostname)
         # IfAddrs as called doesn't return local address, but if standby
         # will be on the same host, we should add it too.
-        if array.coordinator.getSegmentHostName() == options.standby_host:
+        if array.coordinator.getSegmentHostName() == options.standby_hostname:
             standby_ips.append('127.0.0.1')
         current_user = unix.UserId.local('get userid')
         
@@ -540,7 +557,7 @@ def update_pg_hba_conf(options, array):
                 address = ip + cidr_suffix
                 add_entry_to_new_section(['host', 'all', current_user, address, 'trust'])
         else:
-            add_entry_to_new_section(['host', 'all', current_user, options.standby_host, 'trust'])
+            add_entry_to_new_section(['host', 'all', current_user, options.standby_address, 'trust'])
 
         # new replication requires 'replication' string in database
         # column to allow walsender connections.  We still keep 'all'
@@ -551,13 +568,13 @@ def update_pg_hba_conf(options, array):
         # Add samehost replication to support single-host development.
         add_entry_to_new_section(['host', 'replication', current_user, 'samehost', 'trust'])
         if not options.hba_hostnames:
-            if_addrs = gp.IfAddrs.list_addrs(options.standby_host)
+            if_addrs = gp.IfAddrs.list_addrs(options.standby_address)
             for ip in if_addrs:
                 cidr_suffix = '/128' if ':' in ip else '/32'  # MPP-15889
                 address = ip + cidr_suffix
                 add_entry_to_new_section(['host', 'replication', current_user, address, 'trust'])
         else:
-            add_entry_to_new_section(['host', 'replication', current_user, options.standby_host, 'trust'])
+            add_entry_to_new_section(['host', 'replication', current_user, options.standby_address, 'trust'])
 
         # insert new section
         pg_hba_conf[index:index] = new_section
@@ -606,19 +623,19 @@ def validate_standby_init(options, array, standby_datadir):
     # make sure we have top level dir
     base_dir = os.path.dirname(os.path.normpath(standby_datadir))
     if not unix.FileDirExists.remote('check for parent of data dir',
-                                     options.standby_host,
+                                     options.standby_address,
                                      base_dir):
-        logger.error('Parent directory %s does not exist on host %s' %(base_dir, options.standby_host))
+        logger.error('Parent directory %s does not exist on host %s' %(base_dir, options.standby_address))
         logger.error('This directory must be created before running gpactivatestandby')
         raise GpInitStandbyException('Parent directory %s does not exist' % base_dir)
 
     # check that coordinator data dir does not exist on new host unless we are just re-syncing
-    logger.info('Checking for data directory %s on %s' % (standby_datadir, options.standby_host))
-    if unix.FileDirExists.remote('check for data dir', options.standby_host, standby_datadir):
-        logger.error('Data directory already exists on host %s' % options.standby_host)
+    logger.info('Checking for data directory %s on %s' % (standby_datadir, options.standby_hostname))
+    if unix.FileDirExists.remote('check for data dir', options.standby_hostname, standby_datadir):
+        logger.error('Data directory already exists on host %s' % options.standby_hostname)
         if array.standbyCoordinator:
             logger.error('If you want to just start the stopped standby, use the -n option')
-        if options.standby_host == array.coordinator.hostname:
+        if options.standby_hostname == array.coordinator.hostname:
             logger.error(
                 'If you want to initialize a new standby on the same host as '
                 'the coordinator (not recommended), use -S and -P to specify a new '
@@ -627,7 +644,7 @@ def validate_standby_init(options, array, standby_datadir):
         raise GpInitStandbyException('coordinator data directory exists')
 
     # disallow to create the same host/port
-    if (options.standby_host == array.coordinator.hostname and
+    if (options.standby_hostname == array.coordinator.hostname and
             (not options.standby_port or
                 options.standby_port == array.coordinator.port)):
         raise GpInitStandbyException('cannot create standby on the same host and port')
@@ -664,8 +681,8 @@ def add_standby_to_catalog(options, standby_datadir):
     
         logger.info('Adding standby coordinator to catalog...')
     
-        sql = get_add_standby_sql(options.standby_host,
-                                  options.standby_host,
+        sql = get_add_standby_sql(options.standby_hostname,
+                                  options.standby_address,
                                   standby_datadir,
                                   options.standby_port)
     
@@ -715,10 +732,10 @@ def copy_coordinator_datadir_to_standby(options, array, standby_datadir):
     # map the per-dbid directories to the new dbid.
     
     cmd = PgBaseBackup(pgdata=standby_datadir,
-                       host=array.coordinator.getSegmentHostName(),
+                       host=array.coordinator.getSegmentAddress(),
                        port=str(array.coordinator.getSegmentPort()),
                        ctxt=base.REMOTE,
-                       remoteHost=options.standby_host,
+                       remoteHost=options.standby_hostname,
                        forceoverwrite=True,
                        target_gp_dbid=array.standbyCoordinator.dbid)
     try:
@@ -814,7 +831,7 @@ try:
         check_and_start_standby()
     else:
         create_standby(options)
-        logger.info('Successfully created standby coordinator on %s' % options.standby_host)
+        logger.info('Successfully created standby coordinator on %s' % options.standby_hostname)
 
 except KeyboardInterrupt:
     logger.error('User canceled')

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -34,6 +34,7 @@ else
     exit 1
 fi
 
+MKDIR=mkdir
 #******************************************************************************
 # Script Specific Variables
 #******************************************************************************
@@ -358,6 +359,7 @@ CHK_PARAMS () {
 		# Check that we have write access to the proposed coordinator data directory
 		W_DIR=$COORDINATOR_DIRECTORY
 		LOG_MSG "[INFO]:-Checking write access to $W_DIR on coordinator host"
+		$MKDIR -p ${W_DIR}
 		$TOUCH ${W_DIR}/tmp_file_test
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ];then
@@ -757,6 +759,7 @@ CHK_QES () {
         # Check that we can write to the QE directory
         W_DIR=`$DIRNAME $GP_DIR`
         LOG_MSG "[INFO]:-Checking write access to $W_DIR on $GP_HOSTADDRESS"
+        $TRUSTED_SHELL $GP_HOSTADDRESS "$MKDIR -p ${W_DIR}"
         $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
         RETVAL=$?
         if [ $RETVAL -ne 0 ];then
@@ -782,6 +785,7 @@ CHK_QES () {
             # Check that we can write to the QE directory
             W_DIR=`$DIRNAME $GP_DIR`
             LOG_MSG "[INFO]:-Checking write access to $W_DIR on $GP_HOSTADDRESS"
+            $TRUSTED_SHELL $GP_HOSTADDRESS "$MKDIR -p ${W_DIR}"
             $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
             RETVAL=$?
             if [ $RETVAL -ne 0 ];then
@@ -829,6 +833,7 @@ CHK_SEG () {
 	# Check that we can write to the QE directory
     W_DIR=`$DIRNAME $GP_DIR`
     LOG_MSG "[INFO]:-Checking write access to $W_DIR on $GP_HOSTADDRESS"
+    $TRUSTED_SHELL $GP_HOSTADDRESS "$MKDIR -p ${W_DIR}"
     $TRUSTED_SHELL $GP_HOSTADDRESS "$TOUCH ${W_DIR}/tmp_file_test"
     RETVAL=$?
     if [ $RETVAL -ne 0 ];then
@@ -1271,7 +1276,6 @@ CREATE_QD_DB () {
 		BACKOUT_COMMAND "if [ -d $GP_DIR ]; then $EXPORT_LIB_PATH;export PGPORT=$GP_PORT; $PG_CTL -D $GP_DIR stop; fi"
 		BACKOUT_COMMAND "$ECHO \"Stopping Coordinator instance\""
 		LOG_MSG "[INFO]:-Completed starting the Coordinator in admin mode"
-		GP_HOSTNAME=$GP_HOSTADDRESS
 		PING_HOST $GP_HOSTNAME
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ]; then
@@ -1318,7 +1322,6 @@ LOAD_QE_SYSTEM_DATA () {
 		do
 				SET_VAR $I
 				LOG_MSG "[INFO]:-Adding segment $GP_HOSTADDRESS to Coordinator system tables"
-				GP_HOSTNAME=$GP_HOSTADDRESS
 				PING_HOST $GP_HOSTNAME
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -978,9 +978,9 @@ class ConfigureNewSegment(Command):
             isTargetReusedLocation = isTargetReusedLocationArr and isTargetReusedLocationArr[segIndex]
             # only a mirror segment has these two attributes
             # added on the fly, by callers
-            primaryHostname = getattr(seg, 'primaryHostname', "")
+            primaryAddress = getattr(seg, 'primaryAddress', "")
             primarySegmentPort = getattr(seg, 'primarySegmentPort', "-1")
-            if primaryHostname == "":
+            if primaryAddress == "":
                 isPrimarySegment =  "true" if seg.isSegmentPrimary(current_role=True) else "false"
                 isTargetReusedLocationString = "true" if isTargetReusedLocation else "false"
             else:
@@ -994,7 +994,7 @@ class ConfigureNewSegment(Command):
                                                           isTargetReusedLocationString,
                                                           seg.getSegmentDbId(),
                                                           seg.getSegmentContentId(),
-                                                          primaryHostname,
+                                                          primaryAddress,
                                                           primarySegmentPort,
                                                           progressFile
             )

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -166,9 +166,9 @@ class GpMirrorListToBuild:
         targetSegment is of type gparray.Segment.  All progressFiles should have
         the same timeStamp.
         """
-        def __init__(self, targetSegment, sourceHostname, sourcePort, timeStamp):
+        def __init__(self, targetSegment, sourceAddress, sourcePort, timeStamp):
             self.targetSegment = targetSegment
-            self.sourceHostname = sourceHostname
+            self.sourceAddress = sourceAddress
             self.sourcePort = sourcePort
             self.progressFile = '%s/pg_rewind.%s.dbid%s.out' % (gplog.get_logger_dir(),
                                                                 timeStamp,
@@ -273,7 +273,7 @@ class GpMirrorListToBuild:
             if not toRecover.isFullSynchronization() \
                and seg.getSegmentRole() == gparray.ROLE_MIRROR:
                 rewindInfo[seg.getSegmentDbId()] = GpMirrorListToBuild.RewindSegmentInfo(
-                    seg, primarySeg.getSegmentHostName(), primarySeg.getSegmentPort(),
+                    seg, primarySeg.getSegmentAddress(), primarySeg.getSegmentPort(),
                     timeStamp)
 
             # The change in configuration to of the mirror to down requires that
@@ -334,8 +334,8 @@ class GpMirrorListToBuild:
         for rewindSeg in list(rewindInfo.values()):
             # Do CHECKPOINT on source to force TimeLineID to be updated in pg_control.
             # pg_rewind wants that to make incremental recovery successful finally.
-            self.__logger.debug('Do CHECKPOINT on %s (port: %d) before running pg_rewind.' % (rewindSeg.sourceHostname, rewindSeg.sourcePort))
-            dburl = dbconn.DbURL(hostname=rewindSeg.sourceHostname,
+            self.__logger.debug('Do CHECKPOINT on %s (port: %d) before running pg_rewind.' % (rewindSeg.sourceAddress, rewindSeg.sourcePort))
+            dburl = dbconn.DbURL(hostname=rewindSeg.sourceAddress,
                                  port=rewindSeg.sourcePort,
                                  dbname='template1')
             conn = dbconn.connect(dburl, utility=True)
@@ -356,9 +356,9 @@ class GpMirrorListToBuild:
             # object.
             cmd = gp.SegmentRewind('rewind dbid: %s' %
                                    rewindSeg.targetSegment.getSegmentDbId(),
-                                   rewindSeg.targetSegment.getSegmentHostName(),
+                                   rewindSeg.targetSegment.getSegmentAddress(),
                                    rewindSeg.targetSegment.getSegmentDataDirectory(),
-                                   rewindSeg.sourceHostname,
+                                   rewindSeg.sourceAddress,
                                    rewindSeg.sourcePort,
                                    rewindSeg.progressFile,
                                    verbose=True)
@@ -540,7 +540,7 @@ class GpMirrorListToBuild:
         for directive in directives:
             srcSegment = directive.getSrcSegment()
             destSegment = directive.getDestSegment()
-            destSegment.primaryHostname = srcSegment.getSegmentHostName()
+            destSegment.primaryAddress = srcSegment.getSegmentAddress()
             destSegment.primarySegmentPort = srcSegment.getSegmentPort()
             destSegment.progressFile = '%s/pg_basebackup.%s.dbid%s.out' % (gplog.get_logger_dir(),
                                                                            timeStamp,

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -176,7 +176,7 @@ class StartSegmentsOperation:
                                    self.__timeout,
                                    verbose=logging_is_verbose(),
                                    ctxt=base.REMOTE,
-                                   remoteHost=segments[0].getSegmentAddress(),
+                                   remoteHost=segments[0].getSegmentHostName(),
                                    pickledTransitionData=pickledTransitionData,
                                    specialMode=self.__specialMode,
                                    wrapper=self.__wrapper,

--- a/gpMgmt/bin/lib/Makefile
+++ b/gpMgmt/bin/lib/Makefile
@@ -14,6 +14,7 @@ PROGRAMS= __init__.py \
 	gpcreateseg.sh \
 	gppinggpfdist.py \
 	gpstate.py \
+	ifaddr.py \
 	multidd
 
 installdirs:

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -30,6 +30,7 @@ if [ ${#GPPATH[@]} -eq 0 ];then
 	exit 1
 fi
 
+WORKDIR=`dirname $0`
 #GP_UNIQUE_COMMAND is used to identify the binary directory
 GP_UNIQUE_COMMAND=gpstart
 
@@ -674,12 +675,7 @@ GET_CIDRADDR () {
     # assuming argument is an ip address, return the address
     # with a /32 or /128 cidr suffix based on whether or not the
     # address contains a :
-
-    if [ `echo $1 | grep -c :` -gt 0 ]; then
-	echo $1/128
-    else
-	echo $1/32
-    fi
+    $GPHOME/bin/lib/ifaddr.py "$1"
 }
 
 BUILD_COORDINATOR_PG_HBA_FILE () {
@@ -699,24 +695,19 @@ BUILD_COORDINATOR_PG_HBA_FILE () {
 
             for ADDR in "${COORDINATOR_IP_ADDRESS_ALL[@]}"
             do
-                # MPP-15889
-                CIDRADDR=$(GET_CIDRADDR $ADDR)
-                $ECHO "host     all         $USER_NAME         $CIDRADDR       trust" >> ${GP_DIR}/$PG_HBA
+                $ECHO "host     all         $USER_NAME         $(GET_CIDRADDR $ADDR)       trust" >> ${GP_DIR}/$PG_HBA
 
             done
             for ADDR in "${STANDBY_IP_ADDRESS_ALL[@]}"
             do
-                # MPP-15889
-                CIDRADDR=$(GET_CIDRADDR $ADDR)
-                $ECHO "host     all         $USER_NAME         $CIDRADDR       trust" >> ${GP_DIR}/$PG_HBA
+                $ECHO "host     all         $USER_NAME         $(GET_CIDRADDR $ADDR)       trust" >> ${GP_DIR}/$PG_HBA
             done
 
             # Add all local IPV6 addresses
             for ADDR in "${COORDINATOR_IPV6_LOCAL_ADDRESS_ALL[@]}"
             do
                 # MPP-15889
-                CIDRADDR=$(GET_CIDRADDR $ADDR)
-                $ECHO "host     all         $USER_NAME         $CIDRADDR       trust" >> ${GP_DIR}/$PG_HBA
+                $ECHO "host     all         $USER_NAME         $(GET_CIDRADDR $ADDR)       trust" >> ${GP_DIR}/$PG_HBA
             done
         else
             $ECHO "host     all         $USER_NAME         localhost    trust" >> ${GP_DIR}/$PG_HBA
@@ -735,8 +726,7 @@ BUILD_COORDINATOR_PG_HBA_FILE () {
             fi
             for ADDR in "${COORDINATOR_IP_ADDRESS_NO_LOOPBACK[@]}" "${STANDBY_IP_ADDRESS_NO_LOOPBACK[@]}"
             do
-                CIDRADDR=$(GET_CIDRADDR $ADDR)
-                $ECHO "host     replication $USER_NAME         $CIDRADDR       trust" >> ${GP_DIR}/$PG_HBA
+                $ECHO "host     replication $USER_NAME         $(GET_CIDRADDR $ADDR)       trust" >> ${GP_DIR}/$PG_HBA
             done
         else
             $ECHO "host     replication $USER_NAME         $COORDINATOR_HOSTNAME       trust" >> ${GP_DIR}/$PG_HBA

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -42,7 +42,7 @@ class ValidationException(Exception):
 
 class ConfExpSegCmd(Command):
     def __init__(self, name, cmdstr, datadir, port, dbid, contentid, newseg, tarfile, useLighterDirectoryValidation, isPrimary,
-                 syncWithSegmentHostname, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile):
+                 syncWithSegmentAddress, syncWithSegmentPort, verbose, validationOnly, forceoverwrite, replicationSlotName, logfileDirectory, progressFile):
         """
         @param useLighterDirectoryValidation if True then we don't require an empty directory; we just require that
                                              database stuff is not there.
@@ -56,7 +56,7 @@ class ConfExpSegCmd(Command):
         self.verbose = verbose
         self.useLighterDirectoryValidation = useLighterDirectoryValidation
         self.isPrimary = isPrimary
-        self.syncWithSegmentHostname = syncWithSegmentHostname
+        self.syncWithSegmentAddress = syncWithSegmentAddress
         self.syncWithSegmentPort = syncWithSegmentPort
         self.replicationSlotName = replicationSlotName
         self.logfileDirectory = logfileDirectory
@@ -136,7 +136,7 @@ class ConfExpSegCmd(Command):
                                                                                 self.dbid)
                     # Create a mirror based on the primary
                     cmd = PgBaseBackup(pgdata=self.datadir,
-                                       host=self.syncWithSegmentHostname,
+                                       host=self.syncWithSegmentAddress,
                                        port=str(self.syncWithSegmentPort),
                                        create_slot = False,
                                        replication_slot_name=self.replicationSlotName,
@@ -157,7 +157,7 @@ class ConfExpSegCmd(Command):
                         #  GPDB_12_MERGE_FIXME could we check it before? or let
                         #  pg_basebackup create slot if not exists.
                         cmd = PgBaseBackup(pgdata=self.datadir,
-                                           host=self.syncWithSegmentHostname,
+                                           host=self.syncWithSegmentAddress,
                                            port=str(self.syncWithSegmentPort),
                                            create_slot = True,
                                            replication_slot_name=self.replicationSlotName,
@@ -391,7 +391,7 @@ try:
 
         # These variables should not be used if it's a primary
         # they will be junk data passed through the config.
-        primaryHostName = seg[6]
+        primaryAddress = seg[6]
         primarySegmentPort = int(seg[7])
         progressFile = seg[8]
 
@@ -405,7 +405,7 @@ try:
                            , tarfile = options.tarfile
                            , useLighterDirectoryValidation = directoryValidationLevel
                            , isPrimary = isPrimary
-                           , syncWithSegmentHostname = primaryHostName
+                           , syncWithSegmentAddress = primaryAddress
                            , syncWithSegmentPort = primarySegmentPort
                            , verbose = options.verbose
                            , validationOnly = options.validationOnly

--- a/gpMgmt/bin/lib/ifaddr.py
+++ b/gpMgmt/bin/lib/ifaddr.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import socket
+import sys
+
+class Address:
+  def __init__(self, address):
+    self.address = address
+    try:
+      tup = socket.getaddrinfo(address, 0, socket.AF_UNSPEC, socket.SOCK_DGRAM, 0, socket.AI_NUMERICHOST)
+      self.family, _, _, canonname, sockaddr = tup[0]
+      self.extra = {
+          'canonname': canonname,
+          'sockaddr': sockaddr,
+          }
+    except:
+      # it means the address is not an IP address
+      self.family = 0
+
+  def __str__(self):
+    return '''Address('%s'):type=%d''' % (self.address, self.getAddressType())
+
+  def getAddressType(self):
+    if self.family == 0:
+      return 0
+    if self.family == socket.AF_INET:
+      return 4
+    if self.family == socket.AF_INET6:
+      return 6
+    raise Exception('unknown: bad state')
+
+  def getCIDR4IP(self):
+    if self.family == 0:
+      return self.address
+    if self.family == socket.AF_INET:
+      return self.address + "/32"
+    if self.family == socket.AF_INET6:
+      return self.address + "/128"
+    raise Exception('unknown: bad state')
+
+
+if __name__ == '__main__':
+  if len(sys.argv) < 2:
+    usage()
+  addr = Address(sys.argv[1])
+  print(addr.getCIDR4IP())

--- a/gpMgmt/doc/gpinitstandby_help
+++ b/gpMgmt/doc/gpinitstandby_help
@@ -125,7 +125,7 @@ OPTIONS
 
 -s <standby_hostname> or <standby_address>
 
- The address of the standby coordinaator host. It will be the `address` of
+ The address of the standby coordinator host. It will be the `address` of
  the standby in gp_segment_configuration, the `hostname` column of the standby
  in gp_segment_configuration is resolved by this address. If the provided
  `standby_address` is the same as the hostname, they will be the same.

--- a/gpMgmt/doc/gpinitstandby_help
+++ b/gpMgmt/doc/gpinitstandby_help
@@ -7,7 +7,7 @@ Adds and/or initializes a standby coordinator host for a Greenplum Database syst
 SYNOPSIS
 *****************************************************
 
-gpinitstandby { -s <standby_hostname> [-P <port>] | -r | -n } 
+gpinitstandby { -s <standby_address> [-P <port>] | -r | -n } 
 
 [-a] [-q] [-D] [-S <standby data directory>] [-l <logfile_directory>]
 
@@ -123,9 +123,12 @@ OPTIONS
  Database system. 
 
 
--s <standby_hostname> 
+-s <standby_hostname> or <standby_address>
 
- The host name of the standby coordinator host. 
+ The address of the standby coordinaator host. It will be the `address` of
+ the standby in gp_segment_configuration, the `hostname` column of the standby
+ in gp_segment_configuration is resolved by this address. If the provided
+ `standby_address` is the same as the hostname, they will be the same.
 
 --hba-hostnames
 

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -9,6 +9,7 @@ Feature: Tests for gpaddmirrors
           And the segments are synchronized
          Then verify the database has mirrors
           And the tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
          When user stops all primary processes
           And user can start transactions
@@ -25,6 +26,7 @@ Feature: Tests for gpaddmirrors
         And the segments are synchronized
         And verify the database has mirrors
         And the tablespace is valid
+        And check if the addresses of wal replication are correct for all pairs
         And user stops all primary processes
         And user can start transactions
         And the tablespace is valid
@@ -49,6 +51,7 @@ Feature: Tests for gpaddmirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -68,16 +71,19 @@ Feature: Tests for gpaddmirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         Given a preferred primary has failed
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         When primary and mirror switch to non-preferred roles
         When the user runs "gprecoverseg -a -r"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -95,16 +101,19 @@ Feature: Tests for gpaddmirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         Given a preferred primary has failed
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         When primary and mirror switch to non-preferred roles
         When the user runs "gprecoverseg -a -r"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -114,6 +123,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
         And gpaddmirrors adds mirrors
         Then verify the database has mirrors
+        And check if the addresses of wal replication are correct for all pairs
         And save the gparray to context
         And the database is not running
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
@@ -121,6 +131,7 @@ Feature: Tests for gpaddmirrors
         Then gpinitstandby should return a return code of 0
         And gpaddmirrors adds mirrors
         Then mirror hostlist matches the one saved in context
+        And check if the addresses of wal replication are correct for all pairs
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -194,6 +205,7 @@ Feature: Tests for gpaddmirrors
           And a tablespace is created with data
          When gpaddmirrors adds mirrors
          Then verify the database has mirrors
+          And check if the addresses of wal replication are correct for all pairs
 
          When an FTS probe is triggered
           And the segments are synchronized

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -124,12 +124,14 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with mirrors on "mdw" and "sdw1"
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1"
         And the number of segments have been saved
         When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors
         Then verify that the cluster has 4 new segments
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_mirrors
     @gpexpand_segment
@@ -138,6 +140,7 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with mirrors on "mdw" and "sdw1"
+        And check if the addresses of wal replication are correct for all pairs
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1"
         And the user runs gpexpand with a static inputfile for a two-node cluster with mirrors
@@ -146,10 +149,12 @@ Feature: expand the cluster by adding more segments
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_mirrors
     @gpexpand_host
@@ -158,14 +163,17 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with mirrors on "mdw" and "sdw1"
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
         And the new host "sdw2,sdw3" is ready to go
         When the user runs gpexpand interview to add 0 new segment and 2 new host "sdw2,sdw3"
         Then the number of segments have been saved
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 8 new segments
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_mirrors
     @gpexpand_host_and_segment
@@ -176,6 +184,7 @@ Feature: expand the cluster by adding more segments
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with mirrors on "mdw" and "sdw1"
         And the user runs gpinitstandby with options " "
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
@@ -184,6 +193,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_mirrors
     @gpexpand_host_and_segment
@@ -194,6 +204,7 @@ Feature: expand the cluster by adding more segments
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with mirrors on "mdw" and "sdw1"
         And the user runs gpinitstandby with options " "
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And a tablespace is created with data
         And another tablespace is created with data
@@ -202,10 +213,13 @@ Feature: expand the cluster by adding more segments
         And the new host "sdw2,sdw3" is ready to go
         When the user runs gpexpand interview to add 1 new segment and 2 new host "sdw2,sdw3"
         Then the number of segments have been saved
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand to redistribute
         Then the tablespace is valid after gpexpand
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_verify_redistribution
     Scenario: Verify data is correctly redistributed after expansion
@@ -213,6 +227,7 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the cluster is generated with "1" primaries only
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And the user connects to "gptest" with named connection "default"
         And the user executes "CREATE TEMP TABLE temp_t1 (c1 int) DISTRIBUTED BY (c1)" with named connection "default"
@@ -223,11 +238,14 @@ Feature: expand the cluster by adding more segments
         And the cluster is setup for an expansion on hosts "localhost"
         When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
         And the user drops the named connection "default"
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand to redistribute
         Then distribution information from table "public.redistribute" with data in "gptest" is verified against saved data
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_verify_writable_external_redistribution
     Scenario: Verify policy of writable external table is correctly updated after redistribution
@@ -235,16 +253,20 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the cluster is generated with "1" primaries only
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And the user create a writable external table with name "ext_test"
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "localhost"
         When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand to redistribute
         Then the numsegments of table "ext_test" is 4
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_icw_db_concourse
     Scenario: Use a dump of the ICW database for expansion
@@ -252,6 +274,7 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with mirrors on "mdw" and "sdw1"
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And the user runs psql with "-f /home/gpadmin/sqldump/dump.sql" against database "gptest"
         And there are no gpexpand_inputfiles
@@ -261,6 +284,7 @@ Feature: expand the cluster by adding more segments
         And the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         And verify that the cluster has 14 new segments
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_no_mirrors
     @gpexpand_no_restart
@@ -411,16 +435,20 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the cluster is generated with "1" primaries only
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And the user create an external table with name "ext_test" in partition table t
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "localhost"
         When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand to redistribute
         Then the numsegments of table "ext_test" is 4
+        And check if the addresses of wal replication are correct for all pairs
 
     @gpexpand_verify_matview
     Scenario: Gpexpand should succeed when expand materialized view
@@ -428,6 +456,7 @@ Feature: expand the cluster by adding more segments
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And the cluster is generated with "1" primaries only
+        And check if the addresses of wal replication are correct for all pairs
         And database "gptest" exists
         And the user runs psql with "-c 'CREATE TABLE public.test_matview_base AS SELECT i FROM generate_series(1,10000) i DISTRIBUTED BY (i)'" against database "gptest"
         And the user runs psql with "-c 'CREATE MATERIALIZED VIEW public.test_matview as select * from public.test_matview_base DISTRIBUTED BY (i)'" against database "gptest"
@@ -435,8 +464,11 @@ Feature: expand the cluster by adding more segments
         And the cluster is setup for an expansion on hosts "localhost"
         When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 3 new segments
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs gpexpand to redistribute
         Then the numsegments of table "public.test_matview" is 4
         And distribution information from table "public.test_matview" and "public.test_matview_base" in "gptest" are the same
+        And check if the addresses of wal replication are correct for all pairs

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -9,11 +9,13 @@ Feature: Tests for gpinitstandby feature
         And verify the standby coordinator entries in catalog
         And the user runs gpinitstandby with options "-n"
         And gpinitstandby should print "Standy coordinator is already up and running" to stdout
+        And check if the addresses of wal replication are correct for all pairs
         When the standby coordinator goes down
         And the user runs gpinitstandby with options "-n"
         Then gpinitstandby should return a return code of 0
         And verify the standby coordinator entries in catalog
         And gpinitstandby should print "Successfully started standby coordinator" to stdout
+        And check if the addresses of wal replication are correct for all pairs
 
     Scenario: gpinitstandby fails if given same host and port as coordinator segment
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -8,6 +8,7 @@ Feature: gpinitsystem tests
         And gpconfig should print "Values on all segments are consistent" to stdout
         And gpconfig should print "Coordinator value: on" to stdout
         And gpconfig should print "Segment     value: on" to stdout
+        And check if the addresses of wal replication are correct for all pairs
 
     Scenario: gpinitsystem creates a cluster with data_checksums off
         Given the database is initialized with checksum "off"

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -32,6 +32,7 @@ Feature: Tests for gpmovemirrors
         And all the segments are running
         And the segments are synchronized
         And verify that mirrors are recognized after a restart
+        And check if the addresses of wal replication are correct for all pairs
 
     Scenario: gpmovemirrors can change the port of mirrors within a single host
         Given a standard local demo cluster is created
@@ -43,6 +44,7 @@ Feature: Tests for gpmovemirrors
         And all the segments are running
         And the segments are synchronized
         And verify that mirrors are recognized after a restart
+        And check if the addresses of wal replication are correct for all pairs
 
     Scenario: gpmovemirrors gives a warning when passed identical attributes for new and old mirrors
         Given a standard local demo cluster is created
@@ -55,6 +57,7 @@ Feature: Tests for gpmovemirrors
         And all the segments are running
         And the segments are synchronized
         And verify that mirrors are recognized after a restart
+        And check if the addresses of wal replication are correct for all pairs
 
     Scenario: tablespaces work
         Given a standard local demo cluster is created
@@ -129,6 +132,7 @@ Feature: Tests for gpmovemirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: gpmovemirrors can change from spread mirroring to group mirroring
@@ -166,6 +170,7 @@ Feature: Tests for gpmovemirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: tablespaces work on a multi-host environment
@@ -183,6 +188,7 @@ Feature: Tests for gpmovemirrors
           And the segments are synchronized
           And verify that mirrors are recognized after a restart
           And the tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
          When user stops all primary processes
           And user can start transactions

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -3,6 +3,7 @@ Feature: gprecoverseg tests
 
     Scenario: incremental recovery works with tablespaces
         Given the database is running
+          And check if the addresses of wal replication are correct for all pairs
           And a tablespace is created with data
           And user stops all primary processes
           And user can start transactions
@@ -10,6 +11,7 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
         Given another tablespace is created with data
          When the user runs "gprecoverseg -ra"
@@ -17,9 +19,11 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
     Scenario: full recovery works with tablespaces
         Given the database is running
+          And check if the addresses of wal replication are correct for all pairs
           And a tablespace is created with data
           And user stops all primary processes
           And user can start transactions
@@ -27,21 +31,26 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
         Given another tablespace is created with data
+          And check if the addresses of wal replication are correct for all pairs
          When the user runs "gprecoverseg -ra"
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
     Scenario Outline: full recovery limits number of parallel processes correctly
         Given a standard local demo cluster is created
+        And check if the addresses of wal replication are correct for all pairs
         And 2 gprecoverseg directory under '/tmp/recoverseg' with mode '0700' is created
         And a good gprecoverseg input file is created for moving 2 mirrors
         When the user runs gprecoverseg with input file and additional args "-a -F -v <args>"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should only spawn up to <coordinator_workers> workers in WorkerPool
+        And check if the addresses of wal replication are correct for all pairs
         And check if gprecoverseg ran "$GPHOME/bin/lib/gpconfigurenewsegment" 2 times with args "-b <segHost_workers>"
         And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
         And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
@@ -55,13 +64,16 @@ Feature: gprecoverseg tests
 
     Scenario Outline: Rebalance correctly limits the number of concurrent processes
       Given the database is running
+      And check if the addresses of wal replication are correct for all pairs
       And user stops all primary processes
       And user can start transactions
       And the user runs "gprecoverseg -a -v <args>"
       And gprecoverseg should return a return code of 0
       And the segments are synchronized
+      And check if the addresses of wal replication are correct for all pairs
       When the user runs "gprecoverseg -ra -v <args>"
       Then gprecoverseg should return a return code of 0
+      And check if the addresses of wal replication are correct for all pairs
       And gprecoverseg should only spawn up to <coordinator_workers> workers in WorkerPool
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
@@ -74,26 +86,31 @@ Feature: gprecoverseg tests
 
     Scenario: gprecoverseg should not output bootstrap error on success
         Given the database is running
+        And check if the addresses of wal replication are correct for all pairs
         And user stops all primary processes
         And user can start transactions
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
+        And check if the addresses of wal replication are correct for all pairs
         And gprecoverseg should print "Running pg_rewind on failed segments" to stdout
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
+        And check if the addresses of wal replication are correct for all pairs
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
 
     Scenario: gprecoverseg full recovery displays pg_basebackup progress to the user
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And user stops all mirror processes
         When user can start transactions
         And the user runs "gprecoverseg -F -a -s"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for each mirror
+        And check if the addresses of wal replication are correct for all pairs
         And gpAdminLogs directory has no "pg_basebackup*" files
         And all the segments are running
         And the segments are synchronized
@@ -102,12 +119,14 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And user stops all primary processes
         And user can start transactions
         When the user runs "gprecoverseg -a -s"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each primary
         And gpAdminLogs directory has no "pg_rewind*" files
+        And check if the addresses of wal replication are correct for all pairs
         And all the segments are running
         And the segments are synchronized
         And the cluster is rebalanced
@@ -116,12 +135,14 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And user stops all mirror processes
         When user can start transactions
         And the user runs "gprecoverseg -F -a --no-progress"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
         And gpAdminLogs directory has no "pg_basebackup*" files
+        And check if the addresses of wal replication are correct for all pairs
         And all the segments are running
         And the segments are synchronized
 
@@ -129,6 +150,7 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the "primary" segment information is saved
         When the postmaster.pid file on "primary" segment is saved
         And user stops all primary processes
@@ -145,6 +167,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the backup pid file is deleted on "primary" segment
         And the background pid is killed on "primary" segment
 
@@ -153,6 +176,7 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
         And the "primary" segment information is saved
+        And check if the addresses of wal replication are correct for all pairs
         When the postmaster.pid file on "primary" segment is saved
         And user stops all primary processes
         When user can start transactions
@@ -163,27 +187,32 @@ Feature: gprecoverseg tests
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
         And the backup pid file is deleted on "primary" segment
+        And check if the addresses of wal replication are correct for all pairs
 
     Scenario: pg_isready functions on recovered segments
         Given the database is running
           And all the segments are running
           And the segments are synchronized
+          And check if the addresses of wal replication are correct for all pairs
          When user stops all primary processes
           And user can start transactions
 
          When the user runs "gprecoverseg -a"
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
+          And check if the addresses of wal replication are correct for all pairs
 
          When the user runs "gprecoverseg -ar"
          Then gprecoverseg should return a return code of 0
           And all the segments are running
           And the segments are synchronized
+          And check if the addresses of wal replication are correct for all pairs
           And pg_isready reports all primaries are accepting connections
 
     Scenario: gprecoverseg incremental recovery displays status for mirrors after pg_rewind call
@@ -206,6 +235,7 @@ Feature: gprecoverseg tests
       Given the database is running
       And all the segments are running
       And the segments are synchronized
+      And check if the addresses of wal replication are correct for all pairs
 
       And the primary on content 0 is stopped
       And user can start transactions
@@ -234,6 +264,7 @@ Feature: gprecoverseg tests
 
       And the user runs psql with "-c 'DROP TABLE foo'" against database "postgres"
       And the cluster is returned to a good state
+      And check if the addresses of wal replication are correct for all pairs
 
       Examples:
         | scenario    | args |
@@ -248,6 +279,7 @@ Feature: gprecoverseg tests
         Given the database is running
         Given database "gptest" exists
         And the information of a "mirror" segment on a remote host is saved
+        And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: When gprecoverseg full recovery is executed and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
@@ -255,6 +287,7 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
         And the "primary" segment information is saved
+        And check if the addresses of wal replication are correct for all pairs
         When the postmaster.pid file on "primary" segment is saved
         And user stops all primary processes
         When user can start transactions
@@ -266,10 +299,12 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Skipping to stop segment.* on host.* since it is not a postgres process" to stdout
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the backup pid file is deleted on "primary" segment
         And the background pid is killed on "primary" segment
 
@@ -278,6 +313,7 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the information of a "mirror" segment on a remote host is saved
         When user kills a "mirror" process with the saved information
         And user can start transactions
@@ -287,12 +323,14 @@ Feature: gprecoverseg tests
         And gprecoverseg should not print "Running pg_rewind on failed segments" to stdout
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: gprecoverseg with -i and -o option
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the information of a "mirror" segment on a remote host is saved
         When user kills a "mirror" process with the saved information
         And user can start transactions
@@ -300,17 +338,20 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -o failedSegmentFile"
         Then gprecoverseg should return a return code of 0
         Then gprecoverseg should print "Configuration file output to failedSegmentFile successfully" to stdout
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs "gprecoverseg -i failedSegmentFile -a"
         Then gprecoverseg should return a return code of 0
         Then gprecoverseg should print "1 segment\(s\) to recover" to stdout
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: gprecoverseg should not throw exception for empty input file
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the information of a "mirror" segment on a remote host is saved
         When user kills a "mirror" process with the saved information
         And user can start transactions
@@ -319,9 +360,11 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -i /tmp/empty_file -a"
         Then gprecoverseg should return a return code of 0
         Then gprecoverseg should print "No segments to recover" to stdout
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs "gprecoverseg -a -F"
         Then all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: gprecoverseg should use the same setting for data_checksums for a full recovery
@@ -330,6 +373,7 @@ Feature: gprecoverseg tests
         # cause a full recovery AFTER a failure on a remote primary
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And the information of a "mirror" segment on a remote host is saved
         And the information of the corresponding primary segment on a remote host is saved
         When user kills a "primary" process with the saved information
@@ -338,11 +382,13 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg" to stdout
+        And check if the addresses of wal replication are correct for all pairs
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg" to stdout
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         # validate the new segment has the correct setting by getting admin connection to that segment
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
 
@@ -356,6 +402,7 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
         Given another tablespace is created with data
          When the user runs "gprecoverseg -ra"
@@ -363,6 +410,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
     @concourse_cluster
     Scenario: full recovery works with tablespaces on a multi-host environment
@@ -374,6 +422,7 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
         Given another tablespace is created with data
          When the user runs "gprecoverseg -ra"
@@ -381,6 +430,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+          And check if the addresses of wal replication are correct for all pairs
 
   @concourse_cluster
   Scenario: moving mirror to a different host must work
@@ -394,6 +444,7 @@ Feature: gprecoverseg tests
        Then the saved "mirror" segment is marked down in config
        When the user runs "gprecoverseg -a -p mdw"
        Then gprecoverseg should return a return code of 0
+        And check if the addresses of wal replication are correct for all pairs
        When user kills a "primary" process with the saved information
         And user can start transactions
        Then the saved "primary" segment is marked down in config
@@ -401,10 +452,12 @@ Feature: gprecoverseg tests
        Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
        When the user runs "gprecoverseg -ra"
        Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
 
   @concourse_cluster
   Scenario: recovering a host with tablespaces succeeds
@@ -436,11 +489,13 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -a -p sdw1"
         Then gprecoverseg should return a return code of 0
         And all the segments are running
+        And check if the addresses of wal replication are correct for all pairs
         And user can start transactions
         And the user runs "gprecoverseg -ra"
         And gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check if the addresses of wal replication are correct for all pairs
         And user can start transactions
 
         # verify the data

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -10,6 +10,7 @@ Feature: gprecoverseg tests involving migrating to a new host
       Given the database is running
       And all the segments are running
       And the segments are synchronized
+      And check if the addresses of wal replication are correct for all pairs
       And database "gptest" exists
       And the user runs gpconfig sets guc "wal_sender_timeout" with "15s"
       And the user runs "gpstop -air"
@@ -20,6 +21,7 @@ Feature: gprecoverseg tests involving migrating to a new host
       Then gprecoverseg should return a return code of 0
       And pg_hba file "/data/gpdata/mirror/gpseg0/pg_hba.conf" on host "<acting_primary>" contains entries for "<used>"
       And the cluster configuration is saved for "<test_case>"
+      And check if the addresses of wal replication are correct for all pairs
       And the "before" and "<test_case>" cluster configuration matches with the expected for gprecoverseg newhost
       And the mirrors replicate and fail over and back correctly
       And segment hosts <down> are reconnected to the cluster and to the spare segment hosts "<unused>"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -69,7 +69,7 @@ def _write_datadir_config_for_three_mirrors():
 def add_three_mirrors_with_args(context, args):
     datadir_config = _write_datadir_config_for_three_mirrors()
     mirror_config_output_file = "/tmp/test_gpaddmirrors.config"
-    cmd_str = 'gpaddmirrors -o %s -m %s' % (mirror_config_output_file, datadir_config)
+    cmd_str = 'gpaddmirrors -a -o %s -m %s' % (mirror_config_output_file, datadir_config)
     Command('generate mirror_config file', cmd_str).run(validateAfter=True)
     cmd = 'gpaddmirrors -a -v -i %s %s' % (mirror_config_output_file, args)
     run_gpcommand(context, command=cmd)
@@ -325,7 +325,7 @@ def impl(context, file_type):
     segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
     mirror = segments[0].mirrorDB
 
-    valid_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
+    valid_config = '%s|%s|%s' % (mirror.getSegmentAddress(),
                                  mirror.getSegmentPort(),
                                  mirror.getSegmentDataDirectory())
 
@@ -338,21 +338,21 @@ def impl(context, file_type):
         contents = '%s %s' % (valid_config, badhost_config)
     elif file_type == 'samedir':
         valid_config_with_same_dir = '%s|%s|%s' % (
-            mirror.getSegmentHostName(),
+            mirror.getSegmentAddress(),
             mirror.getSegmentPort() + 1000,
             mirror.getSegmentDataDirectory()
         )
         contents = '%s %s' % (valid_config, valid_config_with_same_dir)
     elif file_type == 'identicalAttributes':
         valid_config_with_identical_attributes = '%s|%s|%s' % (
-            mirror.getSegmentHostName(),
+            mirror.getSegmentAddress(),
             mirror.getSegmentPort(),
             mirror.getSegmentDataDirectory()
         )
         contents = '%s %s' % (valid_config, valid_config_with_identical_attributes)
     elif file_type == 'good':
         valid_config_with_different_dir = '%s|%s|%s' % (
-            mirror.getSegmentHostName(),
+            mirror.getSegmentAddress(),
             mirror.getSegmentPort(),
             context.mirror_context.working_directory[0]
         )
@@ -372,11 +372,11 @@ def impl(context, num):
     for i in range(int(num)):
         mirror = segments[i].mirrorDB
 
-        valid_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
+        valid_config = '%s|%s|%s' % (mirror.getSegmentAddress(),
                                      mirror.getSegmentPort(),
                                      mirror.getSegmentDataDirectory())
         valid_config_with_different_dir = '%s|%s|%s' % (
-            mirror.getSegmentHostName(),
+            mirror.getSegmentAddress(),
             mirror.getSegmentPort(),
             context.mirror_context.working_directory[i]
         )

--- a/gpMgmt/test/behave_utils/cluster_expand.py
+++ b/gpMgmt/test/behave_utils/cluster_expand.py
@@ -13,11 +13,6 @@ class Gpexpand:
         self.working_directory = working_directory
         self.context = context
 
-    def get_gp_array(self):
-        dburl = dbconn.DbURL(dbname=self.database)
-        gparray = GpArray.initFromCatalog(dburl, utility=True)
-        return gparray
-
     def do_interview(self, hosts=None, num_of_segments=1, directory_pairs=None, has_mirrors=False):
         """
         hosts: list of hosts to expand to
@@ -48,7 +43,7 @@ class Gpexpand:
         # Would you like to initiate a new System Expansion Yy|Nn (default=N):
         p1.stdin.write(b"y\n")
         
-        gparray = self.get_gp_array()
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(dbname=self.database), utility=True)
         # Are you sure you want to continue with this gpexpand session?
         standard, message = gparray.isStandardArray()
         if not standard:

--- a/gpMgmt/test/behave_utils/cluster_expand.py
+++ b/gpMgmt/test/behave_utils/cluster_expand.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from subprocess import Popen, PIPE
 from .utils import run_gpcommand
 
+from gppylib.gparray import GpArray
 from gppylib.commands.base import Command
 from gppylib.db import dbconn
 
@@ -12,6 +13,10 @@ class Gpexpand:
         self.working_directory = working_directory
         self.context = context
 
+    def get_gp_array(self):
+        dburl = dbconn.DbURL(dbname=self.database)
+        gparray = GpArray.initFromCatalog(dburl, utility=True)
+        return gparray
 
     def do_interview(self, hosts=None, num_of_segments=1, directory_pairs=None, has_mirrors=False):
         """
@@ -42,6 +47,12 @@ class Gpexpand:
 
         # Would you like to initiate a new System Expansion Yy|Nn (default=N):
         p1.stdin.write(b"y\n")
+        
+        gparray = self.get_gp_array()
+        # Are you sure you want to continue with this gpexpand session?
+        standard, message = gparray.isStandardArray()
+        if not standard:
+            p1.stdin.write(b"y\n")
 
         # **Enter a blank line to only add segments to existing hosts**[]:
         p1.stdin.write(("%s\n" % (",".join(hosts) if hosts else "")).encode())

--- a/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
+++ b/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
@@ -11,7 +11,8 @@
 -- generate_recover_config_file:
 --   generate config file used by recoverseg -i
 --
-create or replace function generate_recover_config_file(datadir text, port text) returns void as $$ import io import os myhost = os.uname()[1] inplaceConfig = myhost + '|' + port + '|' + datadir configStr = inplaceConfig + ' ' + inplaceConfig  f = open("/tmp/recover_config_file", "w") f.write(configStr) f.close() $$ language plpython3u;
+create or replace function generate_recover_config_file(address text, datadir text, port text) returns void as $$ inplaceConfig = address + '|' + port + '|' + datadir configStr = inplaceConfig + ' ' + inplaceConfig  with open("/tmp/recover_config_file", "w") as f: f.write(configStr) 
+$$ language plpython3u;
 CREATE
 
 SELECT dbid, role, preferred_role, content, mode, status FROM gp_segment_configuration order by dbid;
@@ -73,7 +74,7 @@ select gp_request_fts_probe_scan();
 0Uq: ... <quitting>
 
 -- generate recover config file
-select generate_recover_config_file( (select datadir from gp_segment_configuration c where c.role='m' and c.content=1), (select port from gp_segment_configuration c where c.role='m' and c.content=1)::text);
+select generate_recover_config_file(address, datadir, port::text) from gp_segment_configuration where role='m' and content=1;
  generate_recover_config_file 
 ------------------------------
                               

--- a/src/test/isolation2/sql/segwalrep/recoverseg_from_file.sql
+++ b/src/test/isolation2/sql/segwalrep/recoverseg_from_file.sql
@@ -11,17 +11,14 @@
 -- generate_recover_config_file:
 --   generate config file used by recoverseg -i
 --
-create or replace function generate_recover_config_file(datadir text, port text)
+create or replace function generate_recover_config_file(address text, datadir text, port text)
 returns void as $$
-    import io
-    import os
-    myhost = os.uname()[1]
-    inplaceConfig = myhost + '|' + port + '|' + datadir
+    inplaceConfig = address + '|' + port + '|' + datadir
     configStr = inplaceConfig + ' ' + inplaceConfig
 	
-    f = open("/tmp/recover_config_file", "w")
-    f.write(configStr)
-    f.close()
+    with open("/tmp/recover_config_file", "w") as f:
+        f.write(configStr)
+
 $$ language plpython3u;
 
 SELECT dbid, role, preferred_role, content, mode, status FROM gp_segment_configuration order by dbid;
@@ -51,9 +48,9 @@ select gp_request_fts_probe_scan();
 0Uq:
 
 -- generate recover config file
-select generate_recover_config_file(
-	(select datadir from gp_segment_configuration c where c.role='m' and c.content=1),
-	(select port from gp_segment_configuration c where c.role='m' and c.content=1)::text);
+select generate_recover_config_file(address, datadir, port::text)
+  from gp_segment_configuration
+  where role='m' and content=1;
 
 -- recover from config file, only seg with content=1 will be recovered
 !\retcode gprecoverseg -a -i /tmp/recover_config_file;


### PR DESCRIPTION
gp_segment_configuration has two confusing columns for
addressing the segment: `hostname` and `address`. We've
discussed their semantics in the mail-list: 
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/LfusrgthupY

In short, `address` is used internally and it's usually a private
IP address or name. `hostname` may be publicly accessible
and the utility tool uses it to run some operations per-host,
e.g. install exactly one copy of a binary package per-host.

WAL replication is internal for GPDB cluster, it should absolutely
use the `address` instead of `hostname` in gp_segment_configuration.
The address for WAL replication is saved in the `primary_conninfo`
in `recovery.conf` on the data directory of the mirrors.

This commit fixes the utility tools to use the `address` and adds
test cases to ensure that the address for WAL replication is the
desired internal address, rather than the hostname. The affected
utility tools include:
gpinitsystem, gpinitstandby, gprecoverseg, gpexpand, gpaddmirrors.

Here are the details:
[demo-cluster]: Use the unicast IP address as the `address` column in
                `gp_segment_configuration`, which is different to the
                `hostname` field for all segments, so we know whether
                it gets from `address` or `hostname`.
                
[gpinitsystem]: Fix a bug(issue #12218) in gpinitsystem that address
                could not be an IP address in configuration file.
                Make the data directory if it doesn't exist.
                
[gpinitstandby]: It accepts only the standby hostname, so the `address`
                 and `hostname` in gp_segment_configuration are the
                 same values. This commit accepts the standby address
                 and resolves the hostname by the passed address. It's
                 fine for the standby address to be anyone of an IP
                 address, resolvable name or hostname.
                 
[gprecoverseg]: gprecoverseg contains mainly 2 types of recovery:
                1) incremental recovery, uses pg_rewind
                2) full recovery, uses pg_basebackup
                Both of pg_rewind and pg_basebackup may write the `postgresql.auto.conf`,
                The address for WAL replication is the `address` of
                the primary in gp_segment_configuratioin, which is part of
                the conninfo passed to pg_rewind/pg_basebackup.
                
[gpexpand]: gpexpand uses pg_basebackup to create the mirrors.

[gpaddmirrors]: It accepts the address of the mirrors and resolves
                the hostnames by the passed address
                

This PR fixes the following issues:
  * #11090
  * #9060
  * #11092
  * #9531
  * #9132
  * #12218


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
