### PR TITLE
[5X]: Avoid disconnecting IPC during init processing

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -581,7 +581,7 @@ assign_gp_role(const char *newval, bool doit, GucSource source)
 		bool		do_disconnect = false;
 		bool		do_connect = false;
 
-		if (Gp_role != newrole && IsUnderPostmaster)
+		if (Gp_role != newrole && IsUnderPostmaster && !IsInitProcessingMode())
 		{
 			if (Gp_role != GP_ROLE_UTILITY)
 				do_disconnect = true;


### PR DESCRIPTION
When setting gp_role to utility mode on the commandline using the
PGOPTIONS='-c gp_role=utility' construction, the role is set during
init processing before the interconnect has been set up. There is
however a disconnect/reconnect step in assign_gp_role() intended to
ensure that a role switch is correctly propagated, which in this
case coredumps as it tries to tear down a connection which has never
been established.

Fix by only reconnecting during normal processing and not init mode
processing.

Reported-by: Adam Berlin on Github #6231
Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
(cherry picked from commit 92b440fa38cee24bb3b9633bc125c9f43b0ee906)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
