### PR TITLE
Do not pass deprecated flags to gpnetbenchClient

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -530,8 +530,12 @@ def killProc(proc):
 
 
 def spawnNetperfTestBetween(x, y, netperf_path, netserver_port, sec=5):
-    cmd = ('%s -H %s -p %d -t TCP_STREAM -l %s -f M -P 0 '
-           % (netperf_path, y, netserver_port, sec))
+    if GV.opt['--netclient'] == 'netperf' and GV.opt['--netserver'] == 'netserver':
+        cmd = ('%s -H %s -p %d -t TCP_STREAM -l %s -f M -P 0 '
+               % (netperf_path, y, netserver_port, sec))
+    else:
+        cmd = ('%s -H %s -p %d -l %s -P 0 '
+               % (netperf_path, y, netserver_port, sec))
     c = ['ssh', '-o', 'BatchMode yes',
          '-o', 'StrictHostKeyChecking no',
          x, cmd]

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -14,3 +14,4 @@ Feature: Tests for gpcheckperf
     When  the user runs "gpcheckperf -h mdw -h sdw1 -d /data/gpdata/ -r n"
     Then  gpcheckperf should return a return code of 0
     And   gpcheckperf should print "avg = " to stdout
+    And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout


### PR DESCRIPTION
-t and -f flags are deprecated and gpcheckperf kept printing

NOTICE: -t is deprecated, and has no effect
NOTICE: -f is deprecated, and has no effect

Co-authored-by: M Hari Krishna hmaddileti@vmware.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
