### PR TITLE
[6X Only]Agg on entryDB shouldn't raise error

### DIFF
--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -578,6 +578,10 @@ make_agg_subplan(PlannerInfo *root, MinMaxAggInfo *mminfo)
 	{
 		plan = (Plan *) make_motion_gather(subroot, plan, subroot->sort_pathkeys, CdbLocusType_SingleQE);
 	}
+	else if (plan->flow->flotype == FLOW_SINGLETON && plan->flow->locustype == CdbLocusType_Entry)
+	{
+		/* No need to gather if the plan is executed on entryDB. */
+	}
 	else
 		elog(ERROR, "MIN/MAX subplan has unexpected flowtype: %d", plan->flow->type);
 

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -62,6 +62,13 @@ SELECT array_agg(a order by a) over (order by a) FROM aggtest; -- window derived
 ERROR:  aggregate ORDER BY is not implemented for window functions
 LINE 1: SELECT array_agg(a order by a) over (order by a) FROM aggtes...
                ^
+-- agg on entryDB, this used to raise error "MIN/MAX subplan has unexpected flowtype"
+SELECT min(attnum) min_attnum FROM pg_catalog.pg_attribute WHERE attrelid = 'pg_proc'::regclass AND attnum > 0;
+ min_attnum 
+------------
+          1
+(1 row)
+
 -- check for mpp-2687
 CREATE TEMPORARY TABLE mpp2687t (
     dk text,

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -18,6 +18,9 @@ SELECT lag(a order by a) over (order by a) FROM aggtest;  -- window function
 SELECT count(a order by a) over (order by a) FROM aggtest;  -- window derived aggregate
 SELECT array_agg(a order by a) over (order by a) FROM aggtest; -- window derived ordered aggregate
 
+-- agg on entryDB, this used to raise error "MIN/MAX subplan has unexpected flowtype"
+SELECT min(attnum) min_attnum FROM pg_catalog.pg_attribute WHERE attrelid = 'pg_proc'::regclass AND attnum > 0;
+
 -- check for mpp-2687
 CREATE TEMPORARY TABLE mpp2687t (
     dk text,


### PR DESCRIPTION
This is a regression caused by commit: 6ae9179dca7.
The refactor forget to consider agg on entryDB.
So fix the issue and add a test case to cover it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
