### PR TITLE
Fix flaky gprecoverseg behave test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -65,6 +65,7 @@ Feature: gprecoverseg tests
       And gprecoverseg should only spawn up to <coordinator_workers> workers in WorkerPool
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
+      And the segments are synchronized
 
     Examples:
       | args      | coordinator_workers | segHost_workers |
@@ -84,6 +85,7 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
+	And the segments are synchronized
 
     Scenario: gprecoverseg full recovery displays pg_basebackup progress to the user
         Given the database is running


### PR DESCRIPTION
Tests performing gprecoverseg rebalance should wait to have the
segments in synchronized state. This makes sure following tests starts
with expected state.

CI many times encountered flaky behavior as next test call "stop all
primaries". If the segments were not in sync and primaries are stopped
creates double fault situation.

Ideally, stop all primaries or mirrors test function should have check
for segments are in-sync before stopping. Though that's patch for some
other day.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
