### PR TITLE
Add retry loop in autovacuum tests to avoid flakiness

### DIFF
--- a/src/test/regress/input/autovacuum-segment.source
+++ b/src/test/regress/input/autovacuum-segment.source
@@ -38,7 +38,29 @@ SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) fr
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- catalog table should be young
-SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
+-- We only wait for 1 worker above to update the datfrozenxid. Based
+-- on age of database multiple workers can be invoked to perform the
+-- job. Given that number is not deterministic, we need to have retry
+-- logic to check for age dropped for the database or not.
+DO $$
+DECLARE young BOOLEAN;
+BEGIN
+     FOR i in 1..1500 loop
+	      SELECT age(relfrozenxid) < 200 * 1000000
+	      FROM gp_dist_random('pg_class') WHERE relname='pg_class' AND gp_segment_id = 0
+	      into young;
+
+	      IF young THEN
+	         raise notice 'Regression Database is young now';
+		 EXIT;
+	      END IF;
+	      PERFORM pg_sleep(0.2);
+     END LOOP;
+
+     IF not young THEN
+	raise notice 'Regression Database is still old';
+     END IF;
+END$$;
 
 -- Reset GUCs.
 -- start_ignore

--- a/src/test/regress/input/autovacuum-template0-segment.source
+++ b/src/test/regress/input/autovacuum-template0-segment.source
@@ -40,12 +40,14 @@ SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) fr
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
 
 -- template0 should be young
--- Sometimes one trigger of autovacuum doesn't bring down the age for
--- template0, hence wait for few triggers to drop it
+-- We only wait for 1 worker above to update the datfrozenxid. Based
+-- on age of database multiple workers can be invoked to perform the
+-- job. Given that number is not deterministic, we need to have retry
+-- logic to check for age dropped for the database or not.
 DO $$
 DECLARE young BOOLEAN;
 BEGIN
-     FOR i in 1..300 loop
+     FOR i in 1..1500 loop
 	      SELECT age(datfrozenxid) < 200 * 1000000
 	      FROM gp_dist_random('pg_database') WHERE datname='template0' AND gp_segment_id = 0
 	      into young;

--- a/src/test/regress/input/autovacuum.source
+++ b/src/test/regress/input/autovacuum.source
@@ -35,7 +35,29 @@ SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, 1);
 SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
 
 -- catalog table should be young
-SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
+-- We only wait for 1 worker above to update the datfrozenxid. Based
+-- on age of database multiple workers can be invoked to perform the
+-- job. Given that number is not deterministic, we need to have retry
+-- logic to check for age dropped for the database or not.
+DO $$
+DECLARE young BOOLEAN;
+BEGIN
+     FOR i in 1..1500 loop
+	      SELECT age(relfrozenxid) < 200 * 1000000
+	      FROM pg_class WHERE relname='pg_class'
+	      into young;
+
+	      IF young THEN
+	         raise notice 'Regression Database is young now';
+		 EXIT;
+	      END IF;
+	      PERFORM pg_sleep(0.2);
+     END LOOP;
+
+     IF not young THEN
+	raise notice 'Regression Database is still old';
+     END IF;
+END$$;
 
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;

--- a/src/test/regress/output/autovacuum-segment.source
+++ b/src/test/regress/output/autovacuum-segment.source
@@ -87,14 +87,30 @@ SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_se
 (1 row)
 
 -- catalog table should be young
-SELECT gp_segment_id, age(relfrozenxid) < 200 * 1000000 FROM gp_dist_random('pg_class') WHERE relname='pg_class';
- gp_segment_id | ?column? 
----------------+----------
-             1 | t
-             2 | t
-             0 | t
-(3 rows)
+-- We only wait for 1 worker above to update the datfrozenxid. Based
+-- on age of database multiple workers can be invoked to perform the
+-- job. Given that number is not deterministic, we need to have retry
+-- logic to check for age dropped for the database or not.
+DO $$
+DECLARE young BOOLEAN;
+BEGIN
+     FOR i in 1..1500 loop
+	      SELECT age(relfrozenxid) < 200 * 1000000
+	      FROM gp_dist_random('pg_class') WHERE relname='pg_class' AND gp_segment_id = 0
+	      into young;
 
+	      IF young THEN
+	         raise notice 'Regression Database is young now';
+		 EXIT;
+	      END IF;
+	      PERFORM pg_sleep(0.2);
+     END LOOP;
+
+     IF not young THEN
+	raise notice 'Regression Database is still old';
+     END IF;
+END$$;
+NOTICE:  Regression Database is young now
 -- Reset GUCs.
 -- start_ignore
 \! gpconfig -r debug_burn_xids --skipvalidation

--- a/src/test/regress/output/autovacuum-template0-segment.source
+++ b/src/test/regress/output/autovacuum-template0-segment.source
@@ -77,12 +77,14 @@ SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_se
 (1 row)
 
 -- template0 should be young
--- Sometimes one trigger of autovacuum doesn't bring down the age for
--- template0, hence wait for few triggers to drop it
+-- We only wait for 1 worker above to update the datfrozenxid. Based
+-- on age of database multiple workers can be invoked to perform the
+-- job. Given that number is not deterministic, we need to have retry
+-- logic to check for age dropped for the database or not.
 DO $$
 DECLARE young BOOLEAN;
 BEGIN
-     FOR i in 1..300 loop
+     FOR i in 1..1500 loop
 	      SELECT age(datfrozenxid) < 200 * 1000000
 	      FROM gp_dist_random('pg_database') WHERE datname='template0' AND gp_segment_id = 0
 	      into young;

--- a/src/test/regress/output/autovacuum.source
+++ b/src/test/regress/output/autovacuum.source
@@ -85,12 +85,30 @@ SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', 1);
 (1 row)
 
 -- catalog table should be young
-SELECT age(relfrozenxid) < 200 * 1000000 FROM pg_class WHERE relname='pg_class';
- ?column? 
-----------
- t
-(1 row)
+-- We only wait for 1 worker above to update the datfrozenxid. Based
+-- on age of database multiple workers can be invoked to perform the
+-- job. Given that number is not deterministic, we need to have retry
+-- logic to check for age dropped for the database or not.
+DO $$
+DECLARE young BOOLEAN;
+BEGIN
+     FOR i in 1..1500 loop
+	      SELECT age(relfrozenxid) < 200 * 1000000
+	      FROM pg_class WHERE relname='pg_class'
+	      into young;
 
+	      IF young THEN
+	         raise notice 'Regression Database is young now';
+		 EXIT;
+	      END IF;
+	      PERFORM pg_sleep(0.2);
+     END LOOP;
+
+     IF not young THEN
+	raise notice 'Regression Database is still old';
+     END IF;
+END$$;
+NOTICE:  Regression Database is young now
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;
 select * from pg_reload_conf();


### PR DESCRIPTION
Based on investigation from Hubert and Asim in referenced discussion,
if multiple workers are launched for autovacuum, then the test can
exhibit flaky behavior, as we can only reliable wait for pre-known
number of fault hits not a dynamic number.

Hence, to make the test reliable adding retry to check if autovacuum
performed the job or not for 5 minutes else fail. Picked 5 minutes as
timeout as on CI we have seen cases where it took close to 2 mins time
to complete the autovacuum for regression database.

Discussion:
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/8QNIiwtjh2U/m/TSGeLp8hBAAJ

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
