### PR TITLE
(6x only) Fix flaky test case in bfv_dml.

### DIFF
--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -332,11 +332,24 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
-create table foo (a int, b int) distributed randomly;
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+drop table if exists bar;
+NOTICE:  table "bar" does not exist, skipping
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -340,17 +340,24 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
--- start_ignore
 drop table if exists foo;
 NOTICE:  table "foo" does not exist, skipping
 drop table if exists bar;
 NOTICE:  table "bar" does not exist, skipping
--- end_ignore
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The case is flaky because of the table is defined as randomly
distributed and then load data into it which will lead to
random cost and different plans.

This commit fixes the flakiness by firstly define the table
to hash distributed and then load data into it. This will ensure
us a stable data distribution. Then we use alter table to change
the policy of this table to randomly without moving the data.

--------------------

I find some jobs fail in 6x pipeline:

* https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE/jobs/icw_planner_oracle7/builds/436
* https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE_without_asserts/jobs/icw_planner_ictcp_centos6/builds/1030
* https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE_without_asserts/jobs/icw_gporca_icproxy_centos6/builds/411
