### PR TITLE
complete gpload error message when cannot create external table

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2545,7 +2545,19 @@ class gpload:
         try:
             self.db.query(sql.encode('utf-8'))
         except Exception, e:
-            self.log(self.ERROR, 'could not run SQL "%s": %s' % (sql, unicode(e)))
+            get_standard_conforming_strings = 'show standard_conforming_strings;'
+            try:
+                scs = self.db.query(get_standard_conforming_strings.encode('utf-8')).getresult()
+                if scs[0][0] == 'off':
+                    self.log(self.ERROR, 'could not run SQL "%s": %s ' % (sql, unicode(e)) +
+                    "standard_conforming_strings is set to 'off', please set it to 'on' and try again \n")
+                else:
+                    self.log(self.ERROR, 'could not run SQL "%s": %s' % (sql, unicode(e)))
+            except Exception, ee:
+                self.log(self.ERROR, 'could not run SQL "%s": %s ' % (sql, unicode(e)) +
+                "could not get standard_conforming_strings, %s " % unicode(ee) +
+                "if standard_conforming_strings is set to 'off', please set it to 'on' and try again \n"
+                )
 
         # set up to drop the external table at the end of operation, unless user
         # specified the 'reuse_tables' option, in which case we don't drop

--- a/gpMgmt/bin/gpload_test/.gitignore
+++ b/gpMgmt/bin/gpload_test/.gitignore
@@ -4,6 +4,10 @@ gpload/config
 gpload2/config
 gpload2/setup.out
 gpload2/data_file.txt
+gpload2/data_file.txt.gz
+gpload2/data_file1.txt
+gpload2/data_file1.txt.bz2
+gpload2/data_file2.txt
 GPTest.pm
 gpstringsubs.pl
 gpdiff.pl

--- a/gpMgmt/bin/gpload_test/gpload2/query37.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query37.ans
@@ -1,22 +1,26 @@
-2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
-2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
-2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:52:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7
-2018-11-05 22:52:11|ERROR|could not run SQL "create external table ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2021-07-16 16:50:49|INFO|gpload session started 2021-07-16 16:50:49
+2021-07-16 16:50:49|INFO|setting schema 'public' for table 'texttable'
+2021-07-16 16:50:49|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:50:49|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-07-16 16:50:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_eb6a7508_e612_11eb_9d41_0050569ea4ff
+2021-07-16 16:50:49|ERROR|could not run SQL "create external table ext_gpload_reusable_eb6a7508_e612_11eb_9d41_0050569ea4ff("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2018-11-05 22:52:11|INFO|rows Inserted          = 0
-2018-11-05 22:52:11|INFO|rows Updated           = 0
-2018-11-05 22:52:11|INFO|data formatting errors = 0
-2018-11-05 22:52:11|INFO|gpload failed
-2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
-2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
-2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:52:12|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7
-2018-11-05 22:52:12|ERROR|could not run SQL "create external table ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2021-07-16 16:50:49|INFO|rows Inserted          = 0
+2021-07-16 16:50:49|INFO|rows Updated           = 0
+2021-07-16 16:50:49|INFO|data formatting errors = 0
+2021-07-16 16:50:49|INFO|gpload failed
+2021-07-16 16:50:49|INFO|gpload session started 2021-07-16 16:50:49
+2021-07-16 16:50:50|INFO|setting schema 'public' for table 'texttable'
+2021-07-16 16:50:50|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:50:50|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-07-16 16:50:50|INFO|did not find an external table to reuse. creating ext_gpload_reusable_eb7fcb88_e612_11eb_b6d0_0050569ea4ff
+2021-07-16 16:50:50|ERROR|could not run SQL "create external table ext_gpload_reusable_eb7fcb88_e612_11eb_b6d0_0050569ea4ff("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2018-11-05 22:52:12|INFO|rows Inserted          = 0
-2018-11-05 22:52:12|INFO|rows Updated           = 0
-2018-11-05 22:52:12|INFO|data formatting errors = 0
-2018-11-05 22:52:12|INFO|gpload failed
+2021-07-16 16:50:50|INFO|rows Inserted          = 0
+2021-07-16 16:50:50|INFO|rows Updated           = 0
+2021-07-16 16:50:50|INFO|data formatting errors = 0
+2021-07-16 16:50:50|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query44.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query44.ans
@@ -1,11 +1,11 @@
 Traceback (most recent call last):
-  File "pathto/gpload.py", line 3060, in <module>
+  File "pathto/gpload.py", line 3072, in <module>
     g = gpload(sys.argv[1:])
   File "pathto/gpload.py", line 1230, in __init__
     sys.stderr.write("Option %s needs a parameter.\n"%argv[0])
 IndexError: list index out of range
 Traceback (most recent call last):
-  File "pathto/gpload.py", line 3060, in <module>
+  File "pathto/gpload.py", line 3072, in <module>
     g = gpload(sys.argv[1:])
   File "pathto/gpload.py", line 1230, in __init__
     sys.stderr.write("Option %s needs a parameter.\n"%argv[0])

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -1,28 +1,29 @@
-2021-06-21 16:22:34|INFO|gpload session started 2021-06-21 16:22:34
-2021-06-21 16:22:34|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:34|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:34|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d4877fd2_d269_11eb_bf9f_0050569ea4ff
-2021-06-21 16:22:34|ERROR|could not run SQL "create external table ext_gpload_reusable_d4877fd2_d269_11eb_bf9f_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
+2021-07-16 16:51:06|INFO|setting schema 'public' for table 'chinese表'
+2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:51:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f51b4226_e612_11eb_805c_0050569ea4ff
+2021-07-16 16:51:06|ERROR|could not run SQL "create external table ext_gpload_reusable_f51b4226_e612_11eb_805c_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
+ standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-06-21 16:22:34|INFO|rows Inserted          = 0
-2021-06-21 16:22:34|INFO|rows Updated           = 0
-2021-06-21 16:22:34|INFO|data formatting errors = 0
-2021-06-21 16:22:34|INFO|gpload failed
-2021-06-21 16:22:34|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
-2021-06-21 16:22:34|INFO|gpload session started 2021-06-21 16:22:34
-2021-06-21 16:22:34|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:34|ERROR|no mapping for input column "'列1'" to output table
-2021-06-21 16:22:34|INFO|rows Inserted          = 0
-2021-06-21 16:22:34|INFO|rows Updated           = 0
-2021-06-21 16:22:34|INFO|data formatting errors = 0
-2021-06-21 16:22:34|INFO|gpload failed
-2021-06-21 16:22:34|INFO|gpload session started 2021-06-21 16:22:34
-2021-06-21 16:22:34|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:34|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:34|ERROR|unexpected error -- backtrace written to log file
-2021-06-21 16:22:34|INFO|rows Inserted          = 0
-2021-06-21 16:22:34|INFO|rows Updated           = 0
-2021-06-21 16:22:34|INFO|data formatting errors = 0
-2021-06-21 16:22:34|INFO|gpload failed
+2021-07-16 16:51:06|INFO|rows Inserted          = 0
+2021-07-16 16:51:06|INFO|rows Updated           = 0
+2021-07-16 16:51:06|INFO|data formatting errors = 0
+2021-07-16 16:51:06|INFO|gpload failed
+2021-07-16 16:51:06|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
+2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
+2021-07-16 16:51:06|INFO|setting schema 'public' for table 'chinese表'
+2021-07-16 16:51:06|ERROR|no mapping for input column "'列1'" to output table
+2021-07-16 16:51:06|INFO|rows Inserted          = 0
+2021-07-16 16:51:06|INFO|rows Updated           = 0
+2021-07-16 16:51:06|INFO|data formatting errors = 0
+2021-07-16 16:51:06|INFO|gpload failed
+2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
+2021-07-16 16:51:06|INFO|setting schema 'public' for table 'chinese表'
+2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:51:06|ERROR|unexpected error -- backtrace written to log file
+2021-07-16 16:51:06|INFO|rows Inserted          = 0
+2021-07-16 16:51:06|INFO|rows Updated           = 0
+2021-07-16 16:51:06|INFO|data formatting errors = 0
+2021-07-16 16:51:06|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query77.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query77.ans
@@ -1,45 +1,50 @@
-2021-06-21 16:22:34|INFO|gpload session started 2021-06-21 16:22:34
-2021-06-21 16:22:34|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-21 16:22:34|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:34|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d4da3768_d269_11eb_9513_0050569ea4ff
-2021-06-21 16:22:34|ERROR|could not run SQL "create external table ext_gpload_reusable_d4da3768_d269_11eb_9513_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
+2021-07-16 16:51:06|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:51:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f56e7414_e612_11eb_9860_0050569ea4ff
+2021-07-16 16:51:06|ERROR|could not run SQL "create external table ext_gpload_reusable_f56e7414_e612_11eb_9860_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
+ standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-06-21 16:22:34|INFO|rows Inserted          = 0
-2021-06-21 16:22:34|INFO|rows Updated           = 0
-2021-06-21 16:22:34|INFO|data formatting errors = 0
-2021-06-21 16:22:34|INFO|gpload failed
-2021-06-21 16:22:35|INFO|gpload session started 2021-06-21 16:22:35
-2021-06-21 16:22:35|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-21 16:22:35|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:35|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
-2021-06-21 16:22:35|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d4ee1aa8_d269_11eb_b922_0050569ea4ff
-2021-06-21 16:22:35|ERROR|could not run SQL "create external table ext_gpload_reusable_d4ee1aa8_d269_11eb_b922_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-16 16:51:06|INFO|rows Inserted          = 0
+2021-07-16 16:51:06|INFO|rows Updated           = 0
+2021-07-16 16:51:06|INFO|data formatting errors = 0
+2021-07-16 16:51:06|INFO|gpload failed
+2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
+2021-07-16 16:51:06|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:51:06|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
+2021-07-16 16:51:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f582aac4_e612_11eb_8049_0050569ea4ff
+2021-07-16 16:51:06|ERROR|could not run SQL "create external table ext_gpload_reusable_f582aac4_e612_11eb_8049_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-06-21 16:22:35|INFO|rows Inserted          = 0
-2021-06-21 16:22:35|INFO|rows Updated           = 0
-2021-06-21 16:22:35|INFO|data formatting errors = 0
-2021-06-21 16:22:35|INFO|gpload failed
-2021-06-21 16:22:35|INFO|gpload session started 2021-06-21 16:22:35
-2021-06-21 16:22:35|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-21 16:22:35|ERROR|no mapping for input column "'Field1'" to output table
-2021-06-21 16:22:35|INFO|rows Inserted          = 0
-2021-06-21 16:22:35|INFO|rows Updated           = 0
-2021-06-21 16:22:35|INFO|data formatting errors = 0
-2021-06-21 16:22:35|INFO|gpload failed
-2021-06-21 16:22:35|INFO|gpload session started 2021-06-21 16:22:35
-2021-06-21 16:22:35|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-21 16:22:35|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:35|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
-2021-06-21 16:22:35|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d51458a8_d269_11eb_9311_0050569ea4ff
-2021-06-21 16:22:35|ERROR|could not run SQL "create external table ext_gpload_reusable_d51458a8_d269_11eb_9311_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-16 16:51:06|INFO|rows Inserted          = 0
+2021-07-16 16:51:06|INFO|rows Updated           = 0
+2021-07-16 16:51:06|INFO|data formatting errors = 0
+2021-07-16 16:51:06|INFO|gpload failed
+2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
+2021-07-16 16:51:06|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-16 16:51:06|ERROR|no mapping for input column "'Field1'" to output table
+2021-07-16 16:51:06|INFO|rows Inserted          = 0
+2021-07-16 16:51:06|INFO|rows Updated           = 0
+2021-07-16 16:51:06|INFO|data formatting errors = 0
+2021-07-16 16:51:06|INFO|gpload failed
+2021-07-16 16:51:07|INFO|gpload session started 2021-07-16 16:51:07
+2021-07-16 16:51:07|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-16 16:51:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-16 16:51:07|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
+2021-07-16 16:51:07|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f5a91e48_e612_11eb_920a_0050569ea4ff
+2021-07-16 16:51:07|ERROR|could not run SQL "create external table ext_gpload_reusable_f5a91e48_e612_11eb_920a_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-06-21 16:22:35|INFO|rows Inserted          = 0
-2021-06-21 16:22:35|INFO|rows Updated           = 0
-2021-06-21 16:22:35|INFO|data formatting errors = 0
-2021-06-21 16:22:35|INFO|gpload failed
+2021-07-16 16:51:07|INFO|rows Inserted          = 0
+2021-07-16 16:51:07|INFO|rows Updated           = 0
+2021-07-16 16:51:07|INFO|data formatting errors = 0
+2021-07-16 16:51:07|INFO|gpload failed


### PR DESCRIPTION
complete gpload error message when cannot create external table

Some  creation fail may be caused by standard_conforming_strings set to off,
We check the standard_conforming_strings in gpdb and if it is 'off' than advice clients to try again with standard_conforming_strings on.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
