### PR TITLE
Fix flaky test case in bfv_dml.

### DIFF
--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -297,11 +297,25 @@ drop table execinsert_test;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
-create table foo (a int, b int) distributed randomly;
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+drop table if exists bar;
+NOTICE:  table "bar" does not exist, skipping
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- Previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+-- Following cases are using the same skill here.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
@@ -325,11 +339,15 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-insert into foo select generate_series(1, 10);
-insert into bar select generate_series(1, 10);
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a = bar.a returning foo.*;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
@@ -368,8 +386,11 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo where foo.a=1;
                          QUERY PLAN                          
 -------------------------------------------------------------
@@ -381,11 +402,15 @@ explain delete from foo where foo.a=1;
 
 delete from foo where foo.a=1;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.b;
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
@@ -406,14 +431,21 @@ explain delete from foo using bar where foo.a=bar.b;
 delete from foo using bar where foo.a=bar.b;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+-- Turn off redistribute motion for ORCA just for this case.
+-- This is to get a broadcast motion over foo_1 so that no
+-- motion is above the resultrelation foo thus no ExplicitMotion.
+set optimizer_enable_motion_redistribute = off;
 explain delete from foo using foo foo_1 where foo_1.a=foo.a;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Delete on foo  (cost=1253.75..179313.85 rows=2471070 width=16)
-   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1253.75..179313.85 rows=2471070 width=16)
-         ->  Hash Join  (cost=1253.75..129892.45 rows=2471070 width=16)
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=1.14..2.35 rows=3 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.14..2.35 rows=3 width=16)
+         ->  Hash Join  (cost=1.14..2.29 rows=3 width=16)
                Hash Cond: (foo.a = foo_1.a)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=14)
                      Hash Key: foo.a
@@ -426,9 +458,13 @@ explain delete from foo using foo foo_1 where foo_1.a=foo.a;
 (12 rows)
 
 delete from foo using foo foo_1 where foo_1.a=foo.a;
+reset optimizer_enable_motion_redistribute;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo;
                            QUERY PLAN                           
 ----------------------------------------------------------------
@@ -439,10 +475,16 @@ explain delete from foo;
 
 delete from foo;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
@@ -458,12 +500,16 @@ explain delete from foo using bar;
 delete from foo using bar;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into bar select i, i from generate_series(1, 1000)i;
 insert into foo select i,i from generate_series(1, 10)i;
-analyze foo;
-analyze bar;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze	foo;
+analyze	bar;
 set optimizer_enable_motion_redistribute=off;
 explain delete from foo using bar where foo.b=bar.b;
                                                QUERY PLAN                                                
@@ -566,10 +612,16 @@ select * from foo;
 drop table foo;
 drop table bar;
 drop table jazz;
-create table foo (a int) distributed randomly;
-create table bar (b int) distributed randomly;
+create table foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar (b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
 insert into foo select i from generate_series(1, 10)i;
 insert into bar select i from generate_series(1, 10)i;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using (select a from foo union all select b from bar) v;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -303,11 +303,25 @@ drop table execinsert_test;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
-create table foo (a int, b int) distributed randomly;
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+drop table if exists bar;
+NOTICE:  table "bar" does not exist, skipping
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- Previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+-- Following cases are using the same skill here.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
@@ -332,11 +346,15 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-insert into foo select generate_series(1, 10);
-insert into bar select generate_series(1, 10);
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a = bar.a returning foo.*;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
@@ -375,8 +393,11 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo where foo.a=1;
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -388,11 +409,15 @@ explain delete from foo where foo.a=1;
 
 delete from foo where foo.a=1;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.b;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
@@ -409,25 +434,36 @@ explain delete from foo using bar where foo.a=bar.b;
 delete from foo using bar where foo.a=bar.b;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+-- Turn off redistribute motion for ORCA just for this case.
+-- This is to get a broadcast motion over foo_1 so that no
+-- motion is above the resultrelation foo thus no ExplicitMotion.
+set optimizer_enable_motion_redistribute = off;
 explain delete from foo using foo foo_1 where foo_1.a=foo.a;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Delete on foo  (cost=0.00..862.03 rows=1 width=1)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..862.29 rows=4 width=1)
+   ->  Hash Join  (cost=0.00..862.00 rows=10 width=18)
          Hash Cond: (foo_1.a = foo_2.a)
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
-         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                     ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=10 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=30 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=30 width=4)
+                     ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=4 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 delete from foo using foo foo_1 where foo_1.a=foo.a;
+reset optimizer_enable_motion_redistribute;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo;
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -438,10 +474,16 @@ explain delete from foo;
 
 delete from foo;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
@@ -458,12 +500,16 @@ explain delete from foo using bar;
 delete from foo using bar;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into bar select i, i from generate_series(1, 1000)i;
 insert into foo select i,i from generate_series(1, 10)i;
-analyze foo;
-analyze bar;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze	foo;
+analyze	bar;
 set optimizer_enable_motion_redistribute=off;
 explain delete from foo using bar where foo.b=bar.b;
                                               QUERY PLAN                                              
@@ -564,10 +610,16 @@ select * from foo;
 drop table foo;
 drop table bar;
 drop table jazz;
-create table foo (a int) distributed randomly;
-create table bar (b int) distributed randomly;
+create table foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar (b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
 insert into foo select i from generate_series(1, 10)i;
 insert into bar select i from generate_series(1, 10)i;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using (select a from foo union all select b from bar) v;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The case is flaky because of the table is defined as randomly
distributed and then load data into it which will lead to
random cost and different plans.

This commit fixes the flakiness by firstly define the table
to hash distributed and then load data into it. This will ensure
us a stable data distribution. Then we use alter table to change
the policy of this table to randomly without moving the data.

----------------

It seems that on master branch's pipeline we do not encounter such flakiness.

Also in last pr for 6x, I miss later SQL, we should add them later.
