### PR TITLE
Fix compiler warning for unused variable.

### DIFF
--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -58,13 +58,10 @@ lockEqual(LockInstanceData *lock1, LockInstanceData *lock2)
 static bool
 lockIsHoldTillEndXact(LockInstanceData *lock)
 {
-	LOCKTAG		*tag = &lock->locktag;
-
 	if (lock->holdTillEndXact)
 		return true;
 
 	/* FIXME: other types */
-
 	return false;
 }
 


### PR DESCRIPTION
Commit 036a31bdd24 refactor the function lockIsHoldTillEndXact
but forgot to remove the unused variable. Just remove it to
slient compiler.
