### PR TITLE
(6x backport) Fix flaky test case in bfv_dml.

### DIFF
--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -332,11 +332,25 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
-create table foo (a int, b int) distributed randomly;
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+drop table if exists bar;
+NOTICE:  table "bar" does not exist, skipping
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- Previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+-- Following cases are using the same skill here.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
@@ -360,11 +374,15 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-insert into foo select generate_series(1, 10);
-insert into bar select generate_series(1, 10);
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a = bar.a returning foo.*;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -403,8 +421,11 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo where foo.a=1;
                         QUERY PLAN                        
 ----------------------------------------------------------
@@ -416,11 +437,15 @@ explain delete from foo where foo.a=1;
 
 delete from foo where foo.a=1;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.b;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -441,14 +466,21 @@ explain delete from foo using bar where foo.a=bar.b;
 delete from foo using bar where foo.a=bar.b;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+-- Turn off redistribute motion for ORCA just for this case.
+-- This is to get a broadcast motion over foo_1 so that no
+-- motion is above the resultrelation foo thus no ExplicitMotion.
+set optimizer_enable_motion_redistribute = off;
 explain delete from foo using foo foo_1 where foo_1.a=foo.a;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
- Delete on foo  (cost=3.43..6.86 rows=4 width=16)
-   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=3.43..6.86 rows=4 width=16)
-         ->  Hash Join  (cost=3.43..6.86 rows=4 width=16)
+ Delete on foo  (cost=1.14..2.35 rows=3 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.14..2.35 rows=3 width=16)
+         ->  Hash Join  (cost=1.14..2.29 rows=3 width=16)
                Hash Cond: (foo.a = foo_1.a)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.30 rows=4 width=14)
                      Hash Key: foo.a
@@ -461,9 +493,13 @@ explain delete from foo using foo foo_1 where foo_1.a=foo.a;
 (12 rows)
 
 delete from foo using foo foo_1 where foo_1.a=foo.a;
+reset optimizer_enable_motion_redistribute;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo;
                         QUERY PLAN                        
 ----------------------------------------------------------
@@ -474,10 +510,16 @@ explain delete from foo;
 
 delete from foo;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
@@ -494,12 +536,16 @@ explain delete from foo using bar;
 delete from foo using bar;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into bar select i, i from generate_series(1, 1000)i;
 insert into foo select i,i from generate_series(1, 10)i;
-analyze foo;
-analyze bar;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze	foo;
+analyze	bar;
 set optimizer_enable_motion_redistribute=off;
 explain delete from foo using bar where foo.b=bar.b;
                                                QUERY PLAN                                                
@@ -604,10 +650,16 @@ select * from foo;
 drop table foo;
 drop table bar;
 drop table jazz;
-create table foo (a int) distributed randomly;
-create table bar (b int) distributed randomly;
+create table foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar (b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
 insert into foo select i from generate_series(1, 10)i;
 insert into bar select i from generate_series(1, 10)i;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using (select a from foo union all select b from bar) v;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -332,24 +332,11 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
-drop table if exists foo;
-NOTICE:  table "foo" does not exist, skipping
-drop table if exists bar;
-NOTICE:  table "bar" does not exist, skipping
-create table foo (a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table foo (a int, b int) distributed randomly;
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
--- previously, table foo is defined as  randomly distributed and 
--- that might lead to flaky result of the explain statement
--- since random cost. We set policy to random without move the
--- data after data is all inserted. This method can both have
--- a random dist table and a stable test result.
-alter table foo set with(REORGANIZE=false) distributed randomly;
-analyze foo;
-analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -483,17 +483,18 @@ analyze foo;
 -- motion is above the resultrelation foo thus no ExplicitMotion.
 set optimizer_enable_motion_redistribute = off;
 explain delete from foo using foo foo_1 where foo_1.a=foo.a;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Delete on foo  (cost=0.00..862.29 rows=4 width=1)
-   ->  Hash Join  (cost=0.00..862.00 rows=10 width=18)
-         Hash Cond: (foo_1.a = foo_2.a)
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=10 width=18)
-         ->  Hash  (cost=431.00..431.00 rows=30 width=4)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=30 width=4)
-                     ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=4 width=4)
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..862.29 rows=4 width=1)
+   ->  Result  (cost=0.00..862.00 rows=4 width=22)
+         ->  Hash Join  (cost=0.00..862.00 rows=4 width=18)
+               Hash Cond: (foo.a = foo_1.a)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=18)
+               ->  Hash  (cost=431.00..431.00 rows=10 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+                           ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 delete from foo using foo foo_1 where foo_1.a=foo.a;
 reset optimizer_enable_motion_redistribute;

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -340,17 +340,25 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
--- start_ignore
 drop table if exists foo;
 NOTICE:  table "foo" does not exist, skipping
 drop table if exists bar;
 NOTICE:  table "bar" does not exist, skipping
--- end_ignore
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- Previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+-- Following cases are using the same skill here.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
@@ -375,11 +383,15 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-insert into foo select generate_series(1, 10);
-insert into bar select generate_series(1, 10);
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a = bar.a returning foo.*;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -418,8 +430,11 @@ select * from foo;
 
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo where foo.a=1;
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -432,11 +447,15 @@ explain delete from foo where foo.a=1;
 
 delete from foo where foo.a=1;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.b;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -454,30 +473,36 @@ explain delete from foo using bar where foo.a=bar.b;
 delete from foo using bar where foo.a=bar.b;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+-- Turn off redistribute motion for ORCA just for this case.
+-- This is to get a broadcast motion over foo_1 so that no
+-- motion is above the resultrelation foo thus no ExplicitMotion.
+set optimizer_enable_motion_redistribute = off;
 explain delete from foo using foo foo_1 where foo_1.a=foo.a;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Delete  (cost=0.00..862.29 rows=4 width=1)
-   ->  Result  (cost=0.00..862.00 rows=4 width=22)
-         ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..862.00 rows=4 width=18)
-               ->  Hash Join  (cost=0.00..862.00 rows=4 width=18)
-                     Hash Cond: (foo.a = foo_1.a)
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=18)
-                           Hash Key: foo.a
-                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=18)
-                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
-                                 Hash Key: foo_1.a
-                                 ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=4)
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Delete on foo  (cost=0.00..862.29 rows=4 width=1)
+   ->  Hash Join  (cost=0.00..862.00 rows=10 width=18)
+         Hash Cond: (foo_1.a = foo_2.a)
+         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=10 width=18)
+         ->  Hash  (cost=431.00..431.00 rows=30 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=30 width=4)
+                     ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=4 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 delete from foo using foo foo_1 where foo_1.a=foo.a;
+reset optimizer_enable_motion_redistribute;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo;
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -489,10 +514,16 @@ explain delete from foo;
 
 delete from foo;
 drop table foo;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -510,12 +541,16 @@ explain delete from foo using bar;
 delete from foo using bar;
 drop table foo;
 drop table bar;
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into bar select i, i from generate_series(1, 1000)i;
 insert into foo select i,i from generate_series(1, 10)i;
-analyze foo;
-analyze bar;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze	foo;
+analyze	bar;
 set optimizer_enable_motion_redistribute=off;
 explain delete from foo using bar where foo.b=bar.b;
                                                  QUERY PLAN                                                 
@@ -618,10 +653,16 @@ select * from foo;
 drop table foo;
 drop table bar;
 drop table jazz;
-create table foo (a int) distributed randomly;
-create table bar (b int) distributed randomly;
+create table foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+create table bar (b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
 insert into foo select i from generate_series(1, 10)i;
 insert into bar select i from generate_series(1, 10)i;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using (select a from foo union all select b from bar) v;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -340,24 +340,17 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 --
 -- Verify that DELETE properly redistributes in the case of joins
 --
+-- start_ignore
 drop table if exists foo;
 NOTICE:  table "foo" does not exist, skipping
 drop table if exists bar;
 NOTICE:  table "bar" does not exist, skipping
-create table foo (a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+-- end_ignore
+create table foo (a int, b int) distributed randomly;
 create table bar(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
--- previously, table foo is defined as  randomly distributed and 
--- that might lead to flaky result of the explain statement
--- since random cost. We set policy to random without move the
--- data after data is all inserted. This method can both have
--- a random dist table and a stable test result.
-alter table foo set with(REORGANIZE=false) distributed randomly;
-analyze foo;
-analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -220,73 +220,103 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 -- Verify that DELETE properly redistributes in the case of joins
 --
 
--- start_ignore
 drop table if exists foo;
 drop table if exists bar;
--- end_ignore
 
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
 create table bar(a int, b int);
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+-- Previously, table foo is defined as  randomly distributed and 
+-- that might lead to flaky result of the explain statement
+-- since random cost. We set policy to random without move the
+-- data after data is all inserted. This method can both have
+-- a random dist table and a stable test result.
+-- Following cases are using the same skill here.
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
 delete from foo using bar where foo.a=bar.a;
 select * from foo;
 drop table foo;
 drop table bar;
 
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
 create table bar(a int, b int);
-insert into foo select generate_series(1, 10);
-insert into bar select generate_series(1, 10);
+insert into foo select generate_series(1,10);
+insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a = bar.a returning foo.*;
 delete from foo using bar where foo.a = bar.a returning foo.*;
 select * from foo;
 drop table foo;
 drop table bar;
 
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo where foo.a=1;
 delete from foo where foo.a=1;
 drop table foo;
 
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
 create table bar(a int, b int);
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar where foo.a=bar.b;
 delete from foo using bar where foo.a=bar.b;
 drop table foo;
 drop table bar;
 
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+-- Turn off redistribute motion for ORCA just for this case.
+-- This is to get a broadcast motion over foo_1 so that no
+-- motion is above the resultrelation foo thus no ExplicitMotion.
+set optimizer_enable_motion_redistribute = off;
 explain delete from foo using foo foo_1 where foo_1.a=foo.a;
 delete from foo using foo foo_1 where foo_1.a=foo.a;
+reset optimizer_enable_motion_redistribute;
 drop table foo;
 
-create table foo (a int, b int) distributed randomly;
+create table foo (a int, b int);
 insert into foo select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+analyze foo;
 explain delete from foo;
 delete from foo;
 drop table foo;
 
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+create table bar(a int, b int);
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using bar;
 delete from foo using bar;
 drop table foo;
 drop table bar;
 
-create table foo (a int, b int) distributed randomly;
-create table bar(a int, b int) distributed randomly;
+create table foo (a int, b int);
+create table bar(a int, b int);
 insert into bar select i, i from generate_series(1, 1000)i;
 insert into foo select i,i from generate_series(1, 10)i;
-analyze foo;
-analyze bar;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze	foo;
+analyze	bar;
 set optimizer_enable_motion_redistribute=off;
 explain delete from foo using bar where foo.b=bar.b;
 delete from foo using bar where foo.b=bar.b;
@@ -326,10 +356,14 @@ drop table foo;
 drop table bar;
 drop table jazz;
 
-create table foo (a int) distributed randomly;
-create table bar (b int) distributed randomly;
+create table foo (a int);
+create table bar (b int);
 insert into foo select i from generate_series(1, 10)i;
 insert into bar select i from generate_series(1, 10)i;
+alter table foo set with(REORGANIZE=false) distributed randomly;
+alter table bar set with(REORGANIZE=false) distributed randomly;
+analyze foo;
+analyze bar;
 explain delete from foo using (select a from foo union all select b from bar) v;
 delete from foo using (select a from foo union all select b from bar) v;
 select * from foo;

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -220,21 +220,15 @@ delete from tabwithoids RETURNING oid > 1000, tabwithoids;
 -- Verify that DELETE properly redistributes in the case of joins
 --
 
+-- start_ignore
 drop table if exists foo;
 drop table if exists bar;
+-- end_ignore
 
-create table foo (a int, b int);
+create table foo (a int, b int) distributed randomly;
 create table bar(a int, b int);
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
--- previously, table foo is defined as  randomly distributed and 
--- that might lead to flaky result of the explain statement
--- since random cost. We set policy to random without move the
--- data after data is all inserted. This method can both have
--- a random dist table and a stable test result.
-alter table foo set with(REORGANIZE=false) distributed randomly;
-analyze foo;
-analyze bar;
 explain delete from foo using bar where foo.a=bar.a;
 delete from foo using bar where foo.a=bar.a;
 select * from foo;


### PR DESCRIPTION
The case is flaky because of the table is defined as randomly
distributed and then load data into it which will lead to
random cost and different plans.

This commit fixes the flakiness by firstly define the table
to hash distributed and then load data into it. This will ensure
us a stable data distribution. Then we use alter table to change
the policy of this table to randomly without moving the data.


-----------------------------------

This PR first revert my previous commit https://github.com/greenplum-db/gpdb/commit/0cc730a51d4adc30136483cb44a9d9eaf4885610
and then a simply cherry-pick of the PR of master https://github.com/greenplum-db/gpdb/pull/12338
