### PR TITLE
Don't choose indexscan when you need a motion for a subplan [Backport]

### DIFF
--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -229,7 +229,7 @@ create_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		/* Add index path to caller's list. */
 		*pindexpathlist = lappend(*pindexpathlist, ipath);
 
-		if (!root->config->enable_seqscan ||
+		if (!enable_seqscan ||
 			(ipath->indexselectivity < 1.0 &&
 			 !ScanDirectionIsBackward(ipath->indexscandir)))
 			bitindexpaths = lappend(bitindexpaths, ipath);
@@ -1855,7 +1855,7 @@ best_inner_indexscan(PlannerInfo *root, RelOptInfo *rel,
 	Assert(rel->relstorage != '\0');
 
 	/* Exclude plain index paths if user doesn't want them. */
-	if (!root->config->enable_indexscan && !root->config->mpp_trying_fallback_plan)
+	if (!enable_indexscan && !root->config->mpp_trying_fallback_plan)
 		indexpaths = NIL;
 
 	/* Exclude plain index paths if the relation is an append-only relation. */
@@ -1868,7 +1868,7 @@ best_inner_indexscan(PlannerInfo *root, RelOptInfo *rel,
 	 * promising combination of bitmap index paths.
 	 */
 	if (bitindexpaths != NIL &&
-		(root->config->enable_bitmapscan || root->config->mpp_trying_fallback_plan))
+		(enable_bitmapscan || root->config->mpp_trying_fallback_plan))
 	{
 		Path	   *bitmapqual;
 		Path	   *bpath;

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -498,10 +498,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 {
 	PlannerConfig *c1 = (PlannerConfig *) palloc(sizeof(PlannerConfig));
 	c1->cdbpath_segments = planner_segment_count();
-	c1->enable_seqscan = enable_seqscan;
-	c1->enable_indexscan = enable_indexscan;
-	c1->enable_bitmapscan = enable_bitmapscan;
-	c1->enable_tidscan = enable_tidscan;
 	c1->enable_sort = enable_sort;
 	c1->enable_hashagg = enable_hashagg;
 	c1->enable_groupagg = enable_groupagg;
@@ -526,7 +522,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->gp_eager_two_phase_agg = gp_eager_two_phase_agg;
 	c1->gp_enable_groupext_distinct_pruning = gp_enable_groupext_distinct_pruning;
 	c1->gp_enable_groupext_distinct_gather = gp_enable_groupext_distinct_gather;
-	c1->gp_enable_sort_limit = gp_enable_sort_limit;
 	c1->gp_enable_sort_distinct = gp_enable_sort_distinct;
 	c1->gp_enable_mk_sort = gp_enable_mk_sort;
 	c1->gp_enable_motion_mk_sort = gp_enable_motion_mk_sort;
@@ -535,6 +530,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->gp_dynamic_partition_pruning = gp_dynamic_partition_pruning;
 
 	c1->gp_cte_sharing = gp_cte_sharing;
+
+	c1->is_under_subplan = false;
 
 	return c1;
 }

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -536,6 +536,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	else
 		root->wt_param_id = -1;
 	root->non_recursive_plan = NULL;
+	root->is_correlated_subplan = false;
 
 	/*
 	 * If there is a WITH list, process each WITH query and build an
@@ -575,6 +576,19 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	 */
 	parse->jointree = (FromExpr *)
 		pull_up_subqueries(root, (Node *) parse->jointree, false, false);
+
+	if ((parent_root && parent_root->is_correlated_subplan) ||
+		((Gp_role == GP_ROLE_DISPATCH) &&
+		root->config->is_under_subplan &&
+		IsSubqueryCorrelated(parse)))
+	{
+		root->is_correlated_subplan = true;
+		/*
+		 * Generate the plan for the subquery with certain options disabled.
+		 */
+		config->gp_enable_direct_dispatch = false;
+		config->gp_enable_multiphase_agg = false;
+	}
 
 	/*
 	 * Detect whether any rangetable entries are RTE_JOIN kind; if not, we can

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -420,24 +420,8 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 				 errmsg("correlated subquery with skip-level correlations is not supported")));
 	}
 
-	if ((Gp_role == GP_ROLE_DISPATCH)
-			&& IsSubqueryCorrelated(subquery)
-			&& QueryHasDistributedRelation(subquery))
-	{
-		/*
-		 * Generate the plan for the subquery with certain options disabled.
-		 */
-		config->gp_enable_direct_dispatch = false;
-		config->gp_enable_multiphase_agg = false;
-
-		/*
-		 * Only create subplans with sequential scans
-		 */
-		config->enable_indexscan = false;
-		config->enable_bitmapscan = false;
-		config->enable_tidscan = false;
-		config->enable_seqscan = true;
-	}
+	if (Gp_role == GP_ROLE_DISPATCH)
+		config->is_under_subplan = true;
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -13,10 +13,6 @@
  */
 typedef struct PlannerConfig
 {
-	bool		enable_seqscan;
-	bool		enable_indexscan;
-	bool		enable_bitmapscan;
-	bool		enable_tidscan;
 	bool		enable_sort;
 	bool		enable_hashagg;
 	bool		enable_groupagg;
@@ -42,7 +38,6 @@ typedef struct PlannerConfig
 	bool		gp_eager_two_phase_agg;
 	bool        gp_enable_groupext_distinct_pruning;
 	bool        gp_enable_groupext_distinct_gather;
-	bool		gp_enable_sort_limit;
 	bool		gp_enable_sort_distinct;
 	bool		gp_enable_mk_sort;
 	bool		gp_enable_motion_mk_sort;
@@ -51,6 +46,8 @@ typedef struct PlannerConfig
 	bool		gp_dynamic_partition_pruning;
 
 	bool		gp_cte_sharing; /* Indicate whether sharing is to be disabled on any CTEs */
+
+	bool		is_under_subplan; /* True for plan rooted at a subquery which is planned as a subplan */
 
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -263,6 +263,8 @@ typedef struct PlannerInfo
 	PlannerConfig *config;		/* Planner configuration */
 
 	List	   *dynamicScans;	/* DynamicScanInfos */
+
+	bool		is_correlated_subplan; /* true for correlated subqueries nested within subplans */
 } PlannerInfo;
 
 /*----------

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -818,27 +818,26 @@ set enable_nestloop to on;
 set enable_hashjoin to off;
 set enable_mergejoin to off;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.26 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.26 rows=1 width=4)
+                                                     QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.40 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.40 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.11..2.12 rows=1 width=8)
-                 ->  Aggregate  (cost=2.05..2.06 rows=1 width=8)
-                       ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
-                             Join Filter: a.a = b.x
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   Filter: a.b = $0
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.18..2.19 rows=1 width=8)
+                 ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
+                       Join Filter: a.a = b.x
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             Filter: a.b = $0
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=off; enable_nestloop=on; optimizer=off
  Optimizer status: legacy query optimizer
-(18 rows)
+(17 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
  d 
@@ -851,31 +850,30 @@ set enable_nestloop to off;
 set enable_hashjoin to off;
 set enable_mergejoin to on;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.33 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.33 rows=1 width=4)
+                                                        QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.46 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.46 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.14..2.15 rows=1 width=8)
-                 ->  Aggregate  (cost=2.08..2.09 rows=1 width=8)
-                       ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
-                             Merge Cond: a.a = b.x
-                             ->  Sort  (cost=1.02..1.03 rows=1 width=4)
-                                   Sort Key: a.a
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         Filter: a.b = $0
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Sort  (cost=1.02..1.02 rows=1 width=4)
-                                   Sort Key: b.x
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.21..2.22 rows=1 width=8)
+                 ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
+                       Merge Cond: a.a = b.x
+                       ->  Sort  (cost=1.02..1.03 rows=1 width=4)
+                             Sort Key: a.a
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   Filter: a.b = $0
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+                             Sort Key: b.x
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=on; enable_nestloop=off; optimizer=off
  Optimizer status: legacy query optimizer
-(22 rows)
+(21 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
  d 

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -834,19 +834,18 @@ explain select (select count(*) from (select 'random' from t_join_squelch_a a jo
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.26 rows=2 width=4)
    ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.26 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.11..2.12 rows=1 width=8)
-                 ->  Aggregate  (cost=2.05..2.06 rows=1 width=8)
-                       ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
-                             Join Filter: a.a = b.x
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   Filter: a.b = $0
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+          ->  Aggregate  (cost=2.18..2.19 rows=1 width=8)
+                 ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
+                       Join Filter: a.a = b.x
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             Filter: a.b = $0
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=off; enable_nestloop=on; optimizer=off
  Optimizer status: legacy query optimizer
 (18 rows)
@@ -867,23 +866,22 @@ explain select (select count(*) from (select 'random' from t_join_squelch_a a jo
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.33 rows=2 width=4)
    ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.33 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.14..2.15 rows=1 width=8)
-                 ->  Aggregate  (cost=2.08..2.09 rows=1 width=8)
-                       ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
-                             Merge Cond: a.a = b.x
-                             ->  Sort  (cost=1.02..1.03 rows=1 width=4)
-                                   Sort Key: a.a
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         Filter: a.b = $0
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Sort  (cost=1.02..1.02 rows=1 width=4)
-                                   Sort Key: b.x
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.21..2.22 rows=1 width=8)
+                 ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
+                       Merge Cond: a.a = b.x
+                       ->  Sort  (cost=1.02..1.03 rows=1 width=4)
+                             Sort Key: a.a
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   Filter: a.b = $0
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+                             Sort Key: b.x
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=on; enable_nestloop=off; optimizer=off
  Optimizer status: legacy query optimizer
 (22 rows)

--- a/src/test/regress/expected/subselect_gp_indexes.out
+++ b/src/test/regress/expected/subselect_gp_indexes.out
@@ -1,0 +1,109 @@
+--
+-- Test correlated subquery in subplan with motion chooses correct scan type
+--
+-- Given distributed table
+create table subplan_motion_t
+(a bigint NOT NULL) DISTRIBUTED BY (a);
+-- with constraint
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (a);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subplan_motion_t_pkey" for table "subplan_motion_t"
+-- and some data
+insert into subplan_motion_t
+select gen from generate_series(1, 20000) gen;
+-- Check that Index Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
+(1 row)
+
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+                                            QUERY PLAN
+--------------------------------------------------------------------------------------------------
+ Subquery Scan cte  (cost=0.00..274.02 rows=1 width=4)
+   Filter: ((subplan)) IS NOT NULL
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   SubPlan 1
+     ->  Result  (cost=274.00..274.01 rows=1 width=8)
+           Filter: subplan_motion_t.a = $0
+           ->  Materialize  (cost=274.00..274.01 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=8)
+                       ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=8)
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- Check that TID Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+NOTICE:  SELECT uses system-defined column "subplan_motion_t.ctid" without the necessary companion column "subplan_motion_t.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+ b
+---
+ 7
+(1 row)
+
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+NOTICE:  SELECT uses system-defined column "subplan_motion_t.ctid" without the necessary companion column "subplan_motion_t.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Subquery Scan cte  (cost=0.00..598.02 rows=1 width=4)
+   Filter: ((subplan)) IS NOT NULL
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   SubPlan 2
+     ->  Result  (cost=598.00..598.01 rows=1 width=8)
+           Filter: public.subplan_motion_t.ctid = $0 AND public.subplan_motion_t.a = $1
+           ->  Materialize  (cost=598.00..598.01 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=274.00..598.00 rows=1 width=8)
+                       ->  Seq Scan on subplan_motion_t  (cost=274.00..598.00 rows=1 width=8)
+                             InitPlan  (slice3)
+                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=6)
+                                     ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=6)
+                                           Filter: a = 7
+ Optimizer status: legacy query optimizer
+(14 rows)
+
+set enable_indexscan = off;
+set enable_bitmapscan = on;
+-- Check that Bitmap Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
+(1 row)
+
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+        where(select u.a from (select * from subplan_motion_t) u
+              where u.a = cte."b") is not null;
+                                            QUERY PLAN
+--------------------------------------------------------------------------------------------------
+ Subquery Scan cte  (cost=0.00..274.02 rows=1 width=4)
+   Filter: ((subplan)) IS NOT NULL
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   SubPlan 1
+     ->  Result  (cost=274.00..274.01 rows=1 width=8)
+           Filter: subplan_motion_t.a = $0
+           ->  Materialize  (cost=274.00..274.01 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=8)
+                       ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=8)
+ Settings:  enable_bitmapscan=on; enable_indexscan=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
+-- start_ignore
+drop table if exists subplan_motion_t;
+-- end_ignore

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -1,0 +1,117 @@
+--
+-- Test correlated subquery in subplan with motion chooses correct scan type
+--
+-- Given distributed table
+create table subplan_motion_t
+(a bigint NOT NULL) DISTRIBUTED BY (a);
+-- with constraint
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (a);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subplan_motion_t_pkey" for table "subplan_motion_t"
+-- and some data
+insert into subplan_motion_t
+select gen from generate_series(1, 20000) gen;
+-- Check that Index Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
+(1 row)
+
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..447546.78 rows=1 width=4)
+   Filter: NOT ((subplan)) IS NULL
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   SubPlan 1
+     ->  Result  (cost=0.00..6.00 rows=1 width=8)
+           Filter: a = $0
+           ->  Materialize  (cost=0.00..6.00 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
+                       ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=8)
+                             Index Cond: a = 7
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.2
+(13 rows)
+
+-- Check that TID Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
+(1 row)
+
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+                                                                    QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..464961450.41 rows=1 width=4)
+   Filter: NOT ((subplan)) IS NULL
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   SubPlan 2
+     ->  Result  (cost=0.00..453632.86 rows=1 width=8)
+           Filter: public.subplan_motion_t.a = $0
+           ->  Materialize  (cost=0.00..453632.86 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..453632.86 rows=1 width=8)
+                       ->  Result  (cost=0.00..453632.86 rows=1 width=8)
+                             ->  Result  (cost=0.00..453632.86 rows=1 width=8)
+                                   Filter: public.subplan_motion_t.ctid = ((subplan))
+                                   ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=14)
+                                         Index Cond: a = 7
+                                   SubPlan 1
+                                     ->  Materialize  (cost=0.00..6.00 rows=1 width=6)
+                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=6)
+                                                 ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=6)
+                                                       Index Cond: a = 7
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.2
+(21 rows)
+
+set enable_indexscan = off;
+set enable_bitmapscan = on;
+-- Check that Bitmap Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
+(1 row)
+
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+        where(select u.a from (select * from subplan_motion_t) u
+              where u.a = cte."b") is not null;
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..447546.78 rows=1 width=4)
+   Filter: NOT ((subplan)) IS NULL
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   SubPlan 1
+     ->  Result  (cost=0.00..6.00 rows=1 width=8)
+           Filter: a = $0
+           ->  Materialize  (cost=0.00..6.00 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
+                       ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=8)
+                             Index Cond: a = 7
+ Settings:  enable_bitmapscan=on; enable_indexscan=off; optimizer=on
+ Optimizer status: PQO version 3.114.2
+ (13 rows)
+
+-- start_ignore
+drop table if exists subplan_motion_t;
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -62,7 +62,7 @@ test: dtm_retry
 
 # The appendonly test cannot be run concurrently with tests that have
 # serializable transactions (may conflict with AO vacuum operations).
-test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
+test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish subselect_gp_indexes
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.

--- a/src/test/regress/sql/subselect_gp_indexes.sql
+++ b/src/test/regress/sql/subselect_gp_indexes.sql
@@ -1,0 +1,47 @@
+--
+-- Test correlated subquery in subplan with motion chooses correct scan type
+--
+-- Given distributed table
+create table subplan_motion_t
+(a bigint NOT NULL) DISTRIBUTED BY (a);
+-- with constraint
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (a);
+-- and some data
+insert into subplan_motion_t
+select gen from generate_series(1, 20000) gen;
+
+-- Check that Index Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+
+-- Check that TID Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+
+set enable_indexscan = off;
+set enable_bitmapscan = on;
+
+-- Check that Bitmap Scan is not used
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+-- Plan
+explain select cte."b" from (select 7 as "b" ) cte
+        where(select u.a from (select * from subplan_motion_t) u
+              where u.a = cte."b") is not null;
+
+-- start_ignore
+drop table if exists subplan_motion_t;
+-- end_ignore


### PR DESCRIPTION
The problem is that `indexscan` cannot be used together with `Motion` node.  So we have to import a commit from 6x to fix it.
https://github.com/greenplum-db/gpdb/commit/cd055f999f87c8bd381cc3fd7a64ee94dfa46073

## Steps to reproduce 
1. Create table
```sql
CREATE SCHEMA test_schema;

CREATE TABLE test_schema.users_unmasked (
  user_id bigint NOT NULL,
  params text
) DISTRIBUTED BY (user_id);

ALTER TABLE ONLY test_schema.users_unmasked
ADD CONSTRAINT users_20171219_pkey PRIMARY KEY (user_id);

INSERT INTO test_schema.users_unmasked
SELECT
  gen,
  case when random() > 0.5 then 'A' else 'B' end
FROM generate_series(1,20000) gen;
```
2. Run two queries. The second one returns incorrect data, because of incorrect plan with indexscan node without Motion.
```sql
SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
  SELECT
      u.user_id
  FROM
      test_schema.users_unmasked u
  WHERE
      u.user_id = cte."userId"
) is not null;

SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
  SELECT
     u.user_id
  FROM
      (select * from test_schema.users_unmasked) u
  WHERE
      u.user_id = cte."userId"
) IS NOT NULL;
```