### PR TITLE
(backport to 6x) Init holdTillEndXact and add asserts.

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1254,6 +1254,10 @@ SetupLockInTable(LockMethod lockMethodTable, PGPROC *proc,
 		lock->nGranted = 0;
 		MemSet(lock->requested, 0, sizeof(int) * MAX_LOCKMODES);
 		MemSet(lock->granted, 0, sizeof(int) * MAX_LOCKMODES);
+		/*
+		 * By default, holdTillEndXact is true only for LOCKTAG_TRANSACTION
+		 */
+		lock->holdTillEndXact = locktag->locktag_type == LOCKTAG_TRANSACTION;
 		LOCK_PRINT("LockAcquire: new", lock, lockmode);
 	}
 	else
@@ -1263,6 +1267,16 @@ SetupLockInTable(LockMethod lockMethodTable, PGPROC *proc,
 		Assert((lock->nGranted >= 0) && (lock->granted[lockmode] >= 0));
 		Assert(lock->nGranted <= lock->nRequested);
 	}
+
+	/*
+	 * holdTillEndXact must be true for LOCKTAG_TRANSACTION and
+	 * false for LOCKTAG_RELATION_EXTEND no matter if it is a new lock or
+	 * an existing lock
+	 */
+	AssertImply(locktag->locktag_type == LOCKTAG_TRANSACTION,
+				lock->holdTillEndXact);
+	AssertImply(locktag->locktag_type == LOCKTAG_RELATION_EXTEND,
+				!(lock->holdTillEndXact));
 
 	/*
 	 * Create the hash key for the proclock table.
@@ -2149,6 +2163,27 @@ LockRelease(const LOCKTAG *locktag, LOCKMODE lockmode, bool sessionLock)
 			 lockMethodTable->lockModeNames[lockmode]);
 		RemoveLocalLock(locallock);
 		return FALSE;
+	}
+
+	/*
+	 * There are 3 possibilities for holdTillEndXact:
+	 * 1. must be true for LOCKTAG_TRANSACTION
+	 * 2. might be true or false for LOCKTAG_RELATION
+	 * 3. must be false for others
+	 */
+	if(locktag->locktag_type == LOCKTAG_TRANSACTION)
+	{
+		/* must be true */
+		Assert(lock->holdTillEndXact);
+	}
+	else if(locktag->locktag_type == LOCKTAG_RELATION)
+	{
+		/* might be true or false, no assert */
+	}
+	else
+	{
+		/* must be false for others */
+		Assert(!(lock->holdTillEndXact));
 	}
 
 	/*

--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -73,16 +73,10 @@ lockEqual(LockInstanceData *lock1, LockInstanceData *lock2)
 static bool
 lockIsHoldTillEndXact(LockInstanceData *lock)
 {
-	LOCKTAG		*tag = &lock->locktag;
-
 	if (lock->holdTillEndXact)
 		return true;
 
-	if (tag->locktag_type == LOCKTAG_TRANSACTION)
-		return true;
-
 	/* FIXME: other types */
-
 	return false;
 }
 


### PR DESCRIPTION
The fix is from github issue 11923, which is about some incorrect behavior due to that holdTillEndXact is not initialized:

Basically the change includes:

1. Setting holdTillEndXact to false in the initialization block.
2. Adding an assert to check if holdTillEndXact is false when a lock with type LOCKTAG_RELATION_EXTEND is released.

No extra test case was added, because the change is related to all actions requiring a lock, which have been covered by existing tests.

----------------

Cherry-pick https://github.com/greenplum-db/gpdb/commit/036a31bdd24226d7977ef780796e281750764b67 and https://github.com/greenplum-db/gpdb/commit/2145129d631ee1fee409f805296b16962818af14 from master to 6X.

I also squash the two commits into one.
