### PR TITLE
Fix assertion failure for GroupingFunc with subqueries

### DIFF
--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -2932,6 +2932,9 @@ View definition:
    FROM sale
   GROUP BY ROLLUP (sale.cn, (sale.vn, sale.pn, sale.dt));
 
+-- GroupingFunc with subqueries
+select (select grouping(v1)) from (values ((select 1))) v(v1);
+ERROR:  column "v"."v1" is not in GROUP BY
 -- GROUP_ID function --
 select pn, sum(qty), group_id() from sale group by rollup(pn);
  pn  | sum  | ?column? 

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -348,6 +348,9 @@ create view rollup_nested_rowexpr_view as
 select cn, vn, pn, dt, count(distinct dt) from sale group by rollup(cn, (vn, (pn, dt)));
 \d+ rollup_nested_rowexpr_view
 
+-- GroupingFunc with subqueries
+select (select grouping(v1)) from (values ((select 1))) v(v1);
+
 -- GROUP_ID function --
 
 select pn, sum(qty), group_id() from sale group by rollup(pn);


### PR DESCRIPTION
Retrieve the correct pstate for GroupingFunc according to varlevelsup

Fixes #12343

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
