### PR TITLE
[6X]Make the GUC log_min_error_statement working for GPDB

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4984,7 +4984,7 @@ PostgresMain(int argc, char *argv[],
 		 */
 		if (debug_query_string != NULL)
 		{
-			elog(LOG, "An exception was encountered during the execution of statement: %s", debug_query_string);
+			elog_exception_statement(debug_query_string);
 			debug_query_string = NULL;
 		}
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -2091,6 +2091,30 @@ pg_re_throw(void)
 						 __FILE__, __LINE__);
 }
 
+/*
+ * GPDB: elog_exception_statement
+ * Write statement in log file if an exception was encountered during
+ * its execution.
+ */
+void
+elog_exception_statement(const char* statement)
+{
+	ErrorData  *edata = NULL;
+
+	if (errordata_stack_depth < 0 || statement == NULL)
+		return;
+
+	edata = &errordata[errordata_stack_depth];
+	/*
+	 * We should also honour whether hide the statement and GUC
+	 * log_min_error_statement to prevent print the statement
+	 * when error happens.
+	 */
+	if (!edata->hide_stmt &&
+		is_log_level_output(edata->elevel, log_min_error_statement))
+		elog(LOG, "An exception was encountered during the execution of statement: %s",
+			 statement);
+}
 
 /*
  * CDB: elog_demote
@@ -3952,7 +3976,11 @@ write_syslogger_in_csv(ErrorData *edata, bool amsyslogger)
 	write_syslogger_file_string(edata->context, amsyslogger, true);
 
 	/* user query */
-	write_syslogger_file_string(debug_query_string, amsyslogger, true);
+	if (!edata->hide_stmt &&
+		is_log_level_output(edata->elevel, log_min_error_statement))
+		write_syslogger_file_string(debug_query_string, amsyslogger, true);
+	else
+		write_syslogger_file_string("", amsyslogger, true);
 
 	/* cursor pos */
 	syslogger_write_int32(true, "", edata->cursorpos, amsyslogger, true);
@@ -4107,7 +4135,10 @@ write_message_to_server_log(int elevel,
 	append_string_to_pipe_chunk(&buffer, context);
 
 	/* debug_query_string */
-	append_string_to_pipe_chunk(&buffer, query_text);
+	if (is_log_level_output(elevel, log_min_error_statement))
+		append_string_to_pipe_chunk(&buffer, query_text);
+	else
+		append_string_to_pipe_chunk(&buffer, NULL);
 
 	/* error_func_name */
 	if (show_funcname)

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -515,6 +515,13 @@ extern PGDLLIMPORT emit_log_hook_type emit_log_hook;
 extern ErrorData *errfinish_and_return(int dummy,...);
 
 /*
+ * GPDB: elog_exception_statement
+ * Write statement in log file if an exception was encountered during
+ * its execution.
+ */
+extern void	elog_exception_statement(const char* statement);
+
+/*
  * CDB: elog_demote
  *
  * A PG_CATCH() handler can call this to downgrade the error that it is

--- a/src/test/regress/expected/log_guc.out
+++ b/src/test/regress/expected/log_guc.out
@@ -1,0 +1,110 @@
+-- Test the log related GUCs
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+set log_min_error_statement = error;
+-- Case 1, test the log_min_error_statement GUC for coordinator log
+-- the error statement will be logged as default
+creat table log_aaa (id int, c text); -- this should raise error
+ERROR:  syntax error at or near "creat"
+LINE 1: creat table log_aaa (id int, c text);
+        ^
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='ERROR' and logmessage like '%"creat"%' order by logtime desc limit 1;
+ logseverity |           logmessage            |               logdebug                
+-------------+---------------------------------+---------------------------------------
+ ERROR       | syntax error at or near "creat" | creat table log_aaa (id int, c text);
+(1 row)
+
+-- should contain the log from elog_exception_statement()
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='LOG' and logmessage like '%exception was encountered%'
+and logmessage not like '%__gp_log_master_ext%'
+order by logtime desc limit 1;
+ logseverity |                                              logmessage                                               |               logdebug                
+-------------+-------------------------------------------------------------------------------------------------------+---------------------------------------
+ LOG         | An exception was encountered during the execution of statement: creat table log_aaa (id int, c text); | creat table log_aaa (id int, c text);
+(1 row)
+
+-- set log_min_error_statement to panic to skip log the error statement
+set log_min_error_statement = panic;
+creat table log_aaa (id int, c text); -- this should raise error
+ERROR:  syntax error at or near "creat"
+LINE 1: creat table log_aaa (id int, c text);
+        ^
+-- logdebug should be null
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='ERROR' and logmessage like '%"creat"%' order by logtime desc limit 1;
+ logseverity |           logmessage            | logdebug 
+-------------+---------------------------------+----------
+ ERROR       | syntax error at or near "creat" | 
+(1 row)
+
+-- this should only show the two select and log from elog_exception_statement() is not included
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='LOG' and logmessage like '%exception was encountered%'
+order by logtime desc limit 2;
+ logseverity |                                       logmessage                                        |                                   logdebug                                   
+-------------+-----------------------------------------------------------------------------------------+------------------------------------------------------------------------------
+ LOG         | statement: select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext+| 
+             | where logseverity='LOG' and logmessage like '%exception was encountered%'              +| 
+             | order by logtime desc limit 2;                                                          | 
+ LOG         | statement: select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext+| select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext+
+             | where logseverity='LOG' and logmessage like '%exception was encountered%'              +| where logseverity='LOG' and logmessage like '%exception was encountered%'   +
+             | and logmessage not like '%__gp_log_master_ext%'                                        +| and logmessage not like '%__gp_log_master_ext%'                             +
+             | order by logtime desc limit 1;                                                          | order by logtime desc limit 1;
+(2 rows)
+
+set log_min_error_statement = error;
+-- Case 2, test the log_min_error_statement GUC for segments log
+-- the error statement will be logged as default
+create table log_test(id int, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into log_test select i, 'test' from generate_series(1, 10) as i;
+-- use fault inject to trigger error
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'error', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from log_test;
+ERROR:  fault triggered, fault name:'qe_got_snapshot_and_interconnect' fault type:'error'  (seg0 slice1 192.168.33.11:6002 pid=9061)
+select gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_segment_ext
+where logseverity='ERROR' and logsegment = 'seg0' and logmessage like '%fault triggered%'
+order by logtime desc limit 1;
+ logseverity |                                    logmessage                                     |        logdebug         
+-------------+-----------------------------------------------------------------------------------+-------------------------
+ ERROR       | fault triggered, fault name:'qe_got_snapshot_and_interconnect' fault type:'error' | select * from log_test;
+(1 row)
+
+set log_min_error_statement = panic;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'error', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from log_test;
+ERROR:  fault triggered, fault name:'qe_got_snapshot_and_interconnect' fault type:'error'  (seg0 slice1 192.168.33.11:6002 pid=9061)
+select gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- logdebug should be null
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_segment_ext
+where logseverity='ERROR' and logsegment = 'seg0' and logmessage like '%fault triggered%'
+order by logtime desc limit 1;
+ logseverity |                                    logmessage                                     | logdebug 
+-------------+-----------------------------------------------------------------------------------+----------
+ ERROR       | fault triggered, fault name:'qe_got_snapshot_and_interconnect' fault type:'error' | 
+(1 row)
+
+set log_min_error_statement = error;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -20,6 +20,7 @@
 # vacuum from removing dead tuples. And run gp_toolkit early to make some log
 # file related tests (like gp_log_system, etc) faster.
 test: gp_toolkit
+test: log_guc
 
 # enable query metrics cluster GUC
 test: instr_in_shmem_setup

--- a/src/test/regress/sql/log_guc.sql
+++ b/src/test/regress/sql/log_guc.sql
@@ -1,0 +1,55 @@
+-- Test the log related GUCs
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+set log_min_error_statement = error;
+
+-- Case 1, test the log_min_error_statement GUC for coordinator log
+-- the error statement will be logged as default
+creat table log_aaa (id int, c text); -- this should raise error
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='ERROR' and logmessage like '%"creat"%' order by logtime desc limit 1;
+
+-- should contain the log from elog_exception_statement()
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='LOG' and logmessage like '%exception was encountered%'
+and logmessage not like '%__gp_log_master_ext%'
+order by logtime desc limit 1;
+
+-- set log_min_error_statement to panic to skip log the error statement
+set log_min_error_statement = panic;
+creat table log_aaa (id int, c text); -- this should raise error
+-- logdebug should be null
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='ERROR' and logmessage like '%"creat"%' order by logtime desc limit 1;
+
+-- this should only show the two select and log from elog_exception_statement() is not included
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_master_ext
+where logseverity='LOG' and logmessage like '%exception was encountered%'
+order by logtime desc limit 2;
+set log_min_error_statement = error;
+
+
+-- Case 2, test the log_min_error_statement GUC for segments log
+-- the error statement will be logged as default
+create table log_test(id int, c text);
+insert into log_test select i, 'test' from generate_series(1, 10) as i;
+
+-- use fault inject to trigger error
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'error', 2);
+select * from log_test;
+select gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_segment_ext
+where logseverity='ERROR' and logsegment = 'seg0' and logmessage like '%fault triggered%'
+order by logtime desc limit 1;
+
+set log_min_error_statement = panic;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'error', 2);
+select * from log_test;
+select gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
+-- logdebug should be null
+select logseverity, logmessage, logdebug from gp_toolkit.__gp_log_segment_ext
+where logseverity='ERROR' and logsegment = 'seg0' and logmessage like '%fault triggered%'
+order by logtime desc limit 1;
+
+set log_min_error_statement = error;
+


### PR DESCRIPTION
When writing server log, GPDB always write out the statement string and
ignore the GUC log_min_error_statement. So fix it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
