### PR TITLE
(backport to 5x) Fix query string truncation while writing it to server logs

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -2916,7 +2916,7 @@ append_string_to_pipe_chunk(PipeProtoChunk *buffer, const char* input)
 	 */
 	if (len >= PIPE_MAX_PAYLOAD * 20)
 	{
-		len = PIPE_MAX_PAYLOAD * 20 - 1;
+		len = pg_mbcliplen(input, len, PIPE_MAX_PAYLOAD * 20 - 1);
 	}
 
 	char *data = buffer->data + buffer->hdr.len;


### PR DESCRIPTION
Long queries are truncated when logged. This wasn't done correctly
because it doesn't consider the encoding. This results in some utf
characters being truncated in the middle.

------------

cherry-pick https://github.com/greenplum-db/gpdb/commit/24f51bb06b8595ca2dc583004b5191fad72f4e4c
to 5X.
