### PR TITLE
(backport to 5x) Don't append duplicated initplans even if referred at multi places.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -3092,13 +3092,14 @@ fixup_subplan_walker(Node *node, SubPlanWalkerContext *context)
 		 * while traversing the plan
 		 */
 			context->bms_subplans = bms_add_member(context->bms_subplans, plan_id);
-		else
+		else if (!((SubPlan *) node)->is_initplan)
 		{
 			/*
 			 * If plan_id is already available in the bitmapset, it means that there is
 			 * more than one subplan node which refer to the same plan_id. In this case
 			 * create a duplicate subplan, append it to the glob->subplans and update the plan_id
-			 * of the subplan to refer to the new copy of the subplan node
+			 * of the subplan to refer to the new copy of the subplan node and initplans are
+			 * not needed to be duplicated.
 			 */
 			PlannerInfo *root = (PlannerInfo *)context->base.node;
 			Plan *dupsubplan = (Plan *) copyObject(planner_subplan_get_plan(root, subplan));

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1975,6 +1975,93 @@ SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedu
  4 | 4
 (4 rows)
 
+-- Regression of duplicated initplans of a partitioned table
+DROP TABLE IF EXISTS foo, lookup_table;
+NOTICE:  table "lookup_table" does not exist, skipping
+CREATE TABLE foo(a int, b text, c timestamp)
+  DISTRIBUTED BY (a)
+    PARTITION BY LIST(b) (VALUES('a'), VALUES('b'));
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+    INSERT INTO foo VALUES (1, 'a', '2012-12-12 13:00');
+    INSERT INTO foo VALUES (2, 'b', '2012-12-13 12:00');
+CREATE TABLE lookup_table(a text, c timestamp)
+  DISTRIBUTED BY (a);
+  INSERT INTO lookup_table VALUES ('a', '2012-12-12 12:00');
+  INSERT INTO lookup_table VALUES ('b', '2021-12-21 21:00');
+CREATE OR REPLACE FUNCTION my_lookup(a_in text) RETURNS timestamp AS
+$$
+DECLARE
+   c_var timestamp;
+   BEGIN
+      BEGIN
+            SELECT c INTO c_var FROM lookup_table WHERE a = a_in;
+	       END;
+	          RETURN c_var;
+		  END;
+		  $$
+		  LANGUAGE plpgsql NO SQL;
+SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.c > (SELECT my_lookup('a')));
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+-- The following case is from Github Issue:
+-- https://github.com/greenplum-db/gpdb/issues/12353
+drop table if exists rank;
+NOTICE:  table "rank" does not exist, skipping
+create table
+  rank_12353 (id int, rank int, year int, gender char(1))
+  distributed by (id)
+  partition by range (year)
+  ( start (2006) end (2016) every (1),
+    default partition extra );
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_extra" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_2" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_3" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_4" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_5" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_6" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_7" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_8" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_9" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_10" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_11" for table "rank_12353"
+create or replace function f_12353(i integer) returns integer as
+$$
+DECLARE
+a integer;
+begin
+  select 1 into a;
+    return a;
+    end;
+    $$
+language plpgsql no sql;
+select
+  count(1)
+from rank_12353
+where
+  (
+    (
+      select
+        case
+          when gender = 'm' and
+               (
+                 (select
+                   f_12353(5) as x)
+               ) = 1
+               then 1
+          else 0
+        end as y
+    )
+  ) = 0;
+ count 
+-------
+     0
+(1 row)
+
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2088,6 +2088,93 @@ SELECT * FROM dedup_test1 WHERE NOT EXISTS (SELECT 1 FROM dedup_test2 WHERE dedu
  2 | 2
 (4 rows)
 
+-- Regression of duplicated initplans of a partitioned table
+DROP TABLE IF EXISTS foo, lookup_table;
+NOTICE:  table "lookup_table" does not exist, skipping
+CREATE TABLE foo(a int, b text, c timestamp)
+  DISTRIBUTED BY (a)
+    PARTITION BY LIST(b) (VALUES('a'), VALUES('b'));
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+    INSERT INTO foo VALUES (1, 'a', '2012-12-12 13:00');
+    INSERT INTO foo VALUES (2, 'b', '2012-12-13 12:00');
+CREATE TABLE lookup_table(a text, c timestamp)
+  DISTRIBUTED BY (a);
+  INSERT INTO lookup_table VALUES ('a', '2012-12-12 12:00');
+  INSERT INTO lookup_table VALUES ('b', '2021-12-21 21:00');
+CREATE OR REPLACE FUNCTION my_lookup(a_in text) RETURNS timestamp AS
+$$
+DECLARE
+   c_var timestamp;
+   BEGIN
+      BEGIN
+            SELECT c INTO c_var FROM lookup_table WHERE a = a_in;
+	       END;
+	          RETURN c_var;
+		  END;
+		  $$
+		  LANGUAGE plpgsql NO SQL;
+SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.c > (SELECT my_lookup('a')));
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+-- The following case is from Github Issue:
+-- https://github.com/greenplum-db/gpdb/issues/12353
+drop table if exists rank;
+NOTICE:  table "rank" does not exist, skipping
+create table
+  rank_12353 (id int, rank int, year int, gender char(1))
+  distributed by (id)
+  partition by range (year)
+  ( start (2006) end (2016) every (1),
+    default partition extra );
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_extra" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_2" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_3" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_4" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_5" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_6" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_7" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_8" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_9" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_10" for table "rank_12353"
+NOTICE:  CREATE TABLE will create partition "rank_12353_1_prt_11" for table "rank_12353"
+create or replace function f_12353(i integer) returns integer as
+$$
+DECLARE
+a integer;
+begin
+  select 1 into a;
+    return a;
+    end;
+    $$
+language plpgsql no sql;
+select
+  count(1)
+from rank_12353
+where
+  (
+    (
+      select
+        case
+          when gender = 'm' and
+               (
+                 (select
+                   f_12353(5) as x)
+               ) = 1
+               then 1
+          else 0
+        end as y
+    )
+  ) = 0;
+ count 
+-------
+     0
+(1 row)
+
 -- start_ignore
 DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;


### PR DESCRIPTION
We do that for normal subplans, but it's not needed for initplans which
only executed once.

See Github Issue: https://github.com/greenplum-db/gpdb/issues/12353

Backport 70e397ede

