### PR TITLE
Stabilize the test resutls for gp_aggregates

### DIFF
--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -495,7 +495,7 @@ insert into agg_b values (1, 1, 1, 1);
 -- `AGGSTAGE_FINAL` stage and cause a crash since the type expected here should be numeric, but
 -- get a int value when executing numeric_avg_deserialize.
 set enable_groupagg = false;
-set optimizer_enable_groupagg = false; -- to force orca generate same plan
+set optimizer = off; -- the case is planner only, so disable orca
 explain (costs off, verbose)
 SELECT bb.v::text, count(distinct a.a), avg(a.c)	-- note the type cast
 FROM agg_a a
@@ -646,5 +646,5 @@ GROUP BY bb.v;
  1 |     1 |     1 | 100.0000000000000000
 (1 row)
 
-reset optimizer_enable_groupagg;
+reset optimizer;
 reset enable_groupagg;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -206,7 +206,7 @@ insert into agg_b values (1, 1, 1, 1);
 -- get a int value when executing numeric_avg_deserialize.
 
 set enable_groupagg = false;
-set optimizer_enable_groupagg = false; -- to force orca generate same plan
+set optimizer = off; -- the case is planner only, so disable orca
 explain (costs off, verbose)
 SELECT bb.v::text, count(distinct a.a), avg(a.c)	-- note the type cast
 FROM agg_a a
@@ -245,5 +245,5 @@ Join ( SELECT b.b,
 		FROM agg_b b) as bb
 ON a.a = bb.b
 GROUP BY bb.v;
-reset optimizer_enable_groupagg;
+reset optimizer;
 reset enable_groupagg;


### PR DESCRIPTION
Previous commit d87d5e6bf8eb9605d2349e938c813f0622cfccd7 use GUC
optimizer_enable_groupagg to force orca generate same plan with
planner for a test, but seems it can not guarantee this right now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
