### PR TITLE
Dump extension functions under pg_catalog for 5X

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6792,7 +6792,14 @@ getFuncs(Archive *fout, int *numFuncs)
 							  "\n  OR p.oid = pg_transform.trftosql))",
 							  g_last_builtin_oid);
 
+/*
+ * GPDB: Much of the extension machinery was backported into GPDB 5 from higher
+ * major versions. So include the clause if we are running against GPDB 5.
+ */
+#if 0
 		if (dopt->binary_upgrade && fout->remoteVersion >= 90100)
+#endif
+		if (dopt->binary_upgrade && fout->remoteVersion >= 80300)
 			appendPQExpBufferStr(query,
 								 "\n  OR EXISTS(SELECT 1 FROM pg_depend WHERE "
 								 "classid = 'pg_proc'::regclass AND "


### PR DESCRIPTION
This is a forward port of 6X_STABLE commit: bdad273 in order to
support upgrading extensions that install dependent functions under
pg_catalog in a 5X->7X+ upgrade path.

Original commit message follows:

------------------------------------------------------------------------

This ensures that when pg_dump is invoked in binary_upgrade mode against
a 5X cluster during pg_upgrade, it collects and dumps the functions
under pg_catalog belonging to an extension.

We found this bug when we tried to upgrade PXF and PXF's functions
did not get dumped in binary upgrade mode. (PXF's functions are created
under pg_catalog)

This change in 6X should have accompanied the backport of the
extension machinery into 5X.

------------------------------------------------------------------------

Co-authored-by: Kalen Krempely <kkrempely@vmware.com>