### PR TITLE
Sandbox escape with CVE-2020-25695

### DIFF
--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -646,6 +646,10 @@ pgfdw_report_error(int elevel, PGresult *res, PGconn *conn,
 
 /*
  * pgfdw_xact_callback --- cleanup at main-transaction end.
+ *
+ * This runs just late enough that it must not enter user-defined code
+ * locally.  (Entering such code on the remote side is fine.  Its remote
+ * COMMIT TRANSACTION may run deferred triggers.)
  */
 static void
 pgfdw_xact_callback(XactEvent event, void *arg)

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2744,9 +2744,10 @@ CommitTransaction(void)
 
 	/*
 	 * Do pre-commit processing that involves calling user-defined code, such
-	 * as triggers.  Since closing cursors could queue trigger actions,
-	 * triggers could open cursors, etc, we have to keep looping until there's
-	 * nothing left to do.
+	 * as triggers.  SECURITY_RESTRICTED_OPERATION contexts must not queue an
+	 * action that would run here, because that would bypass the sandbox.
+	 * Since closing cursors could queue trigger actions, triggers could open
+	 * cursors, etc, we have to keep looping until there's nothing left to do.
 	 */
 	for (;;)
 	{
@@ -2764,15 +2765,15 @@ CommitTransaction(void)
 			break;
 	}
 
-	CallXactCallbacks(is_parallel_worker ? XACT_EVENT_PARALLEL_PRE_COMMIT
-					  : XACT_EVENT_PRE_COMMIT);
-
 	/*
 	 * The remaining actions cannot call any user-defined code, so it's safe
 	 * to start shutting down within-transaction services.  But note that most
 	 * of this stuff could still throw an error, which would switch us into
 	 * the transaction-abort path.
 	 */
+
+	CallXactCallbacks(is_parallel_worker ? XACT_EVENT_PARALLEL_PRE_COMMIT
+					  : XACT_EVENT_PRE_COMMIT);
 
 	/* If we might have parallel workers, clean them up now. */
 	if (IsInParallelMode())

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -556,6 +556,7 @@ cdbdisp_buildUtilityQueryParms(struct Node *stmt,
 	QueryDispatchDesc *qddesc;
 	PlannedStmt *pstmt;
 	DispatchCommandQueryParms *pQueryParms;
+	Oid	save_userid;
 
 	Assert(stmt != NULL);
 	Assert(stmt->type < 1000);
@@ -589,6 +590,7 @@ cdbdisp_buildUtilityQueryParms(struct Node *stmt,
 	{
 		qddesc = makeNode(QueryDispatchDesc);
 		qddesc->oidAssignments = oid_assignments;
+		GetUserIdAndSecContext(&save_userid, &qddesc->secContext);
 
 		serializedQueryDispatchDesc = serializeNode((Node *) qddesc, &serializedQueryDispatchDesc_len,
 													NULL /* uncompressed_size */ );
@@ -624,6 +626,7 @@ cdbdisp_buildPlanQueryParms(struct QueryDesc *queryDesc,
 				splan_len_uncompressed,
 				sddesc_len,
 				rootIdx;
+	Oid			save_userid;
 
 	rootIdx = RootSliceIndex(queryDesc->estate);
 
@@ -653,6 +656,7 @@ cdbdisp_buildPlanQueryParms(struct QueryDesc *queryDesc,
 
 	Assert(splan != NULL && splan_len > 0 && splan_len_uncompressed > 0);
 
+	GetUserIdAndSecContext(&save_userid, &queryDesc->ddesc->secContext);
 	sddesc = serializeNode((Node *) queryDesc->ddesc, &sddesc_len, NULL /* uncompressed_size */ );
 
 	pQueryParms->strCommand = queryDesc->sourceText;

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -30,6 +30,7 @@
 #include "executor/executor.h"
 #include "executor/tstoreReceiver.h"
 #include "rewrite/rewriteHandler.h"
+#include "miscadmin.h"
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"
 #include "utils/memutils.h"
@@ -71,6 +72,10 @@ PerformCursorOpen(DeclareCursorStmt *cstmt, ParamListInfo params,
 	 */
 	if (!(cstmt->options & CURSOR_OPT_HOLD))
 		RequireTransactionBlock(isTopLevel, "DECLARE CURSOR");
+	else if (InSecurityRestrictedOperation())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("cannot create a cursor WITH HOLD within security-restricted operation")));
 
 	/*
 	 * Parse analysis was done already, but we still have to run the rule

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -4494,6 +4494,7 @@ afterTriggerMarkEvents(AfterTriggerEventList *events,
 					   bool immediate_only)
 {
 	bool		found = false;
+	bool		deferred_found = false;
 	AfterTriggerEvent event;
 	AfterTriggerEventChunk *chunk;
 
@@ -4529,12 +4530,23 @@ afterTriggerMarkEvents(AfterTriggerEventList *events,
 		 */
 		if (defer_it && move_list != NULL)
 		{
+			deferred_found = true;
 			/* add it to move_list */
 			afterTriggerAddEvent(move_list, event, evtshared);
 			/* mark original copy "done" so we don't do it again */
 			event->ate_flags |= AFTER_TRIGGER_DONE;
 		}
 	}
+
+	/*
+	 * We could allow deferred triggers if, before the end of the
+	 * security-restricted operation, we were to verify that a SET CONSTRAINTS
+	 * ... IMMEDIATE has fired all such triggers.  For now, don't bother.
+	 */
+	if (deferred_found && InSecurityRestrictedOperation())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("cannot fire deferred trigger within security-restricted operation")));
 
 	return found;
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -161,6 +161,7 @@ _copyQueryDispatchDesc(const QueryDispatchDesc *from)
 	COPY_NODE_FIELD(oidAssignments);
 	COPY_NODE_FIELD(cursorPositions);
 	COPY_SCALAR_FIELD(useChangedAOOpts);
+	COPY_SCALAR_FIELD(secContext);
 	COPY_NODE_FIELD(paramInfo);
 
 	return newnode;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -405,6 +405,7 @@ _outQueryDispatchDesc(StringInfo str, const QueryDispatchDesc *node)
 	WRITE_NODE_FIELD(sliceTable);
 	WRITE_NODE_FIELD(cursorPositions);
 	WRITE_BOOL_FIELD(useChangedAOOpts);
+	WRITE_INT_FIELD(secContext);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -882,6 +882,7 @@ _readQueryDispatchDesc(void)
 	READ_NODE_FIELD(sliceTable);
 	READ_NODE_FIELD(cursorPositions);
 	READ_BOOL_FIELD(useChangedAOOpts);
+	READ_INT_FIELD(secContext);
 	READ_DONE();
 }
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1203,6 +1203,10 @@ exec_mpp_query(const char *query_string,
 		ddesc = (QueryDispatchDesc *) deserializeNode(serializedQueryDispatchDesc,serializedQueryDispatchDesclen);
 		if (!ddesc || !IsA(ddesc, QueryDispatchDesc))
 			elog(ERROR, "MPPEXEC: received invalid QueryDispatchDesc with planned statement");
+		/*
+		 * Deserialize and apply security context from QD.
+		 */
+		SetUserIdAndSecContext(GetUserId(), ddesc->secContext);
 
         sliceTable = ddesc->sliceTable;
 
@@ -5425,7 +5429,7 @@ PostgresMain(int argc, char *argv[],
 									   serializedPlantree, serializedPlantreelen,
 									   serializedQueryDispatchDesc, serializedQueryDispatchDesclen);
 
-					SetUserIdAndContext(GetOuterUserId(), false);
+					SetUserIdAndSecContext(GetOuterUserId(), 0);
 
 					send_ready_for_query = true;
 				}

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -229,6 +229,11 @@ typedef struct QueryDispatchDesc
 	 * set, use default reloptions + gp_default_storage_options.
 	 */
 	bool useChangedAOOpts;
+
+	/*
+	 * Security context flags.
+	 */
+	int		secContext;
 } QueryDispatchDesc;
 
 /*

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -2135,6 +2135,121 @@ revoke select on dep_priv_test from regress_priv_user4 cascade;
 
 set session role regress_priv_user1;
 drop table dep_priv_test;
+-- security-restricted operations
+\c -
+CREATE ROLE regress_sro_user;
+SET SESSION AUTHORIZATION regress_sro_user;
+CREATE FUNCTION unwanted_grant() RETURNS void LANGUAGE sql AS
+	'GRANT regress_priv_group2 TO regress_sro_user';
+CREATE FUNCTION mv_action() RETURNS bool LANGUAGE sql AS
+	'DECLARE c CURSOR WITH HOLD FOR SELECT unwanted_grant(); SELECT true';
+-- REFRESH of this MV will queue a GRANT at end of transaction
+CREATE MATERIALIZED VIEW sro_mv AS SELECT mv_action() WITH NO DATA;
+REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot create a cursor WITH HOLD within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
+\c -
+REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot create a cursor WITH HOLD within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
+SET SESSION AUTHORIZATION regress_sro_user;
+-- INSERT to this table will queue a GRANT at end of transaction
+CREATE TABLE sro_trojan_table ();
+CREATE FUNCTION sro_trojan() RETURNS trigger LANGUAGE plpgsql AS
+	'BEGIN PERFORM unwanted_grant(); RETURN NULL; END';
+CREATE CONSTRAINT TRIGGER t AFTER INSERT ON sro_trojan_table
+    INITIALLY DEFERRED FOR EACH ROW EXECUTE PROCEDURE sro_trojan();
+-- Now, REFRESH will issue such an INSERT, queueing the GRANT
+CREATE OR REPLACE FUNCTION mv_action() RETURNS bool LANGUAGE sql AS
+	'INSERT INTO sro_trojan_table DEFAULT VALUES; SELECT true';
+REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
+\c -
+REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
+BEGIN; SET allow_segment_DML = ON; SET CONSTRAINTS ALL IMMEDIATE; REFRESH MATERIALIZED VIEW sro_mv; COMMIT;
+ERROR:  must have admin option on role "regress_priv_group2"
+CONTEXT:  SQL function "unwanted_grant" statement 1
+SQL statement "SELECT unwanted_grant()"
+PL/pgSQL function sro_trojan() line 1 at PERFORM
+SQL function "mv_action" statement 1
+DROP OWNED BY regress_sro_user;
+DROP ROLE regress_sro_user;
+-- Test sandbox escape with CVE-2020-25695 on Greenplum.
+--
+-- The idea of CVE-2020-25695 is to make superuser fire a defered
+-- trigger with security invoker function that executes some malicious
+-- code with superuser privileges.
+--
+-- We create a two-step trap for a superuser running a maintenance
+-- operation (ANALYZE) on a "trap" table. First of all we create
+-- an index with stable function and replace it with volatile one after
+-- creation. This index function is invoked by ANALYZE and acts as a
+-- vulnerability firestarter - it inserts data to some table aside ("executor").
+-- "Executor" table has a defered insert trigger with security invoker
+-- function that executes malicious code under superuser. In a current example
+-- we give superuser to our unprivileged user on segments (not on coordinator node).
+\c -
+CREATE ROLE regress_sro_user;
+SET SESSION AUTHORIZATION regress_sro_user;
+CREATE TABLE executor (s varchar) DISTRIBUTED REPLICATED;
+CREATE TABLE trap (a int) WITH(appendonly = true) DISTRIBUTED REPLICATED;
+-- Create a "firestarter" stable index funcion
+CREATE OR REPLACE FUNCTION trap_sfunc(integer) RETURNS integer
+LANGUAGE sql IMMUTABLE AS
+'SELECT $1';
+CREATE INDEX trap_idx ON trap (trap_sfunc(a));
+-- and replace it with volatile security invoker to prodice insert operation on ANALYZE.
+CREATE OR REPLACE FUNCTION trap_sfunc(integer) RETURNS integer
+LANGUAGE sql SECURITY INVOKER AS
+'SET allow_segment_DML = ON; INSERT INTO executor VALUES (current_user); SELECT $1';
+-- Populate data in a "trap" table to run ANALYZE on.
+SET allow_segment_DML = ON;
+INSERT INTO trap VALUES(1);
+-- Create malicious function to run in defered trigger
+CREATE OR REPLACE FUNCTION executor_sfunc(integer) RETURNS integer
+LANGUAGE sql SECURITY INVOKER AS
+'SET allow_segment_DML = ON; ALTER USER regress_sro_user WITH superuser; SELECT $1';
+-- and the trigger itself.
+CREATE OR REPLACE FUNCTION executor_trig_sfunc() RETURNS trigger
+AS $$
+BEGIN PERFORM executor_sfunc(1000); RETURN NEW; END
+$$ LANGUAGE plpgsql;
+CREATE CONSTRAINT TRIGGER executor_trig
+AFTER INSERT ON executor
+INITIALLY DEFERRED FOR EACH ROW
+EXECUTE PROCEDURE executor_trig_sfunc();
+-- Check "regress_sro_user" superuser privileges on segments.
+CREATE OR REPLACE FUNCTION is_superuser_on_segments(username text) RETURNS boolean AS $$
+SELECT rolsuper FROM pg_roles WHERE rolname = $1;
+$$ LANGUAGE sql EXECUTE ON ALL SEGMENTS;
+SELECT DISTINCT is_superuser_on_segments('regress_sro_user');
+ is_superuser_on_segments 
+--------------------------
+ f
+(1 row)
+
+-- Execute a trap with superuser.
+RESET SESSION AUTHORIZATION;
+ANALYZE trap;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "trap_sfunc" statement 2
+-- Check "regress_sro_user" superuser privileges on segments.
+SELECT DISTINCT is_superuser_on_segments('regress_sro_user');
+ is_superuser_on_segments 
+--------------------------
+ f
+(1 row)
+
+DROP TABLE trap;
+DROP TABLE executor;
+DROP FUNCTION trap_sfunc(integer);
+DROP FUNCTION executor_sfunc(integer);
+DROP FUNCTION executor_trig_sfunc();
+DROP FUNCTION is_superuser_on_segments(text);
+DROP ROLE regress_sro_user;
 -- clean up
 \c
 drop sequence x_seq;


### PR DESCRIPTION
CVE-2020-25695 exploits vulnerability for enqueued security-restricted operations at commit code. Specifically defered triggers on index relations, materialize view refresh and cursors with hold are affected. An attacker having permission to create non-temp objects in at least one schema can execute arbitrary SQL functions under the identity of the bootstrap superuser.

Current PR consists of two commits. The first one demonstrates the problem in GPDB with analyze and defered triggers. The second one is a backport of https://github.com/postgres/postgres/commit/43ebfea5a988582e9edc752cb1e22e929edac03b with an important addition - we also add security context flags to dispatch message protocol. Otherwise QD backend can have security flags in a static memory, but QEs executing some trigger function don't know anything about these flags and can't cancel a restricted operation.

Should be backported to 6X (have not checked on 5X).
