### PR TITLE
Make gplogfilter support python3

### DIFF
--- a/gpMgmt/bin/README.md
+++ b/gpMgmt/bin/README.md
@@ -17,7 +17,7 @@ This will be set automatically with a `source $GPHOME/greenplum_path.sh`
 
 ## Python Version
 
-System python 2.7 is currently required.
+System python 3 is currently required.
 
 
 Where Things Go

--- a/gpMgmt/bin/gplogfilter
+++ b/gpMgmt/bin/gplogfilter
@@ -23,7 +23,7 @@ try:
     from gppylib.datetimeutils import str_to_datetime, str_to_duration, DatetimeValueError
     from gppylib.logfilter import *
     from gppylib.commands.gp import get_coordinatordatadir
-except ImportError, e:
+except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 # These values are from cdb-pg/src/backend/po/*.po
@@ -245,7 +245,7 @@ def openInputFile(ifn, options):
             zname = zname[0:-3]
             if os.path.splitext(zname)[1] == '':
                 zname += '.log'
-        fileIn = open(ifn, (unzip and 'rb') or 'rU')
+        fileIn = open(ifn, (unzip and 'rb') or 'r')
         filesToClose.append(fileIn)
 
     # Set up input decompression
@@ -310,9 +310,9 @@ def openOutputFile(ifn, zname, options):
 
         if options.verbose:
             if options.append:
-                print >> sys.stderr, ' append to ', ofn
+                print(' append to', ofn, file=sys.stderr)
             else:
-                print >> sys.stderr, ' output to ', ofn
+                print(' output to', ofn, file=sys.stderr)
 
     # Set up output compression
     if zipout:
@@ -399,7 +399,7 @@ try:
         if options.verbose:
             msg = ('requested timestamp range from %s to %s'
                    % (begin or 'beginning of data', end or 'end of data'))
-            print >> sys.stderr, msg
+            print(msg, file=sys.stderr)
 
         # Loop over input files
         for ifn in args:
@@ -434,7 +434,7 @@ try:
 
                 if goodFormat and begin and filedate < begin:
                     if end and filedate > end:
-                        print >> sys.stderr, "SKIP file: %s" % zname
+                        print("SKIP file: %s" % zname, file=sys.stderr)
                         for f in inputFilesToClose:
                             f.close()
                         inputFilesToClose = []
@@ -442,7 +442,7 @@ try:
 
             # Announce each input file *before* its output file if --out is dir
             if options.verbose and outputFilePerInputFile:
-                print >> sys.stderr, '---------- ', ifn, '---------- '
+                print('----------', ifn, '----------', file=sys.stderr)
 
             # Open the output file (once per input file if --out is a directory)
             if fileOut is None:
@@ -450,7 +450,7 @@ try:
 
             # Announce input files *after* single output file
             if options.verbose and not outputFilePerInputFile:
-                print >> sys.stderr, '---------- ', ifn, '---------- '
+                print('----------', ifn, '----------', file=sys.stderr)
 
             # Construct the filtering pipeline
             filteredInput = FilterLogEntries(fileIn,
@@ -464,7 +464,7 @@ try:
             # Write filtered lines to output file.  Don't append \n to
             # each line, because the original line ends are still there.
             for line in filteredInput:
-                print >> fileOut, line,
+                print(line, file=fileOut)
 
             # Close input and output files
             for file in inputFilesToClose:
@@ -482,7 +482,7 @@ try:
             file.close()
         for file in inputFilesToClose:
             file.close()
-except IOError, msg:
+except IOError as msg:
     execname = os.path.basename(sys.argv[0])
-    print >> sys.stderr, '%s: (IOError) "%s"' % (execname, msg)
+    print('%s: (IOError) "%s"' % (execname, msg), file=sys.stderr)
     sys.exit(2)

--- a/gpMgmt/bin/gppylib/logfilter.py
+++ b/gpMgmt/bin/gppylib/logfilter.py
@@ -253,7 +253,7 @@ def FilterLogEntries(iterable,
             msg += '; timestamps from %s to %s' % srange
         print(msg, file=msgfile)
 
-    
+
 
 #------------------------------- Spying --------------------------------
 class CsvFlatten(object):
@@ -261,13 +261,13 @@ class CsvFlatten(object):
     Used to flatten a CSV parsed log line into something that looks like the 
     old format.
     """
-    
+
     def __init__(self,iterable):
         self.source = iter(iterable)
-    
+
     def __iter__(self):
         return self
-    
+
     def __next__(self):
         item = next(self.source)
         #we need to make a minor format change to the log level field so that
@@ -541,7 +541,7 @@ def TimestampInBounds(iterable, begin, end):
     # any following lines which do not have timestamps.
     if isinstance(item, str):
         withinbounds = False
-        while True:
+        for item in source:
             if begin <= item < end:
                 withinbounds = True
                 yield item
@@ -549,17 +549,14 @@ def TimestampInBounds(iterable, begin, end):
                 withinbounds = False
             elif withinbounds:
                 yield item
-            item = next(source)
 
     # Else assume input consists of groups (i.e. sequences) of lines.
     # Yield groups in which the first line starts with a timestamp within
     # the given bounds.  Skip groups which are empty or have no timestamp.
-    while True:
+    for item in source:
         if (len(item) > 0 and
             begin <= item[0] < end):
             yield item
-        item = next(source)
-
 
 #--------------------------- Pattern Matching ----------------------------
     
@@ -699,7 +696,7 @@ def MatchColumns(iterable, cols):
             for s in item:
                 n = 1
                 out = []
-                
+
                 for c in s.split('|'):
                     if n in cols:
                         out.append(c)


### PR DESCRIPTION
gplogfilter is a log filter tool like awk, but easy to use.

[our document](https://gpdb.docs.pivotal.io/6-17/utility_guide/ref/gplogfilter.html) still says this tool is available. so upgrade this tool to fit python3.