### PR TITLE
Check if index pathkeys list is empty in find_usable_indexes() function

### DIFF
--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -402,6 +402,12 @@ find_usable_indexes(PlannerInfo *root, RelOptInfo *rel,
 		if (index_is_ordered && possibly_useful_pathkeys &&
 			istoplevel && outer_rel == NULL)
 		{
+			/*
+			 * index_pathkeys might be NULL when target index does not provide
+			 * a desired sort order in query or when useful for sorting
+			 * index corresponding to inherited or child relation does not
+			 * participate in join.
+			 */
 			index_pathkeys = build_index_pathkeys(root, index,
 												  ForwardScanDirection);
 
@@ -410,7 +416,7 @@ find_usable_indexes(PlannerInfo *root, RelOptInfo *rel,
 			 * of the child's baserel.  Transform the pathkey list to refer to
 			 * columns of the appendrel.
 			 */
-			if (rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
+			if (index_pathkeys && rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
 			{
 				AppendRelInfo *appinfo = NULL;
 				RelOptInfo *appendrel = NULL;


### PR DESCRIPTION
index_pathkeys might be NULL when target index does not provide
a desired sort order in query or when useful for sorting index
corresponding to inherited or child relation does not participate
in join.

Due to that the following fragment fails:
```
    CREATE TABLE clstr_tst (a int, b INT) DISTRIBUTED BY (a);
    CREATE INDEX clstr_tst_b_c ON clstr_tst (b);
    CREATE TABLE clstr_tst_inh () INHERITS (clstr_tst);
    SELECT a FROM clstr_tst ORDER BY 1
```

The solution is to check if index_pathkeys list is empty before using it.

There are already number of tests in regression that fails if enable
asserts (with passing --enable-cassert flag to ./configure).

For example, cluster test was failing:

> INSERT INTO clstr_tst (b, c, d) VALUES (6, 'seis', repeat('xyzzy', 100000));
> CLUSTER clstr_tst_c ON clstr_tst;
> SELECT a,b,c,substring(d for 30), length(d) from clstr_tst ORDER BY 1,2,3,4;
> ! FATAL: Unexpected internal error (indxpath.c:436)
> ! DETAIL: FailedAssertion("!(cdbpathlocus_is_valid(*_locus))", File: "indxpath.c", Line: 436)
> ! HINT: Process 14390 will wait for gp_debug_linger=120 seconds before termination.
> ! Note that its locks and other resources will not be released until then.
> ! server closed the connection unexpectedly
> ! This probably means the server terminated abnormally
> ! before or while processing the request.
> ! connection to server was lost
> 

So now it passes.
And this is not the only test. More tests started to pass.
It means that there are tests conversing this fix - without it tests will fail (if built with asserts).

Resolves: #12221

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
