### PR TITLE
7X: Do not include compiled python bytecode in exported tarball

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -109,9 +109,9 @@ function export_gpdb() {
 	server_build="${GPDB_ARTIFACTS_DIR}/server-build-${server_version}-${BLD_ARCH}${RC_BUILD_TYPE_GCS}.tar.gz"
 
 	pushd ${GREENPLUM_INSTALL_DIR}
-	source greenplum_path.sh
-	python3 -m compileall -q -x test .
 	chmod -R 755 .
+	# Remove python bytecode
+	find . -type f \( -iname \*.pyc -o -iname \*.pyo \) -delete
 	tar -czf "${TARBALL}" ./*
 	popd
 


### PR DESCRIPTION
The bytecode is compiled and installed during package installation.

Authored-by: Brent Doil <bdoil@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
