### PR TITLE
6X gpinitsystem: fix backout script creation

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -527,21 +527,21 @@ CHK_PARAMS () {
 				ERROR_EXIT "[FATAL]-Value $LCMESSAGES is not a valid value for --lc-messages on this system." 2
 			fi
 		fi
-		
+
 		if [ x"" != x"$LCMONETARY" ]; then
 			IN_ARRAY $LCMONETARY "`locale -a`"
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCMONETARY is not a valid value for --lc-monetary on this system." 2
 			fi
 		fi
-		
+
 		if [ x"" != x"$LCNUMERIC" ]; then
 			IN_ARRAY $LCNUMERIC "`locale -a`"
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCNUMERIC is not a valid value for --lc-numeric on this system." 2
 			fi
 		fi
-		
+
 		if [ x"" != x"$LCTIME" ]; then
 			IN_ARRAY $LCTIME "`locale -a`"
 			if [ $? -eq 0 ]; then
@@ -815,6 +815,10 @@ CHK_QES () {
         else
             $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
             LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
+            $ECHO "$ECHO \"Stopping segment instance on $GP_HOSTADDRESS\"" >> $BACKOUT_FILE
+            $ECHO "$TRUSTED_SHELL $GP_HOSTADDRESS \"if [ -f $GP_DIR/postmaster.pid ]; then  ${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop; fi\"" >> $BACKOUT_FILE
+            $ECHO "$ECHO \"removing directory $GP_DIR on $GP_HOSTADDRESS\"" >> $BACKOUT_FILE
+            $ECHO "$TRUSTED_SHELL ${GP_HOSTADDRESS} \"$RM -rf $GP_DIR > /dev/null 2>&1\"" >> $BACKOUT_FILE
         fi
 
     done
@@ -840,6 +844,10 @@ CHK_QES () {
             else
                 $TRUSTED_SHELL $GP_HOSTADDRESS "$RM -f ${W_DIR}/tmp_file_test"
                 LOG_MSG "[INFO]:-Write test passed on $GP_HOSTADDRESS $W_DIR directory"
+                $ECHO "$ECHO \"Stopping segment instance on $GP_HOSTADDRESS\"" >> $BACKOUT_FILE
+                $ECHO "$TRUSTED_SHELL $GP_HOSTADDRESS \"if [ -f $GP_DIR/postmaster.pid ]; then  ${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop; fi\"" >> $BACKOUT_FILE
+                $ECHO "$ECHO \"removing directory $GP_DIR on $GP_HOSTADDRESS\"" >> $BACKOUT_FILE
+                $ECHO "$TRUSTED_SHELL ${GP_HOSTADDRESS} \"$RM -rf $GP_DIR > /dev/null 2>&1\"" >> $BACKOUT_FILE
             fi
         done
     else
@@ -1204,7 +1212,7 @@ CREATE_QD_DB () {
         if [ x"" != x"$LCTIME" ]; then
 			LC_TIME_SETTING="--lc-time=$LCTIME"
 		fi
-		
+
 		LC_ALL_SETTINGS=" $LC_COLLATE_SETTING $LC_CTYPE_SETTING $LC_MESSAGES_SETTING $LC_MONETARY_SETTING $LC_NUMERIC_SETTING $LC_TIME_SETTING"
 
 
@@ -1228,7 +1236,7 @@ CREATE_QD_DB () {
 		# if there was an error, copy ${GP_DIR}.initdb to the log
 		if [ $RETVAL -ne 0 ]; then
 		    $CAT ${GP_DIR}.initdb >> $LOG_FILE
-		fi    
+		fi
 		$RM -f ${GP_DIR}.initdb
 		if [ $RETVAL -ne 0 ]; then
 		    ERROR_EXIT "[FATAL]:- Command $cmd failed with error status $RETVAL, see log file $LOG_FILE for more detail" 2
@@ -1363,7 +1371,7 @@ LOAD_QE_SYSTEM_DATA () {
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
 					ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration." 2
-				fi				
+				fi
 				UPDATE_GPCONFIG $MASTER_PORT $GP_DBID $GP_CONTENT $GP_HOSTNAME $GP_HOSTADDRESS $GP_PORT $GP_DIR p
 				LOG_MSG "[INFO]:-Successfully added segment $GP_HOSTADDRESS to Master system tables"
 		done
@@ -1673,15 +1681,15 @@ READ_INPUT_CONFIG () {
 
     # Validation
     if [ x"" != x"${MASTER_PORT}" ] ; then
-        ERROR_EXIT "[FATAL]:-Problem with configuration. Cannot specify MASTER_PORT and QD_PRIMARY_ARRAY" 2             
+        ERROR_EXIT "[FATAL]:-Problem with configuration. Cannot specify MASTER_PORT and QD_PRIMARY_ARRAY" 2
     fi
 
     if [ x"" != x"${MASTER_HOSTNAME}" ] ; then
-        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_HOSTNAME and QD_PRIMARY_ARRAY" 2                            
+        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_HOSTNAME and QD_PRIMARY_ARRAY" 2
     fi
 
     if [ x"" != x"${MASTER_DIRECTORY}" ] ; then
-        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_DIRECTORY and QD_PRIMARY_ARRAY" 2                           
+        ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify MASTER_DIRECTORY and QD_PRIMARY_ARRAY" 2
     fi
 
     # Make sure it is not a dos file with CTRL M at end of each line
@@ -1752,7 +1760,7 @@ READ_INPUT_CONFIG () {
 
     if [ $TOTAL_MIRRORS -ne 0 ] ; then
         if [ $TOTAL_SEG -ne $TOTAL_MIRRORS ] ; then
-            ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify different number of primary and mirror segments." 2   
+            ERROR_EXIT "[FATAL]:-Problem with configuration file. Cannot specify different number of primary and mirror segments." 2
         fi
     fi
 }
@@ -1978,21 +1986,8 @@ CREATE_SEGMENT IS_PRIMARY
 if [ $REPORT_FAIL -ne 0 ];then
 	LOG_MSG "[FATAL]:-Errors generated from parallel processes" 1
 	LOG_MSG "[INFO]:-Dumped contents of status file to the log file" 1
-	# Need to build a central backout file
-	LOG_MSG "[INFO]:-Building composite backout file" 1
-	for I in /tmp/gpsegcreate.sh_backout*
-	do
-		$CAT $I >> $BACKOUT_FILE
-		$RM -f $I
-	done
-	$ECHO "$RM -f $BACKOUT_FILE" >> $BACKOUT_FILE
 	ERROR_EXIT "[FATAL]:-Failures detected, see log file $LOG_FILE for more detail" 2
 else
-	LOG_MSG "[INFO]:-Deleting distributed backout files" 1
-	for I in ls /tmp/gpsegcreate.sh_backout*
-	do
-		$RM -f $I
-	done
 	LOG_MSG "[INFO]:-Removing back out file" 1
 	$RM -f $BACKOUT_FILE
 	LOG_MSG "[INFO]:-No errors generated from parallel processes" 1

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -278,8 +278,7 @@ ERROR_EXIT () {
 		if [ $BACKOUT_FILE ]; then
 				if [ -s $BACKOUT_FILE ]; then
 						LOG_MSG "[WARN]:-Script has left Greenplum Database in an incomplete state"
-						LOG_MSG "[WARN]:-Run command bash $BACKOUT_FILE to remove these changes"
-						BACKOUT_COMMAND "if [ x$MASTER_HOSTNAME != x\`$HOSTNAME\` ];then $ECHO \"[FATAL]:-Not on original master host $MASTER_HOSTNAME, backout script exiting!\";exit 2;fi"
+						LOG_MSG "[WARN]:-Run command bash $BACKOUT_FILE on master to remove these changes"
 						$ECHO "$RM -f $BACKOUT_FILE" >> $BACKOUT_FILE
 				fi
 		fi

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -105,7 +105,7 @@ CREATE_QES_PRIMARY () {
         cmd="$cmd --data-checksums"
     fi
     cmd="$cmd --backend_output=$GP_DIR.initdb"
-    
+
     $TRUSTED_SHELL ${GP_HOSTADDRESS} $cmd >> $LOG_FILE 2>&1
     RETVAL=$?
     
@@ -113,8 +113,6 @@ CREATE_QES_PRIMARY () {
         $TRUSTED_SHELL ${GP_HOSTADDRESS} "cat $GP_DIR.initdb" >> $LOG_FILE 2>&1
     fi
     $TRUSTED_SHELL ${GP_HOSTADDRESS} "rm -f $GP_DIR.initdb" >> $LOG_FILE 2>&1
-    BACKOUT_COMMAND "$TRUSTED_SHELL ${GP_HOSTADDRESS} \"$RM -rf $GP_DIR > /dev/null 2>&1\""
-    BACKOUT_COMMAND "$ECHO \"removing directory $GP_DIR on $GP_HOSTADDRESS\""
     PARA_EXIT $RETVAL "to start segment instance database $GP_HOSTADDRESS $GP_DIR"
     
     # Configure postgresql.conf
@@ -238,13 +236,9 @@ START_QE() {
 	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL $PG_CTL_WAIT -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-i -p ${GP_PORT}\" start" >> $LOG_FILE 2>&1
 	RETVAL=$?
 	if [ $RETVAL -ne 0 ]; then
-		BACKOUT_COMMAND "$TRUSTED_SHELL $GP_HOSTADDRESS \"${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop\""
-		BACKOUT_COMMAND "$ECHO \"Stopping segment instance on $GP_HOSTADDRESS\""
 		$TRUSTED_SHELL ${GP_HOSTADDRESS} "$CAT ${GP_DIR}/pg_log/startup.log "|$TEE -a $LOG_FILE
 		PARA_EXIT $RETVAL "Start segment instance database"
-	fi	
-	BACKOUT_COMMAND "$TRUSTED_SHELL $GP_HOSTADDRESS \"${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop\""
-	BACKOUT_COMMAND "$ECHO \"Stopping segment instance on $GP_HOSTADDRESS\""
+	fi
 	LOG_MSG "[INFO][$INST_COUNT]:-Successfully started segment instance on $GP_HOSTADDRESS"
 }
 
@@ -308,7 +302,6 @@ if [ x"IS_MIRROR" == x"$PRIMARY_OR_MIRROR_IDENTIFIER" ]; then
 fi
 
 INST_COUNT=$1;shift		#Unique number for this parallel script, starts at 0
-BACKOUT_FILE=/tmp/gpsegcreate.sh_backout.$$
 LOG_FILE=$1;shift		#Central logging file
 LOG_MSG "[INFO][$INST_COUNT]:-Start Main"
 LOG_MSG "[INFO][$INST_COUNT]:-Command line options passed to utility = $*"

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -55,6 +55,34 @@ Feature: gpinitsystem tests
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
+    Scenario Outline: gpinitsystem creates a backout file when process terminated
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end <terminated_process> process when "Waiting for parallel processes" is printed in gpinitsystem logs
+        And the user waits 30 second
+        Then gpintsystem logs should contain lines about running backout script
+        And the user runs the gpinitsystem backout script
+        And all files in gpAdminLogs directory are deleted
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And gpinitsystem should return a return code of 0
+        And gpintsystem logs should not contain lines about running backout script
+
+    Examples:
+        | terminated_process |
+        | bin/gpinitsystem   |
+        | gpcreateseg        |
+
+    Scenario: gpinitsystem does not create or need backout file when user terminated very early
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
+        And the user waits 10 second
+        Then gpintsystem logs should not contain lines about running backout script
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+
     Scenario: gpinitsystem fails with exit code 2 when the functions file is not found
        Given create demo cluster config
            # force a load error when trying to source gp_bash_functions.sh

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -364,11 +364,20 @@ def impl(context, command):
     run_gpcommand(context, command)
 
 
-@given('the user asynchronously sets up to end that process in {secs} seconds')
-def impl(context, secs):
-    command = "sleep %d; kill -9 %d" % (int(secs), context.asyncproc.pid)
+@given('the user asynchronously sets up to end {process_name} process in {secs} seconds')
+@when('the user asynchronously sets up to end {process_name} process in {secs} seconds')
+def impl(context, process_name, secs):
+    if process_name == 'that':
+        command = "sleep %d; kill -9 %d" % (int(secs), context.asyncproc.pid)
+    else:
+        command = "sleep %d; ps ux | grep %s | awk '{print $2}' | xargs kill" % (int(secs), process_name)
     run_async_command(context, command)
 
+
+@when('the user asynchronously sets up to end {process_name} process when {log_msg} is printed in gpinitsystem logs')
+def impl(context, process_name, log_msg):
+    command = "while sleep 3; do if egrep --quiet %s  ~/gpAdminLogs/gpinitsystem*log ; then ps ux | grep %s |awk '{print $2}' | xargs kill ;break 2; fi; done" % (log_msg, process_name)
+    run_async_command(context, command)
 
 @given('the user asynchronously runs "{command}" and the process is saved')
 @when('the user asynchronously runs "{command}" and the process is saved')
@@ -814,6 +823,28 @@ def impl(context, options):
 def impl(context, options):
     context.execute_steps(u'''Then the user runs command "gpactivatestandby -a %s" from standby master''' % options)
     context.standby_was_activated = True
+
+@then('gpintsystem logs should {contain} lines about running backout script')
+def impl(context, contain):
+    string_to_find = 'Run command bash .*backout_gpinitsystem.* on master to remove these changes$'
+    command = "egrep '{}' ~/gpAdminLogs/gpinitsystem*log".format(string_to_find)
+    run_command(context, command)
+    if contain == "contain":
+        if has_exception(context):
+            raise context.exception
+        context.gpinit_backout_command = re.search('Run command(.*)on master', context.stdout_message).group(1)
+    elif contain == "not contain":
+        if not has_exception(context):
+            raise Exception("Logs contain lines about running backout script")
+    else:
+        raise Exception("Incorrect step name, only use 'should contain' and 'should not contain'")
+
+@then('the user runs the gpinitsystem backout script')
+def impl(context):
+    command = context.gpinit_backout_command
+    run_command(context, command)
+    if has_exception(context):
+        raise context.exception
 
 @when('the user runs command "{command}" from standby master')
 @then('the user runs command "{command}" from standby master')
@@ -2176,6 +2207,13 @@ def impl(context, location):
             'mv', '{}.bak'.format(greenplum_path), greenplum_path
         ])
 
+@given('all files in gpAdminLogs directory are deleted')
+@then('all files in gpAdminLogs directory are deleted')
+def impl(context):
+    log_dir = _get_gpAdminLogs_directory()
+    files_found = glob.glob('%s/*' % (log_dir))
+    for file in files_found:
+        os.remove(file)
 
 @then('gpAdminLogs directory has no "{expected_file}" files')
 def impl(context, expected_file):


### PR DESCRIPTION
gpinitsystem currently creates backout script on coordinator and on
each segment, and then appends all the segment backout scripts to the
coordinator backout script and we ask the user to run only that script.
If some of the gpcreateseg fail, the segment backout scripts aren't
appended correctly in some cases, and the user has to manually
cleanup those directories.

This change creates a single backout script early in gpinitsystem run,
so even if anything fails later, we would always be able to
cleanup all segment directories. To simplify, we are using 'echo' to
add lines into backout script instead of using BACKOUT_COMMAND

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>
(cherry picked from commit b0493ceb97c24eb48cae9017ce62949ff2f583e5)
