### PR TITLE
Fix autovacuum crash

### DIFF
--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -3177,7 +3177,6 @@ relation_needs_vacanalyze(Oid relid,
 	 * at risk of wrap around and proceed to vacuum)
 	 */
 	if (*dovacuum && !IsSystemClass(relid, classForm) &&
-		strcmp(get_namespace_name(classForm->relnamespace), "information_schema") != 0 &&
 		!force_vacuum)
 	{
 		*dovacuum = false;

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -3172,15 +3172,11 @@ relation_needs_vacanalyze(Oid relid,
 	}
 
 	/*
-	 * GPDB: Autovacuum VACUUM is only enabled for catalog tables. In this
-	 * case we include tables in information_schema namespace.  (But ignore if
-	 * at risk of wrap around and proceed to vacuum)
+	 * GPDB: Autovacuum VACUUM is only enabled for catalog tables. (But ignore
+	 * if at risk of wrap around and proceed to vacuum)
 	 */
-	if (*dovacuum && !IsSystemClass(relid, classForm) &&
-		!force_vacuum)
-	{
+	if (!IsSystemClass(relid, classForm) && !force_vacuum)
 		*dovacuum = false;
-	}
 }
 
 /*


### PR DESCRIPTION
Issue is that get_namespace_name() can return NULL values when nspid no
longer exists in the cat cache and the tuple has been deleted from the
relation on disk. This can happen during the normal lifecycle of a tuple
in pg_namespace. And so without a NULL check, the strcmp call is at risk
of crashing autovacuum process.

Fix is to remove the offending calls altogether. Previously we treated
information_schema special in order to vacuum all tables in template0.
That allowed commit 379512a3fbf to keep parity with previous behavior
that vacuumed all tables in non-connectable databases. However, initdb
already freezes all tuples in information_schema tables on database
creation. And even in the worst case where we're at risk of wraparound,
auto-vacuum will force a vacuum regardless of the table/schema.

Fixes #12364

Co-authored-by: Alexandra Wang <walexandra@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
