### PR TITLE
gpstate: show Mirror sync progress

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -362,6 +362,9 @@ class GpRecoverSegmentProgram:
             self.logger.info("Segments successfully recovered.")
             self.logger.info("********************************")
 
+            self.logger.info("Recovered mirror segments need to sync WAL with primary segments.")
+            self.logger.info("Use 'gpstate -e' to check progress of WAL sync remaining bytes")
+
         sys.exit(0)
 
     def trigger_fts_probe(self, port=0):

--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -64,6 +64,7 @@ CATEGORY__REPLICATION_INFO = "Replication Info"
 VALUE__REPL_SENT_LSN = FieldDefinition("WAL Sent Location", "sent_lsn", "text")
 VALUE__REPL_FLUSH_LSN = FieldDefinition("WAL Flush Location", "flush_lsn", "text")
 VALUE__REPL_REPLAY_LSN = FieldDefinition("WAL Replay Location", "replay_lsn", "text")
+VALUE__REPL_SYNC_REMAINING_BYTES = FieldDefinition("WAL sync remaining bytes", "wal_sync_bytes", "int")
 
 CATEGORY__STATUS = "Status"
 VALUE__COORDINATOR_REPORTS_STATUS = FieldDefinition("Configuration reports status as", "status_in_config", "text", "Config status")
@@ -132,6 +133,7 @@ class GpStateData:
             VALUE__REPL_SENT_LSN,
             VALUE__REPL_FLUSH_LSN,
             VALUE__REPL_REPLAY_LSN,
+            VALUE__REPL_SYNC_REMAINING_BYTES,
         ]
 
         self.__entriesByCategory[CATEGORY__STATUS] = \
@@ -642,12 +644,11 @@ class GpSystemStateProgram:
             pass # logger.info( "No segment pairs with switched roles")
 
         # segments that are not synchronized
-        unsyncedPrimaries = [s for s in gpArray.getSegDbList() if s.isSegmentPrimary(current_role=True) and \
-                                                    not s.isSegmentModeSynchronized()]
-        if unsyncedPrimaries:
+        unsync_segs = self._get_unsync_segs_add_wal_remaining_bytes(data, gpArray)
+        if unsync_segs:
             logger.info("----------------------------------------------------")
             logger.info("Unsynchronized Segment Pairs")
-            logSegments(unsyncedPrimaries, logAsPairs=True)
+            logSegments(unsync_segs, True, [VALUE__REPL_SYNC_REMAINING_BYTES])
             exitCode = 1
         else:
             pass # logger.info( "No segment pairs are in resynchronization")
@@ -927,6 +928,44 @@ class GpSystemStateProgram:
             logger.warn("*****************************************************" )
 
         return 1 if hasWarnings else 0
+
+    @staticmethod
+    def _get_unsync_segs_add_wal_remaining_bytes(data, gpArray):
+        """
+        helper function for adding WAL sync remaining bytes to GpstateData and get unsync segments
+        :param gpArray: gpArray instance
+        returns list of primary segments of pairs which aren't in sync state
+        """
+        unsync_segs = []
+        primaries = [s for s in gpArray.getSegDbList() if s.isSegmentPrimary(current_role=True)]
+        for s in primaries:
+            try:
+                data.switchSegment(s)
+                url = dbconn.DbURL(hostname=s.hostname, port=s.port, dbname='template1')
+                conn = dbconn.connect(url, utility=True)
+                with closing(conn) as conn:
+                    cursor = dbconn.query(conn,
+                                          "SELECT pg_wal_lsn_diff(pg_current_wal_flush_lsn(), sent_lsn)"
+                                          ",sync_state FROM pg_stat_replication")
+                    rows = cursor.fetchall()
+                    cursor.close()
+                    if rows:
+                        # wal connection is active.
+                        if rows[0][1] != 'sync':
+                            # walsender is in 'catchup' state
+                            wal_sync_bytes_out = rows[0][0]
+                            unsync_segs.append(s)
+                            data.addValue(VALUE__REPL_SYNC_REMAINING_BYTES, wal_sync_bytes_out)
+                    else:
+                        # no return value from pg_stat_replication, there isn't a replication connection
+                        wal_sync_bytes_out = 'Unknown'
+                        unsync_segs.append(s)
+                        data.addValue(VALUE__REPL_SYNC_REMAINING_BYTES, wal_sync_bytes_out)
+            except pgdb.InternalError:
+                logger.warning('could not query segment {} ({}:{})'.format(
+                    s.dbid, s.hostname, s.port
+                ))
+        return unsync_segs
 
     @staticmethod
     def _add_replication_info(data, primary, mirror):

--- a/gpMgmt/test/behave/mgmt_utils/steps/analyzedb_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/analyzedb_mgmt_utils.py
@@ -266,8 +266,10 @@ def impl(context, num_dirs, dbname):
 
 @given('the user waits {num_secs} seconds')
 @when('the user waits {num_secs} seconds')
+@then('the user waits {num_secs} seconds')
 @given('the user waits {num_secs} second')
 @when('the user waits {num_secs} second')
+@then('the user waits {num_secs} second')
 def impl(context, num_secs):
     time.sleep(int(num_secs))
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1098,7 +1098,7 @@ def impl(context, dbname):
     sql = context.text
     execute_sql(dbname, sql)
 
-
+@given('sql "{sql}" is executed in "{dbname}" db')
 @when('sql "{sql}" is executed in "{dbname}" db')
 @then('sql "{sql}" is executed in "{dbname}" db')
 def impl(context, sql, dbname):

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -684,6 +684,19 @@ def get_primary_segment_host_port():
     return primary_seg_host, primary_seg_port
 
 
+def get_primary_segment_host_port_for_content(content='0'):
+    """
+    return host, port of primary segment for the content id
+    """
+    get_psegment_sql = 'select hostname, port from gp_segment_configuration where content=%s;' % content
+    with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
+        cur = dbconn.query(conn, get_psegment_sql)
+        rows = cur.fetchall()
+        primary_seg_host = rows[0][0]
+        primary_seg_port = rows[0][1]
+    return primary_seg_host, primary_seg_port
+
+
 def remove_local_path(dirname):
     list = glob.glob(os.path.join(os.path.curdir, dirname))
     for dir in list:


### PR DESCRIPTION
This PR is a combination of changes for enhancing gpstate output on showing mirror sync progress. (More technical details in commit message)

[1] gpstate -e: Add `WAL sync remaining bytes` field for unsyncronized segment
pairs catching up to get to sync. 

- This is only required when walsender starts for the first time (after mirror
recovery) and is in catchup state.

- Sample output:
```
----------------------------------------------------
Unsynchronized Segment Pairs
Current Primary           Port    WAL sync remaining bytes   Mirror                    Port
vanjared-a01.vmware.com   15434   2802320                    vanjared-a01.vmware.com   15437
```

[2] gpstate -s: Add WAL fields for commit queue/delay for tracking delays on
commit queue. This change aims at giving the user additional tool for
troubleshooting network or I/O delays for a segment pair

- On primary segment's output, we added fields for: `current write location` and `Bytes remaining to send to mirror` 
- On mirror segment's output, we refined the output for `Bytes received but remain to flush` and `Bytes received but remain to replay` and make it static.

-Sample output
```
----------------------------------------------------
Segment Instance Status Report
----------------------------------------------------
   Segment Info
      Hostname                              = vanjared-a01.vmware.com
      Address                               = vanjared-a01.vmware.com
      Datadir                               = /Users/vanjared/gpdb7/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
      Port                                  = 7002
   Mirroring Info
      Current role                          = Primary
      Preferred role                        = Primary
      Mirror status                         = Synchronized
   Replication Info
      Current write location                = 0/C0B4548
      Bytes remaining to send to mirror     = 82336
   Status
      PID                                   = 59223
      Configuration reports status as       = Up
      Database status                       = Up
----------------------------------------------------
   Segment Info
      Hostname                              = vanjared-a01.vmware.com
      Address                               = vanjared-a01.vmware.com
      Datadir                               = /Users/vanjared/gpdb7/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
      Port                                  = 7005
   Mirroring Info
      Current role                          = Mirror
      Preferred role                        = Mirror
      Mirror status                         = Streaming
   Replication Info
      WAL Sent Location                     = 0/C0A03A8
      WAL Flush Location                    = 0/C062B88
      WAL Replay Location                   = 0/C062B88
      Bytes received but remain to flush    = 251936
      Bytes received but remain to replay   = 251936
   Status
      PID                                   = 60298
      Configuration reports status as       = Up
      Segment status                        = Up
```