### PR TITLE
6X: Fix memory leak issues which reported by Coverity

### DIFF
--- a/gpAux/platform/gpnetbench/gpnetbenchServer.c
+++ b/gpAux/platform/gpnetbench/gpnetbenchServer.c
@@ -151,12 +151,19 @@ static int setupListen(char hostname[], char port[], int protocol) {
 		if (clientPid < 0)
 		{
 			perror("error forking process for incoming connection");
+			close(clientFd);
 			exit(1);
 		}
 
 		if (clientPid == 0)
 		{
+			// child
 			handleIncomingConnection(clientFd);
+		}
+		else
+		{
+			// father
+			close(clientFd);
 		}
 	}
 
@@ -176,6 +183,7 @@ handleIncomingConnection(int fd)
 		{
 			// error from rev, assuming client disconnection
 			// this is the end of the child process used for handling 1 client connection
+			close(fd);
 			exit(0);
 		}
 	}

--- a/src/backend/cdb/cdblegacyhash.c
+++ b/src/backend/cdb/cdblegacyhash.c
@@ -390,11 +390,10 @@ cdblegacyhash_numeric(PG_FUNCTION_ARGS)
 	void	   *buf;		/* pointer to the data */
 	size_t		len;		/* length for the data buffer */
 	uint32		hash;
+	uint32		nanbuf = NAN_VAL;
 
 	if (numeric_is_nan(num))
 	{
-		uint32		nanbuf = NAN_VAL;
-
 		buf = &nanbuf;
 		len = sizeof(nanbuf);
 	}

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2231,8 +2231,7 @@ format_sockaddr(struct sockaddr *sa, char *buf, int bufsize)
 #ifdef HAVE_IPV6
 	else if (sa->sa_family == AF_INET6)
 	{
-		char		remote_port[32];
-		remote_port[0] = '\0';
+		char		remote_port[32] = {'\0'};
 
 		if (bufsize > 10)
 		{

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2232,6 +2232,7 @@ format_sockaddr(struct sockaddr *sa, char *buf, int bufsize)
 	else if (sa->sa_family == AF_INET6)
 	{
 		char		remote_port[32];
+		remote_port[0] = '\0';
 
 		if (bufsize > 10)
 		{

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -1472,7 +1472,7 @@ setup_config(void)
 	 * have to run on a machine without.
 	 */
 	{
-		struct addrinfo *gai_result;
+		struct addrinfo *gai_result = NULL;
 		struct addrinfo hints;
 		int			err = 0;
 
@@ -1495,14 +1495,24 @@ setup_config(void)
 
 		if (err != 0 ||
 			getaddrinfo("::1", NULL, &hints, &gai_result) != 0)
+		{
 			conflines = replace_token(conflines,
 							   "host    all             all             ::1",
 							 "#host    all             all             ::1");
+			if (gai_result != NULL)
+				freeaddrinfo(gai_result);
+			gai_result = NULL;
+		}
 		if (err != 0 ||
 			getaddrinfo("fe80::1", NULL, &hints, &gai_result) != 0)
+		{
 			conflines = replace_token(conflines,
 							   "host    all             all             fe80::1",
 							 "#host    all             all             fe80::1");
+			if (gai_result != NULL)
+				freeaddrinfo(gai_result);
+			gai_result = NULL;
+		}
 	}
 #else							/* !HAVE_IPV6 */
 	/* If we didn't compile IPV6 support at all, always comment it out */
@@ -2308,6 +2318,7 @@ setup_cdb_schema(void)
 		sprintf(path, "%s/cdb_init.d/%s", share_path, scriptnames[i]);
 
 		lines = readfile(path);
+		pg_free(path);
 
 		/*
 		 * We use -j here to avoid backslashing stuff in

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -1870,13 +1870,14 @@ describeOneTableDetails(const char *schemaname,
 				 * If there are no entries, we go to the pre-4.1 values stored in the pg_appendonly table.
 				 */
 				char *attributeOptions;
+				char emptyOptions = '\0';
 				if (isGE42 == true)
 				{
-				   attributeOptions = PQgetvalue(res, i, firstvcol + 2); /* pg_catalog.pg_attribute_storage(attoptions) */
-				   includeAOCS = 1;
+					attributeOptions = PQgetvalue(res, i, firstvcol + 2); /* pg_catalog.pg_attribute_storage(attoptions) */
+					includeAOCS = 1;
 				}
 				else
-					 attributeOptions = pg_malloc0(1);  /* Make an empty options string so the reset of the code works correctly. */
+					attributeOptions = &emptyOptions;  /* Make an empty options string so the reset of the code works correctly. */
 				char *key = strtok(attributeOptions, ",=");
 				char *value = NULL;
 				char *compressionType = NULL;


### PR DESCRIPTION
These issues are reported by Coverity: [detail link](https://pivotal.polaris.synopsys.com/projects/34158812-801e-47d3-8aad-492774ea4d91/branches/12d9ee7f-fb2e-4153-be92-bc147e3a5603/issues?filter=issue%5Bstatus%5D%5B%24eq%5D%3Dopened%26issue%5Btaxonomy%5D%5Bid%5D%5B4bae258d-865d-4a06-9ff8-a7e141cabb2d%5D%5Btaxon%5D%5B%24eq%5D%3Dhigh%26issue%5Btriage-status%5D%5B%24eq%5D%3Dto-be-fixed)

Actually, more issues are found, but some of them are the same as upstream code 
and not a very big deal (e.g. in utility, like pg_dump), so ignore them.

Just fix issues which gpdb introduced in this PR.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
