### PR TITLE
Fix gpconfig filedescriptor out of range issue

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -308,7 +308,7 @@ def do_change(options):
     if not options.masteronly:
         hosts.extend(gp_array.get_hostlist(includeMaster=False))
 
-    unreachable_hosts = get_unreachable_segment_hosts(hosts, len(hosts))
+    unreachable_hosts = get_unreachable_segment_hosts(hosts, len(set(hosts)))
     if len(unreachable_hosts) > 0:
         confirm_user_wants_to_continue()
 

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -12,7 +12,7 @@ def get_unreachable_segment_hosts(hosts, num_workers):
 
     pool = base.WorkerPool(numWorkers=num_workers)
     try:
-        for host in hosts:
+        for host in set(hosts):
             cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
             pool.addCommand(cmd)
         pool.join()

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -215,3 +215,10 @@ Feature: gpconfig integration tests
         | asks for confirmation and completes when user selects yes | 0           | should         | completed successfully | should               | should                | gpconfig -c application_name -v "easy" < test/behave/mgmt_utils/steps/data/yes.txt|
         | asks for confirmation and aborts when user selects no     | 1           | should         | User Aborted. Exiting. | should not           | should not            | gpconfig -c application_name -v "easy" < test/behave/mgmt_utils/steps/data/no.txt |
         | does not ask for confirmation for master only change      | 0           | should not     | completed successfully | should               | should not            | gpconfig -c application_name -v "easy" --masteronly                               |
+
+    @demo_cluster
+    Scenario: gpconfig checks liveness of correct number of hosts
+      Given the database is running
+       When the user runs "gpconfig --debug -c optimizer -v on"
+       Then gpconfig should return a return code of 0
+        And gpconfig should print "WorkerPool() initialized with 1 workers" escaped to stdout


### PR DESCRIPTION
We should check unique hostnames instead of checking for hostname associated
with each dbid. Each hostname has multiple dbids associated with it. In larger
clusters it led to 100s of liveness checks and failed with filedescriptor out
of range in select() error. In future we should move from `select` to `poll`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
