### PR TITLE
Delete 'pg_hba.conf.bak' after standby is fully setup

### DIFF
--- a/gpMgmt/bin/gppylib/operations/initstandby.py
+++ b/gpMgmt/bin/gppylib/operations/initstandby.py
@@ -43,7 +43,7 @@ def cleanup_pg_hba_backup(data_dirs_list):
                 os.remove(backup_file)
                 logger.info('Removing pg_hba.conf backup file %s' % backup_file)
             else:
-                logger.warning('pg_hba.conf backup file %s is not exist' % backup_file)
+                logger.warning('pg_hba.conf backup file %s does not exist' % backup_file)
     except Exception as ex:
         logger.error('Unable to cleanup backup of pg_hba.conf %s' % ex)
 

--- a/gpMgmt/bin/gppylib/operations/initstandby.py
+++ b/gpMgmt/bin/gppylib/operations/initstandby.py
@@ -39,9 +39,11 @@ def cleanup_pg_hba_backup(data_dirs_list):
     try:
         for data_dir in data_dirs_list:
             backup_file = os.path.join(data_dir, PG_HBA_BACKUP)
-            logger.info('Removing pg_hba.conf backup file %s' % backup_file)
             if os.path.exists(backup_file):
                 os.remove(backup_file)
+                logger.info('Removing pg_hba.conf backup file %s' % backup_file)
+            else:
+                logger.warning('pg_hba.conf backup file %s is not exist' % backup_file)
     except Exception as ex:
         logger.error('Unable to cleanup backup of pg_hba.conf %s' % ex)
 
@@ -63,7 +65,7 @@ def cleanup_pg_hba_backup_on_segment(gparr, unreachable_hosts=[]):
         for host, data_dirs_list in list(host_to_seg_map.items()):
             if host in unreachable_hosts:
                 continue
-            json_data_dirs_list = json.dumps(str(data_dirs_list))
+            json_data_dirs_list = json.dumps(data_dirs_list)
             cmdStr = "$GPHOME/lib/python/gppylib/operations/initstandby.py -d '%s' -D" % json_data_dirs_list
             cmd = Command('Cleanup the pg_hba.conf backups on remote hosts', cmdStr=cmdStr , ctxt=REMOTE, remoteHost=host)
             pool.addCommand(cmd)

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -42,7 +42,7 @@ Feature: Tests for gpinitstandby feature
         And the file "log/testfile" does not exist under standby coordinator data directory
         And the file "db_dumps/testfile" does not exist under standby coordinator data directory
         And the file "promote/testfile" does not exist under standby coordinator data directory
-        And the file "pg_hba.conf.bak" dose not exist under standby coordinator data directory
+        And the file "pg_hba.conf.bak" does not exist under standby coordinator data directory
         ## maybe clean up the directories created in the coordinator data directory
 
     Scenario: gpstate -f shows standby coordinator information after running gpinitstandby

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -42,6 +42,7 @@ Feature: Tests for gpinitstandby feature
         And the file "log/testfile" does not exist under standby coordinator data directory
         And the file "db_dumps/testfile" does not exist under standby coordinator data directory
         And the file "promote/testfile" does not exist under standby coordinator data directory
+        And the file "pg_hba.conf.bak" dose not exist under standby coordinator data directory
         ## maybe clean up the directories created in the coordinator data directory
 
     Scenario: gpstate -f shows standby coordinator information after running gpinitstandby


### PR DESCRIPTION
fix #12397 follow up #10853

`data_dirs_list` is `[Str]` (a list of string). after use `str()` the type will become a `Str`.
the subprocess will not deserialize correctly.

before: `-d '"["foo", "bar"]"'`

after: `-d '["foo", "bar"]'`

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
