### PR TITLE
Remove reference to publicly hosted docker images

### DIFF
--- a/README.Docker.md
+++ b/README.Docker.md
@@ -21,7 +21,7 @@ To make Greenplum accessible outside of the docker container use the -p switch (
 This will proxy connections / requests made to the `<port_on_local_machine>` across to `<greenplum_port_in_docker>` which will allow Greenplum within docker to receive them.
 
 ```bash
-docker run -t -v ~/workspace/gpdb:/home/gpadmin/gpdb_src --privileged --security-opt seccomp:unconfined -i pivotaldata/gpdb6-centos7-build:latest bash
+docker run -t -v ~/workspace/gpdb:/home/gpadmin/gpdb_src --privileged --security-opt seccomp:unconfined -i gcr.io/data-gpdb-public-images/gpdb6-centos7-build:latest bash
 ```
 
 ## Set up Container Dependencies and the gpadmin User

--- a/README.md
+++ b/README.md
@@ -153,10 +153,7 @@ See [Building GPDB client tools on Windows](README.Windows.md) for details.
 See [README.Docker.md](README.Docker.md).
 
 We provide a docker image with all dependencies required to compile and test
-GPDB [(See Usage)](src/tools/docker/README.md). You can view the dependency dockerfile at `./src/tools/docker/centos6-admin/Dockerfile`.
-The image is hosted on docker hub at `pivotaldata/gpdb-dev:centos6-gpadmin`.
-
-A quickstart guide to Docker can be found on the [Pivotal Engineering Journal](http://engineering.pivotal.io/post/docker-gpdb/).
+GPDB [(See Usage)](src/tools/docker/README.md).
 
 ## Development with Vagrant
 

--- a/src/tools/docker/README.md
+++ b/src/tools/docker/README.md
@@ -14,15 +14,6 @@ docker build --build-arg BASE_IMAGE=ubuntu:16.04 -t local/gpdb-dev:ubuntu16 ubun
 docker build --build-arg BASE_IMAGE=ubuntu:18.04 -t local/gpdb-dev:ubuntu18 ubuntu
 ```
 
-OR
-## Download from docker hub
-```
-docker pull pivotaldata/gpdb-dev:centos6
-docker pull pivotaldata/gpdb-dev:centos7
-docker pull pivotaldata/gpdb-dev:ubuntu16
-docker pull pivotaldata/gpdb-dev:ubuntu18
-```
-
 # Build GPDB code with Docker
 
 Clone GPDB repo
@@ -32,7 +23,7 @@ cd gpdb
 ```
 Use docker image based on gpdb/src/tools/docker/centos7
 ```
-docker run -w /home/build/gpdb -v ${PWD}:/home/build/gpdb:cached -it pivotaldata/gpdb-dev:centos7 /bin/bash
+docker run -w /home/build/gpdb -v ${PWD}:/home/build/gpdb:cached -it local/gpdb-dev:centos7 /bin/bash
 ```
 
 Inside docker


### PR DESCRIPTION
We no longer host these images in pivotaldata. We will leave the code for
building locally if open source developers want to use them.

Co-authored-by: Karen Huddleston <khuddleston@vmware.com>
Co-authored-by: Kris Macoskey <kmacoskey@vmware.com>
Co-authored-by: Brent Doil <bdoil@vmware.com>