### PR TITLE
Revert "Revert "Revert "docs - add content for new gp_resource_group_…

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt_resgroups.xml
@@ -259,12 +259,6 @@
             href="../ref_guide/config_params/guc-list.xml#gp_resource_group_bypass" type="section"
             scope="peer">gp_resource_group_bypass</xref></codeph> to bypass a resource group
         concurrency limit.</p>
-      <p>You can set the server configuration parameter <codeph><xref
-            href="../ref_guide/config_params/guc-list.xml#gp_resource_group_queuing_timeout" type="section"
-            scope="peer">gp_resource_group_queuing_timeout</xref></codeph> to specify the
-         amount of time a transaction remains in the queue before Greenplum Database
-         cancels the transaction. The default timeout is zero, Greenplum queues
-         transactions indefinitely.</p>
     </body>
   </topic>
   <topic id="topic833971717" xml:lang="en">
@@ -858,7 +852,7 @@ gpstart
     </body>
   </topic>
   <topic id="topic_jlz_hzg_pkb">
-    <title>Configuring Automatic Query Termination Based on Memory Usage</title>
+    <title>Configuring Automatic Query Termination</title>
     <body>
       <p>When resource groups have a global shared memory pool, the server configuration parameter
             <codeph><xref
@@ -1037,14 +1031,7 @@ gpstart
           queue but has not yet been executed. Or, you may want to stop a running query that is
           taking too long to execute, or one that is sitting idle in a transaction and taking up
           resource group transaction slots that are needed by other users.</p>
-        <p>By default, transactions can remain queued in a resource group indefinitely.
-          If you want Greenplum Database to cancel a queued transaction after a
-          specific amount of time, set the server configuration parameter <codeph><xref
-            href="../ref_guide/config_params/guc-list.xml#gp_resource_group_queuing_timeout" type="section"
-            scope="peer">gp_resource_group_queuing_timeout</xref></codeph>. When this
-          parameter is set to a value (milliseconds) greater than 0, Greenplum cancels
-          any queued transaction when it has waited longer than the configured timeout.</p>
-        <p>To manually cancel a running or queued transaction, you must first determine the process id (pid)
+        <p>To cancel a running or queued transaction, you must first determine the process id (pid)
           associated with the transaction. Once you have obtained the process id, you can invoke
             <codeph>pg_cancel_backend()</codeph> to end that process, as shown below.</p>
         <p>For example, to view the process information associated with all statements currently

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -5218,38 +5218,6 @@
             <codeph>gp_resource_group_memory_limit</codeph> setting.</p></note>
     </body>
   </topic>
-  <topic id="gp_resource_group_queuing_timeout">
-    <title>gp_resource_group_queuing_timeout</title>
-    <body>
-      <note>The <codeph>gp_resource_group_queuing_timeout</codeph> server configuration parameter
-        is enforced only when resource group-based resource management is active.</note>
-      <p>Cancel a transaction queued in a resource group that waits longer than the
-        specified number of milliseconds. The time limit applies separately to each
-        transaction. The default value is zero; transactions are queued indefinitely
-        and never time out.</p>
-      <table id="gp_resource_group_queuing_timeout_table">
-        <tgroup cols="3">
-          <colspec colnum="1" colname="col1" colwidth="1*"/>
-          <colspec colnum="2" colname="col2" colwidth="1*"/>
-          <colspec colnum="3" colname="col3" colwidth="1*"/>
-          <thead>
-            <row>
-              <entry colname="col1">Value Range</entry>
-              <entry colname="col2">Default</entry>
-              <entry colname="col3">Set Classifications</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry colname="col1">0 - <codeph>INT_MAX</codeph> millisecs</entry>
-              <entry colname="col2">0 millisecs</entry>
-              <entry colname="col3">master<p>system</p><p>session</p><p>reload</p></entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </body>
-  </topic>
   <topic id="gp_resource_manager">
     <title>gp_resource_manager</title>
     <body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1254,9 +1254,6 @@
               <xref href="guc-list.xml#gp_resource_group_memory_limit" type="section"
                 >gp_resource_group_memory_limit</xref>
             </p><p>
-              <xref href="guc-list.xml#gp_resource_group_queuing_timeout" type="section"
-                >gp_resource_group_queuing_timeout</xref>
-            </p><p>
               <xref href="guc-list.xml#gp_resource_manager" type="section"
                 >gp_resource_manager</xref>
             </p></stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -143,7 +143,6 @@
             <topicref href="guc-list.xml#gp_resource_group_bypass"/>
             <topicref href="guc-list.xml#gp_resource_group_cpu_limit"/>
             <topicref href="guc-list.xml#gp_resource_group_memory_limit"/>
-            <topicref href="guc-list.xml#gp_resource_group_queuing_timeout"/>
             <topicref href="guc-list.xml#gp_resource_manager"/>
             <topicref href="guc-list.xml#gp_resqueue_memory_policy"/>
             <topicref href="guc-list.xml#gp_resqueue_priority"/>


### PR DESCRIPTION
…queuing_timeout guc (#9925)"""

This reverts commit c8c09c0753b7f04bc72645b9206476eea9b7800f.

per https://github.com/greenplum-db/gpdb/pull/9925...

not sure about the history (committed, reverted, reverted), but the gp_resource_group_queuing_timeout guc is not in 5X.  remove the docs (again).