### PR TITLE
Fix Segmentation Fault in append_stacktrace

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -158,7 +158,7 @@ static void write_eventlog(int level, const char *line, int len);
 #define ERRORDATA_STACK_SIZE  10
 
 #define CMD_BUFFER_SIZE  1024
-#define SYMBOL_SIZE      512
+#define SYMBOL_SIZE      2048
 #define ADDRESS_SIZE     20
 #define STACK_DEPTH_MAX  100
 
@@ -3607,9 +3607,9 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 			}
 		}
 
-		if (fd_ok && strlen(cmdresult[0]) > 1)
+		if (!fd_ok || strlen(cmdresult[0]) <= 1)
 		{
-			addr2line_ok = true;
+			addr2line_ok = false;
 		}
 
 		if (fd != NULL)
@@ -3678,7 +3678,9 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 				{
 					lineInfo = parenth + 1;
 					parenth = strrchr(lineInfo, ')');
-					*parenth = '\0';
+					if (parenth != NULL) {
+						*parenth = '\0';
+					}
 				}
 
 				/* line info added, print file and line info */

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -158,7 +158,7 @@ static void write_eventlog(int level, const char *line, int len);
 #define ERRORDATA_STACK_SIZE  10
 
 #define CMD_BUFFER_SIZE  1024
-#define SYMBOL_SIZE      2048
+#define SYMBOL_SIZE      512
 #define ADDRESS_SIZE     20
 #define STACK_DEPTH_MAX  100
 


### PR DESCRIPTION
This commit fixes a server Segmentation Fault that can happen while trying to write error messages to the logs.

Also:  fixes logic for detecting errors while calling addr2line or atos (previously, addr2line_ok was always set to true, even after a failure)

This commit has already been reviewed in [PR 11840](https://github.com/greenplum-db/gpdb/pull/11884), and it looks like the consensus was that it should be merged to master.  I lost track of it for a few months, but just noticed it--re-opening it here as a separate PR for the same commit against master instead of 6X_STABLE. 