### PR TITLE
fix gpload cannot deal with column name in upper case

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -580,7 +580,6 @@ def sqlIdentifierCompare(x, y):
        y = quote_unident(y)
     else:
        y = y.lower()
-
     if x == y:
        return True
     else:
@@ -1177,7 +1176,7 @@ class gpload:
                     if argv[0]=='-h':
                         self.options.h = argv[1]
                         argv = argv[2:]
-                    if argv[0]=='--gpfdist_timeout':
+                    elif argv[0]=='--gpfdist_timeout':
                         self.options.gpfdist_timeout = argv[1]
                         argv = argv[2:]
                     elif argv[0]=='-p':
@@ -1887,7 +1886,7 @@ class gpload:
                 """ remove leading or trailing spaces """
                 d = { tempkey.strip() : value }
                 key = d.keys()[0]
-                col_name = self.add_quote_if_not(key)
+                # col_name = self.add_quote_if_not(key)
                 if d[key] is None:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
@@ -1904,7 +1903,7 @@ class gpload:
 
                 # Mark this column as having no mapping, which is important
                 # for do_insert()
-                self.from_columns.append([col_name,d[key].lower(),None, False])
+                self.from_columns.append([key,d[key].lower(),None, False])
         else:
             self.from_columns = self.into_columns
             self.from_cols_from_user = False
@@ -2595,7 +2594,7 @@ class gpload:
 
             # create a string from all reuse conditions for staging tables and ancode it
             conditions_str = self.get_staging_conditions_string(target_table_name, target_columns, distcols)
-            encoding_conditions = hashlib.md5(conditions_str).hexdigest()
+            encoding_conditions = hashlib.md5(conditions_str.encode('utf-8')).hexdigest()
 					
             sql = self.get_reuse_staging_table_query(encoding_conditions)
             resultList = self.db.query(sql.encode('utf-8')).getresult()

--- a/gpMgmt/bin/gpload_test/gpload2/query44.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query44.ans
@@ -1,12 +1,18 @@
-Traceback (most recent call last):
-  File "pathto/gpload.py", line 3072, in <module>
-    g = gpload(sys.argv[1:])
-  File "pathto/gpload.py", line 1230, in __init__
-    sys.stderr.write("Option %s needs a parameter.\n"%argv[0])
-IndexError: list index out of range
-Traceback (most recent call last):
-  File "pathto/gpload.py", line 3072, in <module>
-    g = gpload(sys.argv[1:])
-  File "pathto/gpload.py", line 1230, in __init__
-    sys.stderr.write("Option %s needs a parameter.\n"%argv[0])
-IndexError: list index out of range
+2021-08-09 11:09:19|INFO|gpload session started 2021-08-09 11:09:19
+2021-08-09 11:09:19|INFO|setting schema 'public' for table 'texttable'
+2021-08-09 11:09:19|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-08-09 11:09:19|INFO|reusing external table ext_gpload_table
+2021-08-09 11:09:19|INFO|running time: 0.05 seconds
+2021-08-09 11:09:19|INFO|rows Inserted          = 16
+2021-08-09 11:09:19|INFO|rows Updated           = 0
+2021-08-09 11:09:19|INFO|data formatting errors = 0
+2021-08-09 11:09:19|INFO|gpload succeeded
+2021-08-09 11:09:19|INFO|gpload session started 2021-08-09 11:09:19
+2021-08-09 11:09:20|INFO|setting schema 'public' for table 'texttable'
+2021-08-09 11:09:20|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-08-09 11:09:20|INFO|reusing external table ext_gpload_table
+2021-08-09 11:09:20|INFO|running time: 0.05 seconds
+2021-08-09 11:09:20|INFO|rows Inserted          = 16
+2021-08-09 11:09:20|INFO|rows Updated           = 0
+2021-08-09 11:09:20|INFO|data formatting errors = 0
+2021-08-09 11:09:20|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query71.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query71.ans
@@ -1,27 +1,32 @@
-2021-06-21 16:22:32|INFO|gpload session started 2021-06-21 16:22:32
-2021-06-21 16:22:32|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:32|ERROR|unexpected error -- backtrace written to log file
-2021-06-21 16:22:32|INFO|rows Inserted          = 0
-2021-06-21 16:22:32|INFO|rows Updated           = 0
-2021-06-21 16:22:32|INFO|data formatting errors = 0
-2021-06-21 16:22:32|INFO|gpload failed
-2021-06-21 16:22:32|INFO|gpload session started 2021-06-21 16:22:32
-2021-06-21 16:22:32|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:32|ERROR|unexpected error -- backtrace written to log file
-2021-06-21 16:22:32|INFO|rows Inserted          = 0
-2021-06-21 16:22:32|INFO|rows Updated           = 0
-2021-06-21 16:22:32|INFO|data formatting errors = 0
-2021-06-21 16:22:32|INFO|gpload failed
-   列1    | 列#2 |        lie3         | 列four 
-----------+------+---------------------+--------
- Line 1   |    1 | 2012-06-01 15:30:30 |    1.2
- 2nd line |    2 | 2012-06-01 15:30:40 |    2.3
- test     |    3 | 2012-06-01 15:30:50 |      3
- Vide     |    4 | 2012-06-01 15:30:10 |    4.5
- Field 2  |    5 | 2012-06-01 15:10:30 |      5
- new line |    6 | 2012-06-01 17:30:30 |    5.6
- Line 10  |    7 | 2012-06-02 15:30:30 |    6.6
-(7 rows)
+2021-07-29 20:09:37|INFO|gpload session started 2021-07-29 20:09:37
+2021-07-29 20:09:37|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 20:09:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 20:09:37|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_574412e30ee9763b91661726a67363d6
+2021-07-29 20:09:37|INFO|reusing external table ext_gpload_reusable_d7f1d482_f065_11eb_9d7a_0050569ea4ff
+2021-07-29 20:09:37|INFO|running time: 0.07 seconds
+2021-07-29 20:09:37|INFO|rows Inserted          = 1
+2021-07-29 20:09:37|INFO|rows Updated           = 7
+2021-07-29 20:09:37|INFO|data formatting errors = 0
+2021-07-29 20:09:37|INFO|gpload succeeded
+2021-07-29 20:09:37|INFO|gpload session started 2021-07-29 20:09:37
+2021-07-29 20:09:37|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 20:09:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 20:09:37|INFO|reusing staging table staging_gpload_reusable_574412e30ee9763b91661726a67363d6
+2021-07-29 20:09:37|INFO|reusing external table ext_gpload_reusable_d7f1d482_f065_11eb_9d7a_0050569ea4ff
+2021-07-29 20:09:37|INFO|running time: 0.06 seconds
+2021-07-29 20:09:37|INFO|rows Inserted          = 0
+2021-07-29 20:09:37|INFO|rows Updated           = 8
+2021-07-29 20:09:37|INFO|data formatting errors = 0
+2021-07-29 20:09:37|INFO|gpload succeeded
+    列1    | 列#2 |        lie3         | 列four 
+-----------+------+---------------------+--------
+ Line 1    |    1 | 2012-06-01 15:30:30 |    1.2
+ 2nd line  |    2 | 2012-06-01 15:30:40 |    2.3
+ test      |    3 | 2012-06-01 15:30:50 |      3
+ Vide      |    4 | 2012-06-01 15:30:10 |    4.5
+ Field 234 |    5 | 2012-06-01 15:10:30 |      5
+ new line  |    6 | 2012-06-01 17:30:30 |    5.6
+ Line 10   |    7 | 2012-06-02 15:30:30 |    6.8
+ 第11列    |    8 | 2012-06-01 15:30:30 |    6.6
+(8 rows)
 

--- a/gpMgmt/bin/gpload_test/gpload2/query73.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query73.ans
@@ -1,14 +1,14 @@
-2021-05-24 17:37:12|INFO|gpload session started 2021-05-24 17:37:12
-2021-05-24 17:37:12|INFO|setting schema 'public' for table 'chinese表'
-2021-05-24 17:37:12|ERROR|no mapping for input column ""notexist"" to output table
-2021-05-24 17:37:12|INFO|rows Inserted          = 0
-2021-05-24 17:37:12|INFO|rows Updated           = 0
-2021-05-24 17:37:12|INFO|data formatting errors = 0
-2021-05-24 17:37:12|INFO|gpload failed
-2021-05-24 17:37:12|INFO|gpload session started 2021-05-24 17:37:12
-2021-05-24 17:37:12|INFO|setting schema 'public' for table 'chinese表'
-2021-05-24 17:37:12|ERROR|no mapping for input column ""notexist"" to output table
-2021-05-24 17:37:12|INFO|rows Inserted          = 0
-2021-05-24 17:37:12|INFO|rows Updated           = 0
-2021-05-24 17:37:12|INFO|data formatting errors = 0
-2021-05-24 17:37:12|INFO|gpload failed
+2021-07-29 21:08:32|INFO|gpload session started 2021-07-29 21:08:32
+2021-07-29 21:08:32|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 21:08:32|ERROR|no mapping for input column "notexist" to output table
+2021-07-29 21:08:32|INFO|rows Inserted          = 0
+2021-07-29 21:08:32|INFO|rows Updated           = 0
+2021-07-29 21:08:32|INFO|data formatting errors = 0
+2021-07-29 21:08:32|INFO|gpload failed
+2021-07-29 21:08:33|INFO|gpload session started 2021-07-29 21:08:33
+2021-07-29 21:08:33|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 21:08:33|ERROR|no mapping for input column "notexist" to output table
+2021-07-29 21:08:33|INFO|rows Inserted          = 0
+2021-07-29 21:08:33|INFO|rows Updated           = 0
+2021-07-29 21:08:33|INFO|data formatting errors = 0
+2021-07-29 21:08:33|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query75.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query75.ans
@@ -1,25 +1,36 @@
-2021-06-21 16:22:33|INFO|gpload session started 2021-06-21 16:22:33
-2021-06-21 16:22:33|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:33|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:33|INFO|reusing external table ext_gpload_reusable_d3399c46_d269_11eb_9789_0050569ea4ff
-2021-06-21 16:22:33|ERROR|unexpected error -- backtrace written to log file
-2021-06-21 16:22:33|INFO|rows Inserted          = 0
-2021-06-21 16:22:33|INFO|rows Updated           = 0
-2021-06-21 16:22:33|INFO|data formatting errors = 0
-2021-06-21 16:22:33|INFO|gpload failed
-2021-06-21 16:22:33|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
-2021-06-21 16:22:34|INFO|gpload session started 2021-06-21 16:22:34
-2021-06-21 16:22:34|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:34|ERROR|no mapping for input column "'列1'" to output table
-2021-06-21 16:22:34|INFO|rows Inserted          = 0
-2021-06-21 16:22:34|INFO|rows Updated           = 0
-2021-06-21 16:22:34|INFO|data formatting errors = 0
-2021-06-21 16:22:34|INFO|gpload failed
-2021-06-21 16:22:34|INFO|gpload session started 2021-06-21 16:22:34
-2021-06-21 16:22:34|INFO|setting schema 'public' for table 'chinese表'
-2021-06-21 16:22:34|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-06-21 16:22:34|ERROR|unexpected error -- backtrace written to log file
-2021-06-21 16:22:34|INFO|rows Inserted          = 0
-2021-06-21 16:22:34|INFO|rows Updated           = 0
-2021-06-21 16:22:34|INFO|data formatting errors = 0
-2021-06-21 16:22:34|INFO|gpload failed
+2021-07-29 21:00:51|INFO|gpload session started 2021-07-29 21:00:51
+2021-07-29 21:00:51|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 21:00:51|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 21:00:51|INFO|did not find an external table to reuse. creating ext_gpload_reusable_0075db36_f06d_11eb_9f82_0050569ea4ff
+2021-07-29 21:00:51|INFO|running time: 0.05 seconds
+2021-07-29 21:00:51|INFO|rows Inserted          = 8
+2021-07-29 21:00:51|INFO|rows Updated           = 0
+2021-07-29 21:00:51|INFO|data formatting errors = 0
+2021-07-29 21:00:51|INFO|gpload succeeded
+2021-07-29 21:00:51|INFO|gpload session started 2021-07-29 21:00:51
+2021-07-29 21:00:51|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 21:00:51|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 21:00:51|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-07-29 21:00:51|INFO|reusing external table ext_gpload_reusable_0075db36_f06d_11eb_9f82_0050569ea4ff
+2021-07-29 21:00:51|INFO|running time: 0.07 seconds
+2021-07-29 21:00:51|INFO|rows Inserted          = 0
+2021-07-29 21:00:51|INFO|rows Updated           = 8
+2021-07-29 21:00:51|INFO|data formatting errors = 0
+2021-07-29 21:00:51|INFO|gpload succeeded
+2021-07-29 21:00:51|INFO|gpload session started 2021-07-29 21:00:51
+2021-07-29 21:00:51|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 21:00:51|ERROR|no mapping for input column "'列1'" to output table
+2021-07-29 21:00:51|INFO|rows Inserted          = 0
+2021-07-29 21:00:51|INFO|rows Updated           = 0
+2021-07-29 21:00:51|INFO|data formatting errors = 0
+2021-07-29 21:00:51|INFO|gpload failed
+2021-07-29 21:00:51|INFO|gpload session started 2021-07-29 21:00:51
+2021-07-29 21:00:51|INFO|setting schema 'public' for table 'chinese表'
+2021-07-29 21:00:51|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 21:00:51|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-07-29 21:00:51|INFO|reusing external table ext_gpload_reusable_0075db36_f06d_11eb_9f82_0050569ea4ff
+2021-07-29 21:00:51|INFO|running time: 0.07 seconds
+2021-07-29 21:00:51|INFO|rows Inserted          = 0
+2021-07-29 21:00:51|INFO|rows Updated           = 8
+2021-07-29 21:00:51|INFO|data formatting errors = 0
+2021-07-29 21:00:51|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -1,29 +1,45 @@
-2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
-2021-07-16 16:51:06|INFO|setting schema 'public' for table 'chinese表'
-2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-16 16:51:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f51b4226_e612_11eb_805c_0050569ea4ff
-2021-07-16 16:51:06|ERROR|could not run SQL "create external table ext_gpload_reusable_f51b4226_e612_11eb_805c_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-30 11:44:08|INFO|gpload session started 2021-07-30 11:44:08
+2021-07-30 11:44:08|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 11:44:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff
+2021-07-30 11:44:08|ERROR|could not run SQL "create external table ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-07-16 16:51:06|INFO|rows Inserted          = 0
-2021-07-16 16:51:06|INFO|rows Updated           = 0
-2021-07-16 16:51:06|INFO|data formatting errors = 0
-2021-07-16 16:51:06|INFO|gpload failed
-2021-07-16 16:51:06|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
-2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
-2021-07-16 16:51:06|INFO|setting schema 'public' for table 'chinese表'
-2021-07-16 16:51:06|ERROR|no mapping for input column "'列1'" to output table
-2021-07-16 16:51:06|INFO|rows Inserted          = 0
-2021-07-16 16:51:06|INFO|rows Updated           = 0
-2021-07-16 16:51:06|INFO|data formatting errors = 0
-2021-07-16 16:51:06|INFO|gpload failed
-2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
-2021-07-16 16:51:06|INFO|setting schema 'public' for table 'chinese表'
-2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-16 16:51:06|ERROR|unexpected error -- backtrace written to log file
-2021-07-16 16:51:06|INFO|rows Inserted          = 0
-2021-07-16 16:51:06|INFO|rows Updated           = 0
-2021-07-16 16:51:06|INFO|data formatting errors = 0
-2021-07-16 16:51:06|INFO|gpload failed
+2021-07-30 11:44:08|INFO|rows Inserted          = 0
+2021-07-30 11:44:08|INFO|rows Updated           = 0
+2021-07-30 11:44:08|INFO|data formatting errors = 0
+2021-07-30 11:44:08|INFO|gpload failed
+2021-07-30 11:44:08|INFO|gpload session started 2021-07-30 11:44:08
+2021-07-30 11:44:08|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:09|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 11:44:09|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-07-30 11:44:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_656d1e98_f0e8_11eb_8ba3_0050569ea4ff
+2021-07-30 11:44:09|ERROR|could not run SQL "create external table ext_gpload_reusable_656d1e98_f0e8_11eb_8ba3_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
+
+2021-07-30 11:44:09|INFO|rows Inserted          = 0
+2021-07-30 11:44:09|INFO|rows Updated           = 0
+2021-07-30 11:44:09|INFO|data formatting errors = 0
+2021-07-30 11:44:09|INFO|gpload failed
+2021-07-30 11:44:09|INFO|gpload session started 2021-07-30 11:44:09
+2021-07-30 11:44:09|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:09|ERROR|no mapping for input column "'列1'" to output table
+2021-07-30 11:44:09|INFO|rows Inserted          = 0
+2021-07-30 11:44:09|INFO|rows Updated           = 0
+2021-07-30 11:44:09|INFO|data formatting errors = 0
+2021-07-30 11:44:09|INFO|gpload failed
+2021-07-30 11:44:09|INFO|gpload session started 2021-07-30 11:44:09
+2021-07-30 11:44:09|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:09|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 11:44:09|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-07-30 11:44:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_65931f44_f0e8_11eb_8b52_0050569ea4ff
+2021-07-30 11:44:09|ERROR|unexpected error -- backtrace written to log file
+2021-07-30 11:44:09|INFO|rows Inserted          = 0
+2021-07-30 11:44:09|INFO|rows Updated           = 0
+2021-07-30 11:44:09|INFO|data formatting errors = 0
+2021-07-30 11:44:09|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query77.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query77.ans
@@ -1,50 +1,42 @@
-2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
-2021-07-16 16:51:06|INFO|setting schema 'public' for table 'testspecialchar'
-2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-16 16:51:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f56e7414_e612_11eb_9860_0050569ea4ff
-2021-07-16 16:51:06|ERROR|could not run SQL "create external table ext_gpload_reusable_f56e7414_e612_11eb_9860_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-29 21:08:35|INFO|gpload session started 2021-07-29 21:08:35
+2021-07-29 21:08:35|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-29 21:08:35|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 21:08:35|INFO|did not find an external table to reuse. creating ext_gpload_reusable_15099ac8_f06e_11eb_abc1_0050569ea4ff
+2021-07-29 21:08:35|ERROR|could not run SQL "create external table ext_gpload_reusable_15099ac8_f06e_11eb_abc1_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-07-16 16:51:06|INFO|rows Inserted          = 0
-2021-07-16 16:51:06|INFO|rows Updated           = 0
-2021-07-16 16:51:06|INFO|data formatting errors = 0
-2021-07-16 16:51:06|INFO|gpload failed
-2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
-2021-07-16 16:51:06|INFO|setting schema 'public' for table 'testspecialchar'
-2021-07-16 16:51:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-16 16:51:06|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
-2021-07-16 16:51:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f582aac4_e612_11eb_8049_0050569ea4ff
-2021-07-16 16:51:06|ERROR|could not run SQL "create external table ext_gpload_reusable_f582aac4_e612_11eb_8049_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-07-29 21:08:35|INFO|rows Inserted          = 0
+2021-07-29 21:08:35|INFO|rows Updated           = 0
+2021-07-29 21:08:35|INFO|data formatting errors = 0
+2021-07-29 21:08:35|INFO|gpload failed
+2021-07-29 21:08:35|INFO|gpload session started 2021-07-29 21:08:35
+2021-07-29 21:08:35|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-29 21:08:35|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-29 21:08:35|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
+2021-07-29 21:08:35|INFO|did not find an external table to reuse. creating ext_gpload_reusable_151dac20_f06e_11eb_8c92_0050569ea4ff
+2021-07-29 21:08:35|ERROR|could not run SQL "create external table ext_gpload_reusable_151dac20_f06e_11eb_8c92_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
  if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-07-16 16:51:06|INFO|rows Inserted          = 0
-2021-07-16 16:51:06|INFO|rows Updated           = 0
-2021-07-16 16:51:06|INFO|data formatting errors = 0
-2021-07-16 16:51:06|INFO|gpload failed
-2021-07-16 16:51:06|INFO|gpload session started 2021-07-16 16:51:06
-2021-07-16 16:51:06|INFO|setting schema 'public' for table 'testspecialchar'
-2021-07-16 16:51:06|ERROR|no mapping for input column "'Field1'" to output table
-2021-07-16 16:51:06|INFO|rows Inserted          = 0
-2021-07-16 16:51:06|INFO|rows Updated           = 0
-2021-07-16 16:51:06|INFO|data formatting errors = 0
-2021-07-16 16:51:06|INFO|gpload failed
-2021-07-16 16:51:07|INFO|gpload session started 2021-07-16 16:51:07
-2021-07-16 16:51:07|INFO|setting schema 'public' for table 'testspecialchar'
-2021-07-16 16:51:07|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-16 16:51:07|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
-2021-07-16 16:51:07|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f5a91e48_e612_11eb_920a_0050569ea4ff
-2021-07-16 16:51:07|ERROR|could not run SQL "create external table ext_gpload_reusable_f5a91e48_e612_11eb_920a_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8082//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
-LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
-                                                                 ^
- could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
- if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
-
-2021-07-16 16:51:07|INFO|rows Inserted          = 0
-2021-07-16 16:51:07|INFO|rows Updated           = 0
-2021-07-16 16:51:07|INFO|data formatting errors = 0
-2021-07-16 16:51:07|INFO|gpload failed
+2021-07-29 21:08:35|INFO|rows Inserted          = 0
+2021-07-29 21:08:35|INFO|rows Updated           = 0
+2021-07-29 21:08:35|INFO|data formatting errors = 0
+2021-07-29 21:08:35|INFO|gpload failed
+2021-07-29 21:08:35|INFO|gpload session started 2021-07-29 21:08:35
+2021-07-29 21:08:35|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-29 21:08:35|ERROR|no mapping for input column "'Field1'" to output table
+2021-07-29 21:08:35|INFO|rows Inserted          = 0
+2021-07-29 21:08:35|INFO|rows Updated           = 0
+2021-07-29 21:08:35|INFO|data formatting errors = 0
+2021-07-29 21:08:35|INFO|gpload failed
+2021-07-29 21:08:35|INFO|gpload session started 2021-07-29 21:08:35
+2021-07-29 21:08:35|INFO|setting schema 'public' for table 'testspecialchar'
+2021-07-29 21:08:35|ERROR|no mapping for input column "Field1" to output table
+2021-07-29 21:08:35|INFO|rows Inserted          = 0
+2021-07-29 21:08:35|INFO|rows Updated           = 0
+2021-07-29 21:08:35|INFO|data formatting errors = 0
+2021-07-29 21:08:35|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query78.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query78.ans
@@ -1,0 +1,54 @@
+2021-07-30 12:31:41|INFO|gpload session started 2021-07-30 12:31:41
+2021-07-30 12:31:41|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-07-30 12:31:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 12:31:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_09bd3310_f0ef_11eb_b617_0050569ea4ff
+2021-07-30 12:31:41|INFO|running time: 0.05 seconds
+2021-07-30 12:31:41|INFO|rows Inserted          = 2
+2021-07-30 12:31:41|INFO|rows Updated           = 0
+2021-07-30 12:31:41|INFO|data formatting errors = 0
+2021-07-30 12:31:41|INFO|gpload succeeded
+2021-07-30 12:31:41|INFO|gpload session started 2021-07-30 12:31:41
+2021-07-30 12:31:41|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-07-30 12:31:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 12:31:41|INFO|reusing external table ext_gpload_reusable_09bd3310_f0ef_11eb_b617_0050569ea4ff
+2021-07-30 12:31:41|INFO|running time: 0.04 seconds
+2021-07-30 12:31:41|INFO|rows Inserted          = 2
+2021-07-30 12:31:41|INFO|rows Updated           = 0
+2021-07-30 12:31:41|INFO|data formatting errors = 0
+2021-07-30 12:31:41|INFO|gpload succeeded
+2021-07-30 12:31:41|INFO|gpload session started 2021-07-30 12:31:41
+2021-07-30 12:31:41|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-07-30 12:31:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 12:31:41|INFO|reusing external table ext_gpload_reusable_09bd3310_f0ef_11eb_b617_0050569ea4ff
+2021-07-30 12:31:41|INFO|running time: 0.04 seconds
+2021-07-30 12:31:41|INFO|rows Inserted          = 2
+2021-07-30 12:31:41|INFO|rows Updated           = 0
+2021-07-30 12:31:41|INFO|data formatting errors = 0
+2021-07-30 12:31:41|INFO|gpload succeeded
+2021-07-30 12:31:42|INFO|gpload session started 2021-07-30 12:31:42
+2021-07-30 12:31:42|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-07-30 12:31:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 12:31:42|INFO|reusing external table ext_gpload_reusable_09bd3310_f0ef_11eb_b617_0050569ea4ff
+2021-07-30 12:31:42|INFO|running time: 0.04 seconds
+2021-07-30 12:31:42|INFO|rows Inserted          = 2
+2021-07-30 12:31:42|INFO|rows Updated           = 0
+2021-07-30 12:31:42|INFO|data formatting errors = 0
+2021-07-30 12:31:42|INFO|gpload succeeded
+2021-07-30 12:31:42|INFO|gpload session started 2021-07-30 12:31:42
+2021-07-30 12:31:42|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-07-30 12:31:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 12:31:42|INFO|reusing external table ext_gpload_reusable_09bd3310_f0ef_11eb_b617_0050569ea4ff
+2021-07-30 12:31:42|INFO|running time: 0.04 seconds
+2021-07-30 12:31:42|INFO|rows Inserted          = 2
+2021-07-30 12:31:42|INFO|rows Updated           = 0
+2021-07-30 12:31:42|INFO|data formatting errors = 0
+2021-07-30 12:31:42|INFO|gpload succeeded
+2021-07-30 12:31:42|INFO|gpload session started 2021-07-30 12:31:42
+2021-07-30 12:31:42|INFO|setting schema 'public' for table 'testheaderreuse'
+2021-07-30 12:31:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 12:31:42|INFO|reusing external table ext_gpload_reusable_09bd3310_f0ef_11eb_b617_0050569ea4ff
+2021-07-30 12:31:42|INFO|running time: 0.04 seconds
+2021-07-30 12:31:42|INFO|rows Inserted          = 2
+2021-07-30 12:31:42|INFO|rows Updated           = 0
+2021-07-30 12:31:42|INFO|data formatting errors = 0
+2021-07-30 12:31:42|INFO|gpload succeeded


### PR DESCRIPTION
fix gpload cannot deal with column name in upper case
we treat column names like `COL, "COL"`as lower case letters unless it is quoted like `'"COL"' or "\"col\""`
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
