### PR TITLE
(5x) Fix wrong levelsup paramenter when coerce_unknown_var for SetOperatio…

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2046,6 +2046,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	}
 
 	/*
+	 * Greenplum specific behavior
 	 * Coerce the UNKNOWN type for target entries to its right type here.
 	 */
 	fixup_unknown_vars_in_setop(pstate, sostmt);

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -712,6 +712,11 @@ fixup_unknown_vars_in_targetlist(ParseState *pstate, List *targetlist)
 /*
  * Fix up the unknown Vars in the subquery specified by rtr. The new
  * types and typemods are given.
+ * Greenplum Specific Logic:
+ *   this function's call chain is
+ *    fixup_unknown_vars_in_RangeTblRef <-- fixup_unknown_vars_in_setop <-- transformSetOperationStmt
+ *   the whole bunch of code is added by Greenplum and it is only used during
+ *   parse-analyze Set Operation Statement.
  */
 static void
 fixup_unknown_vars_in_RangeTblRef(ParseState *pstate, RangeTblRef *rtr,
@@ -740,10 +745,19 @@ fixup_unknown_vars_in_RangeTblRef(ParseState *pstate, RangeTblRef *rtr,
 		if (IsA(tle->expr, Var) &&
 			((Var *)tle->expr)->vartype == UNKNOWNOID)
 		{
+			/*
+			 * As mentioned in this function's comments, this function can only be
+			 * used for Set Operation SQL Statement, like Q: q1 Union q2.
+			 * We are now in Q's context, q1 is parse-analyzed in a sub parse-state of
+			 * Q's and that sub parse-state is free-ed when finishing. So we have to
+			 * pass -1 as levelsup to the following function coerce_unknown_var.
+			 * See Github Issue https://github.com/greenplum-db/gpdb/issues/12407
+			 * for details.
+			 */
 			tle->expr = (Expr *)coerce_unknown_var(pstate, (Var *)tle->expr,
 												   colType, colTypmod,
 												   COERCION_IMPLICIT, COERCE_DONTCARE,
-												   0);
+												   -1);
 		}
 
 		tle_lc = lnext(tle_lc);
@@ -753,6 +767,7 @@ fixup_unknown_vars_in_RangeTblRef(ParseState *pstate, RangeTblRef *rtr,
 }
 
 /*
+ * Greenplum specific function.
  * Fix up the unknown Vars in all subqueries in a SetOperationStmt.
  */
 void

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -2139,6 +2139,58 @@ where ABC.ss = 5;
   5
 (1 row)
 
+-- Test when fixing up unkown type for union statement and the var is from outer
+-- subquery. See Github Issue https://github.com/greenplum-db/gpdb/issues/12407
+-- for details.
+create table t_issue_12407(a int, b int, c varchar(32));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t1_issue_12407(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_issue_12407(a int, b int, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_issue_12407 select i,i,i::varchar(32) from generate_series(1, 10)i;
+insert into t1_issue_12407 select i,i,i from generate_series(1, 10)i;
+insert into t2_issue_12407 select i,i,i::text from generate_series(1, 10)i;
+explain select * from (select 'asdas' tc) xxx left join  t2_issue_12407
+on t2_issue_12407.c = any (array(select xxx.tc union all select t1_issue_12407.a::text from t1_issue_12407));
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join  (cost=3.31..36.35 rows=4 width=42)
+   Join Filter: t2_issue_12407.c = ANY (((subplan)))
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   ->  Materialize  (cost=3.31..3.41 rows=4 width=10)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.30 rows=10 width=10)
+               ->  Seq Scan on t2_issue_12407  (cost=0.00..3.10 rows=4 width=10)
+   SubPlan 1
+     ->  Append  (cost=0.00..3.27 rows=4 width=4)
+           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+           ->  Result  (cost=3.16..3.26 rows=4 width=4)
+                 ->  Materialize  (cost=3.16..3.26 rows=4 width=4)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.15 rows=10 width=4)
+                             ->  Seq Scan on t1_issue_12407  (cost=0.00..3.15 rows=4 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
+select * from (select 'str' tc) xxx left join  t2_issue_12407
+on t2_issue_12407.c = any (array(select xxx.tc union all select t1_issue_12407.a::text from t1_issue_12407));
+ tc  | a  | b  | c  
+-----+----+----+----
+ str |  1 |  1 | 1
+ str |  2 |  2 | 2
+ str |  3 |  3 | 3
+ str |  4 |  4 | 4
+ str |  5 |  5 | 5
+ str |  6 |  6 | 6
+ str |  7 |  7 | 7
+ str |  8 |  8 | 8
+ str |  9 |  9 | 9
+ str | 10 | 10 | 10
+(10 rows)
+
 --
 -- Clean up
 --

--- a/src/test/regress/expected/union_gp_optimizer.out
+++ b/src/test/regress/expected/union_gp_optimizer.out
@@ -2142,6 +2142,58 @@ where ABC.ss = 5;
   5
 (1 row)
 
+-- Test when fixing up unkown type for union statement and the var is from outer
+-- subquery. See Github Issue https://github.com/greenplum-db/gpdb/issues/12407
+-- for details.
+create table t_issue_12407(a int, b int, c varchar(32));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t1_issue_12407(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_issue_12407(a int, b int, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_issue_12407 select i,i,i::varchar(32) from generate_series(1, 10)i;
+insert into t1_issue_12407 select i,i,i from generate_series(1, 10)i;
+insert into t2_issue_12407 select i,i,i::text from generate_series(1, 10)i;
+explain select * from (select 'asdas' tc) xxx left join  t2_issue_12407
+on t2_issue_12407.c = any (array(select xxx.tc union all select t1_issue_12407.a::text from t1_issue_12407));
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join  (cost=3.31..36.35 rows=4 width=42)
+   Join Filter: t2_issue_12407.c = ANY (((subplan)))
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   ->  Materialize  (cost=3.31..3.41 rows=4 width=10)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.30 rows=10 width=10)
+               ->  Seq Scan on t2_issue_12407  (cost=0.00..3.10 rows=4 width=10)
+   SubPlan 1
+     ->  Append  (cost=0.00..3.27 rows=4 width=4)
+           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+           ->  Result  (cost=3.16..3.26 rows=4 width=4)
+                 ->  Materialize  (cost=3.16..3.26 rows=4 width=4)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.15 rows=10 width=4)
+                             ->  Seq Scan on t1_issue_12407  (cost=0.00..3.15 rows=4 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
+select * from (select 'str' tc) xxx left join  t2_issue_12407
+on t2_issue_12407.c = any (array(select xxx.tc union all select t1_issue_12407.a::text from t1_issue_12407));
+ tc  | a  | b  | c  
+-----+----+----+----
+ str |  1 |  1 | 1
+ str |  2 |  2 | 2
+ str |  3 |  3 | 3
+ str |  4 |  4 | 4
+ str |  5 |  5 | 5
+ str |  6 |  6 | 6
+ str |  7 |  7 | 7
+ str |  8 |  8 | 8
+ str |  9 |  9 | 9
+ str | 10 | 10 | 10
+(10 rows)
+
 --
 -- Clean up
 --

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -625,6 +625,24 @@ from
         FROM foo_union
 ) ABC
 where ABC.ss = 5;
+
+-- Test when fixing up unkown type for union statement and the var is from outer
+-- subquery. See Github Issue https://github.com/greenplum-db/gpdb/issues/12407
+-- for details.
+create table t_issue_12407(a int, b int, c varchar(32));
+create table t1_issue_12407(a int, b int, c int);
+create table t2_issue_12407(a int, b int, c text);
+
+insert into t_issue_12407 select i,i,i::varchar(32) from generate_series(1, 10)i;
+insert into t1_issue_12407 select i,i,i from generate_series(1, 10)i;
+insert into t2_issue_12407 select i,i,i::text from generate_series(1, 10)i;
+
+explain select * from (select 'asdas' tc) xxx left join  t2_issue_12407
+on t2_issue_12407.c = any (array(select xxx.tc union all select t1_issue_12407.a::text from t1_issue_12407));
+
+select * from (select 'str' tc) xxx left join  t2_issue_12407
+on t2_issue_12407.c = any (array(select xxx.tc union all select t1_issue_12407.a::text from t1_issue_12407));
+
 --
 -- Clean up
 --


### PR DESCRIPTION
…n statement.

Greenplum has a specific logic to fix up unknown vars during parse-analyzing
set-operation SQL statement. It will invoke fixup_unknown_vars_in_setop to do
the job. A set-operation SQL statement, like Q: q1 union all q2, when fixing up
Q, we are at level 0. Parse-analyze q1 will be in a sub parse-state of Q and that
state will be free-ed when finishing parsing q1. So when we are at Q's context
and decide to fix up unknown type vars in q1 or q2, we need to shift the context
level by 1. See Github Issue greenplum-db#12407 for details.

This commit fixes the issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
