### PR TITLE
gpinitstandby/gprecoverseg utils fail when there is banner on .bashrc  present

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -69,13 +69,13 @@ def get_postmaster_pid_locally(datadir):
         return -1
 
 def getPostmasterPID(hostname, datadir):
-    cmdStr="ps -ef | grep 'postgres -D %s' | grep -v grep" % (datadir)
+    cmdStr="echo 'START_CMD_OUTPUT';ps -ef | grep 'postgres -D %s' | grep -v grep" % (datadir)
     name="get postmaster pid"
     cmd=Command(name,cmdStr,ctxt=REMOTE,remoteHost=hostname)
     try:
         cmd.run(validateAfter=True)
         sout=cmd.get_results().stdout.lstrip(' ')
-        return int(sout.split()[1])
+        return int(sout.split('START_CMD_OUTPUT')[1].split()[1])
     except:
         return -1
 
@@ -1618,7 +1618,7 @@ class GpRecoverSeg(Command):
 class IfAddrs:
     @staticmethod
     def list_addrs(hostname=None, include_loopback=False):
-        cmd = ['%s/libexec/ifaddrs' % GPHOME]
+        cmd = ["echo 'START_CMD_OUTPUT'; %s/libexec/ifaddrs" % GPHOME]
         if not include_loopback:
             cmd.append('--no-loopback')
         if hostname:
@@ -1628,7 +1628,7 @@ class IfAddrs:
             args = cmd
 
         result = subprocess.check_output(args).decode()
-        return result.splitlines()
+        return result.split('START_CMD_OUTPUT')[1].strip().splitlines()
 
 if __name__ == '__main__':
 

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -166,7 +166,14 @@ class PgControlData(Command):
             self.data = {}
             for l in self.results.stdout.split('\n'):
                 if len(l) > 0:
-                    (n,v) = l.split(':', 1)
+                    split_line = l.split(':', 1)
+                    # avoid ValueErrors when there is no value to the key
+                    if len(split_line) == 1:
+                        n = split_line[0]
+                        v = ''
+                    elif len(split_line) == 2:
+                        n = split_line[0]
+                        v = split_line[1]
                     self.data[n.strip()] = v.strip() 
         return self.data[name]
 

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -488,17 +488,17 @@ class RemoveGlob(Command):
 class FileDirExists(Command):
     def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
         self.directory = directory
-        cmdStr = """python3  -c "import os; print(os.path.exists('%s'))" """ % directory
+        cmdStr = "[ -d '%s' ]" % directory
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
     def remote(name, remote_host, directory):
         cmd = FileDirExists(name, directory, ctxt=REMOTE, remoteHost=remote_host)
-        cmd.run(validateAfter=True)
+        cmd.run(validateAfter=False)
         return cmd.filedir_exists()
 
     def filedir_exists(self):
-        return self.results.stdout.strip().upper() == 'TRUE'
+        return (not self.results.rc)
 
 
 # -------------scp------------------

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -26,7 +26,8 @@ def get_unreachable_segment_hosts(hosts, num_workers):
     for item in pool.getCompletedItems():
         result = item.get_results()
         if result.rc == 0:
-            host = result.stdout.strip()
+            # Remove login(banner) messages
+            host = result.stdout.strip().split('\n')[-1]
             reachable_hosts.add(host)
 
     unreachable_hosts = list(set(hosts).difference(reachable_hosts))

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -133,3 +133,10 @@ Feature: Tests for gpinitstandby feature
         And the user runs gpinitstandby with options " "
         Then gpinitstandby should return a return code of 0
         And verify that the file "pg_hba.conf" in the coordinator data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"
+
+    Scenario: gpinitstandby should not throw error when banner exists on the hsot
+        Given the database is running
+        And the standby is not initialized
+        When the user sets banner on host
+        And the user runs gpinitstandby with options " "
+        Then gpinitstandby should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -202,6 +202,19 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+    Scenario: gprecoverseg should not return error when banner configured on host
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        When the user sets banner on host
+        And user stops all mirror processes
+        And user can start transactions
+        When the user runs "gprecoverseg -a"
+        Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
+
     @demo_cluster
     @concourse_cluster
     Scenario Outline: <scenario> recovery skips unreachable segments

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -360,6 +360,13 @@ def impl(context, command):
     run_gpcommand(context, command)
 
 
+@when('the user sets banner on host')
+def impl(context):
+    file = '/etc/bashrc'
+    command = "echo 'echo \"banner test\"' >> %s; source %s" % (file, file)
+    run_cmd(command)
+
+
 @given('the user asynchronously sets up to end {process_name} process in {secs} seconds')
 @when('the user asynchronously sets up to end {process_name} process in {secs} seconds')
 def impl(context, process_name, secs):


### PR DESCRIPTION
Management utils are fails when user configures banner through bashrc.
gprecoverseg and gpinitstandby utils are addressed as part of this PR. Most of
the changes are related to parsing failures which are addressed below.


Note: Hitting issue only when banner set through bashrc.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
