### PR TITLE
Fix: Gang cleanup null pointer reference (#12399)

### DIFF
--- a/src/test/isolation2/expected/gpdispatch.out
+++ b/src/test/isolation2/expected/gpdispatch.out
@@ -1,0 +1,37 @@
+-- Try to verify that a session fatal due to OOM should have no effect on other sessions.
+-- Report on https://github.com/greenplum-db/gpdb/issues/12399
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: begin;
+BEGIN
+
+-- session1 will be fatal.
+1: select count(*) > 0 from gp_dist_random('pg_class');
+FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:306)
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- session2 should be ok.
+2: select count(*) > 0 from gp_dist_random('pg_class');
+ ?column? 
+----------
+ t        
+(1 row)
+2: commit;
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
+
+select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,6 @@
+# test dispatch
+test: gpdispatch
+
 # test if gxid is valid or not on the cluster before running the tests
 test: check_gxid
 

--- a/src/test/isolation2/sql/gpdispatch.sql
+++ b/src/test/isolation2/sql/gpdispatch.sql
@@ -1,0 +1,18 @@
+-- Try to verify that a session fatal due to OOM should have no effect on other sessions.
+-- Report on https://github.com/greenplum-db/gpdb/issues/12399
+
+create extension if not exists gp_inject_fault;
+
+1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+2: begin;
+
+-- session1 will be fatal.
+1: select count(*) > 0 from gp_dist_random('pg_class');
+
+-- session2 should be ok.
+2: select count(*) > 0 from gp_dist_random('pg_class');
+2: commit;
+1q:
+2q:
+
+select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;


### PR DESCRIPTION
fix issue #12399 
The bug exists also in 6X_STABLE and 5X_STABLE, need to backport

cdbdisp_makeResult() may return NULL due to OOM.
Check the pointer when Gang cleanup.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>
Co-authored-by: Mingli Zhang <avamingli@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
