### PR TITLE
(backport to 6x) Fix Gang cleanup null pointer reference

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -77,6 +77,19 @@ cdbdisp_makeResult(struct CdbDispatchResults *meleeResults,
 	dispatchResult->numrowsrejected = 0;
 	dispatchResult->numrowscompleted = 0;
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("make_dispatch_result_error") == FaultInjectorTypeSkip)
+	{
+		/*
+		 * Inject a fault to simulate the createPQExpBuffer return NULL (maybe because of
+		 * malloc failure, this will lead to enter the below if block and return NULL in
+		 * this function. We need to test this code path to verify the gang clean up code
+		 * is correct.
+		 */
+		dispatchResult->resultbuf = NULL;
+	}
+#endif
+
 	if (PQExpBufferBroken(dispatchResult->resultbuf) ||
 		PQExpBufferBroken(dispatchResult->error_message))
 	{
@@ -156,17 +169,24 @@ void
 cdbdisp_resetResult(CdbDispatchResult *dispatchResult)
 {
 	PQExpBuffer buf = dispatchResult->resultbuf;
-	PGresult  **begp = (PGresult **) buf->data;
-	PGresult  **endp = (PGresult **) (buf->data + buf->len);
-	PGresult  **p;
-
 	/*
-	 * Free the PGresult objects.
-	 */
-	for (p = begp; p < endp; ++p)
+	* the resultbuf may be empty due to oom, set in cdbdisp_makeResult()
+ 	* Related to issue: https://github.com/greenplum-db/gpdb/issues/12399
+	*/
+	if (buf)
 	{
-		Assert(*p != NULL);
-		PQclear(*p);
+		PGresult  **begp = (PGresult **) buf->data;
+		PGresult  **endp = (PGresult **) (buf->data + buf->len);
+		PGresult  **p;
+
+		/*
+		 * Free the PGresult objects.
+		 */
+		for (p = begp; p < endp; ++p)
+		{
+			Assert(*p != NULL);
+			PQclear(*p);
+		}
 	}
 
 	/*

--- a/src/test/isolation2/expected/gpdispatch.out
+++ b/src/test/isolation2/expected/gpdispatch.out
@@ -1,0 +1,41 @@
+-- Try to verify that a session fatal due to OOM should have no effect on other sessions.
+-- Report on https://github.com/greenplum-db/gpdb/issues/12399
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+1: set gp_debug_linger = '1s';
+SET
+1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: begin;
+BEGIN
+
+-- session1 will fatal
+1: select count(*) > 0 from gp_dist_random('pg_class');
+FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:301)
+HINT:  Process 31746 will wait for gp_debug_linger=1 seconds before termination.
+Note that its locks and other resources will not be released until then.
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- session 2 should be ok
+2: select count(*) > 0 from gp_dist_random('pg_class');
+ ?column? 
+----------
+ t        
+(1 row)
+2: commit;
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
+
+select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -3,6 +3,14 @@
 m/\s+\(entry db(.*)+\spid=\d+\)/
 s/\s+\(entry db(.*)+\spid=\d+\)//
 
+# Ignore pid in fatal error message
+m/Process [0-9]+ will wait/
+s/Process [0-9]+ will wait/Process xxx will wait/
+
+# Ignore line number in error message
+m/cdbdisp_async.c:[0-9]+/
+s/cdbdisp_async.c:[0-9]+/cdbdisp_async.c:xxx/
+
 # remove beginning output of gpconfig
 m/^\d+.*gpconfig.*-\[INFO\]:-/
 s/^\d+.*gpconfig.*-\[INFO\]:-//

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,5 +1,6 @@
 test: setup
 test: cached_plan
+test: gpdispatch
 test: checkpoint_dtx_info
 test: lockmodes
 # Put test prepare_limit near to test lockmodes since both of them reboot the

--- a/src/test/isolation2/sql/gpdispatch.sql
+++ b/src/test/isolation2/sql/gpdispatch.sql
@@ -1,0 +1,19 @@
+-- Try to verify that a session fatal due to OOM should have no effect on other sessions.
+-- Report on https://github.com/greenplum-db/gpdb/issues/12399
+
+create extension if not exists gp_inject_fault;
+
+1: set gp_debug_linger = '1s';
+1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+2: begin;
+
+-- session1 will fatal
+1: select count(*) > 0 from gp_dist_random('pg_class');
+
+-- session 2 should be ok
+2: select count(*) > 0 from gp_dist_random('pg_class');
+2: commit;
+1q:
+2q:
+
+select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;


### PR DESCRIPTION
dispatchResult->resultbuf returned by cdbdisp_makeResult() may return NULL due to OOM.
We should check the pointer when Gang cleanup in cdbdisp_resetResult().
Set a FAULT_INJECTOR(make_dispatch_result_error) to simulate this scenario.

Github issue https://github.com/greenplum-db/gpdb/issues/12399

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>
Co-authored-by: Mingli Zhang <avamingli@gmail.com>

---------------------------

Backport pr https://github.com/greenplum-db/gpdb/pull/12430 to 6x.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
