### PR TITLE
Add CHECK_FOR_INTERRUPTS() to ExecMotion().

### DIFF
--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -100,6 +100,8 @@ ExecMotion(PlanState *pstate)
 	MotionState *node = castNode(MotionState, pstate);
 	Motion	   *motion = (Motion *) node->ps.plan;
 
+	CHECK_FOR_INTERRUPTS();
+
 	/* sanity check */
  	if (node->stopRequested)
  		ereport(ERROR,

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -100,6 +100,12 @@ ExecMotion(PlanState *pstate)
 	MotionState *node = castNode(MotionState, pstate);
 	Motion	   *motion = (Motion *) node->ps.plan;
 
+	/*
+	 * Check for interrupts. Without this we've seen the scenario before that
+	 * it could be quite slow to cancel a query that selects all the tuples
+	 * from a big distributed table because the motion node on QD has no chance
+	 * of checking the cancel signal.
+	 */
 	CHECK_FOR_INTERRUPTS();
 
 	/* sanity check */


### PR DESCRIPTION
We should check interrupts in ExecMotion(). Or we cannot process interrupts in time.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

Hi, we found that GPDB cannot process interrupts in time in `execMotion()`.

The easiest way to reproduce:

```sql
create table t(a int, b int);
insert into t select i, i%3 from generate_series(1,60000000) i;

select * from t;
/* Hit CTRL-C */
/* We have to wait a very long time until it cancels the query. */
```

