### PR TITLE
[5X] Fix aocsseg inconsistency when rollback add column

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -97,9 +97,11 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
 
     segrel = heap_open(prel->rd_appendonly->segrelid, RowExclusiveLock);
 
-	InsertFastSequenceEntry(prel->rd_appendonly->segrelid,
-							(int64)segno,
-							0);
+	/*
+	 * Create a new entry in gp_fastsequence or increment
+	 * an existing one (it can exist after transaction rollback).
+	 */
+	GetFastSequences(prel->rd_appendonly->segrelid, (int64) segno, 1, 0);
 
     values[Anum_pg_aocs_segno-1] = Int32GetDatum(segno);
     values[Anum_pg_aocs_vpinfo-1] = PointerGetDatum(vpinfo);
@@ -110,15 +112,17 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
 
     segtup = heap_form_tuple(RelationGetDescr(segrel), values, nulls);
 
-    frozen_heap_insert(segrel, segtup);
-    CatalogUpdateIndexes(segrel, segtup);
+	simple_heap_insert(segrel, segtup);
+	CatalogUpdateIndexes(segrel, segtup);
 
     heap_freetuple(segtup);
     heap_close(segrel, RowExclusiveLock);
 
-    pfree(vpinfo);
-    pfree(nulls);
-    pfree(values);
+	CommandCounterIncrement();
+
+	pfree(vpinfo);
+	pfree(nulls);
+	pfree(values);
 }
 
 /* 

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -783,3 +783,69 @@ alter table aocs_with_compress drop column b;
 alter table aocs_with_compress set with (reorganize=true);
 -- The following operation must not fail
 alter table aocs_with_compress alter column c type integer;
+-- test case: alter AOCS table add column, the preference of the storage setting is: the encoding clause > table setting > gp_default_storage_options
+SET gp_add_column_inherits_table_setting = on;
+CREATE TABLE aocs_alter_add_col(a int) WITH (appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2';
+-- use statement encoding 
+ALTER TABLE aocs_alter_add_col ADD COLUMN b int ENCODING(compresstype=zlib, compresslevel=3, blocksize=16384);
+-- use table setting
+ALTER TABLE aocs_alter_add_col ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use table setting
+ALTER TABLE aocs_alter_add_col ADD COLUMN d int;
+\d+ aocs_alter_add_col
+                                 Append-Only Columnar Table "public.aocs_alter_add_col"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ a      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+ b      | integer |           | plain   |              | zlib             | 3                 | 16384      | 
+ c      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+ d      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+Checksum: t
+Distributed by: (a)
+Options: appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536
+
+DROP TABLE aocs_alter_add_col;
+CREATE TABLE aocs_alter_add_col_no_compress(a int) WITH (appendonly=true, orientation=column);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2, blocksize=8192';
+-- use statement encoding
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN b int ENCODING(compresstype=rle_type, compresslevel=3, blocksize=16384);
+-- use gp_default_storage_options
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use default value 
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN d int;
+\d+ aocs_alter_add_col_no_compress 
+                           Append-Only Columnar Table "public.aocs_alter_add_col_no_compress"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ a      | integer |           | plain   |              | none             | 0                 | 32768      | 
+ b      | integer |           | plain   |              | rle_type         | 3                 | 16384      | 
+ c      | integer |           | plain   |              | zlib             | 2                 | 32768      | 
+ d      | integer |           | plain   |              | none             | 0                 | 32768      | 
+Checksum: t
+Distributed by: (a)
+Options: appendonly=true, orientation=column
+
+DROP TABLE aocs_alter_add_col_no_compress;
+RESET gp_add_column_inherits_table_setting;
+--
+-- Test case: validate pg_aocsseg consistency after alter table
+-- add column with rollback.
+--
+-- pg_aocsseg stores vpinfo structure with serialized EOF information
+-- for every column in AOCS table. If transaction adds new columns,
+-- spawns new pg_aocsseg entries and rollbacks, check there is no
+-- inconsistency in pg_aocsseg after it (with vacuum).
+--
+SET gp_default_storage_options='appendonly=true, orientation=column';
+CREATE TABLE aocs_alter_add_col_no_compress AS
+   SELECT g AS a, g AS b FROM generate_series(1, 10) AS g DISTRIBUTED BY (a);
+BEGIN;
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN c int;
+UPDATE aocs_alter_add_col_no_compress SET c = 1;
+ROLLBACK;
+VACUUM aocs_alter_add_col_no_compress;
+DROP TABLE aocs_alter_add_col_no_compress;
+RESET gp_default_storage_options;


### PR DESCRIPTION
User can add column for an AOCS table in a transaction, when this transaction rollbacks, may cause assert error in later operations.

Original discussion and PR: https://github.com/greenplum-db/gpdb/pull/11371
This will be merged in 6x, and backport it to 5X.

(cherry picked from commit a5e28ec)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
