### PR TITLE
Fix reset GUC issue that causes inconsistent GUC values

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -125,9 +125,10 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 void
 cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 					   const char *gpqeid,
-					   const char *options)
+					   const char *options,
+					   const char *diff_options)
 {
-#define MAX_KEYWORDS 10
+#define MAX_KEYWORDS 11
 #define MAX_INT_STRING_LEN 20
 	CdbComponentDatabaseInfo *cdbinfo = segdbDesc->segment_database_info;
 	const char *keywords[MAX_KEYWORDS];
@@ -146,6 +147,12 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	{
 		keywords[nkeywords] = "options";
 		values[nkeywords] = options;
+		nkeywords++;
+	}
+	if (diff_options)
+	{
+		keywords[nkeywords] = "diff_options";
+		values[nkeywords] = diff_options;
 		nkeywords++;
 	}
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -380,7 +380,7 @@ addOneOption(StringInfo option, StringInfo diff, struct config_generic *guc)
 /*
  * Add GUCs to option/diff_options string.
  *
- * `options` is a list of `reset_val` of the GUCs, not the GUC's current value.
+ * `options` is a list of reset_val of the GUCs, not the GUC's current value.
  * `diff_options` is a list of the GUCs' current value. If the GUC is unchanged,
  * `diff_options` will omit it.
  *
@@ -388,15 +388,17 @@ addOneOption(StringInfo option, StringInfo diff, struct config_generic *guc)
  * PGC_S_CLIENT as its guc source. Then, `diff_options` is used to set the GUCs
  * with PGC_S_SESSION as its guc source.
  *
- * With PGC_S_CLIENT, SetConfigOption() will set the GUC's `reset_val`
- * when processing `options`, so the `reset_val` of the involved GUCs on all QD
+ * With PGC_S_CLIENT, SetConfigOption() will set the GUC's reset_val
+ * when processing `options`, so the reset_val of the involved GUCs on all QD
  * and QEs are the same.
  *
  * After applying `diff_options`, the GUCs' current value is set to the same
- * value as the QD and the `reset_val` of the GUC will not change.
+ * value as the QD and the reset_val of the GUC will not change.
  *
- * At last, both the `reset_val` and current value of the GUC are consistent,
+ * At last, both the reset_val and current value of the GUC are consistent,
  * even after RESET.
+ *
+ * See addOneOption() and process_startup_options() for more details.
  */
 void
 makeOptions(char **options, char **diff_options)

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -378,7 +378,25 @@ addOneOption(StringInfo string, StringInfo diff, struct config_generic *guc)
 }
 
 /*
- * Add GUCs to option string.
+ * Add GUCs to option/diff_options string.
+ *
+ * `options` is a list of `reset_val` of the GUCs, not the GUC's current value.
+ * `diff_options` is a list of the GUCs' current value. If the GUC is unchanged,
+ * `diff_options` will omit it.
+ *
+ * In process_startup_options(), `options` is used to set the GUCs with
+ * PGC_S_CLIENT as its guc source. Then, `diff_options` is used to set the GUCs
+ * with PGC_S_SESSION as its guc source.
+ *
+ * With PGC_S_CLIENT, SetConfigOption() will set the GUC's `reset_val`
+ * when processing `options`, so the `reset_val` of the involved GUCs on all QD
+ * and QEs are the same.
+ *
+ * After applying `diff_options`, the GUCs' current value is set to the same
+ * value as the QD and the `reset_val` of the GUC will not change.
+ *
+ * At last, both the `reset_val` and current value of the GUC are consistent,
+ * even after RESET.
  */
 void
 makeOptions(char **options, char **diff_options)
@@ -410,8 +428,8 @@ makeOptions(char **options, char **diff_options)
 			addOneOption(&string, &diff, guc);
 	}
 
-  *options = string.data;
-  *diff_options = diff.data;
+	*options = string.data;
+	*diff_options = diff.data;
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -311,10 +311,8 @@ addOneOption(StringInfo string, StringInfo diff, struct config_generic *guc)
 				struct config_string *sguc = (struct config_string *) guc;
 				const char *str = sguc->reset_val;
 				int			i;
-				int			idx;
 
 				appendStringInfo(string, " -c %s=", guc->name);
-				idx = strlen(string->data);
 
 				/*
 				 * All whitespace characters must be escaped. See
@@ -329,8 +327,15 @@ addOneOption(StringInfo string, StringInfo diff, struct config_generic *guc)
 				}
 				if (strcmp(str, *sguc->variable) != 0)
 				{
+					const char *p = *sguc->variable;
 					appendStringInfo(diff, " %s=", guc->name);
-					appendStringInfoString(diff, &string->data[idx]);
+					for (i = 0; p[i] != '\0'; i++)
+					{
+						if (isspace((unsigned char) p[i]))
+							appendStringInfoChar(diff, '\\');
+
+						appendStringInfoChar(diff, p[i]);
+					}
 				}
 				break;
 			}
@@ -340,10 +345,8 @@ addOneOption(StringInfo string, StringInfo diff, struct config_generic *guc)
 				int			value = eguc->reset_val;
 				const char *str = config_enum_lookup_by_value(eguc, value);
 				int			i;
-				int			idx;
 
 				appendStringInfo(string, " -c %s=", guc->name);
-				idx = strlen(string->data);
 
 				/*
 				 * All whitespace characters must be escaped. See
@@ -359,8 +362,15 @@ addOneOption(StringInfo string, StringInfo diff, struct config_generic *guc)
 				}
 				if (value != *eguc->variable)
 				{
+					const char *p = config_enum_lookup_by_value(eguc, *eguc->variable);
 					appendStringInfo(diff, " %s=", guc->name);
-					appendStringInfoString(diff, &string->data[idx]);
+					for (i = 0; p[i] != '\0'; i++)
+					{
+						if (isspace((unsigned char) p[i]))
+							appendStringInfoChar(diff, '\\');
+
+						appendStringInfoChar(diff, p[i]);
+					}
 				}
 				break;
 			}

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -123,7 +123,8 @@ create_gang_retry:
 		{
 			bool		ret;
 			char		gpqeid[100];
-			char	   *options;
+			char	   *options = NULL;
+			char	   *diff_options = NULL;
 
 			/*
 			 * Create the connection requests.	If we find a segment without a
@@ -156,10 +157,10 @@ create_gang_retry:
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						 errmsg("failed to construct connectionstring")));
 
-			options = makeOptions();
+			makeOptions(&options, &diff_options);
 
 			/* start connection in asynchronous way */
-			cdbconn_doConnectStart(segdbDesc, gpqeid, options);
+			cdbconn_doConnectStart(segdbDesc, gpqeid, options, diff_options);
 
 			if (cdbconn_isBadConnection(segdbDesc))
 				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2482,6 +2482,10 @@ retry1:
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 							 errmsg("invalid value for option: \"%s\"", GPCONN_TYPE)));
 			}
+			else if (strcmp(nameptr, "diff_options") == 0)
+			{
+				port->diff_options = pstrdup(valptr);
+			}
 			else
 			{
 				/* Assume it's a generic GUC option */

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1349,6 +1349,32 @@ process_startup_options(Port *port, bool am_superuser)
 
 		SetConfigOption(name, value, gucctx, PGC_S_CLIENT);
 	}
+
+	/* Set GUCs that have been changed in the QD */
+	if (port->diff_options)
+	{
+		char	  **av;
+		int			maxac;
+		int			ac;
+
+		maxac = 1 + (strlen(port->diff_options) + 1)/2;
+
+		av = (char **) palloc(maxac * sizeof(char *));
+		ac = 0;
+
+		pg_split_opts(av, &ac, port->diff_options);
+
+		av[ac] = NULL;
+		Assert(ac < maxac);
+		for (int i = 0; i < ac; i++)
+		{
+			char *name = NULL;
+			char *val = NULL;
+			ParseLongOption(av[i], &name, &val);
+			SetConfigOption(name, val, gucctx, PGC_S_SESSION);
+		}
+		pfree(av);
+	}
 }
 
 /*

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1351,6 +1351,7 @@ process_startup_options(Port *port, bool am_superuser)
 	}
 
 	/* Set GUCs that have been changed in the QD */
+	/* NOTE: this code block will not change the reset_val of the GUCs */
 	if (port->diff_options)
 	{
 		char	  **av;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -8545,6 +8545,7 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 				Gp_role != GP_ROLE_EXECUTE)
 				WarnNoTransactionBlock(isTopLevel, "RESET TRANSACTION");
 
+			SIMPLE_FAULT_INJECTOR("reset_variable_fault");
 			(void) set_config_option(stmt->name,
 									 NULL,
 									 (superuser() ? PGC_SUSET : PGC_USERSET),

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -68,7 +68,8 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc);
 void
 cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 					   const char *gpqeid,
-					   const char *options);
+					   const char *options,
+					   const char *diff_options);
 void
 cdbconn_doConnectComplete(SegmentDatabaseDescriptor *segdbDesc);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -82,7 +82,7 @@ extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang
 Gang *buildGangDefinition(List *segments, SegmentType segmentType);
 bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs, int icHtabSize);
 
-char *makeOptions(void);
+extern void makeOptions(char **options, char **diff_options);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 extern bool segment_failure_due_to_missing_writer(const char *error_message);
 

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -143,6 +143,7 @@ typedef struct Port
 	char	   *database_name;
 	char	   *user_name;
 	char	   *cmdline_options;
+	char	   *diff_options;
 	List	   *guc_options;
 
 	/*

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -396,6 +396,10 @@ static const internalPQconninfoOption PQconninfoOptions[] = {
 		"connection type", "D", 10,
 	offsetof(struct pg_conn, gpconntype)},
 
+	{"diff_options", NULL, NULL, NULL,
+		"updated synced GUCs", "D", 80,
+	offsetof(struct pg_conn, diffoptions)},
+
 	/* Terminating entry --- MUST BE LAST */
 	{NULL, NULL, NULL, NULL,
 	NULL, NULL, 0}

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2378,6 +2378,8 @@ build_startup_packet(const PGconn *conn, char *packet,
 		ADD_STARTUP_OPTION(GPCONN_TYPE, conn->gpconntype);
 	if (conn->pgoptions && conn->pgoptions[0])
 		ADD_STARTUP_OPTION("options", conn->pgoptions);
+	if (conn->diffoptions && conn->diffoptions[0])
+		ADD_STARTUP_OPTION("diff_options", conn->diffoptions);
 	if (conn->send_appname)
 	{
 		/* Use appname if present, otherwise use fallback */

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -409,7 +409,7 @@ struct pg_conn
 #endif
     char       *gpconntype; /* type of connection */
     char       *gpqeid;        /* MPP: session id & startup info for qExec */
-    char       *diffoptions;
+    char       *diffoptions;  /* MPP: transfer changed GUCs(require sync) from QD to QEs */
 
 	/* Type of connection to make.  Possible values: any, read-write. */
 	char	   *target_session_attrs;

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -409,6 +409,7 @@ struct pg_conn
 #endif
     char       *gpconntype; /* type of connection */
     char       *gpqeid;        /* MPP: session id & startup info for qExec */
+    char       *diffoptions;
 
 	/* Type of connection to make.  Possible values: any, read-write. */
 	char	   *target_session_attrs;

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -1,9 +1,11 @@
+-- TEST 1: Fix Github issue https://github.com/greenplum-db/gpdb/issues/9208
 1: create schema sync_np1;
 CREATE
 1: create schema sync_np2;
 CREATE
+1: CREATE OR REPLACE FUNCTION public.segment_setting(guc text) RETURNS SETOF text EXECUTE ON ALL SEGMENTS AS $$ BEGIN RETURN NEXT pg_catalog.current_setting(guc); END $$ LANGUAGE plpgsql;
+CREATE
 1q: ... <quitting>
-
 -- The SET command will create a Gang on the primaries, and the GUC
 -- values should be the same on all QD/QEs.
 2: show search_path;
@@ -20,6 +22,13 @@ SET
 -- creating the function will fail.
 2: reset search_path;
 RESET
+2: select public.segment_setting('search_path');
+ segment_setting 
+-----------------
+ "$user", public 
+ "$user", public 
+ "$user", public 
+(3 rows)
 2: create or replace function sync_f1() returns int as $$ select 1234; $$language sql;
 CREATE
 2: select sync_f1();
@@ -35,6 +44,7 @@ DROP
 DROP
 2q: ... <quitting>
 
+-- TEST 2: Fix Github issue https://github.com/greenplum-db/gpdb/issues/685
 -- `gp_select_invisible` is default to false. SET command will dispatch
 -- the GUC's `reset_val` and changed value to the created Gang. If the QE(s)
 -- use the incorrect `reset_val`, its value will be inconsistent with the QD's,
@@ -48,6 +58,13 @@ DROP
 SET
 3: reset gp_select_invisible;
 RESET
+3: select public.segment_setting('gp_select_invisible');
+ segment_setting 
+-----------------
+ off             
+ off             
+ off             
+(3 rows)
 3: create table sync_t1(i int);
 CREATE
 3: insert into sync_t1 select i from generate_series(1,10)i;
@@ -62,7 +79,12 @@ DELETE 10
 DROP
 3q: ... <quitting>
 
--- make sure all QEs call RESET if there are more than 1 QE of the session in the primary
+1: drop function public.segment_setting(guc text);
+DROP
+1q: ... <quitting>
+
+-- TEST 3: make sure all QEs call RESET if there are more than 1 QE of the session
+-- in the primary
 4: create temp table sync_t11(a int, b int) distributed by(b);
 CREATE
 4: create temp table sync_t12(a int, b int) distributed by(a);

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -58,6 +58,8 @@ DELETE 10
  i 
 ---
 (0 rows)
+3: drop table sync_t1;
+DROP
 3q: ... <quitting>
 
 -- make sure all QEs call RESET if there are more than 1 QE of the session in the primary

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -1,0 +1,131 @@
+1: create schema sync_np1;
+CREATE
+1: create schema sync_np2;
+CREATE
+1q: ... <quitting>
+
+-- The SET command will create a Gang on the primaries, and the GUC
+-- values should be the same on all QD/QEs.
+2: show search_path;
+ search_path     
+-----------------
+ "$user", public 
+(1 row)
+2: set search_path = 'sync_np1,sync_np2';
+SET
+
+-- The `reset_val` of `search_path` should be synchronized from the QD,
+-- so, the GUC value will be also synchronized with the QD after RESET.
+-- If the search_path is inconsistent between the QD and QEs after RESET,
+-- creating the function will fail.
+2: reset search_path;
+RESET
+2: create or replace function sync_f1() returns int as $$ select 1234; $$language sql;
+CREATE
+2: select sync_f1();
+ sync_f1 
+---------
+ 1234    
+(1 row)
+2: drop function sync_f1();
+DROP
+2: drop schema sync_np1;
+DROP
+2: drop schema sync_np2;
+DROP
+2q: ... <quitting>
+
+-- `gp_select_invisible` is default to false. SET command will dispatch
+-- the GUC's `reset_val` and changed value to the created Gang. If the QE(s)
+-- use the incorrect `reset_val`, its value will be inconsistent with the QD's,
+-- i.e. the `gp_select_invisible` is still false on the QEs.
+3: show gp_select_invisible;
+ gp_select_invisible 
+---------------------
+ off                 
+(1 row)
+3: set gp_select_invisible = on;
+SET
+3: reset gp_select_invisible;
+RESET
+3: create table sync_t1(i int);
+CREATE
+3: insert into sync_t1 select i from generate_series(1,10)i;
+INSERT 10
+3: delete from sync_t1;
+DELETE 10
+3: select * from sync_t1;
+ i 
+---
+(0 rows)
+3q: ... <quitting>
+
+-- make sure all QEs call RESET if there are more than 1 QE of the session in the primary
+4: create temp table sync_t11(a int, b int) distributed by(b);
+CREATE
+4: create temp table sync_t12(a int, b int) distributed by(a);
+CREATE
+
+-- The join will create 2 slices on each primary, and 1 entrydb on the coordinator.
+-- So, every primary and the coordinator should trigger 2 SET/RESET
+-- We'll test SET/RESET xxx will be called for all QEs in the current session.
+4: select relname from sync_t11, sync_t12, pg_class;
+ relname 
+---------
+(0 rows)
+
+4: select gp_inject_fault('set_variable_fault', 'skip', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+4: set statement_mem = '12MB';
+SET
+4: select gp_wait_until_triggered_fault('set_variable_fault', 2, dbid) from gp_segment_configuration where role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+ Success:                      
+(4 rows)
+4: select gp_inject_fault('set_variable_fault', 'reset', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+
+4: select gp_inject_fault('reset_variable_fault', 'skip', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+4: reset statement_mem;
+RESET
+4: select gp_wait_until_triggered_fault('reset_variable_fault', 2, dbid) from gp_segment_configuration where role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+ Success:                      
+(4 rows)
+4: select gp_inject_fault('reset_variable_fault', 'reset', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+4q: ... <quitting>
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -262,3 +262,6 @@ test: orphan_temp_table
 
 # test if gxid is valid or not on the cluster after running the tests
 test: check_gxid
+
+# test if GUC is synchronized from the QD to QEs.
+test: sync_guc

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -30,6 +30,7 @@
 3: insert into sync_t1 select i from generate_series(1,10)i;
 3: delete from sync_t1;
 3: select * from sync_t1;
+3: drop table sync_t1;
 3q:
 
 -- make sure all QEs call RESET if there are more than 1 QE of the session in the primary

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -1,0 +1,60 @@
+1: create schema sync_np1;
+1: create schema sync_np2;
+1q:
+
+-- The SET command will create a Gang on the primaries, and the GUC
+-- values should be the same on all QD/QEs.
+2: show search_path;
+2: set search_path = 'sync_np1,sync_np2';
+
+-- The `reset_val` of `search_path` should be synchronized from the QD,
+-- so, the GUC value will be also synchronized with the QD after RESET.
+-- If the search_path is inconsistent between the QD and QEs after RESET,
+-- creating the function will fail.
+2: reset search_path;
+2: create or replace function sync_f1() returns int as $$ select 1234; $$language sql;
+2: select sync_f1();
+2: drop function sync_f1();
+2: drop schema sync_np1;
+2: drop schema sync_np2;
+2q:
+
+-- `gp_select_invisible` is default to false. SET command will dispatch
+-- the GUC's `reset_val` and changed value to the created Gang. If the QE(s)
+-- use the incorrect `reset_val`, its value will be inconsistent with the QD's,
+-- i.e. the `gp_select_invisible` is still false on the QEs.
+3: show gp_select_invisible;
+3: set gp_select_invisible = on;
+3: reset gp_select_invisible;
+3: create table sync_t1(i int);
+3: insert into sync_t1 select i from generate_series(1,10)i;
+3: delete from sync_t1;
+3: select * from sync_t1;
+3q:
+
+-- make sure all QEs call RESET if there are more than 1 QE of the session in the primary
+4: create temp table sync_t11(a int, b int) distributed by(b);
+4: create temp table sync_t12(a int, b int) distributed by(a);
+
+-- The join will create 2 slices on each primary, and 1 entrydb on the coordinator.
+-- So, every primary and the coordinator should trigger 2 SET/RESET
+-- We'll test SET/RESET xxx will be called for all QEs in the current session.
+4: select relname from sync_t11, sync_t12, pg_class;
+
+4: select gp_inject_fault('set_variable_fault', 'skip', dbid)
+     from gp_segment_configuration where role='p';
+4: set statement_mem = '12MB';
+4: select gp_wait_until_triggered_fault('set_variable_fault', 2, dbid)
+     from gp_segment_configuration where role='p';
+4: select gp_inject_fault('set_variable_fault', 'reset', dbid)
+     from gp_segment_configuration where role='p';
+
+4: select gp_inject_fault('reset_variable_fault', 'skip', dbid)
+     from gp_segment_configuration where role='p';
+4: reset statement_mem;
+4: select gp_wait_until_triggered_fault('reset_variable_fault', 2, dbid)
+     from gp_segment_configuration where role='p';
+4: select gp_inject_fault('reset_variable_fault', 'reset', dbid)
+     from gp_segment_configuration where role='p';
+4q:
+


### PR DESCRIPTION
When we change some GUC values and reset them later in
a session. The GUC values may be inconsistent among QD and/or QEs.
The key steps of current GUC settings are:
1. The QD dispatches its current `sync`ed GUC values(as startup
    options) to create QEs.
2. The QE sets the GUCs' `reset_val` to the options passsed
    from the QD during its process initialization.
2.5 When the QD dispatches `SET XXX=YYY` for an existing QE,
    the QE will set the GUC's current value to YYY, `reset_val`
    is unchanged. Because its guc-source is PGC_S_SESSION.
3. When the QE receives `RESET XXX`, it resets the GUC's value to
    its `reset_val`.

The problem happens in the step 1, which causes the `reset_val`s
between QD and QEs inconsistent if the QD changed the GUC before
creating the QE(s).

The fix is to send the GUC's `reset_val` to create QEs, and we also
have another options(diff_options) to update the changed GUCs. So,
both `reset_val` and current value are consistent among QD and QEs
if the GUC needs to be synchronized.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
