### PR TITLE
Docs: minor change for backout script

### DIFF
--- a/gpdb-doc/dita/install_guide/init_gpdb.xml
+++ b/gpdb-doc/dita/install_guide/init_gpdb.xml
@@ -239,7 +239,7 @@ $ gpinitsystem -c gpconfigs/gpinitsystem_config -h gpconfigs/hostfile_gpinitsyst
               caused <codeph>gpinitsystem</codeph> to fail and running the backout script, you
               should be ready to retry initializing your Greenplum Database array.</p>
             <p>The following example shows how to run the backout script:</p>
-            <codeblock>$ sh backout_gpinitsystem_gpadmin_20071031_121053</codeblock>
+            <codeblock>$ bash ~/gpAdminLogs/backout_gpinitsystem_gpadmin_20071031_121053</codeblock>
           </section>
         </body>
       </topic>


### PR DESCRIPTION
Small change to the backout_gpinitsystem output in order to keep the example consistent with CLI output.
