### PR TITLE
Compute SharedScan xslice buffer file names during ExecInitNode

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2444,6 +2444,7 @@ typedef struct MaterialState
 	void	   *ts_pos;
 	void	   *ts_markpos;
 	void	   *share_lk_ctxt;
+	char	   *share_bufname_prefix;
 } MaterialState;
 
 /* ----------------
@@ -2465,14 +2466,17 @@ typedef struct ShareInputScanState
 
 	void	   *share_lk_ctxt;
 	bool		freed; /* is this node already freed? */
+
+	char	   *share_bufname_prefix;
 } ShareInputScanState;
 
 /* XXX Should move into buf file */
-extern void *shareinput_reader_waitready(int share_id, PlanGenerator planGen);
-extern void *shareinput_writer_notifyready(int share_id, int nsharer_xslice_notify_ready, PlanGenerator planGen);
+extern void *shareinput_init_lk_ctxt(int share_id);
+extern void shareinput_reader_waitready(void *, int share_id, PlanGenerator planGen);
+extern void shareinput_writer_notifyready(void *, int share_id, int nsharer_xslice_notify_ready, PlanGenerator planGen);
 extern void shareinput_reader_notifydone(void *, int share_id);
 extern void shareinput_writer_waitdone(void *, int share_id, int nsharer_xslice_wait_done);
-extern void shareinput_create_bufname_prefix(char* p, int size, int share_id);
+extern char *shareinput_create_bufname_prefix(int share_id);
 
 /* ----------------
  *	 SortState information
@@ -2494,6 +2498,7 @@ typedef struct SortState
 									 * when this node has outputted its last row? */
 
 	void	   *share_lk_ctxt;
+	char	   *share_bufname_prefix;
 
 } SortState;
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13743,3 +13743,28 @@ SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS D
   
 (1 row)
 
+create or replace function one(i int) returns int as $$
+begin
+	return 1;
+end
+$$ language PLPGSQL;
+CREATE TABLE tone (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tone select i,i,i from generate_series(1, 10) i;
+ANALYZE tone;
+WITH cte AS (SELECT one(min(a)) from tone) SELECT 1 FROM tone, cte c1;
+ ?column? 
+----------
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+(10 rows)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14002,3 +14002,28 @@ SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS D
   
 (1 row)
 
+create or replace function one(i int) returns int as $$
+begin
+	return 1;
+end
+$$ language PLPGSQL;
+CREATE TABLE tone (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tone select i,i,i from generate_series(1, 10) i;
+ANALYZE tone;
+WITH cte AS (SELECT one(min(a)) from tone) SELECT 1 FROM tone, cte c1;
+ ?column? 
+----------
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+        1
+(10 rows)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3043,6 +3043,16 @@ SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS D
 
 EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
 SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+create or replace function one(i int) returns int as $$
+begin
+	return 1;
+end
+$$ language PLPGSQL;
+CREATE TABLE tone (a int, b int, c int);
+insert into tone select i,i,i from generate_series(1, 10) i;
+ANALYZE tone;
+
+WITH cte AS (SELECT one(min(a)) from tone) SELECT 1 FROM tone, cte c1;
 
 -- start_ignore
 DROP SCHEMA orca CASCADE;


### PR DESCRIPTION
ShareInputScan node uses temporary files as shared buffers and FIFOs as
a syncing mechanism for cross-slice communication (i.e IPC). The names
of these files is based on gp_session_id, gp_command_count & share_id.

Since these are computed (multiple times) during ExecProcNode, if the
gp_command_count (or another variable) changes between when the files
are created, written to and read from, the executor could ERROR failing
to find the required file, or even see wrong entries.

For the attached test case, ORCA produces a plan that executes an SPI
(pl/pgSQL) function on a master slice, which increments the gp_command
count, between the creation of the shared buffer file and it's
subsequent reading.

This commit fixes this issue by computing the names of all the files
required for cross-slice communication once during ExecInitNode() and
re-using that name for the rest of the query's execution.

The plan produced by ORCA:
```
EXPLAIN WITH cte AS (SELECT myfunc(min(a)) from foo) SELECT 1 FROM foo, cte c1;
                               QUERY PLAN                               
------------------------------------------------------------------------
 Sequence
   ->  Shared Scan (share slice:id 0:0)
         ->  Materialize
               ->  Result
                     ->  Aggregate
                           ->  Gather Motion 3:1  (slice3; segments: 3)
                                 ->  Aggregate
                                       ->  Seq Scan on foo foo_1
   ->  Result
         ->  Gather Motion 3:1  (slice2; segments: 3)
               ->  Nested Loop
                     Join Filter: true
                     ->  Broadcast Motion 1:3  (slice1)
                           ->  Result
                                 ->  Shared Scan (share slice:id 1:0)
                     ->  Seq Scan on foo
 Optimizer: Pivotal Optimizer (GPORCA)
(17 rows)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
