### PR TITLE
(6x only) Disallow unique rowid path when seeing indexonly scan.

### DIFF
--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -310,6 +310,7 @@ typedef struct PlannerInfo
 	bool		is_split_update;	/* true if UPDATE that modifies
 									 * distribution key columns */
 	bool		is_correlated_subplan; /* true for correlated subqueries nested within subplans */
+	bool		disallow_unique_rowid_path; /* true if we decide not to generate unique rowid path */
 } PlannerInfo;
 
 /*

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -785,6 +785,58 @@ drop table t2_12146;
 drop table t3_12146;
 drop table t4_12146;
 reset allow_system_table_mods;
+-- Test index only scan path not error out when semjoin.
+-- Greenplum might add unique_rowid_path to handle semjoin,
+-- that was introduced in Greenplum long before, and after
+-- merging so many commits from upstream, new logic might
+-- not work well. The following cases test for this.
+create table t_indexonly_cdbdedup_1(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t_indexonly_cdbdedup_2(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index on t_indexonly_cdbdedup_2(b);
+-- test only make sense under planner and this file
+-- is bfv_planner, so turn off orca for this.
+set optimizer = off;
+set enable_seqscan = off;
+set enable_bitmapscan = off;
+create extension if not exists gp_inject_fault;
+select gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+explain (costs off)
+select b from t_indexonly_cdbdedup_2 where b in (select b from t_indexonly_cdbdedup_1 where t_indexonly_cdbdedup_1.b = 3) ;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  HashAggregate
+                     Group Key: t_indexonly_cdbdedup_1.b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: t_indexonly_cdbdedup_1.b
+                           ->  Seq Scan on t_indexonly_cdbdedup_1
+                                 Filter: (b = 3)
+         ->  Materialize
+               ->  Index Only Scan using t_indexonly_cdbdedup_2_b_idx on t_indexonly_cdbdedup_2
+                     Index Cond: (b = 3)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+reset enable_bitmapscan;
+reset enable_seqscan;
+reset optimizer;
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1208,7 +1208,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:421)
+ERROR:  could not devise a query plan for the given query (pathnode.c:422)
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1224,7 +1224,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:421)
+ERROR:  could not devise a query plan for the given query (pathnode.c:422)
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -171,7 +171,9 @@ test: rpt rpt_joins rpt_tpch rpt_returning
 # NOTE: The bfv_temp test assumes that there are no temporary tables in
 # other sessions. Therefore the other tests in this group mustn't create
 # temp tables
-test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
+test: bfv_cte bfv_joins bfv_subquery bfv_legacy bfv_temp bfv_dml
+# bfv_planner contains fault inject
+test: bfv_planner
 
 test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_dml_oids trigger_sets_oid
 


### PR DESCRIPTION
Greenplum has a specical method to implement semjoin: it
might create unique rowid path to first do inner join and
then de-duplicated based on ctid. The method was added to
Greenplum long before but after merging so many commits
from upstream, some new logic might fail when applying this
method. IndexOnlyScan is a case that the de-dup logic did
not consider. IndexOnlyScan's var is pointing to the Index
Rel, not the Heap Rel, to totally fix the logic seems risky
on a stable branch like 6X. So this commit just disallows
the unique rowid method when seeing indexonly scan to avoid
error-out. Index paths are set during base rel, and planner
then generates join rels so that the disallow-loigc works.