### PR TITLE
(6x only) Disallow unique rowid path for inheritance plan

### DIFF
--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -858,54 +858,6 @@ create table rank1_12402 (id int, rank int, year int, value int) distributed by 
 partition by range (year) (start (2006) end (2007) every (1), default partition extra );
 NOTICE:  CREATE TABLE will create partition "rank1_12402_1_prt_extra" for table "rank1_12402"
 NOTICE:  CREATE TABLE will create partition "rank1_12402_1_prt_2" for table "rank1_12402"
--- create semi join plan, due to the cost of unique_rowid is high
-explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Update on rank_12402_1_prt_extra
-   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
-         ->  Hash Semi Join
-               Hash Cond: (rank_12402_1_prt_extra.value = rank1_12402_1_prt_extra_1.value)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: rank_12402_1_prt_extra.value
-                     ->  Hash Join
-                           Hash Cond: (rank_12402_1_prt_extra.id = rank1_12402_1_prt_extra.id)
-                           ->  Seq Scan on rank_12402_1_prt_extra
-                           ->  Hash
-                                 ->  HashAggregate
-                                       Group Key: rank1_12402_1_prt_extra.id
-                                       ->  Append
-                                             ->  Seq Scan on rank1_12402_1_prt_extra
-                                             ->  Seq Scan on rank1_12402_1_prt_2
-               ->  Hash
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: rank1_12402_1_prt_extra_1.value
-                           ->  Append
-                                 ->  Seq Scan on rank1_12402_1_prt_extra rank1_12402_1_prt_extra_1
-                                 ->  Seq Scan on rank1_12402_1_prt_2 rank1_12402_1_prt_2_1
-   ->  Explicit Redistribute Motion 3:3  (slice6; segments: 3)
-         ->  Hash Semi Join
-               Hash Cond: (rank_12402_1_prt_2.value = rank1_12402_1_prt_extra_1.value)
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                     Hash Key: rank_12402_1_prt_2.value
-                     ->  Hash Join
-                           Hash Cond: (rank_12402_1_prt_2.id = rank1_12402_1_prt_extra.id)
-                           ->  Seq Scan on rank_12402_1_prt_2
-                           ->  Hash
-                                 ->  HashAggregate
-                                       Group Key: rank1_12402_1_prt_extra.id
-                                       ->  Append
-                                             ->  Seq Scan on rank1_12402_1_prt_extra
-                                             ->  Seq Scan on rank1_12402_1_prt_2
-               ->  Hash
-                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                           Hash Key: rank1_12402_1_prt_extra_1.value
-                           ->  Append
-                                 ->  Seq Scan on rank1_12402_1_prt_extra rank1_12402_1_prt_extra_1
-                                 ->  Seq Scan on rank1_12402_1_prt_2 rank1_12402_1_prt_2_1
- Optimizer: Postgres query optimizer
-(42 rows)
-
 -- set the cost of unique_rowid_path low.
 create extension if not exists gp_inject_fault;
 NOTICE:  extension "gp_inject_fault" already exists, skipping
@@ -915,6 +867,8 @@ select gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) from gp_segme
  Success:
 (1 row)
 
+-- this case only make sense under planner and this file
+-- if bfv_planner, so turn off orca for it.
 set optimizer = off;
 -- It should create a unique_rowid plan.
 -- but it creates a semi-join plan, due to we disallow unique_rowid path in inheritance_planner.

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -837,6 +837,143 @@ select gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) from gp_segm
 reset enable_bitmapscan;
 reset enable_seqscan;
 reset optimizer;
+-- Test append path not error out when semjoin.
+-- issue1:https://github.com/greenplum-db/gpdb/issues/12402
+-- issue2:https://github.com/greenplum-db/gpdb/issues/3719
+-- Greenplum might add unique_rowid_path to handle semjoin, that
+-- was introduced in Greenplum long before, and after merging so
+-- many commits from upstream, new logic might not work well.
+-- We just disallow unique_rowid_path for inheritance_planner.
+-- through injecting fault in unique_row_path to make the cost
+-- of unique_rowid low, however, we use a switch to disallow
+-- create unique_rowid plan for inheritance plan.
+-- the two above issues can work well.
+-- The following cases test for this.
+--create table
+create table rank_12402 (id int, rank int, year int, value int) distributed by (id)
+partition by range (year) (start (2006) end (2007) every (1), default partition extra );
+NOTICE:  CREATE TABLE will create partition "rank_12402_1_prt_extra" for table "rank_12402"
+NOTICE:  CREATE TABLE will create partition "rank_12402_1_prt_2" for table "rank_12402"
+create table rank1_12402 (id int, rank int, year int, value int) distributed by (id)
+partition by range (year) (start (2006) end (2007) every (1), default partition extra );
+NOTICE:  CREATE TABLE will create partition "rank1_12402_1_prt_extra" for table "rank1_12402"
+NOTICE:  CREATE TABLE will create partition "rank1_12402_1_prt_2" for table "rank1_12402"
+-- create semi join plan, due to the cost of unique_rowid is high
+explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Update on rank_12402_1_prt_extra
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         ->  Hash Semi Join
+               Hash Cond: (rank_12402_1_prt_extra.value = rank1_12402_1_prt_extra_1.value)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: rank_12402_1_prt_extra.value
+                     ->  Hash Join
+                           Hash Cond: (rank_12402_1_prt_extra.id = rank1_12402_1_prt_extra.id)
+                           ->  Seq Scan on rank_12402_1_prt_extra
+                           ->  Hash
+                                 ->  HashAggregate
+                                       Group Key: rank1_12402_1_prt_extra.id
+                                       ->  Append
+                                             ->  Seq Scan on rank1_12402_1_prt_extra
+                                             ->  Seq Scan on rank1_12402_1_prt_2
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: rank1_12402_1_prt_extra_1.value
+                           ->  Append
+                                 ->  Seq Scan on rank1_12402_1_prt_extra rank1_12402_1_prt_extra_1
+                                 ->  Seq Scan on rank1_12402_1_prt_2 rank1_12402_1_prt_2_1
+   ->  Explicit Redistribute Motion 3:3  (slice6; segments: 3)
+         ->  Hash Semi Join
+               Hash Cond: (rank_12402_1_prt_2.value = rank1_12402_1_prt_extra_1.value)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                     Hash Key: rank_12402_1_prt_2.value
+                     ->  Hash Join
+                           Hash Cond: (rank_12402_1_prt_2.id = rank1_12402_1_prt_extra.id)
+                           ->  Seq Scan on rank_12402_1_prt_2
+                           ->  Hash
+                                 ->  HashAggregate
+                                       Group Key: rank1_12402_1_prt_extra.id
+                                       ->  Append
+                                             ->  Seq Scan on rank1_12402_1_prt_extra
+                                             ->  Seq Scan on rank1_12402_1_prt_2
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                           Hash Key: rank1_12402_1_prt_extra_1.value
+                           ->  Append
+                                 ->  Seq Scan on rank1_12402_1_prt_extra rank1_12402_1_prt_extra_1
+                                 ->  Seq Scan on rank1_12402_1_prt_2 rank1_12402_1_prt_2_1
+ Optimizer: Postgres query optimizer
+(42 rows)
+
+-- set the cost of unique_rowid_path low.
+create extension if not exists gp_inject_fault;
+NOTICE:  extension "gp_inject_fault" already exists, skipping
+select gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+set optimizer = off;
+-- It should create a unique_rowid plan.
+-- but it creates a semi-join plan, due to we disallow unique_rowid path in inheritance_planner.
+explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Update on rank_12402_1_prt_extra
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
+         ->  Hash Semi Join
+               Hash Cond: (rank_12402_1_prt_extra.value = rank1_12402_1_prt_extra_1.value)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: rank_12402_1_prt_extra.value
+                     ->  Hash Join
+                           Hash Cond: (rank_12402_1_prt_extra.id = rank1_12402_1_prt_extra.id)
+                           ->  Seq Scan on rank_12402_1_prt_extra
+                           ->  Hash
+                                 ->  HashAggregate
+                                       Group Key: rank1_12402_1_prt_extra.id
+                                       ->  Append
+                                             ->  Seq Scan on rank1_12402_1_prt_extra
+                                             ->  Seq Scan on rank1_12402_1_prt_2
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: rank1_12402_1_prt_extra_1.value
+                           ->  Append
+                                 ->  Seq Scan on rank1_12402_1_prt_extra rank1_12402_1_prt_extra_1
+                                 ->  Seq Scan on rank1_12402_1_prt_2 rank1_12402_1_prt_2_1
+   ->  Explicit Redistribute Motion 3:3  (slice6; segments: 3)
+         ->  Hash Semi Join
+               Hash Cond: (rank_12402_1_prt_2.value = rank1_12402_1_prt_extra_1.value)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                     Hash Key: rank_12402_1_prt_2.value
+                     ->  Hash Join
+                           Hash Cond: (rank_12402_1_prt_2.id = rank1_12402_1_prt_extra.id)
+                           ->  Seq Scan on rank_12402_1_prt_2
+                           ->  Hash
+                                 ->  HashAggregate
+                                       Group Key: rank1_12402_1_prt_extra.id
+                                       ->  Append
+                                             ->  Seq Scan on rank1_12402_1_prt_extra
+                                             ->  Seq Scan on rank1_12402_1_prt_2
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                           Hash Key: rank1_12402_1_prt_extra_1.value
+                           ->  Append
+                                 ->  Seq Scan on rank1_12402_1_prt_extra rank1_12402_1_prt_extra_1
+                                 ->  Seq Scan on rank1_12402_1_prt_2 rank1_12402_1_prt_2_1
+ Optimizer: Postgres query optimizer
+(42 rows)
+
+select gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+reset optimizer;
+drop table rank_12402;
+drop table rank1_12402;
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -490,13 +490,12 @@ partition by range (year) (start (2006) end (2007) every (1), default partition 
 create table rank1_12402 (id int, rank int, year int, value int) distributed by (id)
 partition by range (year) (start (2006) end (2007) every (1), default partition extra );
 
--- create semi join plan, due to the cost of unique_rowid is high
-explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
-
 -- set the cost of unique_rowid_path low.
 create extension if not exists gp_inject_fault;
 select gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
 
+-- this case only make sense under planner and this file
+-- if bfv_planner, so turn off orca for it.
 set optimizer = off;
 -- It should create a unique_rowid plan.
 -- but it creates a semi-join plan, due to we disallow unique_rowid path in inheritance_planner.

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -468,6 +468,46 @@ reset enable_bitmapscan;
 reset enable_seqscan;
 reset optimizer;
 
+-- Test append path not error out when semjoin.
+-- issue1:https://github.com/greenplum-db/gpdb/issues/12402
+-- issue2:https://github.com/greenplum-db/gpdb/issues/3719
+
+-- Greenplum might add unique_rowid_path to handle semjoin, that
+-- was introduced in Greenplum long before, and after merging so
+-- many commits from upstream, new logic might not work well.
+-- We just disallow unique_rowid_path for inheritance_planner.
+
+-- through injecting fault in unique_row_path to make the cost
+-- of unique_rowid low, however, we use a switch to disallow
+-- create unique_rowid plan for inheritance plan.
+-- the two above issues can work well.
+-- The following cases test for this.
+
+--create table
+create table rank_12402 (id int, rank int, year int, value int) distributed by (id)
+partition by range (year) (start (2006) end (2007) every (1), default partition extra );
+
+create table rank1_12402 (id int, rank int, year int, value int) distributed by (id)
+partition by range (year) (start (2006) end (2007) every (1), default partition extra );
+
+-- create semi join plan, due to the cost of unique_rowid is high
+explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
+
+-- set the cost of unique_rowid_path low.
+create extension if not exists gp_inject_fault;
+select gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+set optimizer = off;
+-- It should create a unique_rowid plan.
+-- but it creates a semi-join plan, due to we disallow unique_rowid path in inheritance_planner.
+explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
+
+select gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+reset optimizer;
+drop table rank_12402;
+drop table rank1_12402;
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;


### PR DESCRIPTION
Greenplum has a special path to handle semjoin,
planner might add unique_row_id path to first inner join
and then de-duplicate. The logic is added into
Greenplum long before, but when merging more code from
upstream, the old logic does not consider new paths,
there are two relevant issues:
https://github.com/greenplum-db/gpdb/issues/3719
https://github.com/greenplum-db/gpdb/issues/12402

issue-12402 is that while creating a plan for the second append rel,
it will add pseudo column in rtable of subroot, however, do not
add it to final_rtable (subroot->rtable of the first append rel),
so failed to find the corresponding pseudo column in cdbpath_dedup_fixup.

issue-3719 is that the pseudocols of root->rtable is not null,
while creating a plan for first append rel, in build_simple_rel
'Assert(!rte->pseudocols)' rel isn't expected to have any pseudo columns yet.

maybe we should enhance the old logic in cdbpath_dedup_fixup,
but at a stable branch 6X, it seems risky. Here we introduce
a switch to turn off it in inheritance_planner.
by disalow unique_rowid_path, the above two issues is ok.