### PR TITLE
Use ExclusiveLock for accessing the table pg_resgroupcapability when CREATE/ALTER resouce group.

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -431,11 +431,11 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	 * We use ExclusiveLock here to prevent concurrent
 	 * increase on different resource group. 
 	 * We can't use AccessExclusiveLock here, the reason is that, 
-	 * if  there is a database recovery happened when alter resource group 
+	 * if there is a database recovery happened when run "alter resource group"
 	 * and acquire this kind of lock, the initialization of resource group 
 	 * in function InitResGroups will be pending during database startup, 
 	 * since this function will open this table with AccessShareLock, 
-	 * AccessShareLock and AccessExclusiveLock are not compatible.
+	 * AccessExclusiveLock is not compatible with any other lock.
 	 * ExclusiveLock and AccessShareLock are compatible.
 	 */
 	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId,

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -136,10 +136,10 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	/*
 	 * both CREATE and ALTER resource group need check the sum of cpu_rate_limit
 	 * and memory_limit and make sure the sum don't exceed 100. To make it simple,
-	 * acquire AccessExclusiveLock lock on pg_resgroupcapability at the beginning
+	 * acquire ExclusiveLock lock on pg_resgroupcapability at the beginning
 	 * of CREATE and ALTER
 	 */
-	pg_resgroupcapability_rel = table_open(ResGroupCapabilityRelationId, RowExclusiveLock);
+	pg_resgroupcapability_rel = table_open(ResGroupCapabilityRelationId, ExclusiveLock);
 	pg_resgroup_rel = table_open(ResGroupRelationId, RowExclusiveLock);
 
 	/* Check if MaxResourceGroups limit is reached */
@@ -428,11 +428,18 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	/*
 	 * In validateCapabilities() we scan all the resource groups
 	 * to check whether the total cpu_rate_limit exceed 100 or not.
-	 * We need to use AccessExclusiveLock here to prevent concurrent
-	 * increase on different resource group.
+	 * We use ExclusiveLock here to prevent concurrent
+	 * increase on different resource group. 
+	 * We can't use AccessExclusiveLock here, the reason is that, 
+	 * if  there is a database recovery happened when alter resource group 
+	 * and acquire this kind of lock, the initialization of resource group 
+	 * in function InitResGroups will be pending during database startup, 
+	 * since this function will open this table with AccessShareLock, 
+	 * AccessShareLock and AccessExclusiveLock are not compatible.
+	 * ExclusiveLock and AccessShareLock are compatible.
 	 */
 	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId,
-										  RowExclusiveLock);
+										  ExclusiveLock);
 
 	/* Load current resource group capabilities */
 	GetResGroupCapabilities(pg_resgroupcapability_rel, groupid, &oldCaps);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -139,7 +139,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	 * acquire AccessExclusiveLock lock on pg_resgroupcapability at the beginning
 	 * of CREATE and ALTER
 	 */
-	pg_resgroupcapability_rel = table_open(ResGroupCapabilityRelationId, AccessExclusiveLock);
+	pg_resgroupcapability_rel = table_open(ResGroupCapabilityRelationId, RowExclusiveLock);
 	pg_resgroup_rel = table_open(ResGroupRelationId, RowExclusiveLock);
 
 	/* Check if MaxResourceGroups limit is reached */
@@ -432,7 +432,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	 * increase on different resource group.
 	 */
 	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId,
-										  AccessExclusiveLock);
+										  RowExclusiveLock);
 
 	/* Load current resource group capabilities */
 	GetResGroupCapabilities(pg_resgroupcapability_rel, groupid, &oldCaps);

--- a/src/test/isolation2/expected/resgroup/resgroup_seg_down_2pc.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_seg_down_2pc.out
@@ -1,10 +1,10 @@
 -- This test performs segment reconfiguration when "alter resource group" is executed in the two phase commit.
 -- The steps are, when run "alter resource group", before QD broadcasts commit prepared command to QEs(the
 -- second phase of 2PC), we trigger an error and cause one primary segment down.
--- The expectation is "alter resource group" can run sucessfully since the mirror segment is UP.
+-- The expectation is "alter resource group" can run successfully since the mirror segment is UP.
 -- After recover the segment, there is no error or blocking.
 
--- set these values purely to cut down test time, as default ts trigger is
+-- set these values purely to cut down test time, as default fts trigger is
 -- every min and 5 retries
 alter system set gp_fts_probe_interval to 10;
 ALTER
@@ -19,7 +19,7 @@ select pg_reload_conf();
 1:create resource group rgroup_seg_down with (CPU_RATE_LIMIT=35, MEMORY_LIMIT=35, CONCURRENCY=10);
 CREATE
 
--- inject an error in function dtm_broadcast_commit_prepared, that is QD broadcasts commit prepared command to QEs
+-- inject an error in function dtm_broadcast_commit_prepared, that is before QD broadcasts commit prepared command to QEs
 2:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp_segment_configuration where role='p' and content=-1;
  gp_inject_fault_infinite 
 --------------------------

--- a/src/test/isolation2/expected/resgroup/resgroup_seg_down_2pc.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_seg_down_2pc.out
@@ -1,0 +1,120 @@
+-- This test performs segment reconfiguration when "alter resource group" is executed in the two phase commit.
+-- The steps are, when run "alter resource group", before QD broadcasts commit prepared command to QEs(the
+-- second phase of 2PC), we trigger an error and cause one primary segment down.
+-- The expectation is "alter resource group" can run sucessfully since the mirror segment is UP.
+-- After recover the segment, there is no error or blocking.
+
+-- set these values purely to cut down test time, as default ts trigger is
+-- every min and 5 retries
+alter system set gp_fts_probe_interval to 10;
+ALTER
+alter system set gp_fts_probe_retries to 0;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+1:create resource group rgroup_seg_down with (CPU_RATE_LIMIT=35, MEMORY_LIMIT=35, CONCURRENCY=10);
+CREATE
+
+-- inject an error in function dtm_broadcast_commit_prepared, that is QD broadcasts commit prepared command to QEs
+2:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- this session will pend here since the above injected fault
+1&:alter resource group rgroup_seg_down set CONCURRENCY 20;  <waiting ...>
+-- this injected fault can make dispatcher think the primary is down
+2:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2:select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-- make sure one primary segment is down.
+2:select status = 'd' from gp_segment_configuration where content = 0 and role = 'm';
+ ?column? 
+----------
+ t        
+(1 row)
+-- reset the injected fault on QD and the "alter resource group" in session1 can continue
+2:select gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- reset the injected fault on primary segment
+2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+1<:  <... completed>
+ALTER
+-- make sure "alter resource group" has taken effect.
+1:select concurrency from gp_toolkit.gp_resgroup_config where groupname = 'rgroup_seg_down';
+ concurrency 
+-------------
+ 20          
+(1 row)
+2q: ... <quitting>
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+1:select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+1:select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+1:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- verify resource group
+1:select concurrency from gp_toolkit.gp_resgroup_config where groupname = 'rgroup_seg_down';
+ concurrency 
+-------------
+ 20          
+(1 row)
+1:drop resource group rgroup_seg_down;
+DROP
+
+1:alter system reset gp_fts_probe_interval;
+ALTER
+1:alter system reset gp_fts_probe_retries;
+ALTER
+1:select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+1q: ... <quitting>
+

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -10,6 +10,7 @@ test: resgroup/resgroup_name_convention
 # fault injection tests
 test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
+test: resgroup/resgroup_seg_down_2pc
 
 # functions
 test: resgroup/resgroup_concurrency

--- a/src/test/isolation2/sql/resgroup/resgroup_seg_down_2pc.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_seg_down_2pc.sql
@@ -1,0 +1,54 @@
+-- This test performs segment reconfiguration when "alter resource group" is executed in the two phase commit.
+-- The steps are, when run "alter resource group", before QD broadcasts commit prepared command to QEs(the 
+-- second phase of 2PC), we trigger an error and cause one primary segment down. 
+-- The expectation is "alter resource group" can run sucessfully since the mirror segment is UP. 
+-- After recover the segment, there is no error or blocking.
+
+-- set these values purely to cut down test time, as default ts trigger is
+-- every min and 5 retries
+alter system set gp_fts_probe_interval to 10;
+alter system set gp_fts_probe_retries to 0;
+select pg_reload_conf();
+
+1:create resource group rgroup_seg_down with (CPU_RATE_LIMIT=35, MEMORY_LIMIT=35, CONCURRENCY=10);
+
+-- inject an error in function dtm_broadcast_commit_prepared, that is QD broadcasts commit prepared command to QEs
+2:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp_segment_configuration where role='p' and content=-1;
+-- this session will pend here since the above injected fault
+1&:alter resource group rgroup_seg_down set CONCURRENCY 20;
+-- this injected fault can make dispatcher think the primary is down
+2:select gp_inject_fault('fts_conn_startup_packet', 'error', dbid) from gp_segment_configuration where role='p' and content=0;
+2:select gp_request_fts_probe_scan();
+-- make sure one primary segment is down.
+2:select status = 'd' from gp_segment_configuration where content = 0 and role = 'm';
+-- reset the injected fault on QD and the "alter resource group" in session1 can continue
+2:select gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+-- reset the injected fault on primary segment
+2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
+1<:
+-- make sure "alter resource group" has taken effect.
+1:select concurrency from gp_toolkit.gp_resgroup_config where groupname = 'rgroup_seg_down';
+2q:
+
+!\retcode gprecoverseg -aF --no-progress;
+
+-- loop while segments come in sync
+1:select wait_until_all_segments_synchronized();
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+1:select wait_until_all_segments_synchronized();
+
+-- verify no segment is down after recovery
+1:select count(*) from gp_segment_configuration where status = 'd';
+
+-- verify resource group 
+1:select concurrency from gp_toolkit.gp_resgroup_config where groupname = 'rgroup_seg_down';
+1:drop resource group rgroup_seg_down;
+
+1:alter system reset gp_fts_probe_interval;
+1:alter system reset gp_fts_probe_retries;
+1:select pg_reload_conf();
+1q:
+

--- a/src/test/isolation2/sql/resgroup/resgroup_seg_down_2pc.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_seg_down_2pc.sql
@@ -1,10 +1,10 @@
 -- This test performs segment reconfiguration when "alter resource group" is executed in the two phase commit.
 -- The steps are, when run "alter resource group", before QD broadcasts commit prepared command to QEs(the 
 -- second phase of 2PC), we trigger an error and cause one primary segment down. 
--- The expectation is "alter resource group" can run sucessfully since the mirror segment is UP. 
+-- The expectation is "alter resource group" can run successfully since the mirror segment is UP. 
 -- After recover the segment, there is no error or blocking.
 
--- set these values purely to cut down test time, as default ts trigger is
+-- set these values purely to cut down test time, as default fts trigger is
 -- every min and 5 retries
 alter system set gp_fts_probe_interval to 10;
 alter system set gp_fts_probe_retries to 0;
@@ -12,7 +12,7 @@ select pg_reload_conf();
 
 1:create resource group rgroup_seg_down with (CPU_RATE_LIMIT=35, MEMORY_LIMIT=35, CONCURRENCY=10);
 
--- inject an error in function dtm_broadcast_commit_prepared, that is QD broadcasts commit prepared command to QEs
+-- inject an error in function dtm_broadcast_commit_prepared, that is before QD broadcasts commit prepared command to QEs
 2:select gp_inject_fault_infinite('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp_segment_configuration where role='p' and content=-1;
 -- this session will pend here since the above injected fault
 1&:alter resource group rgroup_seg_down set CONCURRENCY 20;


### PR DESCRIPTION
In some cases, the AccessExclusiveLock for table pg_resgroupcapability may cause database setup/recovery pending.
For example in the test resgroup_seg_down_2pc, user ran "alter resource group" firstly, and before the QD broadcasts
the commit prepared command to QEs(that is the second phase of 2PC), if there is one primary segment down, then the "alter resource group" can't get executed successfully. Even run gprecoverseg to recover the segment, the segment is still pending on function InitResGroups.

The reason is that, when run "alter resource group", the AccessExclusiveLock is acquired for table pg_resgroupcapability on each segment, and if primary is switched or restart due to some error, function InitResGroups will acquire AccessShareLock for table pg_resgroupcapability in order to do some initial work, but can't acquire it due to AccessExclusiveLock is not released.

So the fix is use ExclusiveLock, then function InitResGroups can get executed successfully, and the datatbase can
startup. The previous "alter resource group" command can finish.
