### PR TITLE
Fixed missing NULL check in LeftAntiSemiHashJoin2HashJoin (6X)

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2759,9 +2759,12 @@ CXformUtils::FProcessGPDBAntiSemiHashJoin(
 				CPhysicalJoin::FHashJoinCompatible(
 					pexprEquality, pexprOuter,
 					pexprInner) &&	// equality is hash-join compatible
-				CUtils::FUsesNullableCol(
+				!CUtils::FUsesNullableCol(
 					mp, pexprEquality,
-					pexprInner))  // equality uses an inner nullable column
+					pexprInner) &&	// equality uses an inner NOT NULL column
+				!CUtils::FUsesNullableCol(
+					mp, pexprEquality,
+					pexprOuter))  // equality uses an outer NOT NULL column
 			{
 				pexprEquality->AddRef();
 				pdrgpexprNew->Append(pexprEquality);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13676,3 +13676,70 @@ select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join le
 reset optimizer_enable_hashjoin;
 reset enable_nestloop;
 reset enable_hashjoin;
+--- IS DISTINCT FROM FALSE previously simplified to IS TRUE, returning incorrect results for some hash anti joins
+--- the following tests were added to verify the behavior is correct
+CREATE TABLE tt1 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE tt2 (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tt1 VALUES (1, NULL), (2, 2), (3, 4), (NULL, 5);
+INSERT INTO tt2 VALUES (1, 1), (2, NULL), (4, 4), (NULL, 2);
+ANALYZE tt1;
+ANALYZE tt2;
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000002.56 rows=3 width=4)
+   ->  Nested Loop Anti Join  (cost=10000000000.00..10000000002.52 rows=1 width=4)
+         Join Filter: ((tt2.d = tt1.b) IS DISTINCT FROM false)
+         ->  Seq Scan on tt1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Materialize  (cost=0.00..1.09 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.07 rows=4 width=4)
+                     ->  Seq Scan on tt2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
+ b 
+---
+(0 rows)
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM true);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000002.56 rows=3 width=4)
+   ->  Nested Loop Anti Join  (cost=10000000000.00..10000000002.52 rows=1 width=4)
+         Join Filter: ((tt2.d = tt1.b) IS DISTINCT FROM true)
+         ->  Seq Scan on tt1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Materialize  (cost=0.00..1.09 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.07 rows=4 width=4)
+                     ->  Seq Scan on tt2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM true);
+ b 
+---
+(0 rows)
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000002.52 rows=3 width=4)
+   ->  Nested Loop Anti Join  (cost=10000000000.00..10000000002.47 rows=1 width=4)
+         Join Filter: ((tt1.b = tt2.d) IS NOT NULL)
+         ->  Seq Scan on tt1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Materialize  (cost=0.00..1.09 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.07 rows=4 width=4)
+                     ->  Seq Scan on tt2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+ b 
+---
+  
+(1 row)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13935,3 +13935,70 @@ select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_repl r left outer join le
 reset optimizer_enable_hashjoin;
 reset enable_nestloop;
 reset enable_hashjoin;
+--- IS DISTINCT FROM FALSE previously simplified to IS TRUE, returning incorrect results for some hash anti joins
+--- the following tests were added to verify the behavior is correct
+CREATE TABLE tt1 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE tt2 (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tt1 VALUES (1, NULL), (2, 2), (3, 4), (NULL, 5);
+INSERT INTO tt2 VALUES (1, 1), (2, NULL), (4, 4), (NULL, 2);
+ANALYZE tt1;
+ANALYZE tt2;
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.03 rows=4 width=4)
+   ->  Nested Loop Anti Join  (cost=0.00..1324033.03 rows=2 width=4)
+         Join Filter: ((tt2.d = tt1.b) IS DISTINCT FROM false)
+         ->  Seq Scan on tt1  (cost=0.00..431.00 rows=2 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on tt2  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
+ b 
+---
+(0 rows)
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM true);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.03 rows=4 width=4)
+   ->  Nested Loop Anti Join  (cost=0.00..1324033.03 rows=2 width=4)
+         Join Filter: ((tt2.d = tt1.b) IS DISTINCT FROM true)
+         ->  Seq Scan on tt1  (cost=0.00..431.00 rows=2 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on tt2  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM true);
+ b 
+---
+(0 rows)
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.03 rows=4 width=4)
+   ->  Nested Loop Anti Join  (cost=0.00..1324033.03 rows=2 width=4)
+         Join Filter: (NOT ((tt1.b = tt2.d) IS NULL))
+         ->  Seq Scan on tt1  (cost=0.00..431.00 rows=2 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on tt2  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+ b 
+---
+  
+(1 row)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3024,6 +3024,26 @@ reset optimizer_enable_hashjoin;
 reset enable_nestloop;
 reset enable_hashjoin;
 
+--- IS DISTINCT FROM FALSE previously simplified to IS TRUE, returning incorrect results for some hash anti joins
+--- the following tests were added to verify the behavior is correct
+CREATE TABLE tt1 (a int, b int);
+CREATE TABLE tt2 (c int, d int);
+
+INSERT INTO tt1 VALUES (1, NULL), (2, 2), (3, 4), (NULL, 5);
+INSERT INTO tt2 VALUES (1, 1), (2, NULL), (4, 4), (NULL, 2);
+
+ANALYZE tt1;
+ANALYZE tt2;
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM true);
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM true);
+
+EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS DISTINCT FROM NULL);
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Previously, `IS DISTINCT FROM FALSE` was simplified to checking if it is true.
However, due to the three valued logic of SQL, these are not equivalent
statements. This change changes the direct equality check to an OR between the
equality check and `IS NULL`.

```
CREATE TABLE tt1 (a int, b int);
CREATE TABLE tt2 (c int, d int);

INSERT INTO tt1 VALUES (1, NULL), (2, 2), (3, 4), (NULL, 5);
INSERT INTO tt2 VALUES (1, 1), (2, NULL), (4, 4), (NULL, 2);

EXPLAIN SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt2.d = tt1.b) IS DISTINCT FROM false);
```

Expected/Patched:
```
                                            QUERY PLAN
--------------------------------------------------------------------------------------------------
 Result  (cost=0.00..1324032.17 rows=1 width=4)
   Filter: (SubPlan 1)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
         ->  Seq Scan on tt1  (cost=0.00..431.00 rows=1 width=4)
   SubPlan 1
     ->  Result  (cost=0.00..431.00 rows=1 width=4)
           Filter: ((tt2.d = tt1.b) IS DISTINCT FROM false)
           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                       ->  Seq Scan on tt2  (cost=0.00..431.00 rows=1 width=8)
 Optimizer: Pivotal Optimizer (GPORCA)
(11 rows)

RESET
 b
---
(0 rows)
```

Actual:
```
                                            QUERY PLAN
---------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=4)
         Hash Cond: (tt1.b = tt2.d)
         ->  Seq Scan on tt1  (cost=0.00..431.00 rows=1 width=4)
         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                     ->  Seq Scan on tt2  (cost=0.00..431.00 rows=1 width=4)
 Optimizer: Pivotal Optimizer (GPORCA)
(8 rows)

RESET
 b
---
 5

(2 rows)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

NOTE: The 7X version of this PR has passed review and has been merged. No regressions have been found in this back port.
