### PR TITLE
Fix copy command can't read file with special character at the end of line

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6446,6 +6446,58 @@ CopyReadLineText(CopyState cstate)
 			 */
 			c2 = copy_raw_buf[raw_buf_ptr];
 
+			/*
+			* We need to recognize the EOL.
+			* Github issue: https://github.com/greenplum-db/gpdb/issues/12454
+			*/
+			if(c2 == '\n')
+			{
+				if(cstate->eol_type == EOL_UNKNOWN)
+				{
+				/* We still do not found the first EOL.
+				* The current '\n' will be recongnized as EOL
+				* in next loop of c1.
+				*/
+					goto not_end_of_copy;
+				}
+				else if(cstate->eol_type == EOL_NL)
+				{
+					// found a new line with '\n'
+					raw_buf_ptr++;
+					break;
+				}
+			}
+			if (c2 == '\r')
+			{
+				if(cstate->eol_type == EOL_UNKNOWN)
+				{
+					goto not_end_of_copy;
+				}
+				else if(cstate->eol_type == EOL_CR)
+				{
+					// found a new line wirh '\r'
+					raw_buf_ptr++;
+					break;
+				}
+				else if(cstate->eol_type == EOL_CRNL)
+				{
+					/*
+					* Because the eol is '\r\n', we need another character c3
+					* which comes after c2 if exists.
+					*/
+					char c3;
+					raw_buf_ptr++;
+					IF_NEED_REFILL_AND_NOT_EOF_CONTINUE(0);
+					IF_NEED_REFILL_AND_EOF_BREAK(0);
+					c3 = copy_raw_buf[raw_buf_ptr];
+					if(c3 == '\n')
+					{
+						// found a new line with '\r\n'
+						raw_buf_ptr++;
+						break;
+					}
+				}
+			}
 			if (c2 == '.')
 			{
 				raw_buf_ptr++;	/* consume the '.' */
@@ -6534,29 +6586,16 @@ CopyReadLineText(CopyState cstate)
 				 * If we are here, it means we found a backslash followed by
 				 * something other than a period.  In non-CSV mode, anything
 				 * after a backslash is special, so we skip over that second
-				 * character too (except the character is EOL, see below).
-				 * If we didn't do that \\. would be
+				 * character too. If we didn't do that \\. would be
 				 * considered an eof-of copy, while in non-CSV mode it is a
 				 * literal backslash followed by a period.  In CSV mode,
 				 * backslashes are not special, so we want to process the
 				 * character after the backslash just like a normal character,
 				 * so we don't increment in those cases.
 				 */
-				if (c2 == '\n' && cstate->eol_type == EOL_NL)
-				{
-					/*
-					* We need to recognize the EOL.
-					* Github issue: https://github.com/greenplum-db/gpdb/issues/12454
-					*/
-					NO_END_OF_COPY_GOTO;
-				}
-				else
-				{
-					raw_buf_ptr++;
-				}
+				raw_buf_ptr++;
 			}
 		}
-
 		/*
 		 * This label is for CSV cases where \. appears at the start of a
 		 * line, but there is more text after it, meaning it was a data value.

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6529,19 +6529,32 @@ CopyReadLineText(CopyState cstate)
 				break;
 			}
 			else if (!cstate->csv_mode)
-
+			{
 				/*
 				 * If we are here, it means we found a backslash followed by
 				 * something other than a period.  In non-CSV mode, anything
 				 * after a backslash is special, so we skip over that second
-				 * character too.  If we didn't do that \\. would be
+				 * character too (except the character is EOL, see below).
+				 * If we didn't do that \\. would be
 				 * considered an eof-of copy, while in non-CSV mode it is a
 				 * literal backslash followed by a period.  In CSV mode,
 				 * backslashes are not special, so we want to process the
 				 * character after the backslash just like a normal character,
 				 * so we don't increment in those cases.
 				 */
-				raw_buf_ptr++;
+				if (c2 == '\n' && cstate->eol_type == EOL_NL)
+				{
+					/*
+					* We need to recognize the EOL.
+					* Github issue: https://github.com/greenplum-db/gpdb/issues/12454
+					*/
+					NO_END_OF_COPY_GOTO;
+				}
+				else
+				{
+					raw_buf_ptr++;
+				}
+			}
 		}
 
 		/*

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -6495,6 +6495,8 @@ CopyReadLineText(CopyState cstate)
 						// found a new line with '\r\n'
 						raw_buf_ptr++;
 						break;
+					} else {
+						NO_END_OF_COPY_GOTO;
 					}
 				}
 			}
@@ -6586,7 +6588,7 @@ CopyReadLineText(CopyState cstate)
 				 * If we are here, it means we found a backslash followed by
 				 * something other than a period.  In non-CSV mode, anything
 				 * after a backslash is special, so we skip over that second
-				 * character too. If we didn't do that \\. would be
+				 * character too.  If we didn't do that \\. would be
 				 * considered an eof-of copy, while in non-CSV mode it is a
 				 * literal backslash followed by a period.  In CSV mode,
 				 * backslashes are not special, so we want to process the

--- a/src/test/regress/expected/copy_eol.out
+++ b/src/test/regress/expected/copy_eol.out
@@ -1,0 +1,18 @@
+--
+-- copy data to and from file with EOL.
+--
+CREATE TABLE copy_eol(id int, seq text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO copy_eol select '1', 's1\';
+INSERT INTO copy_eol select '2', 's2\';
+-- copy data to a file then copy from it.
+\COPY copy_eol TO '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e', NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+\COPY copy_eol FROM '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+SELECT count(*) FROM copy_eol;
+ count 
+-------
+     4
+(1 row)
+
+DROP TABLE copy_eol;

--- a/src/test/regress/expected/copy_eol.out
+++ b/src/test/regress/expected/copy_eol.out
@@ -6,20 +6,24 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 --- EOL: '\n'
 \!echo -n -e '1\x1es1\\\n2\x1es2\\\n' > /tmp/copy_lf.file;
-\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
-\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
 --- EOL: '\r'
 \!echo -n -e '1\x1es1\\\r2\x1es2\\\r' > /tmp/copy_cr.file;
-\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
-\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
 --- EOL: '\r\n'
 \!echo -n -e '1\x1es1\\\r\n2\x1es2\\\r\n' > /tmp/copy_crlf.file;
-\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
-\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+--- EOL: '\r\n' with a '\r' in data
+\!echo -n -e '1\x1es1\\\r\n2\x1es\\\r2\\\r\r\n3\x1es3\r\n' > /tmp/copy_crlf_1.file;
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
 SELECT count(*) FROM copy_eol;
  count 
 -------
-    12
+    18
 (1 row)
 
 DROP TABLE copy_eol;

--- a/src/test/regress/expected/copy_eol.out
+++ b/src/test/regress/expected/copy_eol.out
@@ -1,18 +1,25 @@
 --
--- copy data to and from file with EOL.
+-- copy data from file with different EOL and NEWLINE option.
 --
 CREATE TABLE copy_eol(id int, seq text);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO copy_eol select '1', 's1\';
-INSERT INTO copy_eol select '2', 's2\';
--- copy data to a file then copy from it.
-\COPY copy_eol TO '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e', NULL E'\x1b\x4e',  ESCAPE E'\x1b');
-\COPY copy_eol FROM '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+--- EOL: '\n'
+\!echo -n -e '1\x1es1\\\n2\x1es2\\\n' > /tmp/copy_lf.file;
+\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
+--- EOL: '\r'
+\!echo -n -e '1\x1es1\\\r2\x1es2\\\r' > /tmp/copy_cr.file;
+\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
+\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+--- EOL: '\r\n'
+\!echo -n -e '1\x1es1\\\r\n2\x1es2\\\r\n' > /tmp/copy_crlf.file;
+\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
 SELECT count(*) FROM copy_eol;
  count 
 -------
-     4
+    12
 (1 row)
 
 DROP TABLE copy_eol;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,10 @@
 #   hitting max_connections limit on segments.
 #
 
+# copy command
+# copy form a file with different EOL
+test: copy_eol
+
 # gp_toolkit performs a vacuum and checks that it truncated the relation. That
 # might not happen if other backends are holding transactions open, preventing
 # vacuum from removing dead tuples. And run gp_toolkit early to make some log

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -260,10 +260,6 @@ COPY copy_regression_text3 from stdin with delimiter '|';
 the at sign: \100|6|c text data|d text data|e text data
 a single backslash \\ in col a|8|c text data|d text data|e text data
 \.
--- This works in PostgreSQL, and these days in GPDB as well, but used to not
--- work until GPDB 6. This is just one line, because the newlines are
--- escaped. (Even on PostgreSQL, the COPY documentation recommends not to do
--- this, but let's test it.)
 COPY copy_regression_text3 from stdin with delimiter '|';
 an embedded linefeed \
 and another one\

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -226,11 +226,9 @@ SELECT * FROM copy_regression_text2;
 COPY copy_regression_text3 from stdin with delimiter '|' escape '#';
 COPY copy_regression_text3 from stdin with delimiter '|' escape 'off';
 COPY copy_regression_text3 from stdin with delimiter '|';
--- This works in PostgreSQL, and these days in GPDB as well, but used to not
--- work until GPDB 6. This is just one line, because the newlines are
--- escaped. (Even on PostgreSQL, the COPY documentation recommends not to do
--- this, but let's test it.)
 COPY copy_regression_text3 from stdin with delimiter '|';
+ERROR:  missing data for column "b"
+CONTEXT:  COPY copy_regression_text3, line 2: "and another one\"
 COPY copy_regression_text3 from stdin with delimiter '|';
 SELECT * FROM copy_regression_text3 ORDER BY b,a;
                  a                  | b |      c      |      d      |      e       
@@ -241,13 +239,10 @@ SELECT * FROM copy_regression_text3 ORDER BY b,a;
  a single backslash \ in col a      | 4 | c text data | d text data | e text data
  c:\\file\data\neew\path            | 5 | c text data | d text data | e text data
  the at sign: @                     | 6 | c text data | d text data | e text data
- an embedded linefeed              +| 7 | c text data | d text data | e text data
- and another one                   +|   |             |             | 
-  in column a                       |   |             |             | 
  an embedded linefeed sequence     +| 7 | c text data | d text data | e text data
  in column a                        |   |             |             | 
  a single backslash \ in col a      | 8 | c text data | d text data | e text data
-(9 rows)
+(8 rows)
 
 DROP TABLE copy_regression_text1;
 DROP TABLE copy_regression_text2;

--- a/src/test/regress/sql/copy_eol.sql
+++ b/src/test/regress/sql/copy_eol.sql
@@ -1,0 +1,15 @@
+--
+-- copy data to and from file with EOL.
+--
+CREATE TABLE copy_eol(id int, seq text);
+
+INSERT INTO copy_eol select '1', 's1\';
+INSERT INTO copy_eol select '2', 's2\';
+
+-- copy data to a file then copy from it.
+\COPY copy_eol TO '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e', NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+\COPY copy_eol FROM '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+
+SELECT count(*) FROM copy_eol;
+
+DROP TABLE copy_eol;

--- a/src/test/regress/sql/copy_eol.sql
+++ b/src/test/regress/sql/copy_eol.sql
@@ -5,18 +5,23 @@ CREATE TABLE copy_eol(id int, seq text);
 
 --- EOL: '\n'
 \!echo -n -e '1\x1es1\\\n2\x1es2\\\n' > /tmp/copy_lf.file;
-\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
-\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
 
 --- EOL: '\r'
 \!echo -n -e '1\x1es1\\\r2\x1es2\\\r' > /tmp/copy_cr.file;
-\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
-\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
 
 --- EOL: '\r\n'
 \!echo -n -e '1\x1es1\\\r\n2\x1es2\\\r\n' > /tmp/copy_crlf.file;
-\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
-\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+
+--- EOL: '\r\n' with a '\r' in data
+\!echo -n -e '1\x1es1\\\r\n2\x1es\\\r2\\\r\r\n3\x1es3\r\n' > /tmp/copy_crlf_1.file;
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
 
 SELECT count(*) FROM copy_eol;
 

--- a/src/test/regress/sql/copy_eol.sql
+++ b/src/test/regress/sql/copy_eol.sql
@@ -1,14 +1,22 @@
 --
--- copy data to and from file with EOL.
+-- copy data from file with different EOL and NEWLINE option.
 --
 CREATE TABLE copy_eol(id int, seq text);
 
-INSERT INTO copy_eol select '1', 's1\';
-INSERT INTO copy_eol select '2', 's2\';
+--- EOL: '\n'
+\!echo -n -e '1\x1es1\\\n2\x1es2\\\n' > /tmp/copy_lf.file;
+\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+\COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
 
--- copy data to a file then copy from it.
-\COPY copy_eol TO '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e', NULL E'\x1b\x4e',  ESCAPE E'\x1b');
-\COPY copy_eol FROM '/tmp/copy_eol.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+--- EOL: '\r'
+\!echo -n -e '1\x1es1\\\r2\x1es2\\\r' > /tmp/copy_cr.file;
+\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
+\COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+
+--- EOL: '\r\n'
+\!echo -n -e '1\x1es1\\\r\n2\x1es2\\\r\n' > /tmp/copy_crlf.file;
+\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+\COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
 
 SELECT count(*) FROM copy_eol;
 


### PR DESCRIPTION
Fix copy command can't read file with special character at the end of line(#12454 )

The copy command read data from a file and process data once a character.
In non-CSV mode, anything after a backslash is skipped over, so that EOL
character after a backslash can not be recognized.

An example file with content:
>
	1, message1
	2, message2\
	3, message3

The copy from command will fail because line2 and line3 will be regarded as one line.

Co-authored-by: Mingli Zhang <avamingli@gmail.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
