### PR TITLE
fix gpload upper case column

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1848,19 +1848,6 @@ class gpload:
                     "the Greenplum Database running on port %i?" % (errorMessage,
                     self.options.p))
 
-    def add_quote_if_not(self, col):
-        '''
-        Judge if the column name string has quotations.
-        If not, return a string with double quotations.
-        pyyaml cannot preserve quotes of string in yaml file.
-        So we need to quote the string for furter comparison if it is not quoted.
-        '''
-        if col[0] == '"' and col[-1] == '"':
-            return col
-        elif col[0] == "'" and col[-1] == "'":
-            return col
-        else:
-            return quote_ident(col)
 
     def read_columns(self):
         columns = self.getconfig('gpload:input:columns',list,None, returnOriginal=True)
@@ -1875,7 +1862,6 @@ class gpload:
                 """ remove leading or trailing spaces """
                 d = { tempkey.strip() : value }
                 key = d.keys()[0]
-                col_name = self.add_quote_if_not(key)
                 if d[key] is None:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
@@ -1892,7 +1878,7 @@ class gpload:
 
                 # Mark this column as having no mapping, which is important
                 # for do_insert()
-                self.from_columns.append([col_name,d[key].lower(),None, False])
+                self.from_columns.append([key,d[key].lower(),None, False])
         else:
             self.from_columns = self.into_columns
             self.from_cols_from_user = False

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -793,6 +793,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_40_gpload_column_withvarious_quotations_standard_conforming_strings_off(self):
         """ 40 test gpload input columns with '"col"'  "\"col\""  "'col'" and "col" when standard_conforming_strings is off"""
+        # columns with special characters are not supported when standard_conforming_strings is off
         copy_data('external_file_15.txt','data_file.txt')
         columns = ['\'"Field1"\': bigint','\'"Field#2"\': text' ]
         write_config_file(mode='insert',reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='4',columns = columns, delimiter=";",SQL=True,sql_before='set standard_conforming_strings =off;')
@@ -813,13 +814,17 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
     def test_41_gpload_column_withvarious_quotations_standard_conforming_strings_on(self):
         """ 41 test gpload input columns with '"col"'  "\"col\""  "'col'" and "col" when standard_conforming_strings is on"""
         copy_data('external_file_15.txt','data_file.txt')
+        # column like '"Field1"', support
         columns = ['\'"Field1"\': bigint','\'"Field#2"\': text' ]
         write_config_file(mode='insert',reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='4',columns = columns, delimiter=";",SQL=True,sql_before='set standard_conforming_strings =on;')
         copy_data('external_file_16.txt','data_file2.txt')
+        # column like "\"Field1\"", support
         columns = ['"\\"Field1\\"": bigint','"\\"Field#2\\"": text' ]
         write_config_file(update_columns='\'"Field#2"\'',config='config/config_file2', mode='merge',reuse_flag='true',fast_match='false', file='data_file2.txt',table='testSpecialChar',columns_flag='4', columns = columns,delimiter=";",match_columns='2',SQL=True,sql_before='set standard_conforming_strings =on;')
+        # column like "'Field1'", not support
         columns = ['"\'Field1\'": bigint','"\'Field#2\'": text' ]
         write_config_file(update_columns='\'"Field#2"\'',config='config/config_file3', mode='merge',reuse_flag='true',fast_match='false', file='data_file2.txt',table='testSpecialChar',columns_flag='4', columns = columns,delimiter=";",match_columns='2',SQL=True,sql_before='set standard_conforming_strings =on;')
+        # column like "Field1", not support
         columns = ['"Field1": bigint','"Field#2": text' ]
         write_config_file(update_columns='\'"Field#2"\'',config='config/config_file4', mode='merge',reuse_flag='true',fast_match='false', file='data_file2.txt',table='testSpecialChar',columns_flag='4', columns = columns,delimiter=";",match_columns='2',SQL=True,sql_before='set standard_conforming_strings =on;')
         f = open(mkpath('query41.sql'),'a')
@@ -833,6 +838,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         """42 test gpload column name without quotes but has capital letters and special characters"""
         copy_data('external_file_15.txt','data_file.txt')
         columns = ['Field1: bigint','Field#2: text' ]
+        # column like Field1: bigint, not support whatever the standard_conforming_strings is
         write_config_file(mode='insert',reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='4',columns = columns, delimiter=";",SQL=True,sql_before='set standard_conforming_strings =on;')
         write_config_file(mode='insert',config='config/config_file2', reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='4',columns = columns, delimiter=";",SQL=True,sql_before='set standard_conforming_strings =off;')
         f = open(mkpath('query42.sql'),'w')

--- a/gpMgmt/bin/gpload_test/gpload2/query40.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query40.ans
@@ -1,57 +1,51 @@
-2021-06-03 14:29:18|INFO|gpload session started 2021-06-03 14:29:18
-2021-06-03 14:29:18|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-03 14:29:18|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-06-03 14:29:18|INFO|did not find an external table to reuse. creating ext_gpload_reusable_062a3284_c435_11eb_8755_0050569e5d5e
-2021-06-03 14:29:18|ERROR|could not run SQL "create external table ext_gpload_reusable_062a3284_c435_11eb_8755_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-08-18 10:35:48|INFO|gpload session started 2021-08-18 10:35:48
+2021-08-18 10:35:48|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:48|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-08-18 10:35:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ff737544_ffcc_11eb_a0d2_0050569e5d5e
+2021-08-18 10:35:48|ERROR|could not run SQL "create external table ext_gpload_reusable_ff737544_ffcc_11eb_a0d2_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
 
-2021-06-03 14:29:18|INFO|rows Inserted          = 0
-2021-06-03 14:29:18|INFO|rows Updated           = 0
-2021-06-03 14:29:18|INFO|data formatting errors = 0
-2021-06-03 14:29:18|INFO|gpload failed
-2021-06-03 14:29:18|INFO|gpload session started 2021-06-03 14:29:18
-2021-06-03 14:29:18|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-03 14:29:18|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-06-03 14:29:18|INFO|did not find an external table to reuse. creating ext_gpload_reusable_063d781c_c435_11eb_b9e0_0050569e5d5e
-2021-06-03 14:29:18|ERROR|could not run SQL "create external table ext_gpload_reusable_063d781c_c435_11eb_b9e0_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-08-18 10:35:48|INFO|rows Inserted          = 0
+2021-08-18 10:35:48|INFO|rows Updated           = 0
+2021-08-18 10:35:48|INFO|data formatting errors = 0
+2021-08-18 10:35:48|INFO|gpload failed
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-08-18 10:35:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ff88c8d6_ffcc_11eb_accb_0050569e5d5e
+2021-08-18 10:35:49|ERROR|could not run SQL "create external table ext_gpload_reusable_ff88c8d6_ffcc_11eb_accb_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
 
-2021-06-03 14:29:18|INFO|rows Inserted          = 0
-2021-06-03 14:29:18|INFO|rows Updated           = 0
-2021-06-03 14:29:18|INFO|data formatting errors = 0
-2021-06-03 14:29:18|INFO|gpload failed
-2021-06-03 14:29:18|INFO|gpload session started 2021-06-03 14:29:18
-2021-06-03 14:29:18|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-03 14:29:18|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
-2021-06-03 14:29:18|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-06-03 14:29:18|INFO|did not find an external table to reuse. creating ext_gpload_reusable_0650a284_c435_11eb_8089_0050569e5d5e
-2021-06-03 14:29:18|ERROR|could not run SQL "create external table ext_gpload_reusable_0650a284_c435_11eb_8089_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-08-18 10:35:49|INFO|rows Inserted          = 0
+2021-08-18 10:35:49|INFO|rows Updated           = 0
+2021-08-18 10:35:49|INFO|data formatting errors = 0
+2021-08-18 10:35:49|INFO|gpload failed
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
+2021-08-18 10:35:49|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-08-18 10:35:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ff9d47fc_ffcc_11eb_b9ee_0050569e5d5e
+2021-08-18 10:35:49|ERROR|could not run SQL "create external table ext_gpload_reusable_ff9d47fc_ffcc_11eb_b9ee_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
 
-2021-06-03 14:29:18|INFO|rows Inserted          = 0
-2021-06-03 14:29:18|INFO|rows Updated           = 0
-2021-06-03 14:29:18|INFO|data formatting errors = 0
-2021-06-03 14:29:18|INFO|gpload failed
-2021-06-03 14:29:18|INFO|gpload session started 2021-06-03 14:29:18
-2021-06-03 14:29:18|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-03 14:29:18|ERROR|no mapping for input column "'Field1'" to output table
-2021-06-03 14:29:18|INFO|rows Inserted          = 0
-2021-06-03 14:29:18|INFO|rows Updated           = 0
-2021-06-03 14:29:18|INFO|data formatting errors = 0
-2021-06-03 14:29:18|INFO|gpload failed
-2021-06-03 14:29:18|INFO|gpload session started 2021-06-03 14:29:18
-2021-06-03 14:29:18|INFO|setting schema 'public' for table 'testspecialchar'
-2021-06-03 14:29:18|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
-2021-06-03 14:29:18|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-06-03 14:29:18|INFO|did not find an external table to reuse. creating ext_gpload_reusable_06769016_c435_11eb_9988_0050569e5d5e
-2021-06-03 14:29:18|ERROR|could not run SQL "create external table ext_gpload_reusable_06769016_c435_11eb_9988_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
-LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
-                                                                 ^
-
-2021-06-03 14:29:18|INFO|rows Inserted          = 0
-2021-06-03 14:29:18|INFO|rows Updated           = 0
-2021-06-03 14:29:18|INFO|data formatting errors = 0
-2021-06-03 14:29:18|INFO|gpload failed
+2021-08-18 10:35:49|INFO|rows Inserted          = 0
+2021-08-18 10:35:49|INFO|rows Updated           = 0
+2021-08-18 10:35:49|INFO|data formatting errors = 0
+2021-08-18 10:35:49|INFO|gpload failed
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|ERROR|no mapping for input column "'Field1'" to output table
+2021-08-18 10:35:49|INFO|rows Inserted          = 0
+2021-08-18 10:35:49|INFO|rows Updated           = 0
+2021-08-18 10:35:49|INFO|data formatting errors = 0
+2021-08-18 10:35:49|INFO|gpload failed
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|ERROR|no mapping for input column "Field1" to output table
+2021-08-18 10:35:49|INFO|rows Inserted          = 0
+2021-08-18 10:35:49|INFO|rows Updated           = 0
+2021-08-18 10:35:49|INFO|data formatting errors = 0
+2021-08-18 10:35:49|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query41.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query41.ans
@@ -1,45 +1,42 @@
-2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
-2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-05-21 14:15:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f7fb3214_b9fb_11eb_9d73_0050569e5d5e
-2021-05-21 14:15:41|INFO|running time: 0.04 seconds
-2021-05-21 14:15:41|INFO|rows Inserted          = 8
-2021-05-21 14:15:41|INFO|rows Updated           = 0
-2021-05-21 14:15:41|INFO|data formatting errors = 0
-2021-05-21 14:15:41|INFO|gpload succeeded
-2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
-2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-05-21 14:15:41|INFO|reusing external table ext_gpload_reusable_f7fb3214_b9fb_11eb_9d73_0050569e5d5e
-2021-05-21 14:15:41|INFO|running time: 0.04 seconds
-2021-05-21 14:15:41|INFO|rows Inserted          = 8
-2021-05-21 14:15:41|INFO|rows Updated           = 0
-2021-05-21 14:15:41|INFO|data formatting errors = 0
-2021-05-21 14:15:41|INFO|gpload succeeded
-2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
-2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
-2021-05-21 14:15:41|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-05-21 14:15:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f823dd5e_b9fb_11eb_bca1_0050569e5d5e
-2021-05-21 14:15:41|INFO|running time: 0.07 seconds
-2021-05-21 14:15:41|INFO|rows Inserted          = 2
-2021-05-21 14:15:41|INFO|rows Updated           = 12
-2021-05-21 14:15:41|INFO|data formatting errors = 0
-2021-05-21 14:15:41|INFO|gpload succeeded
-2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
-2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:41|ERROR|no mapping for input column "'Field1'" to output table
-2021-05-21 14:15:41|INFO|rows Inserted          = 0
-2021-05-21 14:15:41|INFO|rows Updated           = 0
-2021-05-21 14:15:41|INFO|data formatting errors = 0
-2021-05-21 14:15:41|INFO|gpload failed
-2021-05-21 14:15:41|INFO|gpload session started 2021-05-21 14:15:41
-2021-05-21 14:15:41|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
-2021-05-21 14:15:41|INFO|reusing staging table staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-05-21 14:15:41|INFO|reusing external table ext_gpload_reusable_f823dd5e_b9fb_11eb_bca1_0050569e5d5e
-2021-05-21 14:15:41|INFO|running time: 0.07 seconds
-2021-05-21 14:15:41|INFO|rows Inserted          = 0
-2021-05-21 14:15:41|INFO|rows Updated           = 14
-2021-05-21 14:15:41|INFO|data formatting errors = 0
-2021-05-21 14:15:41|INFO|gpload succeeded
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-08-18 10:35:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ffe21f6c_ffcc_11eb_add8_0050569e5d5e
+2021-08-18 10:35:49|INFO|running time: 0.05 seconds
+2021-08-18 10:35:49|INFO|rows Inserted          = 8
+2021-08-18 10:35:49|INFO|rows Updated           = 0
+2021-08-18 10:35:49|INFO|data formatting errors = 0
+2021-08-18 10:35:49|INFO|gpload succeeded
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-08-18 10:35:49|INFO|reusing external table ext_gpload_reusable_ffe21f6c_ffcc_11eb_add8_0050569e5d5e
+2021-08-18 10:35:49|INFO|running time: 0.05 seconds
+2021-08-18 10:35:49|INFO|rows Inserted          = 8
+2021-08-18 10:35:49|INFO|rows Updated           = 0
+2021-08-18 10:35:49|INFO|data formatting errors = 0
+2021-08-18 10:35:49|INFO|gpload succeeded
+2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
+2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-08-18 10:35:49|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-08-18 10:35:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_000ecde6_ffcd_11eb_bf1a_0050569e5d5e
+2021-08-18 10:35:50|INFO|running time: 0.08 seconds
+2021-08-18 10:35:50|INFO|rows Inserted          = 2
+2021-08-18 10:35:50|INFO|rows Updated           = 12
+2021-08-18 10:35:50|INFO|data formatting errors = 0
+2021-08-18 10:35:50|INFO|gpload succeeded
+2021-08-18 10:35:50|INFO|gpload session started 2021-08-18 10:35:50
+2021-08-18 10:35:50|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:50|ERROR|no mapping for input column "'Field1'" to output table
+2021-08-18 10:35:50|INFO|rows Inserted          = 0
+2021-08-18 10:35:50|INFO|rows Updated           = 0
+2021-08-18 10:35:50|INFO|data formatting errors = 0
+2021-08-18 10:35:50|INFO|gpload failed
+2021-08-18 10:35:50|INFO|gpload session started 2021-08-18 10:35:50
+2021-08-18 10:35:50|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:35:50|ERROR|no mapping for input column "Field1" to output table
+2021-08-18 10:35:50|INFO|rows Inserted          = 0
+2021-08-18 10:35:50|INFO|rows Updated           = 0
+2021-08-18 10:35:50|INFO|data formatting errors = 0
+2021-08-18 10:35:50|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query42.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query42.ans
@@ -1,21 +1,14 @@
-2021-05-21 14:15:42|INFO|gpload session started 2021-05-21 14:15:42
-2021-05-21 14:15:42|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-05-21 14:15:42|INFO|reusing external table ext_gpload_reusable_f7fb3214_b9fb_11eb_9d73_0050569e5d5e
-2021-05-21 14:15:42|INFO|running time: 0.04 seconds
-2021-05-21 14:15:42|INFO|rows Inserted          = 8
-2021-05-21 14:15:42|INFO|rows Updated           = 0
-2021-05-21 14:15:42|INFO|data formatting errors = 0
-2021-05-21 14:15:42|INFO|gpload succeeded
-2021-05-21 14:15:42|INFO|gpload session started 2021-05-21 14:15:42
-2021-05-21 14:15:42|INFO|setting schema 'public' for table 'testspecialchar'
-2021-05-21 14:15:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-05-21 14:15:42|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f87b7460_b9fb_11eb_a987_0050569e5d5e
-2021-05-21 14:15:42|ERROR|could not run SQL "create external table ext_gpload_reusable_f87b7460_b9fb_11eb_a987_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://10.117.190.97:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
-LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
-                                                                 ^
-
-2021-05-21 14:15:42|INFO|rows Inserted          = 0
-2021-05-21 14:15:42|INFO|rows Updated           = 0
-2021-05-21 14:15:42|INFO|data formatting errors = 0
-2021-05-21 14:15:42|INFO|gpload failed
+2021-08-18 10:52:35|INFO|gpload session started 2021-08-18 10:52:35
+2021-08-18 10:52:35|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:52:35|ERROR|no mapping for input column "Field1" to output table
+2021-08-18 10:52:35|INFO|rows Inserted          = 0
+2021-08-18 10:52:35|INFO|rows Updated           = 0
+2021-08-18 10:52:35|INFO|data formatting errors = 0
+2021-08-18 10:52:35|INFO|gpload failed
+2021-08-18 10:52:35|INFO|gpload session started 2021-08-18 10:52:35
+2021-08-18 10:52:35|INFO|setting schema 'public' for table 'testspecialchar'
+2021-08-18 10:52:35|ERROR|no mapping for input column "Field1" to output table
+2021-08-18 10:52:35|INFO|rows Inserted          = 0
+2021-08-18 10:52:35|INFO|rows Updated           = 0
+2021-08-18 10:52:35|INFO|data formatting errors = 0
+2021-08-18 10:52:35|INFO|gpload failed


### PR DESCRIPTION
backport fix gpload6 column uppercase  #12416 to gpload5
if column name has upper case letters, column should write like `'"Col"'` or `"\"Col\""` in the yaml file. 
`"Col"` will be treated as lower case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
