### PR TITLE
[5X]Use the correct flow in ParallelizeSubplan for subplan

### DIFF
--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -2066,3 +2066,258 @@ where
 DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 -- end_ignore
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table extra_flow_dist1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+-- case 1 subplan with general locus (CTE and subquery)
+explain with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.08 rows=4 width=12)
+   ->  Nested Loop  (cost=0.00..1.08 rows=2 width=12)
+         ->  Subquery Scan run_dt  (cost=0.00..0.02 rows=1 width=4)
+               Filter: run_dt.dt < '01-01-2010'::date
+               ->  Subquery Scan a  (cost=0.01..3.16 rows=1 width=4)
+                     ->  Aggregate  (cost=0.01..0.03 rows=1 width=4)
+                           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                     SubPlan 1
+                       ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                             Filter: extra_flow_dist.b = $0
+                             ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                         ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+         ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(16 rows)
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 2 for subplan with entry locus (CTE and subquery)
+explain with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.07..1.28 rows=4 width=12)
+   ->  Nested Loop  (cost=0.07..1.28 rows=2 width=12)
+         ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+         ->  Materialize  (cost=0.07..0.10 rows=1 width=4)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..0.06 rows=3 width=4)
+                     ->  Subquery Scan run_dt  (cost=0.00..0.02 rows=1 width=4)
+                           Filter: run_dt.dt < '01-01-2010'::date
+                           ->  Subquery Scan a  (cost=0.00..3.16 rows=1 width=4)
+                                 ->  Limit  (cost=0.00..0.03 rows=1 width=0)
+                                       ->  Seq Scan on pg_trigger  (cost=0.00..1.55 rows=55 width=0)
+                                 SubPlan 1
+                                   ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                                         Filter: extra_flow_dist.b = $0
+                                         ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                                     ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(18 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 3 for subplan with entry locus without param in subplan (CTE and subquery)
+explain with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger ) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=1.09..5.91 rows=55 width=14)
+   Join Filter: (max(1)) < extra_flow_dist1.a
+   ->  Nested Loop Left Join  (cost=0.04..89.59 rows=55 width=6)
+         Join Filter: (subplan)
+         ->  Seq Scan on pg_trigger  (cost=0.00..1.55 rows=55 width=2)
+         ->  Materialize  (cost=0.04..0.05 rows=1 width=4)
+               ->  Aggregate  (cost=0.01..0.03 rows=1 width=4)
+                     ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         SubPlan 1
+           ->  Materialize  (cost=3.13..3.23 rows=4 width=0)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.12 rows=10 width=0)
+                       ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=4 width=0)
+   ->  Materialize  (cost=1.09..1.12 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.09 rows=3 width=8)
+               ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(17 rows)
+
+-- case 4 without CTE, nested subquery
+explain select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=6.35..7.45 rows=4 width=12)
+   ->  Nested Loop  (cost=6.35..7.45 rows=2 width=12)
+         ->  Subquery Scan tbl  (cost=6.35..6.38 rows=1 width=4)
+               Filter: tbl.dt < '01-01-2010'::date
+               ->  Unique  (cost=6.35..6.36 rows=1 width=4)
+                     Group By: ((subplan))
+                     ->  Sort  (cost=6.35..6.35 rows=1 width=4)
+                           Sort Key (Distinct): ((subplan))
+                           ->  Append  (cost=0.01..6.34 rows=1 width=4)
+                                 ->  Subquery Scan a  (cost=0.01..3.16 rows=1 width=4)
+                                       ->  Aggregate  (cost=0.01..0.03 rows=1 width=4)
+                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                                       SubPlan 2
+                                         ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                                               Filter: subselect_gp.extra_flow_dist.b = $0
+                                               ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                                           ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+                                 ->  Subquery Scan aa  (cost=0.01..3.16 rows=1 width=4)
+                                       ->  Aggregate  (cost=0.01..0.03 rows=1 width=4)
+                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                                       SubPlan 1
+                                         ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                                               Filter: subselect_gp.extra_flow_dist.b = $0
+                                               ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                                           ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+         ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(30 rows)
+
+-- case 5 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+explain with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.03..43.53 rows=1000 width=12)
+   ->  Nested Loop  (cost=1.03..43.53 rows=334 width=12)
+         ->  Subquery Scan run_dt  (cost=0.00..22.50 rows=112 width=4)
+               Filter: run_dt.dt < '01-01-2010'::date
+               ->  Function Scan on im x  (cost=0.00..3385.00 rows=334 width=4)
+                     SubPlan 1
+                       ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                             Filter: extra_flow_dist.b = $0
+                             ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                         ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+         ->  Materialize  (cost=1.03..1.06 rows=1 width=8)
+               ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
+-- case 6 function scan without CTE
+explain
+select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.03..6533.53 rows=1000 width=12)
+   ->  Nested Loop  (cost=1.03..6533.53 rows=334 width=12)
+         ->  Function Scan on im x  (cost=0.00..3387.50 rows=112 width=4)
+               Filter: ((subplan)) < '01-01-2010'::date
+               SubPlan 2
+                 ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                       Filter: subselect_gp.extra_flow_dist.b = $0
+                       ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                   ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+         ->  Materialize  (cost=1.03..1.06 rows=1 width=8)
+               ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+         SubPlan 1
+           ->  Result  (cost=3.13..3.14 rows=1 width=4)
+                 Filter: subselect_gp.extra_flow_dist.b = $0
+                 ->  Materialize  (cost=3.13..3.14 rows=1 width=4)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                             ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(20 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2179,3 +2179,278 @@ where
 DROP TABLE IF EXISTS dedup_test1;
 DROP TABLE IF EXISTS dedup_test2;
 -- end_ignore
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table extra_flow_dist1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+-- case 1 subplan with general locus (CTE and subquery)
+explain with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                           QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..904778927.71 rows=3 width=12)
+   ->  Nested Loop  (cost=0.00..904778927.71 rows=1 width=12)
+         Join Filter: true
+         ->  Table Scan on extra_flow_dist1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Materialize  (cost=0.00..882711.17 rows=1 width=4)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..882711.17 rows=3 width=4)
+                     ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                           Filter: ((subplan)) < '01-01-2010'::date
+                           ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                 ->  Aggregate  (cost=0.00..0.00 rows=1 width=4)
+                                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                 SubPlan 1
+                                   ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                                         Filter: extra_flow_dist.b = $0
+                                         ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                     ->  Table Scan on extra_flow_dist  (cost=0.00..431.00 rows=4 width=8)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.119.0
+(19 rows)
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 2 for subplan with entry locus (CTE and subquery)
+explain with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                           QUERY PLAN                                                          
+--------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1356721318.94 rows=3 width=12)
+   ->  Nested Loop  (cost=0.00..1356721318.94 rows=1 width=12)
+         Join Filter: true
+         ->  Table Scan on extra_flow_dist1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Materialize  (cost=0.00..1324061.16 rows=1 width=4)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..1324061.16 rows=3 width=4)
+                     ->  Result  (cost=0.00..1324061.16 rows=1 width=4)
+                           Filter: ((subplan)) < '01-01-2010'::date
+                           ->  Result  (cost=0.00..1324061.16 rows=1 width=4)
+                                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                                       ->  Result  (cost=0.00..431.01 rows=19 width=4)
+                                             ->  Table Scan on pg_trigger  (cost=0.00..431.01 rows=19 width=1)
+                                 SubPlan 1
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                         Filter: extra_flow_dist.b = $0
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                     ->  Table Scan on extra_flow_dist  (cost=0.00..431.00 rows=1 width=8)
+                                                           Filter: b = 1
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.119.0
+(21 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 3 for subplan with entry locus without param in subplan (CTE and subquery)
+explain with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=1.09..5.91 rows=55 width=14)
+   Join Filter: (max(1)) < extra_flow_dist1.a
+   ->  Nested Loop Left Join  (cost=0.04..89.59 rows=55 width=6)
+         Join Filter: (subplan)
+         ->  Seq Scan on pg_trigger  (cost=0.00..1.55 rows=55 width=2)
+         ->  Materialize  (cost=0.04..0.05 rows=1 width=4)
+               ->  Aggregate  (cost=0.01..0.03 rows=1 width=4)
+                     ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         SubPlan 1
+           ->  Materialize  (cost=3.13..3.23 rows=4 width=0)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.12 rows=10 width=0)
+                       ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=4 width=0)
+   ->  Materialize  (cost=1.09..1.12 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.09 rows=3 width=8)
+               ->  Seq Scan on extra_flow_dist1  (cost=0.00..1.03 rows=1 width=8)
+ Settings:  optimizer=on
+ Optimizer status: legacy query optimizer
+(17 rows)
+
+-- case 4 without CTE, nested subquery
+explain select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                                                QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1808675167.14 rows=6 width=12)
+   ->  Nested Loop  (cost=0.00..1808675167.14 rows=2 width=12)
+         Join Filter: true
+         ->  Table Scan on extra_flow_dist1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Materialize  (cost=0.00..1765422.34 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1765422.34 rows=2 width=4)
+                     ->  GroupAggregate  (cost=0.00..1765422.34 rows=1 width=4)
+                           Group By: ((subplan))
+                           ->  Sort  (cost=0.00..1765422.34 rows=1 width=4)
+                                 Sort Key: ((subplan))
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..1765422.34 rows=1 width=4)
+                                       Hash Key: ((subplan))
+                                       ->  GroupAggregate  (cost=0.00..1765422.34 rows=1 width=4)
+                                             Group By: ((subplan))
+                                             ->  Sort  (cost=0.00..1765422.34 rows=1 width=4)
+                                                   Sort Key: ((subplan))
+                                                   ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..1765422.34 rows=2 width=4)
+                                                         ->  Append  (cost=0.00..1765422.34 rows=1 width=4)
+                                                               ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                     Filter: ((subplan)) < '01-01-2010'::date
+                                                                     ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                           ->  Aggregate  (cost=0.00..0.00 rows=1 width=4)
+                                                                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                                           SubPlan 1
+                                                                             ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                                                                                   Filter: subselect_gp.extra_flow_dist.b = $0
+                                                                                   ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                                                               ->  Table Scan on extra_flow_dist  (cost=0.00..431.00 rows=4 width=8)
+                                                               ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                     Filter: ((subplan)) < '01-01-2010'::date
+                                                                     ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                           ->  Aggregate  (cost=0.00..0.00 rows=1 width=4)
+                                                                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                                           SubPlan 2
+                                                                             ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                                                                                   Filter: subselect_gp.extra_flow_dist.b = $1
+                                                                                   ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                                                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                                                               ->  Table Scan on extra_flow_dist  (cost=0.00..431.00 rows=4 width=8)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.119.0
+(42 rows)
+
+-- case 5 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+explain with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                           QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..905477255.24 rows=480 width=12)
+   ->  Nested Loop  (cost=0.00..905477255.22 rows=160 width=12)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=3 width=8)
+               ->  Table Scan on extra_flow_dist1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Materialize  (cost=0.00..883393.12 rows=54 width=4)
+               ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..883393.12 rows=160 width=4)
+                     ->  Result  (cost=0.00..883393.12 rows=54 width=4)
+                           Filter: ((subplan)) < '01-01-2010'::date
+                           ->  Result  (cost=0.00..883393.11 rows=134 width=4)
+                                 ->  Function Scan on im  (cost=0.00..0.00 rows=334 width=4)
+                                 SubPlan 1
+                                   ->  Result  (cost=0.00..431.66 rows=1 width=4)
+                                         Filter: extra_flow_dist.b = $0
+                                         ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                     ->  Table Scan on extra_flow_dist  (cost=0.00..431.00 rows=4 width=8)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.119.0
+(19 rows)
+
+-- case 6 function scan without CTE
+explain
+select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                           QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..905477267.34 rows=3 width=12)
+   ->  Nested Loop  (cost=0.00..905477267.34 rows=1 width=12)
+         Join Filter: true
+         ->  Table Scan on extra_flow_dist1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Materialize  (cost=0.00..883393.14 rows=1 width=4)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..883393.14 rows=3 width=4)
+                     ->  Result  (cost=0.00..883393.14 rows=1 width=4)
+                           Filter: ((subplan)) < '01-01-2010'::date
+                           ->  Result  (cost=0.00..883393.11 rows=334 width=4)
+                                 ->  Function Scan on im  (cost=0.00..0.00 rows=334 width=4)
+                                 SubPlan 1
+                                   ->  Result  (cost=0.00..431.66 rows=1 width=4)
+                                         Filter: extra_flow_dist.b = $0
+                                         ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                     ->  Table Scan on extra_flow_dist  (cost=0.00..431.00 rows=4 width=8)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.119.0
+(18 rows)
+


### PR DESCRIPTION
When creating a plan with subplan in ParallelizeSubplan, it uses
the wrong flow to decide motion type for subplan. And the wrong
flow will cause subplan set wrong motion type and cause assertion
failure Assert(recvSlice->gangSize == 1) in nodeMotion.c.

When ParallelizeSubplan(), if the subplan is uncorrelated, multi-row
subquery, then it either focuses or broadcasts the subplan based on the
flow which describes the containing plan node's slice execution position.
Actually, the flow should be the top-level flow for the corresponding slice
instead of the containing the plan node's flow. To select the correct flow during
the plan tree iteration, we only set currentPlanFlow when jumping into a new slice.

This fixed issue: #12371

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
