### PR TITLE
Mitigate a proclock/lock table corruption case

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -1974,6 +1974,13 @@ CheckDeadLock(void)
 		{
 			ResRemoveFromWaitQueue(MyProc, 
 								   LockTagHashCode(&(MyProc->waitLock->tag)));
+			/*
+			 * lockAwaited's lock/proclock pointers are dangling after the call
+			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
+			 * to avoid de-referencing them in the eventual ResLockRelease() in
+			 * ResLockPortal/ResLockUtilityPortal.
+			 */
+			RemoveLocalLock(lockAwaited);
 		}
 		else
 		{
@@ -2212,6 +2219,13 @@ ResLockWaitCancel(void)
 			Assert(LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD);
 
 			ResRemoveFromWaitQueue(MyProc, lockAwaited->hashcode);
+			/*
+			 * lockAwaited's lock/proclock pointers are dangling after the call
+			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
+			 * to avoid de-referencing them in the eventual ResLockRelease() in
+			 * ResLockPortal/ResLockUtilityPortal.
+			 */
+			RemoveLocalLock(lockAwaited);
 		}
 
 		lockAwaited = NULL;


### PR DESCRIPTION
This commit ensures that the following lock table corruption scenario is
avoided:

Consider two sessions S1 and S2.

1. S1 is currently stuck in ResProcSleep(), waiting for a resource queue
lock (one possible reason being S1 has hit the active_statements limit
on the resource queue)

2. We cancel S1 with pg_cancel_backend() or kill SIGINT.

3. S1 exits ResLockAcquire() with an ERROR due to the cancel (from
withing the ProcessInterrupts() call within PGSemaphoreLock() within
ResProcSleep()).

4. S1 catches the ERROR in the PG_CATCH in ResLockPortal() and calls
ResLockWaitCancel(), which removes the proclock and lock shmem hash
table entries (with call to ResRemoveFromWaitQueue()). However, we don't
remove the locallock entry from the locallock hash table.

Note: When a hash table entry is removed, the shmem chunk used for it is
recycled into the hash table level freeList.

5. S1 now calls ResLockRelease(). Since we haven't removed the locallock
in step 4, S1's subsequent search for the locallock in the locallock
hash table (with the same locallocktag from step 1) will be successful.
Let's say execution proceeds and halts on the line just *after* the
branch with the check:

* Verify that our LOCALLOCK still matches the shared tables.

6. S2 now acquires a relation lock and the same shmem chunks that were
sent to the freeList in step 4 are used for the lock/proclock hash table
entries in LockAcquire(). Also, further consider that the partition# for
the lock/proclock is different from the lock/proclock from step 1-4.

7. Now S1 proceeds to call ResCleanupLock(). Note that its locallock's
lock/proclock pointers point to the lock/proclock entries for the
relation lock grabbed by S2! These pointers are dangling! So when S1
will call ResCleanupLock(), it will clean S2's lock/proclock state. We
will thus end up with a situation where ResCleanupLock() cleans
non-resource-queue locks (in this case a relation lock)!

8. S2 now tries to release the relation lock and cores out in
CleanupLock() as it tries to access memory freed by S1 in step 7.

The fix is simply to remove the locallock at the end of step 4. It
shouldn't exist if its shmem overlords cease to exist.
Note that LockWaitCancel() does not do this as the same locallocktag is
not reused in this manner in PG locking code.
We also added a sanity check and PANIC in ResCleanupLock() to scream if
we ever try to clean up a non-resource queue lock.

IMP note: If in step 2, S1 errors out with a deadlock report, as opposed
to being cancelled, it can give rise to the same corruption. So, we
have to clean up the locallock after the ResRemoveFromWaitQueue() call
in CheckDeadLock() also.

Steps to manually reproduce the corruption scenario:

1. Create a resource queue with active_statements=1 and hold the active
slot forever with a query. (See isolation2 test resource_queue_deadlock
to see how to do this with before_auto_stats suspend fault)

2. In another psql session, run a SELECT query against the resource
queue (e.g. SELECT version()). This will block because step 1 is holding
the resource queue active slot. This SELECT query will act as S1.

3. Run a concurrent workload which will simulate S2. (e.g. 10 concurrent
CTAS/DROP TABLE). Do this in a long-running/infinite loop.

4. In another psql session, run pg_cancel_backend() on the blocked
SELECT query (S1) in an infinite loop.

5. Eventually, a segfault and resultant PANIC will be observed in S1 or
S2.

Co-authored-by: Yao Wang <wayao@vmware.com>
Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Kate Dontsova <edontsova@pivotal.io>
Co-authored-by: Jimmy Yih <jyih@vmware.com>
