### PR TITLE
6X: Mitigate a proclock/lock table corruption case

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -1813,6 +1813,13 @@ CheckDeadLock(void)
 		{
 			ResRemoveFromWaitQueue(MyProc, 
 								   LockTagHashCode(&(MyProc->waitLock->tag)));
+			/*
+			 * lockAwaited's lock/proclock pointers are dangling after the call
+			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
+			 * to avoid de-referencing them in the eventual ResLockRelease() in
+			 * ResLockPortal/ResLockUtilityPortal.
+			 */
+			RemoveLocalLock(lockAwaited);
 		}
 		else
 		{
@@ -2046,6 +2053,13 @@ ResLockWaitCancel(void)
 			Assert(LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD);
 
 			ResRemoveFromWaitQueue(MyProc, lockAwaited->hashcode);
+			/*
+			 * lockAwaited's lock/proclock pointers are dangling after the call
+			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
+			 * to avoid de-referencing them in the eventual ResLockRelease() in
+			 * ResLockPortal/ResLockUtilityPortal.
+			 */
+			RemoveLocalLock(lockAwaited);
 		}
 
 		lockAwaited = NULL;

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -978,6 +978,20 @@ ResCleanUpLock(LOCK *lock, PROCLOCK *proclock, uint32 hashcode, bool wakeupNeede
 	Assert(LWLockHeldExclusiveByMe(ResQueueLock));
 
 	/*
+	 * This check should really be an assertion. But to guard against edge cases
+	 * previously not encountered, PANIC instead.
+	 */
+	if (lock->tag.locktag_type != LOCKTAG_RESOURCE_QUEUE ||
+		proclock->tag.myLock->tag.locktag_type != LOCKTAG_RESOURCE_QUEUE)
+	{
+		ereport(PANIC,
+				(errmsg("We are trying to clean up a non-resource queue lock"),
+				 errdetail("lock's locktag type = %d and proclock's locktag type = %d",
+						  lock->tag.locktag_type,
+						  proclock->tag.myLock->tag.locktag_type)));
+	}
+
+	/*
 	 * If this was my last hold on this lock, delete my entry in the proclock
 	 * table.
 	 */


### PR DESCRIPTION
This is a backport of PR: #12465