### PR TITLE
[6X]Use the correct flow in ParallelizeSubplan for subplan

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -60,6 +60,7 @@ typedef struct PlanProfile
 
 	Flow	   *currentPlanFlow;	/* what is the flow of the current plan
 									 * node */
+	bool	visited;            /* indicate if currentPlanFlow is initialized (across slices) */
 } PlanProfile;
 
 
@@ -165,6 +166,7 @@ cdbparallelize(PlannerInfo *root, Plan *plan, Query *query)
 	planner_init_plan_tree_base(&context->base, root);
 	context->root = root;
 	context->resultSegments = false;
+	context->visited = false;
 
 	switch (query->commandType)
 	{
@@ -824,8 +826,67 @@ prescan_walker(Node *node, PlanProfile *context)
 			 || plan->flow->flotype == FLOW_REPLICATED))
 			context->dispatchParallel = true;
 
-		context->currentPlanFlow = plan->flow;
-		if (context->currentPlanFlow
+		/*
+		* When ParallelizeSubplan(), if the subplan is uncorrelated, multi-row subquery,
+		* then it either focuses or broadcasts the subplan based on the flow which describe
+		* the containing plan node's slice execution position. Actually the flow should be
+		* the top-level flow for the corresponding slice instead of the containing plan node's flow.
+		* This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+		* For example:
+		*  with run_dt as (
+		*       select
+		*       (
+		*         select c from t where b = x
+		*       ) dt
+		*       from (select ( max(1) ) x) a
+		*   )
+		*   select * from run_dt, t1;
+		*
+		*                                 QUERY PLAN
+		* ----------------------------------------------------------------------------
+		* Gather Motion 3:1
+		*   ->Nested Loop (flowtype 3, req_move 0)  -- currentPlanFlow should use this node
+		*       ->Subquery Scan run_dt(flowtype 1, req_move 0)
+		*            ->Subquery Scan a (flowtype 1, req_move 0) -- we used to use this flow to set currentPlanFlow
+		*                  ...
+		*                  SubPlan 1
+		*                   ->  Result
+		*                     ->  Materialize
+		*                        ->  Broadcast Motion
+		*                             -- NOTE: Before, we were using subquery scan a's flow, which will add a Gather Motion, and
+		*                             -- it will cause assertion failure
+		*                          -> ...
+		*   -> ...
+		*/
+        if (!context->visited)
+        {
+            /*
+             * The visited is a flag which is used to initialize the currentPlanFlow.
+             * And it's the top-level slice node of the entire plan.
+             */
+            context->currentPlanFlow = plan->flow;
+        }
+        if (plan->flow && plan->flow->req_move != MOVEMENT_NONE)
+        {
+            /*
+             * To select the correct flow during the plan tree iteration, only
+             * set currentPlanFlow when jump into a new slice. As req_move is
+             * a flag to indicate what motion should be applied to this Plan's
+             * output. So we are using req_move and the motion node to decide
+             * entering into a new slice.
+             */
+            context->currentPlanFlow = plan->flow;
+        }
+        if (IsA(node, Motion))
+        {
+            /*
+             * Motion is used to split slices, use the sub-node's flow of the
+             * motion for ParallelizeSubplan.
+             */
+            context->currentPlanFlow = plan->lefttree->flow;
+        }
+
+        if (context->currentPlanFlow
 			&& context->currentPlanFlow->flow_before_req_move)
 		{
 			context->currentPlanFlow = context->currentPlanFlow->flow_before_req_move;
@@ -883,6 +944,7 @@ prescan_walker(Node *node, PlanProfile *context)
 
 	}
 
+	context->visited = true;
 	bool		result = plan_tree_walker(node, prescan_walker, context);
 
 	if (IsA(node, SubPlan))

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -2226,3 +2226,346 @@ SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.
  2 | b
 (2 rows)
 
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table extra_flow_dist1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+-- case 1 subplan with general locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop
+         ->  Subquery Scan on run_dt
+               Filter: (run_dt.dt < '01-01-2010'::date)
+               ->  Subquery Scan on a
+                     ->  Aggregate
+                           ->  Result
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Filter: (extra_flow_dist.b = a.x)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         ->  Seq Scan on extra_flow_dist
+         ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 22 | 22
+ 10-01-1949 | 21 | 21
+(3 rows)
+
+create table extra_flow_rand(a int) distributed replicated;
+insert into extra_flow_rand values (1);
+-- case 2 for subplan with segment general locus (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x  -- subplan's outer is the below segment general locus path
+	) dt
+	from (select a x from extra_flow_rand) a  -- segment general locus
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: run_dt.dt, extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: run_dt.dt, extra_flow_dist1.a, extra_flow_dist1.b
+         ->  Subquery Scan on run_dt
+               Output: run_dt.dt
+               Filter: (run_dt.dt < '01-01-2010'::date)
+               ->  Seq Scan on subselect_gp.extra_flow_rand
+                     Output: (SubPlan 1)
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Output: extra_flow_dist.c
+                             Filter: (extra_flow_dist.b = extra_flow_rand.a)
+                             ->  Materialize
+                                   Output: extra_flow_dist.c, extra_flow_dist.b
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         Output: extra_flow_dist.c, extra_flow_dist.b
+                                         ->  Seq Scan on subselect_gp.extra_flow_dist
+                                               Output: extra_flow_dist.c, extra_flow_dist.b
+         ->  Seq Scan on subselect_gp.extra_flow_dist1
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+ Optimizer: Postgres query optimizer
+(22 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select a x from extra_flow_rand) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 3 for subplan with entry locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                      QUERY PLAN
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Subquery Scan on run_dt
+                     Filter: (run_dt.dt < '01-01-2010'::date)
+                     ->  Subquery Scan on a
+                           ->  Limit
+                                 ->  Seq Scan on pg_trigger
+                           SubPlan 1  (slice2)
+                             ->  Result
+                                   Filter: (extra_flow_dist.b = a.x)
+                                   ->  Materialize
+                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                               ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 4 subplan with segment general locus without param in subplan (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select x, y dt
+	from (select a x from extra_flow_rand ) a  -- segment general locus
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)  -- subplan's outer is the above segment general locus path
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Nested Loop Left Join
+               Output: extra_flow_rand.a, (max(1))
+               Join Filter: (SubPlan 1)
+               ->  Seq Scan on subselect_gp.extra_flow_rand
+                     Output: extra_flow_rand.a
+               ->  Materialize
+                     Output: (max(1))
+                     ->  Aggregate
+                           Output: max(1)
+                           ->  Result
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Materialize
+                       Output: random()
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             Output: (random())
+                             ->  Seq Scan on subselect_gp.extra_flow_dist
+                                   Output: random()
+         ->  Materialize
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+               ->  Seq Scan on subselect_gp.extra_flow_dist1
+                     Output: extra_flow_dist1.a, extra_flow_dist1.b
+ Optimizer: Postgres query optimizer
+(27 rows)
+
+-- case 5 for subplan with entry locus without param in subplan (CTE and subquery)
+explain (costs off) with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger ) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                QUERY PLAN
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Nested Loop Left Join
+                     Join Filter: (SubPlan 1)
+                     ->  Seq Scan on pg_trigger
+                     ->  Materialize
+                           ->  Aggregate
+                                 ->  Result
+                     SubPlan 1  (slice2)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- case 6 without CTE, nested subquery
+explain (costs off) select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                 QUERY PLAN
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Subquery Scan on tbl
+               Filter: (tbl.dt < '01-01-2010'::date)
+               ->  Unique
+                     Group Key: ((SubPlan 2))
+                     ->  Sort
+                           Sort Key (Distinct): ((SubPlan 2))
+                           ->  Append
+                                 ->  Subquery Scan on a
+                                       ->  Aggregate
+                                             ->  Result
+                                       SubPlan 2  (slice3; segments: 3)
+                                         ->  Result
+                                               Filter: (extra_flow_dist_1.b = a.x)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                           ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+                                 ->  Subquery Scan on aa
+                                       ->  Aggregate
+                                             ->  Result
+                                       SubPlan 1  (slice3; segments: 3)
+                                         ->  Result
+                                               Filter: (extra_flow_dist.b = aa.x)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                           ->  Seq Scan on extra_flow_dist
+         ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(29 rows)
+
+-- case 7 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+explain (costs off) with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop
+         ->  Subquery Scan on run_dt
+               Filter: (run_dt.dt < '01-01-2010'::date)
+               ->  Function Scan on im x
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Filter: (extra_flow_dist.b = x.x)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+-- case 8 function scan without CTE
+explain (costs off) select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Function Scan on im x
+               Filter: ((SubPlan 2) < '01-01-2010'::date)
+               SubPlan 2  (slice3; segments: 3)
+                 ->  Result
+                       Filter: (extra_flow_dist_1.b = x.x)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+         SubPlan 1  (slice3; segments: 3)
+           ->  Result
+                 Filter: (extra_flow_dist.b = x.x)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on extra_flow_dist
+ Optimizer: Postgres query optimizer
+(19 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2350,3 +2350,367 @@ SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.
  2 | b
 (2 rows)
 
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+create table extra_flow_dist1(a int, b int);
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+-- case 1 subplan with general locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Aggregate
+                                       ->  Result
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = (max(1)))
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+create table extra_flow_rand(a int) distributed replicated;
+insert into extra_flow_rand values (1);
+-- case 2 for subplan with segment general locus (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x  -- subplan's outer is the below segment general locus path
+	) dt
+	from (select a x from extra_flow_rand) a  -- segment general locus
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: ((SubPlan 1)), extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: ((SubPlan 1)), extra_flow_dist1.a, extra_flow_dist1.b
+         Join Filter: true
+         ->  Seq Scan on subselect_gp.extra_flow_dist1
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+         ->  Result
+               Output: ((SubPlan 1))
+               Filter: (((SubPlan 1)) < '01-01-2010'::date)
+               ->  Result
+                     Output: (SubPlan 1)
+                     ->  Seq Scan on subselect_gp.extra_flow_rand
+                           Output: extra_flow_rand.a
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Output: extra_flow_dist.c
+                             Filter: (extra_flow_dist.b = extra_flow_rand.a)
+                             ->  Materialize
+                                   Output: extra_flow_dist.b, extra_flow_dist.c
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         Output: extra_flow_dist.b, extra_flow_dist.c
+                                         ->  Seq Scan on subselect_gp.extra_flow_dist
+                                               Output: extra_flow_dist.b, extra_flow_dist.c
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(26 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select a x from extra_flow_rand) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 22 | 22
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+(3 rows)
+
+-- case 3 for subplan with entry locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Limit
+                                       ->  Result
+                                             ->  Seq Scan on pg_trigger
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = "outer".x)
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+                                                           Filter: (b = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 22 | 22
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 20 | 20
+(3 rows)
+
+-- case 4 subplan with segment general locus without param in subplan (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select x, y dt
+	from (select a x from extra_flow_rand ) a  -- segment general locus
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)  -- subplan's outer is the above segment general locus path
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Nested Loop Left Join
+               Output: extra_flow_rand.a, (max(1))
+               Join Filter: (SubPlan 1)
+               ->  Seq Scan on subselect_gp.extra_flow_rand
+                     Output: extra_flow_rand.a
+               ->  Materialize
+                     Output: (max(1))
+                     ->  Aggregate
+                           Output: max(1)
+                           ->  Result
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Materialize
+                       Output: random()
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             Output: (random())
+                             ->  Seq Scan on subselect_gp.extra_flow_dist
+                                   Output: random()
+         ->  Materialize
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+               ->  Seq Scan on subselect_gp.extra_flow_dist1
+                     Output: extra_flow_dist1.a, extra_flow_dist1.b
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(28 rows)
+
+-- case 5 for subplan with entry locus without param in subplan (CTE and subquery)
+explain (costs off) with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger ) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Nested Loop Left Join
+                     Join Filter: (SubPlan 1)
+                     ->  Seq Scan on pg_trigger
+                     ->  Materialize
+                           ->  Aggregate
+                                 ->  Result
+                     SubPlan 1  (slice2)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- case 6 without CTE, nested subquery
+explain (costs off) select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                     ->  GroupAggregate
+                           Group Key: ((SubPlan 1))
+                           ->  Sort
+                                 Sort Key: ((SubPlan 1))
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       Hash Key: ((SubPlan 1))
+                                       ->  GroupAggregate
+                                             Group Key: ((SubPlan 1))
+                                             ->  Sort
+                                                   Sort Key: ((SubPlan 1))
+                                                   ->  Redistribute Motion 1:3  (slice3)
+                                                         ->  Append
+                                                               ->  Result
+                                                                     Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                                                                     ->  Result
+                                                                           ->  Aggregate
+                                                                                 ->  Result
+                                                                           SubPlan 1  (slice3)
+                                                                             ->  Result
+                                                                                   Filter: (extra_flow_dist.b = (max(1)))
+                                                                                   ->  Materialize
+                                                                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                                                               ->  Seq Scan on extra_flow_dist
+                                                               ->  Result
+                                                                     Filter: (((SubPlan 2)) < '01-01-2010'::date)
+                                                                     ->  Result
+                                                                           ->  Aggregate
+                                                                                 ->  Result
+                                                                           SubPlan 2  (slice3)
+                                                                             ->  Result
+                                                                                   Filter: (extra_flow_dist_1.b = (max(1)))
+                                                                                   ->  Materialize
+                                                                                         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                                                               ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(41 rows)
+
+-- case 7 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+explain (costs off) with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Function Scan on im
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = im.im)
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+-- case 8 function scan without CTE
+explain (costs off) select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Function Scan on im
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = im.im)
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -921,3 +921,142 @@ $$
 LANGUAGE plpgsql NO SQL;
 
 SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.c > (SELECT my_lookup('a')));
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+create table extra_flow_dist1(a int, b int);
+
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+
+-- case 1 subplan with general locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+create table extra_flow_rand(a int) distributed replicated;
+insert into extra_flow_rand values (1);
+-- case 2 for subplan with segment general locus (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x  -- subplan's outer is the below segment general locus path
+	) dt
+	from (select a x from extra_flow_rand) a  -- segment general locus
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select a x from extra_flow_rand) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+-- case 3 for subplan with entry locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+-- case 4 subplan with segment general locus without param in subplan (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select x, y dt
+	from (select a x from extra_flow_rand ) a  -- segment general locus
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)  -- subplan's outer is the above segment general locus path
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+
+-- case 5 for subplan with entry locus without param in subplan (CTE and subquery)
+explain (costs off) with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger ) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+
+-- case 6 without CTE, nested subquery
+explain (costs off) select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+-- case 7 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+explain (costs off) with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+
+-- case 8 function scan without CTE
+explain (costs off) select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;


### PR DESCRIPTION
When creating a plan with subplan in ParallelizeSubplan,it use
the wrong flow to decide motion type for subplan. And the wrong
flow will cause subplan set wrong motionType and cause assertion
failure Assert(recvSlice->gangSize == 1) in nodeMotion.c.

When ParallelizeSubplan(), if the subplan is uncorrelated, multi-row
subquery,then it either focuses or broadcasts the subplan based on the
flow which describe the containing plan node's slice execution position.
Actually the flow should be the top-level flow for the corresponding slice
instead of the containing plan node's flow. To select the correct flow during
the plan tree iteration, we only set currentPlanFlow when jump into a new slice.

This fixed issue: #12371

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
