### PR TITLE
Allow hash distributed correlated NL joins

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AssertOneRowWithCorrelation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AssertOneRowWithCorrelation.mdp
@@ -312,99 +312,64 @@ select (select a from x x2 where x2.a=x1.a) from x x1;
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:Result>
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1358.881316" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1314.973219" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="16" Alias="?column?">
-            <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ParamList>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="496.827620" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="a">
-                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="true">
+            <dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1314.958313" Rows="1000.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="16" Alias="?column?">
+              <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.027620" Rows="1000.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="452.939574" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="a">
                       <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.023620" Rows="1000.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="8" Alias="a">
-                        <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.006233" Rows="1000.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="8" Alias="a">
-                          <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.24719017.1.1" TableName="x">
-                        <dxl:Columns>
-                          <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:GatherMotion>
-                </dxl:Materialize>
-              </dxl:Result>
-            </dxl:SubPlan>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.023620" Rows="1000.000000" Width="4"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.24719017.1.1" TableName="x">
+                    <dxl:Columns>
+                      <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:SubPlan>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
+          <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.006233" Rows="1000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1314.956979" Rows="1000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -425,8 +390,8 @@ select (select a from x x2 where x2.a=x1.a) from x x1;
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:GatherMotion>
-      </dxl:Result>
+        </dxl:Result>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
@@ -259,7 +259,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1818">
+    <dxl:Plan Id="0" SpaceSize="954">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.000757" Rows="3.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
@@ -353,7 +353,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="434.387393" Rows="10000.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-Nested.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-Nested.mdp
@@ -368,7 +368,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2000">
+    <dxl:Plan Id="0" SpaceSize="200">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="432.745947" Rows="10000.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-SingleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-SingleColumn.mdp
@@ -349,7 +349,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="432.745947" Rows="10000.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-Without-Agg-Funcs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-Without-Agg-Funcs.mdp
@@ -218,7 +218,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
@@ -974,7 +974,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.284504" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.284520" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -991,7 +991,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.284450" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.284466" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1052,9 +1052,9 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1064,30 +1064,20 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:OneTimeFilter/>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
               </dxl:Properties>
-              <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -1097,43 +1087,68 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="17" Alias="a">
-                    <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="18" Alias="b">
-                    <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-                    <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.2035084633.1.1" TableName="p_prt_1">
+                <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
                   <dxl:Columns>
-                    <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="18" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="19" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="20" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="21" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="22" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="23" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="24" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="25" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:Append>
-          </dxl:RedistributeMotion>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="17" Alias="a">
+                      <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="b">
+                      <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.2035084633.1.1" TableName="p_prt_1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="20" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="21" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="22" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Append>
+            </dxl:RedistributeMotion>
+          </dxl:Result>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -966,7 +966,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="863.294061" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="863.294077" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -983,7 +983,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="863.294007" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="863.294023" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1044,9 +1044,9 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1056,30 +1056,20 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:OneTimeFilter/>
+            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
               </dxl:Properties>
-              <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -1089,113 +1079,122 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="17" Alias="a">
-                    <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="18" Alias="b">
-                    <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-                    <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.2035084633.1.1" TableName="p_prt_1">
+                <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
                   <dxl:Columns>
-                    <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="18" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="19" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="20" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="21" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="22" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="23" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="24" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="25" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="26" Alias="a">
-                    <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="27" Alias="b">
-                    <dxl:Ident ColId="27" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-                    <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.2035084634.1.1" TableName="p_prt_2">
-                  <dxl:Columns>
-                    <dxl:Column ColId="26" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="27" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="28" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="29" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="30" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="31" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="32" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="33" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="34" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="35" Alias="a">
-                    <dxl:Ident ColId="35" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="36" Alias="b">
-                    <dxl:Ident ColId="36" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-                    <dxl:Ident ColId="35" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.2035084635.1.1" TableName="p_prt_3">
-                  <dxl:Columns>
-                    <dxl:Column ColId="35" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="36" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="37" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="38" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="39" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="40" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="41" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="42" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="43" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:Append>
-          </dxl:RedistributeMotion>
+                <dxl:Filter/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="17" Alias="a">
+                      <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="b">
+                      <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.2035084633.1.1" TableName="p_prt_1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="20" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="21" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="22" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="26" Alias="a">
+                      <dxl:Ident ColId="26" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="27" Alias="b">
+                      <dxl:Ident ColId="27" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.2035084634.1.1" TableName="p_prt_2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="26" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="27" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="28" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="29" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="30" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="31" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="32" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="33" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="34" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="35" Alias="a">
+                      <dxl:Ident ColId="35" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="36" Alias="b">
+                      <dxl:Ident ColId="36" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.2035084635.1.1" TableName="p_prt_3">
+                    <dxl:Columns>
+                      <dxl:Column ColId="35" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="36" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="37" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="38" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="39" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="40" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="41" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="42" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="43" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Append>
+            </dxl:RedistributeMotion>
+          </dxl:Result>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -15774,7 +15774,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7020">
+    <dxl:Plan Id="0" SpaceSize="7012">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5944.261371" Rows="20169.272000" Width="76"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -454,7 +454,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7695">
+    <dxl:Plan Id="0" SpaceSize="7145">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>
@@ -648,7 +648,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+              <dxl:Result>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000193" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
@@ -663,16 +663,22 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                     <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:Filter>
+                  <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+                      <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+                      <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                    </dxl:Comparison>
+                  </dxl:Or>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000143" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000160" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="cid">
@@ -685,64 +691,53 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                       <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
-                        <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
-                        <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      </dxl:Comparison>
-                    </dxl:Or>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="22"/>
-                      <dxl:GroupingColumn ColId="23"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="32" Alias="tickets_cnt">
-                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
-                          <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="22" Alias="cid">
                         <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="23" Alias="date_sk">
                         <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="32" Alias="tickets_cnt">
+                        <dxl:Ident ColId="32" ColName="tickets_cnt" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="22"/>
+                        <dxl:GroupingColumn ColId="23"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="32" Alias="tickets_cnt">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
+                            <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="22" Alias="cid">
                           <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="23" Alias="date_sk">
                           <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                          <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="22" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
                         </dxl:Properties>
@@ -758,18 +753,15 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:Result>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="22" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="22" Alias="cid">
@@ -783,36 +775,45 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:Result>
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
                             </dxl:Properties>
-                            <dxl:GroupingColumns>
-                              <dxl:GroupingColumn ColId="22"/>
-                              <dxl:GroupingColumn ColId="23"/>
-                            </dxl:GroupingColumns>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
-                                  <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
-                                </dxl:AggFunc>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="22" Alias="cid">
                                 <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="23" Alias="date_sk">
                                 <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
+                              <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                                <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:OneTimeFilter/>
+                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="24"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
                               </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="22"/>
+                                <dxl:GroupingColumn ColId="23"/>
+                              </dxl:GroupingColumns>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="21" Alias="ticket_number">
-                                  <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
+                                    <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                  </dxl:AggFunc>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="22" Alias="cid">
                                   <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
@@ -822,15 +823,9 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList>
-                                <dxl:SortingColumn ColId="22" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              </dxl:SortingColumnList>
-                              <dxl:LimitCount/>
-                              <dxl:LimitOffset/>
-                              <dxl:TableScan>
+                              <dxl:Sort SortDiscardDuplicates="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="24"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="24"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="21" Alias="ticket_number">
@@ -844,30 +839,53 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.15667489.1.1" TableName="sales">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="20" Attno="1" ColName="item_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="21" Attno="2" ColName="ticket_number" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="22" Attno="3" ColName="cid" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="23" Attno="4" ColName="date_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Sort>
-                          </dxl:Aggregate>
-                        </dxl:Result>
-                      </dxl:RedistributeMotion>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Result>
-              </dxl:RedistributeMotion>
+                                <dxl:SortingColumnList>
+                                  <dxl:SortingColumn ColId="22" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                  <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                </dxl:SortingColumnList>
+                                <dxl:LimitCount/>
+                                <dxl:LimitOffset/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="24"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="21" Alias="ticket_number">
+                                      <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="22" Alias="cid">
+                                      <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="23" Alias="date_sk">
+                                      <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.15667489.1.1" TableName="sales">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="20" Attno="1" ColName="item_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="21" Attno="2" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="22" Attno="3" ColName="cid" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="23" Attno="4" ColName="date_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:Sort>
+                            </dxl:Aggregate>
+                          </dxl:Result>
+                        </dxl:RedistributeMotion>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
+              </dxl:Result>
             </dxl:HashJoin>
           </dxl:RedistributeMotion>
           <dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6362,7 +6362,7 @@ ORDER BY s_name;
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1863552">
+    <dxl:Plan Id="0" SpaceSize="2236032">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="24583535.993774" Rows="49.989277" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -260,7 +260,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="44">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.001095" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
@@ -273,7 +273,7 @@ a < 2 should also be outside the limit but not below.
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="44">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000626" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
@@ -507,7 +507,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="235">
+    <dxl:Plan Id="0" SpaceSize="236">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000970" Rows="1.000000" Width="8"/>
@@ -546,7 +546,7 @@
               <dxl:Ident ColId="18" ColName="max" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+          <dxl:Result>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -558,16 +558,16 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr Opfamily="0.1977.1.0">
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:OneTimeFilter/>
+            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -577,27 +577,42 @@
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr Opfamily="0.1977.1.0">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.133376.1.0" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.133376.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:RedistributeMotion>
+          </dxl:Result>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -816,7 +816,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="257">
+    <dxl:Plan Id="0" SpaceSize="306">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000804" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4044,7 +4044,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="323272">
+    <dxl:Plan Id="0" SpaceSize="323134">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -3144,7 +3144,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="644">
+    <dxl:Plan Id="0" SpaceSize="692">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.264890" Rows="95315.069401" Width="24"/>
@@ -3223,7 +3223,7 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="3" SelectorIds="11">
+            <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="3" SelectorIds="10">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.003571" Rows="156.000000" Width="8"/>
               </dxl:Properties>
@@ -3282,7 +3282,7 @@
                 </dxl:TableDescriptor>
               </dxl:TableScan>
             </dxl:Append>
-            <dxl:PartitionSelector RelationMdid="0.245931.1.0" SelectorId="11" ScanId="3" Partitions="3">
+            <dxl:PartitionSelector RelationMdid="0.245931.1.0" SelectorId="10" ScanId="3" Partitions="3">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000166" Rows="3.000003" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
@@ -1619,7 +1619,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2778615">
+    <dxl:Plan Id="0" SpaceSize="3086628">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.297294" Rows="6.196244" Width="56"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5768,7 +5768,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19655804">
+    <dxl:Plan Id="0" SpaceSize="24703420">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2587.327973" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -352,7 +352,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -360,7 +360,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -588,7 +588,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13648900">
+    <dxl:Plan Id="0" SpaceSize="16600900">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003419" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -828,7 +828,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1118">
+    <dxl:Plan Id="0" SpaceSize="1096">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.020922" Rows="100.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
@@ -694,7 +694,7 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17398">
+    <dxl:Plan Id="0" SpaceSize="17800">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="908.045287" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -916,7 +916,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.005845" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -679,7 +679,7 @@
     <dxl:Plan Id="0" SpaceSize="1680">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.003881" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.003956" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="30" Alias="s1">
@@ -696,7 +696,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.003792" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.003867" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="30"/>
@@ -717,7 +717,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003763" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.003838" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="s1">
@@ -740,7 +740,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.003763" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.003838" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="s1">
@@ -768,7 +768,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.003725" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.003800" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="30"/>
@@ -789,7 +789,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1724.003705" Rows="2.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1724.003780" Rows="2.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="43" Alias="coalesce">
@@ -812,7 +812,7 @@
                   <dxl:LimitOffset/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1724.003705" Rows="2.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1724.003780" Rows="2.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="43" Alias="coalesce">
@@ -832,7 +832,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:HashJoin JoinType="Left">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1724.003689" Rows="2.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1724.003764" Rows="2.000000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="s1">
@@ -859,7 +859,7 @@
                       </dxl:HashCondList>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.002612" Rows="2.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.002662" Rows="2.000000" Width="24"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="30" Alias="s1">
@@ -881,7 +881,7 @@
                         </dxl:HashExprList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.002462" Rows="2.000000" Width="24"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.002512" Rows="2.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="30" Alias="s1">
@@ -929,7 +929,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.002414" Rows="2.000000" Width="24"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.002464" Rows="2.000000" Width="24"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="id">
@@ -956,7 +956,7 @@
                             </dxl:HashCondList>
                             <dxl:HashJoin JoinType="Left">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="862.001325" Rows="2.000000" Width="24"/>
+                                <dxl:Cost StartupCost="0" TotalCost="862.001375" Rows="2.000000" Width="24"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="0" Alias="id">
@@ -989,80 +989,98 @@
                                   </dxl:FuncExpr>
                                 </dxl:Comparison>
                               </dxl:HashCondList>
-                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000238" Rows="1.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000263" Rows="1.000000" Width="8"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="0" Alias="id">
                                     <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:HashExprList>
-                                  <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                <dxl:Filter>
+                                  <dxl:And>
+                                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                          <dxl:Coalesce TypeMdid="0.1042.1.0">
+                                            <dxl:Ident ColId="2" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                            <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                          </dxl:Coalesce>
+                                        </dxl:Cast>
+                                      </dxl:FuncExpr>
+                                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                                    </dxl:Comparison>
+                                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                                         <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                           <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                         </dxl:Cast>
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                                       </dxl:FuncExpr>
-                                    </dxl:FuncExpr>
-                                  </dxl:HashExpr>
-                                </dxl:HashExprList>
-                                <dxl:TableScan>
+                                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                    </dxl:Comparison>
+                                  </dxl:And>
+                                </dxl:Filter>
+                                <dxl:OneTimeFilter/>
+                                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000213" Rows="1.000000" Width="8"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="16"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="0" Alias="id">
                                       <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                     </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="2" Alias="att">
+                                      <dxl:Ident ColId="2" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                    </dxl:ProjElem>
                                   </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:And>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                            <dxl:Coalesce TypeMdid="0.1042.1.0">
-                                              <dxl:Ident ColId="2" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
-                                            </dxl:Coalesce>
-                                          </dxl:Cast>
-                                        </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
-                                      </dxl:Comparison>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:HashExprList>
+                                    <dxl:HashExpr>
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>
+                                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
-                                      </dxl:Comparison>
-                                    </dxl:And>
-                                  </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
-                                      <dxl:Column ColId="2" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
-                                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                              </dxl:RedistributeMotion>
-                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                      </dxl:FuncExpr>
+                                    </dxl:HashExpr>
+                                  </dxl:HashExprList>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000117" Rows="1.000000" Width="16"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="0" Alias="id">
+                                        <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="2" Alias="att">
+                                        <dxl:Ident ColId="2" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
+                                        <dxl:Column ColId="2" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
+                                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:RedistributeMotion>
+                              </dxl:Result>
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000278" Rows="1.000000" Width="16"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000303" Rows="1.000000" Width="16"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="10" Alias="id">
@@ -1072,20 +1090,33 @@
                                     <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:HashExprList>
-                                  <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                        <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
-                                      </dxl:Cast>
-                                    </dxl:FuncExpr>
-                                  </dxl:HashExpr>
-                                </dxl:HashExprList>
-                                <dxl:TableScan>
+                                <dxl:Filter>
+                                  <dxl:And>
+                                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                          <dxl:Coalesce TypeMdid="0.1042.1.0">
+                                            <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                            <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                          </dxl:Coalesce>
+                                        </dxl:Cast>
+                                      </dxl:FuncExpr>
+                                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                                    </dxl:Comparison>
+                                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                          <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                        </dxl:Cast>
+                                      </dxl:FuncExpr>
+                                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                    </dxl:Comparison>
+                                  </dxl:And>
+                                </dxl:Filter>
+                                <dxl:OneTimeFilter/>
+                                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000228" Rows="1.000000" Width="16"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000237" Rows="1.000000" Width="24"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="10" Alias="id">
@@ -1094,46 +1125,54 @@
                                     <dxl:ProjElem ColId="11" Alias="descr">
                                       <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
                                     </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="12" Alias="att">
+                                      <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                    </dxl:ProjElem>
                                   </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:And>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                            <dxl:Coalesce TypeMdid="0.1042.1.0">
-                                              <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
-                                            </dxl:Coalesce>
-                                          </dxl:Cast>
-                                        </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
-                                      </dxl:Comparison>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                            <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
-                                          </dxl:Cast>
-                                        </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
-                                      </dxl:Comparison>
-                                    </dxl:And>
-                                  </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
-                                      <dxl:Column ColId="11" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
-                                      <dxl:Column ColId="12" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
-                                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                              </dxl:RedistributeMotion>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:HashExprList>
+                                    <dxl:HashExpr>
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                          <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                        </dxl:Cast>
+                                      </dxl:FuncExpr>
+                                    </dxl:HashExpr>
+                                  </dxl:HashExprList>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000117" Rows="1.000000" Width="24"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="10" Alias="id">
+                                        <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="11" Alias="descr">
+                                        <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="12" Alias="att">
+                                        <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
+                                        <dxl:Column ColId="11" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
+                                        <dxl:Column ColId="12" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
+                                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:RedistributeMotion>
+                              </dxl:Result>
                             </dxl:HashJoin>
                             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
@@ -1212,9 +1251,9 @@
                           </dxl:HashJoin>
                         </dxl:Result>
                       </dxl:RedistributeMotion>
-                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000180" Rows="1.000000" Width="16"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000205" Rows="1.000000" Width="16"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="33" Alias="id3">
@@ -1224,16 +1263,16 @@
                             <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
+                        <dxl:Filter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.2060.1.0">
+                            <dxl:Ident ColId="35" ColName="to_dt3" TypeMdid="0.1114.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.1114.1.0" Value="ACBkc/fmgAM=" DoubleValue="252455529600000000.000000"/>
+                          </dxl:Comparison>
+                        </dxl:Filter>
+                        <dxl:OneTimeFilter/>
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000130" Rows="1.000000" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000173" Rows="1.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="33" Alias="id3">
@@ -1242,29 +1281,50 @@
                             <dxl:ProjElem ColId="34" Alias="desc3">
                               <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                             </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.2060.1.0">
+                            <dxl:ProjElem ColId="35" Alias="to_dt3">
                               <dxl:Ident ColId="35" ColName="to_dt3" TypeMdid="0.1114.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1114.1.0" Value="ACBkc/fmgAM=" DoubleValue="252455529600000000.000000"/>
-                            </dxl:Comparison>
-                          </dxl:Filter>
-                          <dxl:TableDescriptor Mdid="0.368665.1.0" TableName="t3">
-                            <dxl:Columns>
-                              <dxl:Column ColId="33" Attno="1" ColName="id3" TypeMdid="0.20.1.0" ColWidth="8"/>
-                              <dxl:Column ColId="34" Attno="2" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54" ColWidth="50"/>
-                              <dxl:Column ColId="35" Attno="3" ColName="to_dt3" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                              <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="37" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="38" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="39" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="40" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="41" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="42" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="1.000000" Width="24"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="33" Alias="id3">
+                                <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="34" Alias="desc3">
+                                <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="35" Alias="to_dt3">
+                                <dxl:Ident ColId="35" ColName="to_dt3" TypeMdid="0.1114.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.368665.1.0" TableName="t3">
+                              <dxl:Columns>
+                                <dxl:Column ColId="33" Attno="1" ColName="id3" TypeMdid="0.20.1.0" ColWidth="8"/>
+                                <dxl:Column ColId="34" Attno="2" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54" ColWidth="50"/>
+                                <dxl:Column ColId="35" Attno="3" ColName="to_dt3" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                                <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="37" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="38" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="39" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="40" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="41" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="42" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                      </dxl:Result>
                     </dxl:HashJoin>
                   </dxl:Result>
                 </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,10 +456,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="62302">
-      <dxl:HashJoin JoinType="Inner">
+    <dxl:Plan Id="0" SpaceSize="384079">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.001366" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -470,16 +470,10 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.001330" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -490,7 +484,13 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
@@ -518,38 +518,22 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:GatherMotion>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000967" Rows="1.000000" Width="4"/>
-          </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="27"/>
-          </dxl:GroupingColumns>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="27" Alias="i">
-              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000911" Rows="1.000000" Width="4"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="27"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="27" Alias="i">
                 <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000905" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="i">
@@ -557,115 +541,114 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000905" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="i">
                     <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="j">
-                    <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:TableScan>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000897" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="27" Alias="i">
                       <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="j">
-                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                    <dxl:Columns>
-                      <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000437" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="j">
-                    <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashJoin JoinType="Inner">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000419" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="19" Alias="j">
-                      <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:JoinFilter/>
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                       <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:TableScan>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="10" Alias="j">
-                        <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="27" Alias="i">
+                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="j">
+                        <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                      <dxl:Columns>
-                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="27" Alias="i">
+                          <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="28" Alias="j">
+                          <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="27" Alias="i">
+                            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="j">
+                            <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                          <dxl:Columns>
+                            <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                  </dxl:Result>
+                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000427" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="19" Alias="j">
@@ -674,9 +657,14 @@
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
-                    <dxl:TableScan>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000419" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="j">
@@ -684,27 +672,81 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.1159276.1.1" TableName="a">
-                        <dxl:Columns>
-                          <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:BroadcastMotion>
+                      <dxl:JoinFilter/>
+                      <dxl:HashCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:HashCondList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="10" Alias="j">
+                            <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="j">
+                            <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="19" Alias="j">
+                              <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.1159276.1.1" TableName="a">
+                            <dxl:Columns>
+                              <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:BroadcastMotion>
+                    </dxl:HashJoin>
+                  </dxl:RedistributeMotion>
                 </dxl:HashJoin>
-              </dxl:GatherMotion>
-            </dxl:HashJoin>
-          </dxl:Sort>
-        </dxl:Aggregate>
-      </dxl:HashJoin>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="384581">
+    <dxl:Plan Id="0" SpaceSize="395849">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
@@ -291,7 +291,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
     <dxl:Plan Id="0" SpaceSize="1488">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.001805" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002050" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="f3">
@@ -302,7 +302,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.001776" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002020" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="2"/>
@@ -315,7 +315,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.001766" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.002010" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="f3">
@@ -330,7 +330,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.001766" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.002010" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="2" Alias="f3">
@@ -346,7 +346,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.001753" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001998" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="2"/>
@@ -359,7 +359,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.001728" Rows="9.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.001972" Rows="9.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="f3">
@@ -374,7 +374,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                   <dxl:LimitOffset/>
                   <dxl:Append IsTarget="false" IsZapped="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.001512" Rows="9.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.001757" Rows="9.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="f3">
@@ -384,7 +384,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                     <dxl:Filter/>
                     <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="862.001483" Rows="8.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.001728" Rows="8.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="2" Alias="f3">
@@ -399,9 +399,9 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                           <dxl:Ident ColId="10" ColName="f1" TypeMdid="0.21.1.0"/>
                         </dxl:Comparison>
                       </dxl:HashCondList>
-                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="2.275556" Width="16"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000553" Rows="2.275556" Width="16"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="f1">
@@ -411,57 +411,78 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                             <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.21.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
+                        <dxl:Filter>
+                          <dxl:And>
+                            <dxl:Not>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="1" ColName="f2" TypeMdid="0.23.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                              </dxl:Comparison>
+                            </dxl:Not>
+                            <dxl:Not>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.23.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                              </dxl:Comparison>
+                            </dxl:Not>
+                          </dxl:And>
+                        </dxl:Filter>
+                        <dxl:OneTimeFilter/>
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000268" Rows="2.275556" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000378" Rows="8.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="f1">
                               <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.21.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="f2">
+                              <dxl:Ident ColId="1" ColName="f2" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="2" Alias="f3">
                               <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:And>
-                              <dxl:Not>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="1" ColName="f2" TypeMdid="0.23.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                </dxl:Comparison>
-                              </dxl:Not>
-                              <dxl:Not>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.23.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                                </dxl:Comparison>
-                              </dxl:Not>
-                            </dxl:And>
-                          </dxl:Filter>
-                          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="tb">
-                            <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.21.1.0" ColWidth="2"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="f2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="2" Attno="3" ColName="f3" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.21.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="8.000000" Width="24"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="f1">
+                                <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.21.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="1" Alias="f2">
+                                <dxl:Ident ColId="1" ColName="f2" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="2" Alias="f3">
+                                <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="tb">
+                              <dxl:Columns>
+                                <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.21.1.0" ColWidth="2"/>
+                                <dxl:Column ColId="1" Attno="2" ColName="f2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="2" Attno="3" ColName="f3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                      </dxl:Result>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000165" Rows="8.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
@@ -232,7 +232,7 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16458">
+    <dxl:Plan Id="0" SpaceSize="16686">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalInnerCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalInnerCorrelatedApply.h
@@ -30,6 +30,9 @@ namespace gpopt
 class CLogicalInnerCorrelatedApply : public CLogicalInnerApply
 {
 private:
+	CExpression *pexprPredicate =
+		nullptr;  // JOIN predicate, used to hash distribute inner child
+
 public:
 	CLogicalInnerCorrelatedApply(const CLogicalInnerCorrelatedApply &) = delete;
 
@@ -41,7 +44,19 @@ public:
 	explicit CLogicalInnerCorrelatedApply(CMemoryPool *mp);
 
 	// dtor
-	~CLogicalInnerCorrelatedApply() override = default;
+	~CLogicalInnerCorrelatedApply() override;
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
+
+	CExpression *
+	GetPexprPredicate()
+	{
+		return pexprPredicate;
+	}
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalInnerCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalInnerCorrelatedApply.h
@@ -53,7 +53,7 @@ public:
 	}
 
 	CExpression *
-	GetPexprPredicate()
+	GetPexprPredicate() const
 	{
 		return pexprPredicate;
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApply.h
@@ -51,7 +51,28 @@ public:
 	}
 
 	// dtor
-	~CLogicalLeftAntiSemiCorrelatedApply() override = default;
+	~CLogicalLeftAntiSemiCorrelatedApply() override
+	{
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
+	}
+
+	CExpression *pexprPredicate =
+		nullptr;  // JOIN predicate, used to hash distribute inner child
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
+
+	CExpression *
+	GetPexprPredicate()
+	{
+		return pexprPredicate;
+	}
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApply.h
@@ -69,7 +69,7 @@ public:
 	}
 
 	CExpression *
-	GetPexprPredicate()
+	GetPexprPredicate() const
 	{
 		return pexprPredicate;
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApplyNotIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApplyNotIn.h
@@ -52,8 +52,28 @@ public:
 	}
 
 	// dtor
-	~CLogicalLeftAntiSemiCorrelatedApplyNotIn() override = default;
+	~CLogicalLeftAntiSemiCorrelatedApplyNotIn() override
+	{
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
+	}
 
+	CExpression *pexprPredicate =
+		nullptr;  // JOIN predicate, used to hash distribute inner child
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
+
+	CExpression *
+	GetPexprPredicate()
+	{
+		return pexprPredicate;
+	}
 	// ident accessors
 	EOperatorId
 	Eopid() const override

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApplyNotIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftAntiSemiCorrelatedApplyNotIn.h
@@ -70,7 +70,7 @@ public:
 	}
 
 	CExpression *
-	GetPexprPredicate()
+	GetPexprPredicate() const
 	{
 		return pexprPredicate;
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftOuterCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftOuterCorrelatedApply.h
@@ -48,7 +48,7 @@ public:
 	}
 
 	CExpression *
-	GetPexprPredicate()
+	GetPexprPredicate() const
 	{
 		return pexprPredicate;
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftOuterCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftOuterCorrelatedApply.h
@@ -38,12 +38,26 @@ public:
 	CLogicalLeftOuterCorrelatedApply(CMemoryPool *mp,
 									 CColRefArray *pdrgpcrInner,
 									 EOperatorId eopidOriginSubq);
+	CExpression *pexprPredicate =
+		nullptr;  // JOIN predicate, used to hash distribute inner child
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
+
+	CExpression *
+	GetPexprPredicate()
+	{
+		return pexprPredicate;
+	}
 
 	// ctor for patterns
 	explicit CLogicalLeftOuterCorrelatedApply(CMemoryPool *mp);
 
 	// dtor
-	~CLogicalLeftOuterCorrelatedApply() override = default;
+	~CLogicalLeftOuterCorrelatedApply() override;
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApply.h
@@ -54,7 +54,7 @@ public:
 	}
 
 	CExpression *
-	GetPexprPredicate()
+	GetPexprPredicate() const
 	{
 		return pexprPredicate;
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApply.h
@@ -42,7 +42,22 @@ public:
 									EOperatorId eopidOriginSubq);
 
 	// dtor
-	~CLogicalLeftSemiCorrelatedApply() override = default;
+	~CLogicalLeftSemiCorrelatedApply() override;
+
+	CExpression *pexprPredicate =
+		nullptr;  // JOIN predicate, used to hash distribute inner child
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
+
+	CExpression *
+	GetPexprPredicate()
+	{
+		return pexprPredicate;
+	}
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApplyIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApplyIn.h
@@ -43,8 +43,22 @@ public:
 									  EOperatorId eopidOriginSubq);
 
 	// dtor
-	~CLogicalLeftSemiCorrelatedApplyIn() override = default;
+	~CLogicalLeftSemiCorrelatedApplyIn() override;
 
+	CExpression *pexprPredicate =
+		nullptr;  // JOIN predicate, used to hash distribute inner child
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
+
+	CExpression *
+	GetPexprPredicate()
+	{
+		return pexprPredicate;
+	}
 	// ident accessors
 	EOperatorId
 	Eopid() const override

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApplyIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalLeftSemiCorrelatedApplyIn.h
@@ -55,7 +55,7 @@ public:
 	}
 
 	CExpression *
-	GetPexprPredicate()
+	GetPexprPredicate() const
 	{
 		return pexprPredicate;
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedInLeftSemiNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedInLeftSemiNLJoin.h
@@ -58,8 +58,20 @@ public:
 	~CPhysicalCorrelatedInLeftSemiNLJoin() override
 	{
 		m_pdrgpcrInner->Release();
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
 	}
 
+	// join predicate used for hash distribution optimization request
+	CExpression *pexprPredicate = nullptr;
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
 	// ident accessors
 	EOperatorId
 	Eopid() const override
@@ -104,7 +116,7 @@ public:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) override
 	{
 		return PedCorrelatedJoin(mp, exprhdl, prppInput, child_index,
-								 pdrgpdpCtxt, ulOptReq);
+								 pdrgpdpCtxt, pexprPredicate, ulOptReq);
 	}
 
 	// compute required distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedInnerNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedInnerNLJoin.h
@@ -101,7 +101,7 @@ public:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) override
 	{
 		return PedCorrelatedJoin(mp, exprhdl, prppInput, child_index,
-								 pdrgpdpCtxt, ulOptReq);
+								 pdrgpdpCtxt, nullptr, ulOptReq);
 	}
 
 	// compute required distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedLeftAntiSemiNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedLeftAntiSemiNLJoin.h
@@ -58,8 +58,20 @@ public:
 	~CPhysicalCorrelatedLeftAntiSemiNLJoin() override
 	{
 		m_pdrgpcrInner->Release();
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
 	}
 
+	// join predicate used for hash distribution optimization request
+	CExpression *pexprPredicate = nullptr;
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
+	}
 	// ident accessors
 	EOperatorId
 	Eopid() const override
@@ -104,7 +116,7 @@ public:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) override
 	{
 		return PedCorrelatedJoin(mp, exprhdl, prppInput, child_index,
-								 pdrgpdpCtxt, ulOptReq);
+								 pdrgpdpCtxt, pexprPredicate, ulOptReq);
 	}
 
 	// compute required distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedLeftOuterNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedLeftOuterNLJoin.h
@@ -56,6 +56,19 @@ public:
 	~CPhysicalCorrelatedLeftOuterNLJoin() override
 	{
 		m_pdrgpcrInner->Release();
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
+	}
+
+	// join predicate used for hash distribution optimization request
+	CExpression *pexprPredicate = nullptr;
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
 	}
 
 	// ident accessors
@@ -91,7 +104,7 @@ public:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) override
 	{
 		return PedCorrelatedJoin(mp, exprhdl, prppInput, child_index,
-								 pdrgpdpCtxt, ulOptReq);
+								 pdrgpdpCtxt, pexprPredicate, ulOptReq);
 	}
 
 	// compute required distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedLeftSemiNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedLeftSemiNLJoin.h
@@ -58,6 +58,19 @@ public:
 	~CPhysicalCorrelatedLeftSemiNLJoin() override
 	{
 		m_pdrgpcrInner->Release();
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
+	}
+
+	// join predicate used for hash distribution optimization request
+	CExpression *pexprPredicate = nullptr;
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
 	}
 
 	// ident accessors
@@ -104,7 +117,7 @@ public:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) override
 	{
 		return PedCorrelatedJoin(mp, exprhdl, prppInput, child_index,
-								 pdrgpdpCtxt, ulOptReq);
+								 pdrgpdpCtxt, pexprPredicate, ulOptReq);
 	}
 
 	// compute required distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedNotInLeftAntiSemiNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalCorrelatedNotInLeftAntiSemiNLJoin.h
@@ -60,6 +60,19 @@ public:
 	~CPhysicalCorrelatedNotInLeftAntiSemiNLJoin() override
 	{
 		m_pdrgpcrInner->Release();
+		if (pexprPredicate != nullptr)
+		{
+			pexprPredicate->Release();
+		}
+	}
+
+	// join predicate used for hash distribution optimization request
+	CExpression *pexprPredicate = nullptr;
+
+	void
+	SetPexprPredicate(CExpression *pexprPredicate_)
+	{
+		pexprPredicate = pexprPredicate_;
 	}
 
 	// ident accessors
@@ -106,7 +119,7 @@ public:
 		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) override
 	{
 		return PedCorrelatedJoin(mp, exprhdl, prppInput, child_index,
-								 pdrgpdpCtxt, ulOptReq);
+								 pdrgpdpCtxt, pexprPredicate, ulOptReq);
 	}
 
 	// compute required distribution of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalJoin.h
@@ -59,7 +59,8 @@ protected:
 	// helper to compute required distribution of correlated join's children
 	CEnfdDistribution *PedCorrelatedJoin(
 		CMemoryPool *mp, CExpressionHandle &exprhdl, CReqdPropPlan *prppInput,
-		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq);
+		ULONG child_index, CDrvdPropArray *pdrgpdpCtxt,
+		CExpression *pexprPredicate, ULONG ulOptReq);
 
 	// helper to compute required rewindability of correlated join's children
 	static CRewindabilitySpec *PrsRequiredCorrelatedJoin(

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -433,6 +433,9 @@ private:
 	// translate a scalar op node
 	CDXLNode *PdxlnScOp(CExpression *pexprScOp);
 
+	// translate a scalar subquery
+	CDXLNode *PdxlnScSubquery(CExpression *pexprScConst);
+
 	// translate a scalar constant
 	CDXLNode *PdxlnScConst(CExpression *pexprScConst);
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalInnerCorrelatedApply.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalInnerCorrelatedApply.cpp
@@ -28,6 +28,14 @@ CLogicalInnerCorrelatedApply::CLogicalInnerCorrelatedApply(CMemoryPool *mp)
 {
 }
 
+CLogicalInnerCorrelatedApply::~CLogicalInnerCorrelatedApply()
+{
+	if (pexprPredicate != nullptr)
+	{
+		pexprPredicate->Release();
+	}
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogicalInnerCorrelatedApply::CLogicalInnerCorrelatedApply

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftOuterCorrelatedApply.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftOuterCorrelatedApply.cpp
@@ -44,6 +44,13 @@ CLogicalLeftOuterCorrelatedApply::CLogicalLeftOuterCorrelatedApply(
 {
 }
 
+CLogicalLeftOuterCorrelatedApply::~CLogicalLeftOuterCorrelatedApply()
+{
+	if (pexprPredicate != nullptr)
+	{
+		pexprPredicate->Release();
+	}
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiCorrelatedApply.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiCorrelatedApply.cpp
@@ -43,6 +43,14 @@ CLogicalLeftSemiCorrelatedApply::CLogicalLeftSemiCorrelatedApply(
 {
 }
 
+CLogicalLeftSemiCorrelatedApply::~CLogicalLeftSemiCorrelatedApply()
+{
+	if (pexprPredicate != nullptr)
+	{
+		pexprPredicate->Release();
+	}
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogicalLeftSemiCorrelatedApply::PxfsCandidates

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiCorrelatedApplyIn.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiCorrelatedApplyIn.cpp
@@ -43,6 +43,14 @@ CLogicalLeftSemiCorrelatedApplyIn::CLogicalLeftSemiCorrelatedApplyIn(
 {
 }
 
+CLogicalLeftSemiCorrelatedApplyIn::~CLogicalLeftSemiCorrelatedApplyIn()
+{
+	if (pexprPredicate != nullptr)
+	{
+		pexprPredicate->Release();
+	}
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogicalLeftSemiCorrelatedApplyIn::PxfsCandidates

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -86,6 +86,7 @@
 #include "gpopt/operators/CScalarNullIf.h"
 #include "gpopt/operators/CScalarOp.h"
 #include "gpopt/operators/CScalarProjectElement.h"
+#include "gpopt/operators/CScalarSubquery.h"
 #include "gpopt/operators/CScalarSwitch.h"
 #include "gpopt/translate/CTranslatorExprToDXLUtils.h"
 #include "naucrates/base/CDatumBoolGPDB.h"
@@ -163,6 +164,7 @@
 #include "naucrates/dxl/operators/CDXLScalarRecheckCondFilter.h"
 #include "naucrates/dxl/operators/CDXLScalarSortCol.h"
 #include "naucrates/dxl/operators/CDXLScalarSortColList.h"
+#include "naucrates/dxl/operators/CDXLScalarSubquery.h"
 #include "naucrates/dxl/operators/CDXLScalarSwitch.h"
 #include "naucrates/dxl/operators/CDXLScalarSwitchCase.h"
 #include "naucrates/dxl/operators/CDXLScalarWindowFrameEdge.h"
@@ -625,6 +627,8 @@ CTranslatorExprToDXL::PdxlnScalar(CExpression *pexpr)
 			return CTranslatorExprToDXL::PdxlnScCoerceViaIO(pexpr);
 		case COperator::EopScalarArrayCoerceExpr:
 			return CTranslatorExprToDXL::PdxlnScArrayCoerceExpr(pexpr);
+		case COperator::EopScalarSubquery:
+			return CTranslatorExprToDXL::PdxlnScSubquery(pexpr);
 		case COperator::EopScalarArray:
 			return CTranslatorExprToDXL::PdxlnArray(pexpr);
 		case COperator::EopScalarArrayCmp:
@@ -6623,6 +6627,28 @@ CTranslatorExprToDXL::PdxlnDMLAction(CExpression *
 		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarDMLAction(m_mp));
 }
 
+//---------------------------------------------------------------------------
+//    @function:
+//        CTranslatorExprToDXL::PdxlnScSubquery
+//
+//    @doc:
+//        Create a DXL scalar subquery node
+//
+//---------------------------------------------------------------------------
+CDXLNode *
+CTranslatorExprToDXL::PdxlnScSubquery(CExpression *pexprScSubquery)
+{
+	GPOS_ASSERT(nullptr != pexprScSubquery);
+	GPOS_ASSERT(COperator::EopScalarSubquery ==
+				pexprScSubquery->Pop()->Eopid());
+
+	const CScalarSubquery *subquery =
+		dynamic_cast<CScalarSubquery *>(pexprScSubquery->Pop());
+	GPOS_ASSERT(subquery != nullptr);
+
+	return GPOS_NEW(m_mp) CDXLNode(
+		m_mp, GPOS_NEW(m_mp) CDXLScalarSubquery(m_mp, subquery->Pcr()->Id()));
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CTranslatorExprToDXL::PdxlnScConst

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -795,8 +795,8 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 
 -- outer joins
 select * from dd_singlecol_1 t1 left outer join dd_singlecol_2 t2 on (t1.a=t2.a) where t1.a=1;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
  a | b | a | b 
 ---+---+---+---
  1 | 1 | 1 | 1

--- a/src/test/regress/expected/combocid_gp_optimizer.out
+++ b/src/test/regress/expected/combocid_gp_optimizer.out
@@ -116,16 +116,17 @@ explain (costs off)  SELECT a.i, b.i, a.t FROM manycombocids a, manycombocids b 
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (manycombocids.i = manycombocids_1.i)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: manycombocids.i
-               ->  Seq Scan on manycombocids
-                     Filter: (distkey = 1)
+         ->  Result
+               Filter: (manycombocids.distkey = 1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: manycombocids.i
+                     ->  Seq Scan on manycombocids
          ->  Hash
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: manycombocids_1.i
                      ->  Seq Scan on manycombocids manycombocids_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.95.0
-(12 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 DECLARE c CURSOR FOR SELECT a.i, b.i, a.t FROM manycombocids a, manycombocids b WHERE a.i = b.i AND a.distkey=1;
 -- Start the cursor.

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -276,10 +276,15 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
                                        Sort Method:  quicksort  Memory: 150kB
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
-                                             ->  Seq Scan on t (actual rows=2 loops=1)
-                                                   Filter: (t1 = ('hello'::text || (tid)::text))
+                                             ->  GroupAggregate (actual rows=2 loops=1)
+                                                   Group Key: t.tid
+                                                   ->  Sort (actual rows=2 loops=1)
+                                                         Sort Key: t.tid
+                                                         Sort Method:  quicksort  Memory: 150kB
+                                                         ->  Seq Scan on t (actual rows=2 loops=1)
+                                                               Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: Pivotal Optimizer (GPORCA)
-(25 rows)
+(30 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -667,30 +672,35 @@ set enable_hashjoin=off;
 -- Known_opt_diff: MPP-21322
 -- end_ignore
 explain (costs off, timing off, summary off, analyze) select * from t, pt where tid = ptid and pt1 = 'hello0';
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Hash Join (actual rows=1 loops=1)
-   Hash Cond: (t.tid = pt_1_prt_2.ptid)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
-         ->  Seq Scan on t (actual rows=2 loops=1)
-   ->  Hash (actual rows=1 loops=1)
-         Buckets: 262144  Batches: 1  Memory Usage: 2049kB
-         ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=1 loops=1)
-               ->  Append (actual rows=1 loops=1)
-                     ->  Index Scan using pt_1_prt_2_pt1_idx on pt_1_prt_2 (actual rows=1 loops=1)
-                           Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_3_pt1_idx on pt_1_prt_3 (never executed)
-                           Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_4_pt1_idx on pt_1_prt_4 (never executed)
-                           Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_5_pt1_idx on pt_1_prt_5 (never executed)
-                           Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_6_pt1_idx on pt_1_prt_6 (never executed)
-                           Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_junk_data_pt1_idx on pt_1_prt_junk_data (never executed)
-                           Index Cond: (pt1 = 'hello0'::text)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
+   ->  Hash Join (actual rows=1 loops=1)
+         Hash Cond: (t.tid = pt_1_prt_2.ptid)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
+               Hash Key: t.tid
+               ->  Seq Scan on t (actual rows=2 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Result (actual rows=1 loops=1)
+                     Filter: (pt_1_prt_2.pt1 = 'hello0'::text)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=1 loops=1)
+                           Hash Key: pt_1_prt_2.ptid
+                           ->  Append (actual rows=1 loops=1)
+                                 ->  Index Scan using pt_1_prt_2_pt1_idx on pt_1_prt_2 (actual rows=1 loops=1)
+                                       Index Cond: (pt1 = 'hello0'::text)
+                                 ->  Index Scan using pt_1_prt_3_pt1_idx on pt_1_prt_3 (never executed)
+                                       Index Cond: (pt1 = 'hello0'::text)
+                                 ->  Index Scan using pt_1_prt_4_pt1_idx on pt_1_prt_4 (never executed)
+                                       Index Cond: (pt1 = 'hello0'::text)
+                                 ->  Index Scan using pt_1_prt_5_pt1_idx on pt_1_prt_5 (never executed)
+                                       Index Cond: (pt1 = 'hello0'::text)
+                                 ->  Index Scan using pt_1_prt_6_pt1_idx on pt_1_prt_6 (never executed)
+                                       Index Cond: (pt1 = 'hello0'::text)
+                                 ->  Index Scan using pt_1_prt_junk_data_pt1_idx on pt_1_prt_junk_data (never executed)
+                                       Index Cond: (pt1 = 'hello0'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(26 rows)
 
 select * from t, pt where tid = ptid and pt1 = 'hello0';
  dist | tid |   t1   | t2  | dist |  pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8801,7 +8801,7 @@ select max(a) from foo group by (select e from bar where bar.e = foo.a);
 -- nested subquery in group by
 select max(a) from foo group by (select g from jazz where foo.a = (select max(a) from foo where c = 1 group by b));
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
+DETAIL:  DXL-to-PlStmt Translation: Attribute number 4 not found in project list
  max 
 -----
    3
@@ -9954,9 +9954,9 @@ select c.cid cid,
 from cust c, sales s, datedim d
 where c.cid = s.cid and s.date_sk = d.date_sk and
       ((d.year = 2001 and lower(s.type) = 't1' and plusone(d.moy) = 5) or (d.moy = 4 and upper(s.type) = 'T2'));
-                                                                                      QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=24)
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=24)
    ->  Hash Join  (cost=0.00..1293.00 rows=1 width=24)
          Hash Cond: (cust.cid = sales.cid)
          ->  Seq Scan on cust  (cost=0.00..431.00 rows=1 width=20)
@@ -9966,15 +9966,16 @@ where c.cid = s.cid and s.date_sk = d.date_sk and
                      ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
                            Hash Cond: (sales.date_sk = datedim.date_sk)
                            Join Filter: (((datedim.year = 2001) AND (lower(sales.type) = 't1'::text) AND (plusone(datedim.moy) = 5)) OR ((datedim.moy = 4) AND (upper(sales.type) = 'T2'::text)))
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                                 Hash Key: sales.date_sk
-                                 ->  Seq Scan on sales  (cost=0.00..431.00 rows=1 width=16)
-                                       Filter: ((lower(type) = 't1'::text) OR (upper(type) = 'T2'::text))
+                           ->  Result  (cost=0.00..431.00 rows=1 width=16)
+                                 Filter: ((lower(sales.type) = 't1'::text) OR (upper(sales.type) = 'T2'::text))
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                       Hash Key: sales.date_sk
+                                       ->  Seq Scan on sales  (cost=0.00..431.00 rows=1 width=16)
                            ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                                  ->  Seq Scan on datedim  (cost=0.00..431.00 rows=1 width=12)
                                        Filter: ((year = 2001) OR (moy = 4))
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(19 rows)
 
 reset optimizer_segments;
 -- Bitmap indexes
@@ -13777,8 +13778,8 @@ CREATE TABLE ria (
     filter_match_id bigint
 ) DISTRIBUTED BY (id);
 explain (costs off) select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (ria.ip = oip.cidr)
@@ -13786,12 +13787,13 @@ explain (costs off) select *  from oip oip  join ria a on ip=cidr and oip.oid=19
                Hash Key: ria.ip
                ->  Seq Scan on ria
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Hash Key: oip.cidr
-                     ->  Seq Scan on oip
-                           Filter: (oid = 194073)
+               ->  Result
+                     Filter: (oip.oid = 194073)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: oip.cidr
+                           ->  Seq Scan on oip
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 -- PartTbl-ArrayCoerce.mdp
 -- from comment

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -1865,24 +1865,30 @@ where exists(select * from tenk1 b
                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  GroupAggregate
          Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-               ->  Hash Join
-                     Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
-                     Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
-                     ->  Seq Scan on tenk1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Nested Loop
-                                       Join Filter: true
-                                       ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                             ->  Seq Scan on int4_tbl
-                                       ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
-                                             Index Cond: (tenthous = int4_tbl.f1)
+         ->  Sort
+               Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+                     ->  GroupAggregate
+                           Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
+                           ->  Sort
+                                 Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+                                 ->  Hash Join
+                                       Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
+                                       Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
+                                       ->  Seq Scan on tenk1
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                   ->  Nested Loop
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                               ->  Seq Scan on int4_tbl
+                                                         ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
+                                                               Index Cond: (tenthous = int4_tbl.f1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(24 rows)
 
 --
 -- More complicated constructs
@@ -3815,21 +3821,20 @@ explain (costs off)
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
   where (case when unique2 is null then f1 else 0 end) = 0;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Result
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Result
-               Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
-               ->  Hash Right Join
-                     Hash Cond: (tenk1.unique2 = int4_tbl.f1)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: tenk1.unique2
-                           ->  Seq Scan on tenk1
-                     ->  Hash
-                           ->  Seq Scan on int4_tbl
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
+         ->  Hash Right Join
+               Hash Cond: (tenk1.unique2 = int4_tbl.f1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: tenk1.unique2
+                     ->  Seq Scan on tenk1
+               ->  Hash
+                     ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(11 rows)
 
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
@@ -3962,7 +3967,6 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
-               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -3996,14 +4000,12 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl.f1
-               ->  Redistribute Motion 3:3  (slice6; segments: 3)
+               ->  Broadcast Motion 3:3  (slice6; segments: 3)
                      Output: int4_tbl.f1
-                     Hash Key: (int4_tbl.f1)::bigint
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(48 rows)
+(45 rows)
 
 select t1.* from
   text_tbl t1
@@ -4041,7 +4043,6 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl_1.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
-               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4081,14 +4082,12 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
-               ->  Redistribute Motion 3:3  (slice7; segments: 3)
+               ->  Broadcast Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
-                     Hash Key: (int4_tbl_1.f1)::bigint
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(54 rows)
+(51 rows)
 
 select t1.* from
   text_tbl t1
@@ -4127,7 +4126,6 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl_1.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
-               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4150,9 +4148,8 @@ select t1.* from
                                                          Output: int8_tbl_1.q1
                                                    ->  Hash
                                                          Output: int4_tbl.f1
-                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                                                Output: int4_tbl.f1
-                                                               Hash Key: (int4_tbl.f1)::bigint
                                                                ->  Seq Scan on public.int4_tbl
                                                                      Output: int4_tbl.f1
                            ->  Hash
@@ -4171,14 +4168,12 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
-               ->  Redistribute Motion 3:3  (slice7; segments: 3)
+               ->  Broadcast Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
-                     Hash Key: (int4_tbl_1.f1)::bigint
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(58 rows)
+(54 rows)
 
 select t1.* from
   text_tbl t1
@@ -4721,15 +4716,14 @@ select i8.* from int8_tbl i8 left join (select f1 from int4_tbl group by f1) i4
          Hash Cond: (int8_tbl.q1 = (int4_tbl.f1)::bigint)
          ->  Seq Scan on int8_tbl
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (int4_tbl.f1)::bigint
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  GroupAggregate
                            Group Key: int4_tbl.f1
                            ->  Sort
                                  Sort Key: int4_tbl.f1
                                  ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(12 rows)
 
 -- check join removal with lateral references
 explain (costs off)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3860,10 +3860,10 @@ select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
                Hash Key: tenk1.unique2
                ->  Seq Scan on tenk1
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Hash Key: COALESCE(tenk1_1.twothousand, tenk1_2.twothousand)
-                     ->  Result
-                           Filter: (COALESCE(tenk1_1.twothousand, tenk1_2.twothousand) = 44)
+               ->  Result
+                     Filter: (COALESCE(tenk1_1.twothousand, tenk1_2.twothousand) = 44)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: COALESCE(tenk1_1.twothousand, tenk1_2.twothousand)
                            ->  Hash Right Join
                                  Hash Cond: (tenk1_1.thousand = tenk1_2.unique1)
                                  ->  Redistribute Motion 3:3  (slice4; segments: 3)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -1865,30 +1865,24 @@ where exists(select * from tenk1 b
                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  HashAggregate
          Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-         ->  Sort
-               Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-                           ->  Sort
-                                 Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-                                 ->  Hash Join
-                                       Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
-                                       Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
-                                       ->  Seq Scan on tenk1
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Nested Loop
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                               ->  Seq Scan on int4_tbl
-                                                         ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
-                                                               Index Cond: (tenthous = int4_tbl.f1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+               ->  Hash Join
+                     Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
+                     Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
+                     ->  Seq Scan on tenk1
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Nested Loop
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                             ->  Seq Scan on int4_tbl
+                                       ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
+                                             Index Cond: (tenthous = int4_tbl.f1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(18 rows)
 
 --
 -- More complicated constructs
@@ -3821,20 +3815,21 @@ explain (costs off)
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
   where (case when unique2 is null then f1 else 0 end) = 0;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
-         ->  Hash Right Join
-               Hash Cond: (tenk1.unique2 = int4_tbl.f1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: tenk1.unique2
-                     ->  Seq Scan on tenk1
-               ->  Hash
-                     ->  Seq Scan on int4_tbl
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Result
+               Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
+               ->  Hash Right Join
+                     Hash Cond: (tenk1.unique2 = int4_tbl.f1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1.unique2
+                           ->  Seq Scan on tenk1
+                     ->  Hash
+                           ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(12 rows)
 
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
@@ -3967,6 +3962,7 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
+               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4000,12 +3996,14 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl.f1
-               ->  Broadcast Motion 3:3  (slice6; segments: 3)
+               ->  Redistribute Motion 3:3  (slice6; segments: 3)
                      Output: int4_tbl.f1
+                     Hash Key: (int4_tbl.f1)::bigint
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(45 rows)
+ Settings: optimizer=on
+(48 rows)
 
 select t1.* from
   text_tbl t1
@@ -4043,6 +4041,7 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl_1.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
+               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4082,12 +4081,14 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
-               ->  Broadcast Motion 3:3  (slice7; segments: 3)
+               ->  Redistribute Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
+                     Hash Key: (int4_tbl_1.f1)::bigint
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(51 rows)
+ Settings: optimizer=on
+(54 rows)
 
 select t1.* from
   text_tbl t1
@@ -4126,6 +4127,7 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl_1.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
+               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4148,8 +4150,9 @@ select t1.* from
                                                          Output: int8_tbl_1.q1
                                                    ->  Hash
                                                          Output: int4_tbl.f1
-                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                                                Output: int4_tbl.f1
+                                                               Hash Key: (int4_tbl.f1)::bigint
                                                                ->  Seq Scan on public.int4_tbl
                                                                      Output: int4_tbl.f1
                            ->  Hash
@@ -4168,12 +4171,14 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
-               ->  Broadcast Motion 3:3  (slice7; segments: 3)
+               ->  Redistribute Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
+                     Hash Key: (int4_tbl_1.f1)::bigint
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(54 rows)
+ Settings: optimizer=on
+(58 rows)
 
 select t1.* from
   text_tbl t1
@@ -4716,14 +4721,15 @@ select i8.* from int8_tbl i8 left join (select f1 from int4_tbl group by f1) i4
          Hash Cond: (int8_tbl.q1 = (int4_tbl.f1)::bigint)
          ->  Seq Scan on int8_tbl
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (int4_tbl.f1)::bigint
                      ->  GroupAggregate
                            Group Key: int4_tbl.f1
                            ->  Sort
                                  Sort Key: int4_tbl.f1
                                  ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 -- check join removal with lateral references
 explain (costs off)

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -92,9 +92,8 @@ explain select c1 from t1 where c1 not in
          ->  Hash  (cost=431.00..431.00 rows=5 width=4)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 select c1 from t1 where c1 not in 
 	(select c2 from t2);
@@ -128,9 +127,8 @@ explain select c1 from t1 where c1 not in
                            ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                        ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(15 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select c1 from t1 where c1 not in 
 	(select c2 from t2 where c2 > 2 and c2 not in 
@@ -174,9 +172,8 @@ explain select c1 from t1 where c1 not in
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                                                    ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                          ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(19 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 select c1 from t1 where c1 not in 
 	(select c2 from t2 where c2 not in 
@@ -212,9 +209,8 @@ explain select c1 from t1,
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(13 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select c1 from t1, 
 (select c2 from t2 where c2 not in 
@@ -248,9 +244,8 @@ explain select c1 from t1,
    ->  Hash  (cost=431.00..431.00 rows=1 width=4)
          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(15 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select c1 from t1, 
 (select c2 from t2 where c2 not in 
@@ -276,9 +271,8 @@ explain select c1 from t1 where c1 not in
          ->  Hash  (cost=431.00..431.00 rows=5 width=4)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(10 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select c1 from t1 where c1 not in 
 	(select c2 from t2) and c1 > 1;
@@ -336,7 +330,6 @@ explain select c1 from t1,t2 where c1 not in
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
  Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (13 rows)
 
@@ -409,11 +402,11 @@ explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000002.35..10000000002.40 rows=3 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000004.95..10000000005.00 rows=3 width=8)
    Merge Key: l1.x, l1.y
-   ->  Sort  (cost=10000000002.35..10000000002.36 rows=1 width=8)
+   ->  Sort  (cost=10000000004.95..10000000004.95 rows=1 width=8)
          Sort Key: l1.x, l1.y
-         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000004.94 rows=1 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..1.03 rows=3 width=8)
                ->  Materialize  (cost=1.07..1.14 rows=3 width=12)
@@ -426,7 +419,7 @@ explain select x,y from l1 where (x,y) not in
                                              ->  Seq Scan on l1 l1_1  (cost=0.00..1.04 rows=1 width=8)
                                                    Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(19 rows)
+(17 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
@@ -446,16 +439,16 @@ select x,y from l1 where (x,y) not in
 --
 explain select * from g1 where (a,b,c) not in 
 	(select x,y,z from l1);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.53..14.71 rows=11 width=12)
-   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=3.53..14.71 rows=4 width=12)
-         Join Filter: g1.a = l1.x AND g1.b = l1.y AND g1.c = l1.z
-         ->  Seq Scan on g1  (cost=0.00..2.11 rows=4 width=12)
-         ->  Materialize  (cost=3.53..3.83 rows=10 width=12)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.50 rows=10 width=12)
-                     ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=12)
- Optimizer status: Postgres query optimizer
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000006.00 rows=3 width=12)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10000000005.96 rows=1 width=12)
+         Join Filter: ((g1.a = l1.x) AND (g1.b = l1.y) AND (g1.c = l1.z))
+         ->  Seq Scan on g1  (cost=0.00..1.04 rows=4 width=12)
+         ->  Materialize  (cost=0.00..1.22 rows=10 width=12)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.17 rows=10 width=12)
+                     ->  Seq Scan on l1  (cost=0.00..1.03 rows=3 width=12)
+ Optimizer: Postgres query optimizer
 (8 rows)
 
 select * from g1 where (a,b,c) not in 
@@ -477,7 +470,7 @@ explain select c1 from t1, t2 where c1 not in
 	(select c3 from t3 where c3 = c1) and c1 = c2;
                                                                                                                                                                           QUERY PLAN                                                                                                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324465.54 rows=6 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324465.54 rows=5 width=4)
    ->  Hash Join  (cost=0.00..1324465.54 rows=2 width=4)
          Hash Cond: (t1.c1 = t2.c2)
          ->  Seq Scan on t1  (cost=0.00..1324034.54 rows=4 width=4)
@@ -493,7 +486,7 @@ explain select c1 from t1, t2 where c1 not in
                                                ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
 select c1 from t1, t2 where c1 not in 
@@ -561,7 +554,7 @@ explain select c1 from t1 where c1 not in
                                  Sort Key: t2.c2
                                  ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                                        Filter: ((c2 > 2) AND (c2 > 3))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select c1 from t1 where c1 not in 
@@ -662,7 +655,7 @@ explain select (case when c1%2 = 0
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
                ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
-                     ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..862.00 rows=3 width=8)
+                     ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..862.00 rows=1 width=8)
                            ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
                                  ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
                                        ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
@@ -673,7 +666,7 @@ explain select (case when c1%2 = 0
                                                          ->  Broadcast Motion 3:3  (slice7; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                                                ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=4)
          ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
-               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..862.00 rows=3 width=8)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..862.00 rows=1 width=8)
                      ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
                            ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
                                  ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
@@ -683,7 +676,7 @@ explain select (case when c1%2 = 0
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                                                    ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                          ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (29 rows)
 
 select (case when c1%2 = 0 
@@ -709,7 +702,7 @@ select (case when c1%2 = 0
 explain select c1 from t1 where not c1 >= some (select c2 from t2);
                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324032.88 rows=2 width=4)
+ Result  (cost=0.00..1324032.88 rows=4 width=4)
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
@@ -717,8 +710,8 @@ explain select c1 from t1 where not c1 >= some (select c2 from t2);
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
            Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 >= t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 >= t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                 ->  Result  (cost=0.00..431.00 rows=2 width=8)
-                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                 ->  Result  (cost=0.00..431.00 rows=5 width=8)
+                       ->  Materialize  (cost=0.00..431.00 rows=5 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
@@ -761,7 +754,7 @@ select c2 from t2 where not c2 < all (select c2 from t2);
 explain select c3 from t3 where not c3 <> any (select c4 from t4);
                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324032.31 rows=1 width=4)
+ Result  (cost=0.00..1324032.31 rows=2 width=4)
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
          ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
@@ -769,8 +762,8 @@ explain select c3 from t3 where not c3 <> any (select c4 from t4);
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
            Filter: ((CASE WHEN (sum((CASE WHEN (t3.c3 <> t4.c4) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t4.c4 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t3.c3 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t3.c3 <> t4.c4) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
-                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..431.00 rows=2 width=8)
+                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                    ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
@@ -795,17 +788,16 @@ explain select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3
                Hash Cond: (t1.c1 = t2.c2)
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
                ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=9 width=4)
-                           ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Limit  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                        Merge Key: t2.c2
                                        ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                                              ->  Sort  (cost=0.00..431.00 rows=2 width=4)
                                                    Sort Key: t2.c2
                                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(18 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
 
 select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order by c1;
  c1 
@@ -860,9 +852,8 @@ explain select c1 from t1 where c1 <>all (select c2 from t2);
          ->  Hash  (cost=431.00..431.00 rows=5 width=4)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 select c1 from t1 where c1 <>all (select c2 from t2);
  c1 
@@ -932,9 +923,8 @@ explain select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all
                                ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
                                      ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select c3 from t3));
  c1 
@@ -957,7 +947,7 @@ select c1 from t1 where not c1 =all (select c2 from t2 where not c2 >all (select
 explain select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select c3 from t3 where c3 = c1n));
                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324464.89 rows=8 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324464.89 rows=7 width=4)
    ->  Hash Semi Join  (cost=0.00..1324464.89 rows=3 width=4)
          Hash Cond: (t1.c1 = t1n.c1n)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
@@ -990,16 +980,15 @@ select c1 from t1 where not c1 <>all (select c1n from t1n where c1n <all (select
 explain select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=6 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=5 width=4)
    ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
          Hash Cond: (t1.c1 = t2.c2)
          Join Filter: (t1.c1 < t2.c2)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 select c1 from t1 where not c1 >=all (select c2 from t2 where c2 = c1);
  c1 
@@ -1018,9 +1007,8 @@ explain select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 select c1 from t1 where not exists (select c2 from t2 where c2 = c1);
  c1 
@@ -1049,9 +1037,8 @@ explain select c1 from t1 where not exists (select c2 from t2 where c2 not in (s
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(13 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select c1 from t1 where not exists (select c2 from t2 where c2 not in (select c3 from t3) and c2 = c1);
  c1 
@@ -1084,7 +1071,7 @@ explain select c1 from t1 where not exists (select c2 from t2 where exists (sele
                            Join Filter: true
                            ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
                            ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=1)
+                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=1)
                                        ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                                              ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                                    ->  Limit  (cost=0.00..431.00 rows=1 width=1)
@@ -1149,7 +1136,7 @@ explain select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                      ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                            Filter: (c2 > 4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.77.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
@@ -1221,10 +1208,14 @@ select c1 from t1 where c1::absint not in
 -- q46
 --
 create table table_source (c1 varchar(100),c2 varchar(100),c3 varchar(100),c4 varchar(100));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into table_source (c1 ,c2 ,c3 ,c4 ) values ('000181202006010000003158',null,'INC','0000000001') ;
 create table table_source2 as select * from table_source distributed by (c2);
 create table table_source3 as select * from table_source distributed replicated;
 create table table_source4 (c1 varchar(100),c2 varchar(100) not null,c3 varchar(100),c4 varchar(100));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into table_source4 (c1 ,c2 ,c3 ,c4 ) values ('000181202006010000003158','a','INC','0000000001') ;
 create table table_config (c1 varchar(10) ,c2 varchar(10) ,PRIMARY KEY (c1));
 insert into table_config select i, 'test' from generate_series(1, 1000)i;
@@ -1233,10 +1224,10 @@ delete from table_config where gp_segment_id = 0;
 explain select * from table_source where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=40)
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=32)
    Hash Cond: ((table_source.c2)::text = (table_config.c1)::text)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=40)
-         ->  Seq Scan on table_source  (cost=0.00..431.00 rows=1 width=40)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=32)
+         ->  Seq Scan on table_source  (cost=0.00..431.00 rows=1 width=32)
                Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
    ->  Hash  (cost=431.03..431.03 rows=1000 width=3)
          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.03 rows=1000 width=3)
@@ -1253,10 +1244,10 @@ select * from table_source where c3 = 'INC' and c4 = '0000000001' and c2 not in 
 explain select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=40)
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=124)
    Hash Cond: ((table_source2.c2)::text = (table_config.c1)::text)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=40)
-         ->  Seq Scan on table_source2  (cost=0.00..431.00 rows=1 width=40)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=124)
+         ->  Seq Scan on table_source2  (cost=0.00..431.00 rows=1 width=124)
                Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
    ->  Hash  (cost=431.03..431.03 rows=1000 width=3)
          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.03 rows=1000 width=3)
@@ -1273,10 +1264,10 @@ select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in
 explain select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=40)
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=124)
    Hash Cond: ((table_source3.c2)::text = (table_config.c1)::text)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=40)
-         ->  Seq Scan on table_source3  (cost=0.00..431.00 rows=3 width=40)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=124)
+         ->  Seq Scan on table_source3  (cost=0.00..431.00 rows=3 width=124)
                Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
    ->  Hash  (cost=431.03..431.03 rows=1000 width=3)
          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.03 rows=1000 width=3)
@@ -1291,20 +1282,21 @@ select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in
 (0 rows)
 
 explain select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.19 rows=1 width=42)
-   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.19 rows=1 width=42)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.08 rows=1 width=32)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.08 rows=1 width=32)
          Hash Cond: ((table_source4.c2)::text = (table_config.c1)::text)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
-               Hash Key: table_source4.c2
-               ->  Seq Scan on table_source4  (cost=0.00..431.00 rows=1 width=42)
-                     Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+         ->  Result  (cost=0.00..431.00 rows=1 width=32)
+               Filter: (((table_source4.c3)::text = 'INC'::text) AND ((table_source4.c4)::text = '0000000001'::text))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=32)
+                     Hash Key: table_source4.c2
+                     ->  Seq Scan on table_source4  (cost=0.00..431.00 rows=1 width=32)
          ->  Hash  (cost=431.02..431.02 rows=334 width=3)
                ->  Seq Scan on table_config  (cost=0.00..431.02 rows=334 width=3)
                      Filter: ((c2)::text = 'test'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(12 rows)
 
 select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
             c1            | c2 | c3  |     c4     

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -3,7 +3,11 @@
 --
 -- Given I have two distributed tables
 create table choose_seqscan_t1(id1 int,id2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table choose_seqscan_t2(id1 int,id2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- and they have some data
 insert into choose_seqscan_t1 select i+1,i from generate_series(1,50)i;
 insert into choose_seqscan_t2 select i+1,i from generate_series(1,50)i;
@@ -74,13 +78,13 @@ select (select id1 from (select * from choose_seqscan_t2) foo where id2=choose_s
 explain select (select id1 from (select * from choose_seqscan_t2) foo where id2=choose_seqscan_t1.id2) from choose_seqscan_t1;
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324216.68 rows=50 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324216.68 rows=50 width=4)
    ->  Seq Scan on choose_seqscan_t1  (cost=0.00..1324216.68 rows=334 width=4)
          SubPlan 1
            ->  Result  (cost=0.00..431.17 rows=1 width=4)
                  Filter: (choose_seqscan_t2.id2 = choose_seqscan_t1.id2)
                  ->  Materialize  (cost=0.00..431.01 rows=50 width=8)
-                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=50 width=8)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=50 width=8)
                              ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=17 width=8)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (9 rows)
@@ -115,8 +119,9 @@ explain select t1.id1, (select count(*) from choose_seqscan_t2 t2 where t2.id1 =
                            Sort Key: choose_seqscan_t2.id1
                            ->  Index Scan using bidx2 on choose_seqscan_t2  (cost=0.00..6.00 rows=1 width=4)
                                  Index Cond: (id2 = 1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(13 rows)
+                                 Filter: (id1 < 10)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 -- Test using a join within the subplan. It could perhaps use an Nested Loop Join +
 -- Index Scan to do the join, but at the memont, the planner doesn't consider distributing
@@ -135,10 +140,10 @@ select t1.id1, (select count(*) from generate_series(1,5) g, choose_seqscan_t2 t
 (8 rows)
 
 explain select t1.id1, (select count(*) from generate_series(1,5) g, choose_seqscan_t2 t2 where t1.id1 = t2.id1 and t2.id2 = g) from choose_seqscan_t1 t1 where t1.id1 < 10;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.12 rows=9 width=12)
-   ->  Hash Left Join  (cost=0.00..862.12 rows=3 width=12)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.13 rows=9 width=12)
+   ->  Hash Left Join  (cost=0.00..862.13 rows=3 width=12)
          Hash Cond: (choose_seqscan_t1.id1 = choose_seqscan_t2.id1)
          ->  Seq Scan on choose_seqscan_t1  (cost=0.00..431.00 rows=3 width=4)
                Filter: (id1 < 10)
@@ -154,10 +159,10 @@ explain select t1.id1, (select count(*) from generate_series(1,5) g, choose_seqs
                                        ->  Hash Join  (cost=0.00..431.08 rows=334 width=4)
                                              Hash Cond: (generate_series.generate_series = choose_seqscan_t2.id2)
                                              ->  Result  (cost=0.00..0.01 rows=334 width=4)
+                                                   One-Time Filter: (gp_execution_segment() = 0)
                                                    ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
-                                             ->  Hash  (cost=431.00..431.00 rows=3 width=8)
-                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=3 width=8)
-                                                         Hash Key: choose_seqscan_t2.id2
+                                             ->  Hash  (cost=431.00..431.00 rows=9 width=8)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=9 width=8)
                                                          ->  Seq Scan on choose_seqscan_t2  (cost=0.00..431.00 rows=3 width=8)
                                                                Filter: (id1 < 10)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -214,6 +219,8 @@ drop table if exists choose_seqscan_t2;
 -- end_ignore
 -- Given I have one replicated table
 create table choose_indexscan_t1(id1 int, id2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table choose_indexscan_t2(id1 int, id2 int) distributed replicated;
 -- and it has data
 insert into choose_indexscan_t1 select i+1, i from generate_series(1,20)i;
@@ -259,7 +266,7 @@ explain select (select id1 from (select * from choose_indexscan_t2) foo where id
          SubPlan 1
            ->  Seq Scan on choose_indexscan_t2  (cost=0.00..431.13 rows=1 width=4)
                  Filter: (id2 = choose_indexscan_t1.id2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
 -- then an indexscan is chosen because it is correct to do this on a replicated table since no motion is required
@@ -281,16 +288,16 @@ select c.relname, (select explanation from mytables mt where mt.tablename=c.reln
 
 set enable_seqscan=off;
 explain select c.relname, (select explanation from mytables mt where mt.tablename=c.relname ) from pg_class c where relname = 'pg_class';
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using pg_class_relname_nsp_index on pg_class c  (cost=0.15..10000000002.20 rows=1 width=64)
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using pg_class_relname_nsp_index on pg_class c  (cost=0.15..10000002067.17 rows=1 width=96)
    Index Cond: (relname = 'pg_class'::name)
    SubPlan 1
-     ->  Result  (cost=10000000000.00..10000000001.03 rows=1 width=32)
-           Filter: (mt.tablename = (c.relname)::text)
-           ->  Materialize  (cost=10000000000.00..10000000001.03 rows=1 width=32)
-                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000001.03 rows=1 width=32)
-                       ->  Seq Scan on mytables mt  (cost=10000000000.00..10000000001.01 rows=1 width=32)
+     ->  Result  (cost=10000000000.00..10000002066.00 rows=34800 width=32)
+           Filter: (mt.tablename = c.relname)
+           ->  Materialize  (cost=10000000000.00..10000001718.00 rows=34800 width=64)
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000001544.00 rows=34800 width=64)
+                       ->  Seq Scan on mytables mt  (cost=10000000000.00..10000000848.00 rows=34800 width=64)
  Optimizer: Postgres query optimizer
 (9 rows)
 

--- a/src/test/regress/expected/tidscan_optimizer.out
+++ b/src/test/regress/expected/tidscan_optimizer.out
@@ -150,13 +150,17 @@ FROM tidscan t1 JOIN tidscan t2 ON t1.ctid = t2.ctid WHERE t1.id = 1;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tidscan.ctid = tidscan_1.ctid)
-         ->  Seq Scan on tidscan
+         ->  Result
+               Filter: (tidscan.id = 1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: tidscan.ctid
+                     ->  Seq Scan on tidscan
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: tidscan_1.ctid
                      ->  Seq Scan on tidscan tidscan_1
-                           Filter: (id = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(13 rows)
 
 SELECT t1.ctid, t1.*, t2.ctid, t2.*
 FROM tidscan t1 JOIN tidscan t2 ON t1.ctid = t2.ctid WHERE t1.id = 1;
@@ -170,16 +174,19 @@ SELECT t1.ctid, t1.*, t2.ctid, t2.*
 FROM tidscan t1 LEFT JOIN tidscan t2 ON t1.ctid = t2.ctid WHERE t1.id = 1;
                       QUERY PLAN                      
 ------------------------------------------------------
- Hash Right Join
-   Hash Cond: (tidscan.ctid = tidscan_1.ctid)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on tidscan
-   ->  Hash
-         ->  Gather Motion 3:1  (slice2; segments: 3)
-               ->  Seq Scan on tidscan tidscan_1
-                     Filter: (id = 1)
- Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Left Join
+         Hash Cond: (tidscan.ctid = tidscan_1.ctid)
+         ->  Result
+               Filter: (tidscan.id = 1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: tidscan.ctid
+                     ->  Seq Scan on tidscan
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: tidscan_1.ctid
+                     ->  Seq Scan on tidscan tidscan_1
+(13 rows)
 
 SELECT t1.ctid, t1.*, t2.ctid, t2.*
 FROM tidscan t1 LEFT JOIN tidscan t2 ON t1.ctid = t2.ctid WHERE t1.id = 1;

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -387,10 +387,11 @@ select unique1 from tenk1 except select unique2 from tenk1 where unique2 != 10;
                Hash Cond: (NOT (tenk1.unique1 IS DISTINCT FROM tenk1_1.unique2))
                ->  Seq Scan on tenk1
                ->  Hash
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: tenk1_1.unique2
-                           ->  Seq Scan on tenk1 tenk1_1
-                                 Filter: (unique2 <> 10)
+                     ->  Result
+                           Filter: (tenk1_1.unique2 <> 10)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: tenk1_1.unique2
+                                 ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
@@ -441,10 +442,11 @@ select unique1 from tenk1 except select unique2 from tenk1 where unique2 != 10;
                Hash Cond: (NOT (tenk1.unique1 IS DISTINCT FROM tenk1_1.unique2))
                ->  Seq Scan on tenk1
                ->  Hash
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: tenk1_1.unique2
-                           ->  Seq Scan on tenk1 tenk1_1
-                                 Filter: (unique2 <> 10)
+                     ->  Result
+                           Filter: (tenk1_1.unique2 <> 10)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: tenk1_1.unique2
+                                 ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
@@ -754,14 +756,14 @@ explain (costs off)
          Group Key: ((t1.a || t1.b))
          ->  Sort
                Sort Key: ((t1.a || t1.b))
-               ->  Append
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: ((t1.a || t1.b))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: ((t1.a || t1.b))
+                     ->  Append
                            ->  Result
                                  Filter: (((t1.a || t1.b)) = 'ab'::text)
                                  ->  Seq Scan on t1
-                     ->  Index Scan using t2_pkey on t2
-                           Index Cond: (ab = 'ab'::text)
+                           ->  Index Scan using t2_pkey on t2
+                                 Index Cond: (ab = 'ab'::text)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (14 rows)
 

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -3069,10 +3069,10 @@ WHERE depname = 'sales';
          Partition By: depname
          ->  Sort
                Sort Key: depname
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: depname
-                     ->  Result
-                           Filter: ((depname)::text = 'sales'::text)
+               ->  Result
+                     Filter: ((depname)::text = 'sales'::text)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: depname
                            ->  WindowAgg
                                  Partition By: enroll_date
                                  ->  Sort


### PR DESCRIPTION
Previously, correlated NL joins required either a broadcast across all segments
or a gather on master to execute. This commit allows for two tables to be hash
distributed if co-location is guaranteed. This fix is different than
non-correlated joins in that the JOIN predicate must be executed in
`CPhysicalFilter` and the predicate on the JOIN operation is a constant true.

SQL

```
CREATE TEMP TABLE foo (a int, b int);
INSERT INTO foo SELECT i, pg_catalog.hashint4(i) FROM generate_series(1, 7) AS i;
CREATE TEMP TABLE bar (c, d) AS SELECT i, pg_catalog.hashint4(i) FROM generate_series(3 * (2 ^ 20)::int, 1, -1) AS i DISTRIBUTED BY (c);
CREATE INDEX on bar(c);
CREATE INDEX on bar(d);
ANALYZE foo;
ANALYZE bar;

EXPLAIN SELECT b, (SELECT d FROM bar WHERE (c = a)) FROM foo;
```

Old

```
                                               QUERY PLAN
--------------------------------------------------------------------------------------------------------
 Result  (cost=0.00..2967988.83 rows=7 width=8)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=8)
         ->  Seq Scan on foo  (cost=0.00..431.00 rows=3 width=8)
   SubPlan 1
     ->  Result  (cost=0.00..2036.39 rows=1 width=4)
           Filter: (bar.c = foo.a)
           ->  Materialize  (cost=0.00..587.47 rows=3145728 width=8)
                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..562.30 rows=3145728 width=8)
                       ->  Seq Scan on bar  (cost=0.00..452.92 rows=1048576 width=8)
 Optimizer: Pivotal Optimizer (GPORCA)
(10 rows)
```

New

```
                                    QUERY PLAN
----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1841050.88 rows=7 width=8)
   ->  Seq Scan on foo  (cost=0.00..1841050.88 rows=334 width=8)
         SubPlan 1
           ->  Seq Scan on bar  (cost=0.00..935.89 rows=1 width=4)
                 Filter: (c = foo.a)
 Optimizer: Pivotal Optimizer (GPORCA)
(6 rows)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
