### PR TITLE
Fix reset GUC issue that causes inconsistent GUC values

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -126,9 +126,10 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc)
 void
 cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 					   const char *gpqeid,
-					   const char *options)
+					   const char *options,
+					   const char *diff_options)
 {
-#define MAX_KEYWORDS 10
+#define MAX_KEYWORDS 11
 #define MAX_INT_STRING_LEN 20
 	CdbComponentDatabaseInfo *cdbinfo = segdbDesc->segment_database_info;
 	const char *keywords[MAX_KEYWORDS];
@@ -147,6 +148,12 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	{
 		keywords[nkeywords] = "options";
 		values[nkeywords] = options;
+		nkeywords++;
+	}
+	if (diff_options)
+	{
+		keywords[nkeywords] = "diff_options";
+		values[nkeywords] = diff_options;
 		nkeywords++;
 	}
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -274,7 +274,7 @@ buildGangDefinition(List *segments, SegmentType segmentType)
  * Add one GUC to the option string.
  */
 static void
-addOneOption(StringInfo string, struct config_generic *guc)
+addOneOption(StringInfo option, StringInfo diff, struct config_generic *guc)
 {
 	Assert(guc && (guc->flags & GUC_GPDB_NEED_SYNC));
 	switch (guc->vartype)
@@ -283,30 +283,36 @@ addOneOption(StringInfo string, struct config_generic *guc)
 			{
 				struct config_bool *bguc = (struct config_bool *) guc;
 
-				appendStringInfo(string, " -c %s=%s", guc->name, *(bguc->variable) ? "true" : "false");
+				appendStringInfo(option, " -c %s=%s", guc->name, (bguc->reset_val) ? "true" : "false");
+				if (bguc->reset_val != *bguc->variable)
+					appendStringInfo(diff, " %s=%s", guc->name, *(bguc->variable) ? "true" : "false");
 				break;
 			}
 		case PGC_INT:
 			{
 				struct config_int *iguc = (struct config_int *) guc;
 
-				appendStringInfo(string, " -c %s=%d", guc->name, *iguc->variable);
+				appendStringInfo(option, " -c %s=%d", guc->name, iguc->reset_val);
+				if (iguc->reset_val != *iguc->variable)
+					appendStringInfo(diff, " %s=%d", guc->name, *iguc->variable);
 				break;
 			}
 		case PGC_REAL:
 			{
 				struct config_real *rguc = (struct config_real *) guc;
 
-				appendStringInfo(string, " -c %s=%f", guc->name, *rguc->variable);
+				appendStringInfo(option, " -c %s=%f", guc->name, rguc->reset_val);
+				if (rguc->reset_val != *rguc->variable)
+					appendStringInfo(diff, " %s=%f", guc->name, *rguc->variable);
 				break;
 			}
 		case PGC_STRING:
 			{
 				struct config_string *sguc = (struct config_string *) guc;
-				const char *str = *sguc->variable;
+				const char *str = sguc->reset_val;
 				int			i;
 
-				appendStringInfo(string, " -c %s=", guc->name);
+				appendStringInfo(option, " -c %s=", guc->name);
 
 				/*
 				 * All whitespace characters must be escaped. See
@@ -315,20 +321,32 @@ addOneOption(StringInfo string, struct config_generic *guc)
 				for (i = 0; str[i] != '\0'; i++)
 				{
 					if (isspace((unsigned char) str[i]))
-						appendStringInfoChar(string, '\\');
+						appendStringInfoChar(option, '\\');
 
-					appendStringInfoChar(string, str[i]);
+					appendStringInfoChar(option, str[i]);
+				}
+				if (strcmp(str, *sguc->variable) != 0)
+				{
+					const char *p = *sguc->variable;
+					appendStringInfo(diff, " %s=", guc->name);
+					for (i = 0; p[i] != '\0'; i++)
+					{
+						if (isspace((unsigned char) p[i]))
+							appendStringInfoChar(diff, '\\');
+
+						appendStringInfoChar(diff, p[i]);
+					}
 				}
 				break;
 			}
 		case PGC_ENUM:
 			{
 				struct config_enum *eguc = (struct config_enum *) guc;
-				int			value = *eguc->variable;
+				int			value = eguc->reset_val;
 				const char *str = config_enum_lookup_by_value(eguc, value);
 				int			i;
 
-				appendStringInfo(string, " -c %s=", guc->name);
+				appendStringInfo(option, " -c %s=", guc->name);
 
 				/*
 				 * All whitespace characters must be escaped. See
@@ -338,9 +356,21 @@ addOneOption(StringInfo string, struct config_generic *guc)
 				for (i = 0; str[i] != '\0'; i++)
 				{
 					if (isspace((unsigned char) str[i]))
-						appendStringInfoChar(string, '\\');
+						appendStringInfoChar(option, '\\');
 
-					appendStringInfoChar(string, str[i]);
+					appendStringInfoChar(option, str[i]);
+				}
+				if (value != *eguc->variable)
+				{
+					const char *p = config_enum_lookup_by_value(eguc, *eguc->variable);
+					appendStringInfo(diff, " %s=", guc->name);
+					for (i = 0; p[i] != '\0'; i++)
+					{
+						if (isspace((unsigned char) p[i]))
+							appendStringInfoChar(diff, '\\');
+
+						appendStringInfoChar(diff, p[i]);
+					}
 				}
 				break;
 			}
@@ -350,24 +380,46 @@ addOneOption(StringInfo string, struct config_generic *guc)
 }
 
 /*
- * Add GUCs to option string.
+ * Add GUCs to option/diff_options string.
+ *
+ * `options` is a list of reset_val of the GUCs, not the GUC's current value.
+ * `diff_options` is a list of the GUCs' current value. If the GUC is unchanged,
+ * `diff_options` will omit it.
+ *
+ * In process_startup_options(), `options` is used to set the GUCs with
+ * PGC_S_CLIENT as its guc source. Then, `diff_options` is used to set the GUCs
+ * with PGC_S_SESSION as its guc source.
+ *
+ * With PGC_S_CLIENT, SetConfigOption() will set the GUC's reset_val
+ * when processing `options`, so the reset_val of the involved GUCs on all QD
+ * and QEs are the same.
+ *
+ * After applying `diff_options`, the GUCs' current value is set to the same
+ * value as the QD and the reset_val of the GUC will not change.
+ *
+ * At last, both the reset_val and current value of the GUC are consistent,
+ * even after RESET.
+ *
+ * See addOneOption() and process_startup_options() for more details.
  */
-char *
-makeOptions(void)
+void
+makeOptions(char **options, char **diff_options)
 {
 	struct config_generic **gucs = get_guc_variables();
 	int			ngucs = get_num_guc_variables();
 	CdbComponentDatabaseInfo *qdinfo = NULL;
-	StringInfoData string;
+	StringInfoData optionsStr;
+	StringInfoData diffStr;
 	int			i;
 
-	initStringInfo(&string);
+	initStringInfo(&optionsStr);
+	initStringInfo(&diffStr);
 
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
 	qdinfo = cdbcomponent_getComponentInfo(MASTER_CONTENT_ID); 
-	appendStringInfo(&string, " -c gp_qd_hostname=%s", qdinfo->config->hostip);
-	appendStringInfo(&string, " -c gp_qd_port=%d", qdinfo->config->port);
+	appendStringInfo(&optionsStr, " -c gp_qd_hostname=%s", qdinfo->config->hostip);
+	appendStringInfo(&optionsStr, " -c gp_qd_port=%d", qdinfo->config->port);
 
 	for (i = 0; i < ngucs; ++i)
 	{
@@ -377,10 +429,11 @@ makeOptions(void)
 			(guc->context == PGC_USERSET ||
 			 guc->context == PGC_BACKEND ||
 			 IsAuthenticatedUserSuperUser()))
-			addOneOption(&string, guc);
+			addOneOption(&optionsStr, &diffStr, guc);
 	}
 
-	return string.data;
+	*options = optionsStr.data;
+	*diff_options = diffStr.data;
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -120,7 +120,8 @@ create_gang_retry:
 		{
 			bool		ret;
 			char		gpqeid[100];
-			char	   *options;
+			char	   *options = NULL;
+			char	   *diff_options = NULL;
 
 			/*
 			 * Create the connection requests.	If we find a segment without a
@@ -153,10 +154,10 @@ create_gang_retry:
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						 errmsg("failed to construct connectionstring")));
 
-			options = makeOptions();
+			makeOptions(&options, &diff_options);
 
 			/* start connection in asynchronous way */
-			cdbconn_doConnectStart(segdbDesc, gpqeid, options);
+			cdbconn_doConnectStart(segdbDesc, gpqeid, options, diff_options);
 
 			if (cdbconn_isBadConnection(segdbDesc))
 				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2408,6 +2408,10 @@ retry1:
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 							 errmsg("invalid value for option: \"%s\"", GPCONN_TYPE)));
 			}
+			else if (strcmp(nameptr, "diff_options") == 0)
+			{
+				port->diff_options = pstrdup(valptr);
+			}
 			else
 			{
 				/* Assume it's a generic GUC option */

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1305,6 +1305,33 @@ process_startup_options(Port *port, bool am_superuser)
 
 		SetConfigOption(name, value, gucctx, PGC_S_CLIENT);
 	}
+
+	/* Set GUCs that have been changed in the QD */
+	/* NOTE: this code block will not change the reset_val of the GUCs */
+	if (port->diff_options)
+	{
+		char	  **av;
+		int			maxac;
+		int			ac;
+
+		maxac = 1 + (strlen(port->diff_options) + 1)/2;
+
+		av = (char **) palloc(maxac * sizeof(char *));
+		ac = 0;
+
+		pg_split_opts(av, &ac, port->diff_options);
+
+		av[ac] = NULL;
+		Assert(ac < maxac);
+		for (int i = 0; i < ac; i++)
+		{
+			char *name = NULL;
+			char *val = NULL;
+			ParseLongOption(av[i], &name, &val);
+			SetConfigOption(name, val, gucctx, PGC_S_SESSION);
+		}
+		pfree(av);
+	}
 }
 
 /*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7353,6 +7353,7 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 			if (strcmp(stmt->name, "transaction_isolation") == 0)
 				WarnNoTransactionChain(isTopLevel, "RESET TRANSACTION");
 
+			SIMPLE_FAULT_INJECTOR("reset_variable_fault");
 			(void) set_config_option(stmt->name,
 									 NULL,
 									 (superuser() ? PGC_SUSET : PGC_USERSET),

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -68,7 +68,8 @@ cdbconn_termSegmentDescriptor(SegmentDatabaseDescriptor *segdbDesc);
 void
 cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 					   const char *gpqeid,
-					   const char *options);
+					   const char *options,
+					   const char *diff_options);
 void
 cdbconn_doConnectComplete(SegmentDatabaseDescriptor *segdbDesc);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -83,7 +83,7 @@ extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang
 Gang *buildGangDefinition(List *segments, SegmentType segmentType);
 bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs, int icHtabSize);
 
-char *makeOptions(void);
+extern void makeOptions(char **options, char **diff_options);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 extern bool segment_failure_due_to_missing_writer(const char *error_message);
 

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -191,6 +191,7 @@ typedef struct Port
 	char	   *peer_cn;
 	unsigned long count;
 #endif
+	char	   *diff_options;
 } Port;
 
 

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -357,6 +357,10 @@ static const internalPQconninfoOption PQconninfoOptions[] = {
 		"connection type", "D", 10,
 	offsetof(struct pg_conn, gpconntype)},
 
+	{"diff_options", NULL, NULL, NULL,
+		"updated synced GUCs", "D", 80,
+	offsetof(struct pg_conn, diffoptions)},
+
 	/* Terminating entry --- MUST BE LAST */
 	{NULL, NULL, NULL, NULL,
 	NULL, NULL, 0}

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2331,6 +2331,8 @@ build_startup_packet(const PGconn *conn, char *packet,
 		ADD_STARTUP_OPTION(GPCONN_TYPE, conn->gpconntype);
 	if (conn->pgoptions && conn->pgoptions[0])
 		ADD_STARTUP_OPTION("options", conn->pgoptions);
+	if (conn->diffoptions && conn->diffoptions[0])
+		ADD_STARTUP_OPTION("diff_options", conn->diffoptions);
 	if (conn->send_appname)
 	{
 		/* Use appname if present, otherwise use fallback */

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -515,6 +515,7 @@ struct pg_conn
 
 	/* Buffer for receiving various parts of messages */
 	PQExpBufferData workBuffer; /* expansible string */
+	char       *diffoptions;  /* MPP: transfer changed GUCs(require sync) from QD to QEs */
 };
 
 /* PGcancel stores all data necessary to cancel a connection. A copy of this

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -1,0 +1,155 @@
+-- TEST 1: Fix Github issue https://github.com/greenplum-db/gpdb/issues/9208
+1: create schema sync_np1;
+CREATE
+1: create schema sync_np2;
+CREATE
+1: CREATE OR REPLACE FUNCTION public.segment_setting(guc text) RETURNS SETOF text EXECUTE ON ALL SEGMENTS AS $$ BEGIN RETURN NEXT pg_catalog.current_setting(guc); END $$ LANGUAGE plpgsql;
+CREATE
+1q: ... <quitting>
+-- The SET command will create a Gang on the primaries, and the GUC
+-- values should be the same on all QD/QEs.
+2: show search_path;
+ search_path    
+----------------
+ "$user",public 
+(1 row)
+2: set search_path = 'sync_np1,sync_np2';
+SET
+
+-- The `reset_val` of `search_path` should be synchronized from the QD,
+-- so, the GUC value will be also synchronized with the QD after RESET.
+-- If the search_path is inconsistent between the QD and QEs after RESET,
+-- creating the function will fail.
+2: reset search_path;
+RESET
+2: select public.segment_setting('search_path');
+ segment_setting 
+-----------------
+ "$user",public  
+ "$user",public  
+ "$user",public  
+(3 rows)
+2: create or replace function sync_f1() returns int as $$ select 1234; $$language sql;
+CREATE
+2: select sync_f1();
+ sync_f1 
+---------
+ 1234    
+(1 row)
+2: drop function sync_f1();
+DROP
+2: drop schema sync_np1;
+DROP
+2: drop schema sync_np2;
+DROP
+2q: ... <quitting>
+
+-- TEST 2: Fix Github issue https://github.com/greenplum-db/gpdb/issues/685
+-- `gp_select_invisible` is default to false. SET command will dispatch
+-- the GUC's `reset_val` and changed value to the created Gang. If the QE(s)
+-- use the incorrect `reset_val`, its value will be inconsistent with the QD's,
+-- i.e. the `gp_select_invisible` is still false on the QEs.
+3: show gp_select_invisible;
+ gp_select_invisible 
+---------------------
+ off                 
+(1 row)
+3: set gp_select_invisible = on;
+SET
+3: reset gp_select_invisible;
+RESET
+3: select public.segment_setting('gp_select_invisible');
+ segment_setting 
+-----------------
+ off             
+ off             
+ off             
+(3 rows)
+3: create table sync_t1(i int);
+CREATE
+3: insert into sync_t1 select i from generate_series(1,10)i;
+INSERT 10
+3: delete from sync_t1;
+DELETE 10
+3: select * from sync_t1;
+ i 
+---
+(0 rows)
+3: drop table sync_t1;
+DROP
+3q: ... <quitting>
+
+1: drop function public.segment_setting(guc text);
+DROP
+1q: ... <quitting>
+
+-- TEST 3: make sure all QEs call RESET if there are more than 1 QE of the session
+-- in the primary
+4: create temp table sync_t11(a int, b int) distributed by(b);
+CREATE
+4: create temp table sync_t12(a int, b int) distributed by(a);
+CREATE
+
+-- The join will create 2 slices on each primary, and 1 entrydb on the coordinator.
+-- So, every primary and the coordinator should trigger 2 SET/RESET
+-- We'll test SET/RESET xxx will be called for all QEs in the current session.
+4: select relname from sync_t11, sync_t12, pg_class;
+ relname 
+---------
+(0 rows)
+
+4: select gp_inject_fault('set_variable_fault', 'skip', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+4: set statement_mem = '12MB';
+SET
+4: select gp_wait_until_triggered_fault('set_variable_fault', 2, dbid) from gp_segment_configuration where role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+ Success:                      
+(4 rows)
+4: select gp_inject_fault('set_variable_fault', 'reset', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+
+4: select gp_inject_fault('reset_variable_fault', 'skip', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+4: reset statement_mem;
+RESET
+4: select gp_wait_until_triggered_fault('reset_variable_fault', 2, dbid) from gp_segment_configuration where role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+ Success:                      
+(4 rows)
+4: select gp_inject_fault('reset_variable_fault', 'reset', dbid) from gp_segment_configuration where role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+4q: ... <quitting>
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -277,3 +277,6 @@ test: standby_replay_dtx_info
 
 # Test for concurrent vacuum with delete
 test: concurrent_vacuum_with_delete
+
+# test if GUC is synchronized from the QD to QEs.
+test: sync_guc

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -1,0 +1,72 @@
+-- TEST 1: Fix Github issue https://github.com/greenplum-db/gpdb/issues/9208
+1: create schema sync_np1;
+1: create schema sync_np2;
+1: CREATE OR REPLACE FUNCTION public.segment_setting(guc text)
+    RETURNS SETOF text EXECUTE ON ALL SEGMENTS AS $$
+    BEGIN RETURN NEXT pg_catalog.current_setting(guc); END
+    $$ LANGUAGE plpgsql;
+1q:
+-- The SET command will create a Gang on the primaries, and the GUC
+-- values should be the same on all QD/QEs.
+2: show search_path;
+2: set search_path = 'sync_np1,sync_np2';
+
+-- The `reset_val` of `search_path` should be synchronized from the QD,
+-- so, the GUC value will be also synchronized with the QD after RESET.
+-- If the search_path is inconsistent between the QD and QEs after RESET,
+-- creating the function will fail.
+2: reset search_path;
+2: select public.segment_setting('search_path');
+2: create or replace function sync_f1() returns int as $$ select 1234; $$language sql;
+2: select sync_f1();
+2: drop function sync_f1();
+2: drop schema sync_np1;
+2: drop schema sync_np2;
+2q:
+
+-- TEST 2: Fix Github issue https://github.com/greenplum-db/gpdb/issues/685
+-- `gp_select_invisible` is default to false. SET command will dispatch
+-- the GUC's `reset_val` and changed value to the created Gang. If the QE(s)
+-- use the incorrect `reset_val`, its value will be inconsistent with the QD's,
+-- i.e. the `gp_select_invisible` is still false on the QEs.
+3: show gp_select_invisible;
+3: set gp_select_invisible = on;
+3: reset gp_select_invisible;
+3: select public.segment_setting('gp_select_invisible');
+3: create table sync_t1(i int);
+3: insert into sync_t1 select i from generate_series(1,10)i;
+3: delete from sync_t1;
+3: select * from sync_t1;
+3: drop table sync_t1;
+3q:
+
+1: drop function public.segment_setting(guc text);
+1q:
+
+-- TEST 3: make sure all QEs call RESET if there are more than 1 QE of the session
+-- in the primary
+4: create temp table sync_t11(a int, b int) distributed by(b);
+4: create temp table sync_t12(a int, b int) distributed by(a);
+
+-- The join will create 2 slices on each primary, and 1 entrydb on the coordinator.
+-- So, every primary and the coordinator should trigger 2 SET/RESET
+-- We'll test SET/RESET xxx will be called for all QEs in the current session.
+4: select relname from sync_t11, sync_t12, pg_class;
+
+4: select gp_inject_fault('set_variable_fault', 'skip', dbid)
+     from gp_segment_configuration where role='p';
+4: set statement_mem = '12MB';
+4: select gp_wait_until_triggered_fault('set_variable_fault', 2, dbid)
+     from gp_segment_configuration where role='p';
+4: select gp_inject_fault('set_variable_fault', 'reset', dbid)
+     from gp_segment_configuration where role='p';
+
+4: select gp_inject_fault('reset_variable_fault', 'skip', dbid)
+     from gp_segment_configuration where role='p';
+4: reset statement_mem;
+4: select gp_wait_until_triggered_fault('reset_variable_fault', 2, dbid)
+     from gp_segment_configuration where role='p';
+4: select gp_inject_fault('reset_variable_fault', 'reset', dbid)
+     from gp_segment_configuration where role='p';
+4q:
+


### PR DESCRIPTION
When we change some GUC values and reset them later in
a session. The GUC values may be inconsistent among QD and/or QEs.
The key steps of current GUC settings are:
1. The QD dispatches its current `sync`ed GUC values(as startup
    options) to create QEs.
2. The QE sets the GUCs' `reset_val` to the options passsed
    from the QD during its process initialization.
2.5 When the QD dispatches `SET XXX=YYY` for an existing QE,
    the QE will set the GUC's current value to YYY, `reset_val`
    is unchanged. Because its guc-source is PGC_S_SESSION.
3. When the QE receives `RESET XXX`, it resets the GUC's value to
    its `reset_val`.

The problem happens in the step 1, which causes the `reset_val`s
between QD and QEs inconsistent if the QD changed the GUC before
creating the QE(s).

The fix is to send the GUC's `reset_val` to create QEs, and we also
have another option(diff_options) to update the changed GUCs. So,
both `reset_val` and current value are consistent among QD and QEs
if the GUC needs to be synchronized.

Reviewed-by: Zhenghua Lyu <zlyu@vmware.com>
Reviewed-by: Lei (Alexandra) Wang <walexandra@vmware.com>
Reviewed-by: Paul Guo <paulguo@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
