### PR TITLE
6X: pt_ctl: rework the wrapper function

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -331,9 +331,7 @@ def check_and_start_standby():
     standby = array.standbyMaster
     gp.start_standbymaster(standby.hostname,
                            standby.datadir,
-                           standby.port,
-                           standby.dbid,
-                           array.getNumSegmentContents())
+                           standby.port)
     logger.info("Successfully started standby master")
 
 #-------------------------------------------------------------------------
@@ -405,9 +403,7 @@ def create_standby(options):
             g_init_standby_state = INIT_STANDBY_STATE_STARTING_STANDBY
             gp.start_standbymaster(standby.hostname,
                                    standby.datadir,
-                                   standby.port,
-                                   standby.dbid,
-                                   array.getNumSegmentContents())
+                                   standby.port)
         except Exception, ex:
             raise GpInitStandbyException('failed to start standby')
 

--- a/src/bin/pg_ctl/t/001_start_stop.pl
+++ b/src/bin/pg_ctl/t/001_start_stop.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Config;
 use TestLib;
-use Test::More tests => 16;
+use Test::More tests => 18;
 
 my $tempdir = TestLib::tempdir;
 my $tempdir_short = TestLib::tempdir_short;
@@ -48,3 +48,27 @@ command_ok([ 'pg_ctl', 'restart', '-D', "$tempdir/data", '-w', '-m', 'fast' ],
 	'pg_ctl restart with server running');
 
 system_or_bail 'pg_ctl', 'stop', '-D', "$tempdir/data", '-m', 'fast';
+
+# gpdb specific: verify that --wrapper and --wrapper-args work as expected
+if (not $windows_os)
+{
+	my $keypair = 'TESTKEY=hello';
+	my $file;
+
+	# launch the server with the env command as a wrapper
+	command_ok([ 'pg_ctl', 'start', '-D', "$tempdir/data", '-w',
+			'--wrapper=env', "--wrapper-args=$keypair",
+			'-o', '-c gp_role=utility --gp_dbid=-1 --gp_contentid=-1' ],
+		'pg_ctl start --wrapper');
+
+	# read the pid
+	open($file, '<', "$tempdir/data/postmaster.pid");
+	my $pid = 0 + <$file>;
+	close($file);
+
+	# verify that the envvar is successfully set
+	command_ok([ 'grep', '-z', $keypair, "/proc/$pid/environ" ],
+		'verify wrapper effect');
+
+	system_or_bail 'pg_ctl', 'stop', '-D', "$tempdir/data", '-m', 'fast';
+}


### PR DESCRIPTION
pg_ctl supports two internal cmdline arguments, --wrapper and
--wrapper-args, they are gpdb specific arguments for debugging purpose,
however we lost them since gpdb 5 during the postgres merging. The
arguments are still accepted, just not being used.

Now we bring the function back.

Co-Authored-By: Ning Yu <nyu@pivotal.io>
Co-Authored-By: Adam Lee <adlee@vmware.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change