### PR TITLE
Convert float8 with double instead of long double

### DIFF
--- a/src/backend/utils/adt/float.c
+++ b/src/backend/utils/adt/float.c
@@ -339,7 +339,7 @@ float8in(PG_FUNCTION_ARGS)
 }
 
 /* Convenience macro: set *have_error flag (if provided) or throw error */
-#define RETURN_ERROR(throw_error) \
+#define RETURN_ERROR(throw_error, have_error) \
 do { \
 	if (have_error) { \
 		*have_error = true; \
@@ -375,9 +375,11 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 							const char *type_name, const char *orig_string,
 							bool *have_error)
 {
-	long double		val;
+	double		val;
 	char	   *endptr;
-	bool 		literal_inf = true;
+
+	if (have_error)
+		*have_error = false;
 
 	/* skip leading whitespace */
 	while (*num != '\0' && isspace((unsigned char) *num))
@@ -391,10 +393,11 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 		RETURN_ERROR(ereport(ERROR,
 							 (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 							  errmsg("invalid input syntax for type %s: \"%s\"",
-									 type_name, orig_string))));
+									 type_name, orig_string))),
+					 have_error);
 
 	errno = 0;
-	val = strtold(num, &endptr);
+	val = strtod(num, &endptr);
 
 	/* did we not see anything that looks like a double? */
 	if (endptr == num || errno != 0)
@@ -416,7 +419,7 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 			val = get_float8_nan();
 			endptr = num + 3;
 		}
-		else if (pg_strncasecmp(num, "Infinity", 8) == 0 || pg_strncasecmp(num, "+Infinity", 9) == 0)
+		else if (pg_strncasecmp(num, "Infinity", 8) == 0)
 		{
 			val = get_float8_infinity();
 			endptr = num + 8;
@@ -466,9 +469,9 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 				errnumber[endptr - num] = '\0';
 				RETURN_ERROR(ereport(ERROR,
 									 (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-									  errmsg("\"%s\" is out of range for "
-											 "type double precision",
-											 errnumber))));
+									  errmsg("\"%s\" is out of range for type double precision",
+											 errnumber))),
+							 have_error);
 			}
 		}
 		else
@@ -476,20 +479,9 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 								 (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 								  errmsg("invalid input syntax for type "
 										 "%s: \"%s\"",
-										 type_name, orig_string))));
+										 type_name, orig_string))),
+						 have_error);
 	}
-#ifdef HAVE_BUGGY_SOLARIS_STRTOD
-	else
-	{
-		/*
-		 * Many versions of Solaris have a bug wherein strtod sets endptr to
-		 * point one byte beyond the end of the string when given "inf" or
-		 * "infinity".
-		 */
-		if (endptr != num && endptr[-1] == '\0')
-			endptr--;
-	}
-#endif							/* HAVE_BUGGY_SOLARIS_STRTOD */
 
 	/* skip trailing whitespace */
 	while (*endptr != '\0' && isspace((unsigned char) *endptr))
@@ -503,32 +495,8 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 							 (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 							  errmsg("invalid input syntax for type "
 									 "%s: \"%s\"",
-									 type_name, orig_string))));
-
-	/*
-	 * strtod does not support values from 1e-323 to 1e-308 for double datatype in rhel6
-	 * due to changes in glibc. In order to overcome this issue we use strtold to parse
-	 * the string and store it in long double so that we get higher precision. We check if
-	 * this value is within allowed range for double using the below two checks:- 
-	 *
-	 * 1) Overflow - When we try to store a value > 1e308 in a double datatype, it gets represented 
-	 * internally as "inf". Hence in order to check for overflow, we use the isinf() method in order
-	 * to check if (double) val has overflowed. But "inf" is a legitimate value for float8, hence if the
-	 * user entered "inf"/"Infinity" we allow it. Otherwise we treat it as overflow.
-	 *
-	 * 2) Underflow - When we try to store a value < 1e-323, it gets converted to a 0.0. But "0.0" is a 
-	 * legitimate value allowed by float8 datatype. Hence we examine if the val is > 0 or < 0 with higher 
-	 * precision (as long double). Again, 0.0 is allowed for float8. If the user entered 0.0, val will be 0.0
-	 * in both higher precision and when rounded down and we allow it. Otherwise in higher precision, 
-	 * val will be > 0 or < 0 and when rounded down to double it will be 0 which is treated as underflow.
-	 */
-
-	if ( pg_strncasecmp(num, "Infinity", 8) != 0  && pg_strncasecmp(num, "-Infinity", 9) != 0 &&\
-		 pg_strncasecmp(num, "Inf", 3) != 0 && pg_strncasecmp(num, "-Inf", 4) != 0 &&\
-		 pg_strncasecmp(num, "+Infinity", 9) != 0 && pg_strncasecmp(num, "+Inf", 4) != 0 )
-		literal_inf = false;
-
-	CHECKFLOATVAL((double) val, literal_inf, !(val > 0 || val < 0));
+									 type_name, orig_string))),
+					 have_error);
 
 	return val;
 }

--- a/src/test/regress/expected/float8.out
+++ b/src/test/regress/expected/float8.out
@@ -9,27 +9,27 @@ INSERT INTO FLOAT8_TBL(f1) VALUES ('1.2345678901234e+200');
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1.2345678901234e-200');
 -- test for underflow and overflow handling
 SELECT '10e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "10e400" is out of range for type double precision
 LINE 1: SELECT '10e400'::float8;
                ^
 SELECT '-10e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "-10e400" is out of range for type double precision
 LINE 1: SELECT '-10e400'::float8;
                ^
 SELECT '1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: SELECT '1e309'::float8;
                ^
 SELECT '10e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "10e-400" is out of range for type double precision
 LINE 1: SELECT '10e-400'::float8;
                ^
 SELECT '-10e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "-10e-400" is out of range for type double precision
 LINE 1: SELECT '-10e-400'::float8;
                ^
 SELECT '1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: SELECT '1e-324'::float8;
                ^
 SELECT '1e308'::float8;
@@ -645,27 +645,27 @@ SELECT atanh(float8 'nan');
 RESET extra_float_digits;
 -- test for over- and underflow
 INSERT INTO FLOAT8_TBL(f1) VALUES ('10e400');
-ERROR:  value out of range: overflow
+ERROR:  "10e400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('10e400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e400');
-ERROR:  value out of range: overflow
+ERROR:  "-10e400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e309');
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('1e309');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('10e-400');
-ERROR:  value out of range: underflow
+ERROR:  "10e-400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('10e-400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e-400');
-ERROR:  value out of range: underflow
+ERROR:  "-10e-400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e-400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e-324');
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('1e-324');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e308');
@@ -681,19 +681,19 @@ INSERT INTO FLOAT8_TBL(f1) VALUES ('+naN'::float8);
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-naN'::float8);
 -- test for over- and underflow with update statement
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-324'::fl...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e309'::flo...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-400" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-400'::fl...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e400" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e400'::flo...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='0.0'::float8;
@@ -707,19 +707,19 @@ UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='+naN'::float8;
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='-naN'::float8;
 -- test for over- and underflow with delete statement
 DELETE FROM FLOAT8_TBL WHERE f1='1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e-324'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e309'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e400" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e400'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-400" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e-400'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='0.0'::float8;

--- a/src/test/regress/expected/point.out
+++ b/src/test/regress/expected/point.out
@@ -32,7 +32,7 @@ ERROR:  invalid input syntax for type point: "(10.0,10.0"
 LINE 1: INSERT INTO POINT_TBL(f1) VALUES ('(10.0,10.0');
                                           ^
 INSERT INTO POINT_TBL(f1) VALUES ('(10.0, 1e+500)');	-- Out of range
-ERROR:  value out of range: overflow
+ERROR:  "1e+500" is out of range for type double precision
 LINE 1: INSERT INTO POINT_TBL(f1) VALUES ('(10.0, 1e+500)');
                                           ^
 SELECT '' AS six, * FROM POINT_TBL;


### PR DESCRIPTION
It seems that GPDB faced a glibc bug on RedHat 6 with denormalized numbers and fixed it using two-step conversion in `float8in()`:

- text to long double
- long double to double after denormalized numbers validation

This differs from PG approach where we rely on libc and make the direct conversion to double. RedHat 6 seems to be an old system and there is no much sense to differ from upstream and have additional performance penalty converting long double to double in a two-step manner and making additional checks.

There is another problem with this code - long double can have problems on some architectures that are currently not supported by GPDB, but where it can be ported in the future. Originally this problem was detected as research about porting GPDB to [PowerPC](https://gcc.gnu.org/wiki/Ieee128PowerPC): it doesn't have analogue of Intel 80-bit long double with 63-bit mantissa and extended range between 1.0E-4932W and 1.0E+4932W. Instead, PowerPC has an extended double type combined from two doubles with 106-bit mantissa and the same range as double provides 1.0E−323L - 1.0E+308L. As a result, we can't use the same validation logic for the numbers near +/- infinity as it is possible to do on Intel. So this GPDB specific code doesn't help us to solve
the problem on RedHat 6 on PowerPC and fails the float test.

So, let's get rid of it and return the code to PG approach with a double.