### PR TITLE
Gpinitstandby gprecoverseg gpstart gpstop  fails when there is a banner  on bashrc  --6x

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -70,13 +70,13 @@ def get_postmaster_pid_locally(datadir):
         return -1
 
 def getPostmasterPID(hostname, datadir):
-    cmdStr="ps -ef | grep postgres | grep -v grep | awk '{print $2}' | grep \\`cat %s/postmaster.pid | head -1\\` || echo -1" % (datadir)
+    cmdStr="echo 'START_CMD_OUTPUT';ps -ef | grep postgres | grep -v grep | awk '{print $2}' | grep \\`cat %s/postmaster.pid | head -1\\` || echo -1" % (datadir)
     name="get postmaster pid"
     cmd=Command(name,cmdStr,ctxt=REMOTE,remoteHost=hostname)
     try:
         cmd.run(validateAfter=True)
         sout=cmd.get_results().stdout.lstrip(' ')
-        return int(sout.split()[1])
+        return int(sout.split('START_CMD_OUTPUT\n')[1].split()[1])
     except:
         return -1
 
@@ -1604,7 +1604,7 @@ class GpRecoverSeg(Command):
 class IfAddrs:
     @staticmethod
     def list_addrs(hostname=None, include_loopback=False):
-        cmd = ['%s/libexec/ifaddrs' % GPHOME]
+        cmd = ['echo "START_CMD_OUTPUT";%s/libexec/ifaddrs' % GPHOME]
         if not include_loopback:
             cmd.append('--no-loopback')
         if hostname:
@@ -1614,7 +1614,7 @@ class IfAddrs:
             args = cmd
 
         result = subprocess.check_output(args)
-        return result.splitlines()
+        return result.split('START_CMD_OUTPUT\n')[1].splitlines()
 
 if __name__ == '__main__':
 

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -166,7 +166,10 @@ class PgControlData(Command):
             self.data = {}
             for l in self.results.stdout.split('\n'):
                 if len(l) > 0:
-                    (n,v) = l.split(':', 1)
+                    split_line = l.split(':', 1)
+                    # avoid ValueErrors when there is no value to the key
+                    n = split_line[0]
+                    v = split_line[1] if len(split_line) == 2 else ''
                     self.data[n.strip()] = v.strip() 
         return self.data[name]
 

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -488,17 +488,17 @@ class RemoveGlob(Command):
 class FileDirExists(Command):
     def __init__(self, name, directory, ctxt=LOCAL, remoteHost=None):
         self.directory = directory
-        cmdStr = """python  -c "import os; print os.path.exists('%s')" """ % directory
+        cmdStr = "[ -d '%s' ]" % directory
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
     def remote(name, remote_host, directory):
         cmd = FileDirExists(name, directory, ctxt=REMOTE, remoteHost=remote_host)
-        cmd.run(validateAfter=True)
+        cmd.run(validateAfter=False)
         return cmd.filedir_exists()
 
     def filedir_exists(self):
-        return self.results.stdout.strip().upper() == 'TRUE'
+        return (not self.results.rc)
 
 
 # -------------scp------------------
@@ -586,20 +586,20 @@ class InterfaceAddrs(Command):
         grep = findCmdInPath('grep')
         awk = findCmdInPath('awk')
         cut = findCmdInPath('cut')
-        cmdStr = '%s|%s "inet "|%s -v "127.0.0"|%s \'{print \$2}\'|%s -d: -f2' % (ifconfig, grep, grep, awk, cut)
+        cmdStr = 'echo "START_CMD_OUTPUT";%s|%s "inet "|%s -v "127.0.0"|%s \'{print \$2}\'|%s -d: -f2' % (ifconfig, grep, grep, awk, cut)
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
     @staticmethod
     def local(name):
         cmd = InterfaceAddrs(name)
         cmd.run(validateAfter=True)
-        return cmd.get_results().stdout.split()
+        return cmd.get_results().stdout.split('START_CMD_OUTPUT\n')[1].split()
 
     @staticmethod
     def remote(name, remoteHost):
         cmd = InterfaceAddrs(name, ctxt=REMOTE, remoteHost=remoteHost)
         cmd.run(validateAfter=True)
-        return cmd.get_results().stdout.split()
+        return cmd.get_results().stdout.split('START_CMD_OUTPUT\n')[1].split()
 
 
 # --------------tcp port is active -----------------------

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -26,7 +26,7 @@ def get_unreachable_segment_hosts(hosts, num_workers):
     for item in pool.getCompletedItems():
         result = item.get_results()
         if result.rc == 0:
-            host = result.stdout.strip()
+            host = result.stdout.strip().split('\n')[-1]
             reachable_hosts.add(host)
 
     unreachable_hosts = list(set(hosts).difference(reachable_hosts))

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_utils.py
@@ -109,11 +109,11 @@ class UtilsTestCase(GpTestCase):
     def test_RemoteOperation_logger_debug(self, mock_split, mock_cmd, mock_lods, mock_debug):
         # We want to lock down the Command's get_results().stdout.
         cmd_instance = mock_cmd.return_value
-        cmd_instance.get_results.return_value.stdout = 'output'
+        cmd_instance.get_results.return_value.stdout = 'START_CMD_OUTPUT\noutput'
 
         mockRemoteOperation = RemoteOperation(operation=TestOperation(), host="sdw1", msg_ctx="dbid 2")
         mockRemoteOperation.execute()
-        mock_debug.assert_has_calls([mock.call("Output for dbid 2 on host sdw1: output")])
+        mock_debug.assert_has_calls([mock.call("Output for dbid 2 on host sdw1: START_CMD_OUTPUT\noutput")])
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/operations/utils.py
+++ b/gpMgmt/bin/gppylib/operations/utils.py
@@ -45,14 +45,14 @@ class RemoteOperation(Operation):
         execname = os.path.split(sys.argv[0])[-1]
         pickled_execname = pickle.dumps(execname) 
         pickled_operation = pickle.dumps(self.operation)
-        cmd = Command('pickling an operation', '$GPHOME/sbin/gpoperation.py',
+        cmd = Command('pickling an operation', 'echo "START_CMD_OUTPUT"; $GPHOME/sbin/gpoperation.py',
                       ctxt=REMOTE, remoteHost=self.host, stdin = pickled_execname + pickled_operation)
         cmd.run(validateAfter=True)
         msg =  "Output on host %s: %s" % (self.host, cmd.get_results().stdout)
         if self.msg_ctx:
             msg = "Output for %s on host %s: %s" % (self.msg_ctx, self.host, cmd.get_results().stdout)
         logger.debug(msg)
-        ret = self.operation.ret = pickle.loads(cmd.get_results().stdout)
+        ret = self.operation.ret = pickle.loads(cmd.get_results().stdout.split('START_CMD_OUTPUT\n')[1])
         if isinstance(ret, Exception):
             raise ret
         return ret

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -100,3 +100,10 @@ Feature: Tests for gpinitstandby feature
         And the user runs gpinitstandby with options " "
         Then gpinitstandby should return a return code of 0
         And verify that the file "pg_hba.conf" in the master data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"
+
+    Scenario: gpinitstandby should not throw error when banner exists on the hsot
+        Given the database is running
+        And the standby is not initialized
+        When the user sets banner on host
+        And the user runs gpinitstandby with options " "
+        Then gpinitstandby should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -203,6 +203,19 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+    Scenario: gprecoverseg should not return error when banner configured on host
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        When the user sets banner on host
+        And user stops all mirror processes
+        And user can start transactions
+        When the user runs "gprecoverseg -a"
+        Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
+
     @demo_cluster
     @concourse_cluster
     Scenario Outline: <scenario> recovery skips unreachable segments

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -364,6 +364,13 @@ def impl(context, command):
     run_gpcommand(context, command)
 
 
+@when('the user sets banner on host')
+def impl(context):
+    file = '/etc/bashrc'
+    command = "echo 'echo \"banner test\"' >> %s; source %s" % (file, file)
+    run_cmd(command)
+
+
 @given('the user asynchronously sets up to end {process_name} process in {secs} seconds')
 @when('the user asynchronously sets up to end {process_name} process in {secs} seconds')
 def impl(context, process_name, secs):


### PR DESCRIPTION
Management utils are fails when user configured banner through bashrc
    gprecoverseg and gpinitstandby gpstart and gpstop  are addressed as part of this PR. Most of
    the changes are related to parsing failures which are addresed below.

    Info : Backporting changes from master to 6X with minor changes

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
