### PR TITLE
Inclusion of unit tests for more test coverage of gpstart

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -20,11 +20,10 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
 
 if [ ! -L "${SCRIPT_DIR}" ]; then
-	GPDB_DIR=$(basename "${SCRIPT_DIR}")
+    GPHOME=${SCRIPT_DIR}
 else
-	GPDB_DIR=$(basename "$(readlink "${SCRIPT_DIR}")")
+    GPHOME=$(readlink "${SCRIPT_DIR}")
 fi
-GPHOME=$(dirname "${SCRIPT_DIR}")/"${GPDB_DIR}"
 EOF
 
 cat <<"EOF"

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -178,7 +178,7 @@ class GpStart(GpTestCase):
         self.subject.logger.info.assert_any_call('Coordinator Started...')
         self.assertEqual(return_code, 0)
 
-     def test_option_coordinator_exits_with_user_abort(self):
+    def test_option_coordinator_exits_with_user_abort(self):
         sys.argv = ["gpstart", "-m"]
         self.mock_userinput.ask_yesno.return_value = False
         self.subject.unix.PgPortIsActive.local.return_value = False

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -178,6 +178,65 @@ class GpStart(GpTestCase):
         self.subject.logger.info.assert_any_call('Coordinator Started...')
         self.assertEqual(return_code, 0)
 
+     def test_option_coordinator_exits_with_user_abort(self):
+        sys.argv = ["gpstart", "-m"]
+        self.mock_userinput.ask_yesno.return_value = False
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        return_code = 4
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        with self.assertRaises(UserAbortedException):
+            return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
+        self.assertEqual(return_code, 4)
+
+    def test_gpstart_success_without_auto_accept(self):
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with Greenplum instance startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Database successfully started')
+        self.assertEqual(return_code, 0)
+
+    def test_gpstart_success_with_auto_accept(self):
+        sys.argv = ["gpstart", "-a"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 0)
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Database successfully started')
+        self.assertEqual(return_code, 0)
+
+    def test_gpstart_exits_with_user_abort(self):
+        self.mock_userinput.ask_yesno.return_value = False
+        self.subject.unix.PgPortIsActive.local.return_value = False
+        return_code = 4
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        with self.assertRaises(UserAbortedException):
+            return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with Greenplum instance startup', 'N')
+        self.assertEqual(return_code, 4)
+
     def test_output_to_stdout_and_log_for_coordinator_only_happens_before_heap_checksum(self):
         sys.argv = ["gpstart", "-m"]
         self.mock_userinput.ask_yesno.return_value = True


### PR DESCRIPTION
Patching the below gaps in unit tests of gpstart utility

1. gpstart should success with auto accept
2. gpstart should success without auto accept
3. gpstart should exit when user abort
4. gpstart with master only option should exit when user abort

Co-authored-by: M Hari krishna <hmaddileti@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
