### PR TITLE
Gp vmem mods

### DIFF
--- a/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
@@ -85,12 +85,18 @@
       </sectiondiv>
       <sectiondiv>
         <p><b>Configuring vm.overcommit_ratio when Resource Queue-Based Resource Management is Active</b></p>
-        <p>To calculate a safe value for <codeph>vm.overcommit_ratio</codeph> when resource queue-based resource management is active, first determine the
-          total memory available to Greenplum Database processes, <codeph>gp_vmem_rq</codeph>,
-          with this
-          formula:<codeblock>gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></p>
+        <p>To calculate a safe value for <codeph>vm.overcommit_ratio</codeph> when resource
+          queue-based resource management is active, first determine the total memory available to
+          Greenplum Database processes, <codeph>gp_vmem_rq</codeph>.<ul id="ul_kpv_hkb_sqb">
+            <li>If the total sytem memory is less than 256 GB, use this
+              formula:<codeblock>gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></li>
+            <li>If the total system memory is equal to or higher than 256 GB, use this
+              formula:<codeblock>gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17</codeblock></li>
+          </ul></p>
         <p>where <codeph>SWAP</codeph> is the swap space on the host in GB, and <codeph>RAM</codeph>
-          is the number of GB of RAM installed on the host. When resource queue-based resource management is active, use <codeph>gp_vmem_rq</codeph> to calculate the <codeph>vm.overcommit_ratio</codeph> value with this
+          is the number of GB of RAM installed on the host. </p>
+        <p>When resource queue-based resource management is active, use <codeph>gp_vmem_rq</codeph>
+          to calculate the <codeph>vm.overcommit_ratio</codeph> value with this
           formula:<codeblock>vm.overcommit_ratio = (RAM - 0.026 * gp_vmem_rq) / RAM</codeblock></p>
       </sectiondiv>
       </section>

--- a/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
+++ b/gpdb-doc/dita/admin_guide/wlmgmt_intro.xml
@@ -88,9 +88,9 @@
         <p>To calculate a safe value for <codeph>vm.overcommit_ratio</codeph> when resource
           queue-based resource management is active, first determine the total memory available to
           Greenplum Database processes, <codeph>gp_vmem_rq</codeph>.<ul id="ul_kpv_hkb_sqb">
-            <li>If the total sytem memory is less than 256 GB, use this
+            <li>If the total system memory is less than 256 GB, use this
               formula:<codeblock>gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></li>
-            <li>If the total system memory is equal to or higher than 256 GB, use this
+            <li>If the total system memory is equal to or greater than 256 GB, use this
               formula:<codeblock>gp_vmem_rq = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17</codeblock></li>
           </ul></p>
         <p>where <codeph>SWAP</codeph> is the swap space on the host in GB, and <codeph>RAM</codeph>

--- a/gpdb-doc/dita/best_practices/summary.xml
+++ b/gpdb-doc/dita/best_practices/summary.xml
@@ -88,9 +88,9 @@
             id="ul_bdj_xkq_kv">
             <li><codeph>gp_vmem</codeph> – the total memory available to Greenplum Database<ul
                 id="ul_wbd_fjb_sqb">
-                <li>If the total sytem memory is less than 256 GB, use this
+                <li>If the total system memory is less than 256 GB, use this
                   formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></li>
-                <li>If the total system memory is equal to or higher than 256 GB, use this
+                <li>If the total system memory is equal to or greater than 256 GB, use this
                   formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17</codeblock></li>
               </ul>where <codeph>SWAP</codeph> is the host's swap space in GB, and
                 <codeph>RAM</codeph> is the host's RAM in GB.</li>
@@ -103,10 +103,10 @@
         <li>In a scenario where a large number of workfiles are generated calculate the
             <codeph>gp_vmem</codeph> factor with this formulat to account for the workfiles.<ul
             id="ul_lx5_3jb_sqb">
-            <li>If the total sytem memory is less than 256
+            <li>If the total system memory is less than 256
               GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB *
       <varname>total_#_workfiles</varname>))) / 1.7</codeblock></li>
-            <li>If the total system memory is equal to or higher than 256
+            <li>If the total system memory is equal to or greater than 256
               GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB *
       <varname>total_#_workfiles</varname>))) / 1.17</codeblock></li>
           </ul>

--- a/gpdb-doc/dita/best_practices/summary.xml
+++ b/gpdb-doc/dita/best_practices/summary.xml
@@ -86,20 +86,30 @@
           can allocate for <i>all</i> work being done in each segment database. </li>
         <li> You can use <codeph>gp_vmem_protect_limit</codeph> by calculating:<ul
             id="ul_bdj_xkq_kv">
-            <li><codeph>gp_vmem</codeph> – the total memory available to Greenplum
-              Database<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock>where
-                <codeph>SWAP</codeph> is the host's swap space in GB, and <codeph>RAM</codeph> is
-              the host's RAM in GB</li>
+            <li><codeph>gp_vmem</codeph> – the total memory available to Greenplum Database<ul
+                id="ul_wbd_fjb_sqb">
+                <li>If the total sytem memory is less than 256 GB, use this
+                  formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></li>
+                <li>If the total system memory is equal to or higher than 256 GB, use this
+                  formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17</codeblock></li>
+              </ul>where <codeph>SWAP</codeph> is the host's swap space in GB, and
+                <codeph>RAM</codeph> is the host's RAM in GB.</li>
             <li><codeph>max_acting_primary_segments</codeph> – the maximum number of primary
               segments that could be running on a host when mirror segments are activated due to a
-              host or segment failure</li>
+              host or segment failure.</li>
             <li><codeph>gp_vmem_protect_limit</codeph><codeblock>gp_vmem_protect_limit = gp_vmem / acting_primary_segments</codeblock>Convert
               to MB to set the value of the configuration parameter. </li>
           </ul></li>
         <li>In a scenario where a large number of workfiles are generated calculate the
-            <codeph>gp_vmem</codeph> factor with this formulat to account for the
-          workfiles:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB *
-      <varname>total_#_workfiles</varname>))) / 1.7</codeblock>
+            <codeph>gp_vmem</codeph> factor with this formulat to account for the workfiles.<ul
+            id="ul_lx5_3jb_sqb">
+            <li>If the total sytem memory is less than 256
+              GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB *
+      <varname>total_#_workfiles</varname>))) / 1.7</codeblock></li>
+            <li>If the total system memory is equal to or higher than 256
+              GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB *
+      <varname>total_#_workfiles</varname>))) / 1.17</codeblock></li>
+          </ul>
         </li>
         <li> Never set <codeph>gp_vmem_protect_limit</codeph> too high or larger than the physical
           RAM on the system. </li>

--- a/gpdb-doc/dita/best_practices/sysconfig.xml
+++ b/gpdb-doc/dita/best_practices/sysconfig.xml
@@ -135,11 +135,14 @@ kernel.shmall = 197951838</codeblock>
         amount of memory that all active postgres processes for a single segment can consume at any
         given time. Queries that exceed this amount will fail. Use the following calculations to
         estimate a safe value for <codeph>gp_vmem_protect_limit</codeph>.<ol id="ol_osx_srq_kv">
-          <li>Calculate <codeph>gp_vmem</codeph>, the host memory available to Greenplum Database,
-            using this
-            formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock>where
-              <codeph>SWAP</codeph> is the host's swap space in GB and <codeph>RAM</codeph> is the
-            RAM installed on the host in GB.</li>
+          <li>Calculate <codeph>gp_vmem</codeph>, the host memory available to Greenplum
+              Database.<ul id="ul_pqy_rjb_sqb">
+              <li>If the total sytem memory is less than 256 GB, use this
+                formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></li>
+              <li>If the total system memory is equal to or higher than 256 GB, use this
+                formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17</codeblock></li>
+            </ul>where <codeph>SWAP</codeph> is the host's swap space in GB and <codeph>RAM</codeph>
+            is the RAM installed on the host in GB.</li>
           <li>Calculate <codeph>max_acting_primary_segments</codeph>. This is the maximum number of
             primary segments that can be running on a host when mirror segments are activated due to
             a segment or host failure on another host in the cluster. With mirrors arranged in a
@@ -155,8 +158,13 @@ kernel.shmall = 197951838</codeblock>
         </ol>
       </p>
       <p dir="ltr">For scenarios where a large number of workfiles are generated, adjust the
-        calculation for <codeph>gp_vmem</codeph> to account for the
-        workfiles:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.7</codeblock></p>
+        calculation for <codeph>gp_vmem</codeph> to account for the workfiles.<ul
+          id="ul_af1_zjb_sqb">
+          <li>If the total sytem memory is less than 256
+            GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.7</codeblock></li>
+          <li>If the total system memory is equal to or higher than 256
+            GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.17</codeblock></li>
+        </ul></p>
       <p dir="ltr">For information about monitoring and managing workfile usage, see the
           <i>Greenplum Database Administrator Guide</i>.</p>
       <p dir="ltr">You can calculate the value of the <codeph>vm.overcommit_ratio</codeph> operating

--- a/gpdb-doc/dita/best_practices/sysconfig.xml
+++ b/gpdb-doc/dita/best_practices/sysconfig.xml
@@ -137,9 +137,9 @@ kernel.shmall = 197951838</codeblock>
         estimate a safe value for <codeph>gp_vmem_protect_limit</codeph>.<ol id="ol_osx_srq_kv">
           <li>Calculate <codeph>gp_vmem</codeph>, the host memory available to Greenplum
               Database.<ul id="ul_pqy_rjb_sqb">
-              <li>If the total sytem memory is less than 256 GB, use this
+              <li>If the total system memory is less than 256 GB, use this
                 formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.7</codeblock></li>
-              <li>If the total system memory is equal to or higher than 256 GB, use this
+              <li>If the total system memory is equal to or greater than 256 GB, use this
                 formula:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17</codeblock></li>
             </ul>where <codeph>SWAP</codeph> is the host's swap space in GB and <codeph>RAM</codeph>
             is the RAM installed on the host in GB.</li>
@@ -160,9 +160,9 @@ kernel.shmall = 197951838</codeblock>
       <p dir="ltr">For scenarios where a large number of workfiles are generated, adjust the
         calculation for <codeph>gp_vmem</codeph> to account for the workfiles.<ul
           id="ul_af1_zjb_sqb">
-          <li>If the total sytem memory is less than 256
+          <li>If the total system memory is less than 256
             GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.7</codeblock></li>
-          <li>If the total system memory is equal to or higher than 256
+          <li>If the total system memory is equal to or greater than 256
             GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.17</codeblock></li>
         </ul></p>
       <p dir="ltr">For information about monitoring and managing workfile usage, see the

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -5831,8 +5831,12 @@
       <p>To prevent over-allocation of memory, these calculations can estimate a safe
           <codeph>gp_vmem_protect_limit</codeph> value.</p>
       <p>First calculate the value <varname>gp_vmem</varname>. This is the Greenplum Database memory
-        available on a
-        host<codeblock><varname>gp_vmem</varname> = ((<varname>SWAP</varname> + <varname>RAM</varname>) – (7.5GB + 0.05 * <varname>RAM</varname>)) / 1.7</codeblock></p>
+        available on a host.<ul id="ul_q1h_rkb_sqb">
+          <li>If the total sytem memory is less than 256 GB, use this
+            formula:<codeblock><varname>gp_vmem</varname> = ((<varname>SWAP</varname> + <varname>RAM</varname>) – (7.5GB + 0.05 * <varname>RAM</varname>)) / 1.7</codeblock></li>
+          <li>If the total system memory is equal to or higher than 256 GB, use this
+            formula:<codeblock><varname>gp_vmem</varname> = ((<varname>SWAP</varname> + <varname>RAM</varname>) – (7.5GB + 0.05 * <varname>RAM</varname>)) / 1.17</codeblock></li>
+        </ul></p>
       <p>where <varname>SWAP</varname> is the host swap space and <varname>RAM</varname> is the RAM
         on the host in GB.</p>
       <p>Next, calculate the <varname>max_acting_primary_segments</varname>. This is the maximum
@@ -5847,7 +5851,12 @@
       <codeblock><codeph>gp_vmem_protect_limit</codeph> = <varname>gp_vmem</varname> / <varname>acting_primary_segments</varname></codeblock>
       <p>For scenarios where a large number of workfiles are generated, this is the calculation for
           <varname>gp_vmem</varname> that accounts for the workfiles.</p>
-      <codeblock><varname>gp_vmem</varname> = ((<varname>SWAP</varname> + <varname>RAM</varname>) – (7.5GB + 0.05 * <varname>RAM</varname> - (300KB * <varname>total_#_workfiles</varname>))) / 1.7</codeblock>
+      <ul id="ul_af1_zjb_sqb">
+        <li>If the total sytem memory is less than 256
+          GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.7</codeblock></li>
+        <li>If the total system memory is equal to or higher than 256
+          GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.17</codeblock></li>
+      </ul>
       <p>For information about monitoring and managing workfile usage, see the <cite>Greenplum
           Database Administrator Guide</cite>.</p>
       <p>Based on the <varname>gp_vmem</varname> value you can calculate the value for the

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -5832,9 +5832,9 @@
           <codeph>gp_vmem_protect_limit</codeph> value.</p>
       <p>First calculate the value <varname>gp_vmem</varname>. This is the Greenplum Database memory
         available on a host.<ul id="ul_q1h_rkb_sqb">
-          <li>If the total sytem memory is less than 256 GB, use this
+          <li>If the total system memory is less than 256 GB, use this
             formula:<codeblock><varname>gp_vmem</varname> = ((<varname>SWAP</varname> + <varname>RAM</varname>) – (7.5GB + 0.05 * <varname>RAM</varname>)) / 1.7</codeblock></li>
-          <li>If the total system memory is equal to or higher than 256 GB, use this
+          <li>If the total system memory is equal to or greater than 256 GB, use this
             formula:<codeblock><varname>gp_vmem</varname> = ((<varname>SWAP</varname> + <varname>RAM</varname>) – (7.5GB + 0.05 * <varname>RAM</varname>)) / 1.17</codeblock></li>
         </ul></p>
       <p>where <varname>SWAP</varname> is the host swap space and <varname>RAM</varname> is the RAM
@@ -5852,9 +5852,9 @@
       <p>For scenarios where a large number of workfiles are generated, this is the calculation for
           <varname>gp_vmem</varname> that accounts for the workfiles.</p>
       <ul id="ul_af1_zjb_sqb">
-        <li>If the total sytem memory is less than 256
+        <li>If the total system memory is less than 256
           GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.7</codeblock></li>
-        <li>If the total system memory is equal to or higher than 256
+        <li>If the total system memory is equal to or greater than 256
           GB:<codeblock>gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM - (300KB * <varname>total_#_workfiles</varname>))) / 1.17</codeblock></li>
       </ul>
       <p>For information about monitoring and managing workfile usage, see the <cite>Greenplum


### PR DESCRIPTION
PR for 5X_STABLE equivalent to https://github.com/greenplum-db/gpdb/pull/12477

The calculation of gp_vmem on the tool https://greenplum.org/calc/ has been reviewed and modified to avoid waste of RAM.
When the total system memory is equal to or higher than 256 GB, a new formula applies:

gp_vmem = ((SWAP + RAM) – (7.5GB + 0.05 * RAM)) / 1.17

