### PR TITLE
Refactor stack unwind in GPDB

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -96,11 +96,11 @@ SERVER_PLATFORMS=rhel7_x86_64 rhel6_x86_64 linux_x86_64
 # Compiler options
 #---------------------------------------------------------------------
 
-OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
-PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
+OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -g)"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -g)"
 
 ifeq (on, ${GPDBGOPT})
-CFLAGS_OPT=-O1 -fno-omit-frame-pointer
+CFLAGS_OPT=-O1
 else
 CFLAGS_OPT=-O0
 endif

--- a/src/backend/gporca/CMakeLists.txt
+++ b/src/backend/gporca/CMakeLists.txt
@@ -51,14 +51,6 @@ if (COMPILER_HAS_G3)
   SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g3")
 endif()
 
-# Do not omit frame pointer. Even with RELEASE builds, it is used for
-# backtracing.
-check_cxx_compiler_flag("-fno-omit-frame-pointer"
-                        COMPILER_HAS_FNO_OMIT_FRAME_POINTER)
-if (COMPILER_HAS_FNO_OMIT_FRAME_POINTER)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
-endif()
-
 # Turn on GPOS_DEBUG define for DEBUG builds.
 cmake_policy(SET CMP0043 NEW)
 

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -11,6 +11,4 @@ override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpos/include $(CPPFLA
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
-# Do not omit frame pointer. Even with RELEASE builds, it is used for
-# backtracing.
-override CXXFLAGS := -Werror -Wextra -Wpedantic -fno-omit-frame-pointer $(CXXFLAGS)
+override CXXFLAGS := -Werror -Wextra -Wpedantic $(CXXFLAGS)

--- a/src/backend/gporca/libgpos/include/gpos/utils.h
+++ b/src/backend/gporca/libgpos/include/gpos/utils.h
@@ -30,8 +30,6 @@
 
 #define ALIGN_STORAGE __attribute__((aligned(8)))
 
-#define GPOS_GET_FRAME_POINTER(x) ((x) = (ULONG_PTR) __builtin_frame_address(0))
-
 #define GPOS_MSEC_IN_SEC ((ULLONG) 1000)
 #define GPOS_USEC_IN_MSEC ((ULLONG) 1000)
 #define GPOS_USEC_IN_SEC (((ULLONG) 1000) * 1000)

--- a/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
@@ -11,6 +11,8 @@
 
 #include "gpos/common/CStackDescriptor.h"
 
+#include <execinfo.h>
+
 #include "gpos/string/CWString.h"
 #include "gpos/task/IWorker.h"
 #include "gpos/utils.h"
@@ -30,53 +32,20 @@ using namespace gpos;
 void
 CStackDescriptor::BackTrace(ULONG top_frames_to_skip)
 {
-	// get base pointer of current frame
-	ULONG_PTR current_frame;
-	GPOS_GET_FRAME_POINTER(current_frame);
+	ULONG gpos_stack_trace_depth_actual;
+	void *raddrs[GPOS_STACK_TRACE_DEPTH];
+
+	// get the backtrace in platform-independent way
+	gpos_stack_trace_depth_actual = backtrace(raddrs, GPOS_STACK_TRACE_DEPTH);
 
 	// reset stack depth
 	Reset();
 
-	// pointer to next frame in stack
-	void **next_frame = (void **) current_frame;
-
-	// get stack start address
-	ULONG_PTR stack_start = 0;
-	IWorker *worker = IWorker::Self();
-	if (nullptr == worker)
+	// skip the first top_frames_to_skip
+	for (ULONG i = top_frames_to_skip; i < gpos_stack_trace_depth_actual; i++)
 	{
-		// no worker in stack, return immediately
-		return;
-	}
-
-	// get address from worker
-	stack_start = worker->GetStackStart();
-
-	// consider the first GPOS_STACK_TRACE_DEPTH frames below worker object
-	for (ULONG frame_counter = 0; frame_counter < GPOS_STACK_TRACE_DEPTH;
-		 frame_counter++)
-	{
-		// check if the frame pointer is after stack start and before previous frame
-		if ((ULONG_PTR) *next_frame > stack_start ||
-			(ULONG_PTR) *next_frame < (ULONG_PTR) next_frame)
-		{
-			break;
-		}
-
-		// skip top frames
-		if (0 < top_frames_to_skip)
-		{
-			top_frames_to_skip--;
-		}
-		else
-		{
-			// get return address (one above the base pointer)
-			ULONG_PTR *frame_address = (ULONG_PTR *) (next_frame + 1);
-			m_array_of_addresses[m_depth++] = (void *) *frame_address;
-		}
-
-		// move to next frame
-		next_frame = (void **) *next_frame;
+		// backtrace() produces pure return addresses, so just copy them
+		m_array_of_addresses[m_depth++] = raddrs[i];
 	}
 }
 

--- a/src/backend/postmaster/startup.c
+++ b/src/backend/postmaster/startup.c
@@ -198,6 +198,7 @@ StartupProcessMain(void)
 	pqsignal(SIGUSR1, StartupProcSigUsr1Handler);
 	pqsignal(SIGUSR2, StartupProcTriggerHandler);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGBUS
 	pqsignal(SIGBUS, HandleCrash);
 #endif

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -3154,6 +3154,7 @@ WalSndSignals(void)
 	/* Reset some signals that are accepted by postmaster but not here */
 	pqsignal(SIGCHLD, SIG_DFL);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGILL
 	pqsignal(SIGILL, WalSndCrashHandler);
 #endif

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4737,7 +4737,9 @@ PostgresMain(int argc, char *argv[],
 		 */
 		pqsignal(SIGCHLD, SIG_DFL); /* system() requires this on some
 									 * platforms */
+
 #ifndef _WIN32
+		InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGILL
 		pqsignal(SIGILL, CdbProgramErrorHandler);
 #endif

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -162,24 +162,6 @@ static void write_eventlog(int level, const char *line, int len);
 #define ADDRESS_SIZE     20
 #define STACK_DEPTH_MAX  100
 
-/*
- * Assembly code, gets the values of the frame pointer.
- * It only works for x86 processors.
- */
-#if defined(__i386)
-#define ASMFP asm volatile ("movl %%ebp, %0" : "=g" (ulp));
-#define GET_PTR_FROM_VALUE(value) ((uint32)value)
-#define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
-#elif defined(__x86_64__)
-#define ASMFP asm volatile ("movq %%rbp, %0" : "=g" (ulp));
-#define GET_PTR_FROM_VALUE(value) (value)
-#define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
-#else
-#define ASMFP
-#define GET_PTR_FROM_VALUE(value) (value)
-#define GET_FRAME_POINTER(x)
-#endif
-
 
 static ErrorData errordata[ERRORDATA_STACK_SIZE];
 
@@ -4961,61 +4943,6 @@ uint32 gp_backtrace(void **stackAddresses, uint32 maxStackDepth)
 {
 #ifndef HAVE_BACKTRACE_SYMBOLS
 	return 0;
-#endif
-
-#if defined(__i386) || defined(__x86_64__)
-
-	/*
-	 * Stack base pointer has not been initialized by PostmasterMain,
-	 * or PostgresMain/AuxiliaryProcessMain is called directly by main
-	 * rather than forked by PostmasterMain (such as when initdb).
-	 *
-	 * In this case, just return depth as 0 to indicate that we have not
-	 * stored any frame addresses.
-	 */
-	if (stack_base_ptr == NULL)
-		return 0;
-
-	/* get base pointer of current frame */
-	uint64 framePtrValue = 0;
-	GET_FRAME_POINTER(framePtrValue);
-
-	uint32 depth = 0;
-	void **pFramePtr = (void**) GET_PTR_FROM_VALUE(framePtrValue);
-
-	/* check if the frame pointer is valid */
-	if (pFramePtr != NULL && (void *) &depth < (void *) pFramePtr)
-	{
-		/* consider the first maxStackDepth frames only, below the stack base pointer */
-		for (depth = 0; depth < maxStackDepth; depth++)
-		{
-			/* check if next frame is within stack */
-			if (pFramePtr == NULL ||
-				(void *) pFramePtr > *pFramePtr ||
-				(void *) stack_base_ptr < *pFramePtr)
-			{
-				break;
-			}
-
-			/* get return address (one above the frame pointer) */
-			const uintptr_t *returnAddr = (uintptr_t *)(pFramePtr + 1);
-
-			/* store return address */
-			stackAddresses[depth] = (void *) *returnAddr;
-
-			/* move to next frame */
-			pFramePtr = (void**)*pFramePtr;
-		}
-	}
-	else
-	{
-		depth  = backtrace(stackAddresses, maxStackDepth);
-	}
-
-	Assert(depth > 0);
-
-	return depth;
-
 #else
 	return backtrace(stackAddresses, maxStackDepth);
 #endif
@@ -5074,6 +5001,22 @@ SegvBusIllName(int signal)
 	}
 
 	return NULL;
+}
+
+/*
+ * StandardHandlerForSigillSigsegvSigbus_OnMainThread must be async-safe to be
+ * used as a signal handler. Under hood it calls backtrace() to collect frame
+ * addresses, that is known to be async-unsafe on the first run, while all the
+ * next runs are async-safe. This function must be called before setting
+ * StandardHandlerForSigillSigsegvSigbus_OnMainThread as a signal handler.
+ */
+void
+InitStandardHandlerForSigillSigsegvSigbus_OnMainThread(void)
+{
+	void *singleFrame[1];
+
+	/* Make gp_backtrace() async-safe */
+	gp_backtrace(singleFrame, 1);
 }
 
 /*

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -548,6 +548,7 @@ extern char *stack_base_ptr;
 extern bool gp_log_stack_trace_lines;   /* session GUC, controls line info in stack traces */
 
 extern const char *SegvBusIllName(int signal);
+extern void InitStandardHandlerForSigillSigsegvSigbus_OnMainThread(void);
 extern void StandardHandlerForSigillSigsegvSigbus_OnMainThread(char * processName, SIGNAL_ARGS);
 
 #endif							/* ELOG_H */


### PR DESCRIPTION
ORCA and GPDB relied on frame registers to unwind the stack. This approach required `-fno-omit-frame-pointer` during compilation. Though it works faster than a `backtrace()`, the downside is reserving a register by the compiler that affects the result code's performance. Also, it is not an easy thing to port GPDB to other platforms (we need to write assembly-specific code for that).

Besides, `gp_backtrace()` has some problems:

1. fallback to `backtrace()` from frame pointers was not SIGSEGV-safe for the builds without `-fno-omit-frame-pointer`.
2. `backtrace()` is known to be async-unsafe on the first run, while all the next runs are async-safe. For example on Linux `backtrace()` first run calls `dlopen()` to load libgcc that evaluates `malloc()`. So we need to make an initial call of `backtrace()` before using it in a signal handler.

So, this commit removes the need to use `-fno-omit-frame-pointer` and make all the code use `backtrace()` in a safe manner.

Co-authored-by: Ivan Leskin <leskin.in@phystech.edu>