### PR TITLE
Add check to ensure stats are not null in implementation stage of Orca

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalPartitionSelector.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalPartitionSelector.cpp
@@ -18,8 +18,10 @@
 #include "gpopt/base/CDrvdPropCtxtPlan.h"
 #include "gpopt/base/COptCtxt.h"
 #include "gpopt/base/CUtils.h"
+#include "gpopt/exception.h"
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CPredicateUtils.h"
+
 
 using namespace gpopt;
 
@@ -408,6 +410,13 @@ CPhysicalPartitionSelector::PpfmDerive(CMemoryPool *mp,
 	CPartFilterMap *ppfm = PpfmDeriveCombineRelational(mp, exprhdl);
 	IStatistics *stats = exprhdl.Pstats();
 	GPOS_ASSERT(NULL != stats);
+	if (NULL == stats)
+	{
+		GPOS_RAISE(
+			gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound,
+			GPOS_WSZ_LIT(
+				"Could not derive stats for partition selector since group stats not derived"));
+	}
 	m_pexprCombinedPredicate->AddRef();
 	stats->AddRef();
 	ppfm->AddPartFilter(mp, m_scan_id, m_pexprCombinedPredicate, stats);

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1049,6 +1049,13 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 	// extract part table base stats from passed handle
 	IStatistics *base_table_stats = expr_handle.Pstats();
 	GPOS_ASSERT(NULL != base_table_stats);
+	if (NULL == base_table_stats)
+	{
+		GPOS_RAISE(
+			gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound,
+			GPOS_WSZ_LIT(
+				"Could not derive stats for dynamic scan since group stats not derived"));
+	}
 
 	if (!GPOS_FTRACE(EopttraceDeriveStatsForDPE))
 	{


### PR DESCRIPTION
In some edge cases in Orca, groups may not have had statistics derived
during the exploration stage. This is ok in many cases, as these groups
may not be used during implementation or their stats may not be accessed
during implementation. However, there are some cases where we do need
these stats, and trying to access them resulted in a crash.

This commit adds a defensive check to fall back to planner if we
encounter such a scenario, similar to checks added in
a6f92be1b8327aadc7l.

Co-authored-by: Chris Hajas <chajas@vmware.com>
Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>