### PR TITLE
[Minor] Fix memory uninitalized error complain in gp_hll_compress with higher version gcc

### DIFF
--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -564,7 +564,6 @@ gp_hll_compress_dense(GpHLLCounter hloglog)
     memset(dest,0,data_rawsize + 4);
 
     data = malloc(data_rawsize);
-    memset(data,0,data_rawsize);
     if (data == NULL){
         free(dest);
         ereport(ERROR,
@@ -572,6 +571,7 @@ gp_hll_compress_dense(GpHLLCounter hloglog)
                  errmsg("out of memory"),
                  errdetail("Failed on request of size %zu.", data_rawsize)));
     }
+    memset(data,0,data_rawsize);
 
     /* put all registers in a normal array  i.e. remove dense packing so
      * lz compression can work optimally */

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -564,6 +564,7 @@ gp_hll_compress_dense(GpHLLCounter hloglog)
     memset(dest,0,data_rawsize + 4);
 
     data = malloc(data_rawsize);
+    memset(data,0,data_rawsize);
     if (data == NULL){
         free(dest);
         ereport(ERROR,


### PR DESCRIPTION
When building with higher version gcc, it complains about uninitialized memory when enabling `-Werror=uninitialized` flag, which blocks the compling.

```
在函数‘gp_hll_compress_dense’中,
    内联自‘gp_hll_compress’于 gp_hyperloglog.c:533:13:
gp_hyperloglog.c:584:11: 错误：‘data’ may be used uninitialized [-Werror=maybe-uninitialized]
  584 |     len = pglz_compress(data,data_rawsize,dest,PGLZ_strategy_always);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

## Here are some reminders before you submit the pull request

- [ x] Pass `make installcheck`
