### PR TITLE
Fixup! gpinitsystem backout script creation

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -63,6 +63,7 @@ Feature: gpinitsystem tests
         And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
         And the user waits 10 second
         Then gpintsystem logs should not contain lines about running backout script
+        And all files in gpAdminLogs directory are deleted
         And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
 


### PR DESCRIPTION
Commit b0493ceb97c24eb48cae9017ce62949ff2f583e5 introduced a new gpinitsystem behave test. It has an inaccuracy in error status validation logic - test always failed before current fix. We need to clean FATAL message from gpAdminLogs from the first killed gpinitsystem run before we check the next gpinitsystem status. Otherwise previous FATAL fails the results.