### PR TITLE
Add check to ensure stats are not null in implementation stage of Orca

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CPartialPlan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CPartialPlan.h
@@ -59,8 +59,6 @@ private:
 									CExpressionHandle &exprhdl,
 									ICostModel::SCostingInfo *pci);
 
-	// raise exception if the stats object is NULL
-	static void RaiseExceptionIfStatsNull(IStatistics *stats);
 
 public:
 	CPartialPlan(const CPartialPlan &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/exception.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/exception.h
@@ -37,6 +37,7 @@ enum ExMinor
 	ExmiUnsatisfiedRequiredProperties,
 	ExmiEvalUnsupportedScalarExpr,
 	ExmiCTEProducerConsumerMisAligned,
+	ExmiNoStats,
 
 	ExmiSentinel
 };

--- a/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
@@ -201,10 +201,8 @@ CCostContext::DeriveStats()
 	exprhdl.DeriveCostContextStats();
 	if (nullptr == exprhdl.Pstats())
 	{
-		GPOS_RAISE(
-			gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound,
-			GPOS_WSZ_LIT(
-				"Could not compute cost since statistics for the group no derived"));
+		GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiNoStats,
+				   GPOS_WSZ_LIT("CCostContext"));
 	}
 
 	exprhdl.Pstats()->AddRef();

--- a/src/backend/gporca/libgpopt/src/engine/CPartialPlan.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CPartialPlan.cpp
@@ -89,7 +89,11 @@ CPartialPlan::ExtractChildrenCostingInfo(CMemoryPool *mp, ICostModel *pcm,
 
 		CReqdPropPlan *prppChild = exprhdl.Prpp(ul);
 		IStatistics *child_stats = pgroupChild->Pstats();
-		RaiseExceptionIfStatsNull(child_stats);
+		if (nullptr == child_stats)
+		{
+			GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiNoStats,
+					   GPOS_WSZ_LIT("CPartialPlan"));
+		}
 
 		if (ul == m_ulChildIndex)
 		{
@@ -144,27 +148,6 @@ CPartialPlan::ExtractChildrenCostingInfo(CMemoryPool *mp, ICostModel *pcm,
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CPartialPlan::RaiseExceptionIfStatsNull
-//
-//	@doc:
-//		Raise exception if the stats object is NULL
-//
-//---------------------------------------------------------------------------
-void
-CPartialPlan::RaiseExceptionIfStatsNull(IStatistics *stats)
-{
-	if (nullptr == stats)
-	{
-		GPOS_RAISE(
-			gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound,
-			GPOS_WSZ_LIT(
-				"Could not compute cost of partial plan since statistics for the group not derived"));
-	}
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CPartialPlan::CostCompute
 //
 //	@doc:
@@ -192,7 +175,11 @@ CPartialPlan::CostCompute(CMemoryPool *mp)
 	pdrgpdp->Release();
 
 	IStatistics *stats = m_pgexpr->Pgroup()->Pstats();
-	RaiseExceptionIfStatsNull(stats);
+	if (nullptr == stats)
+	{
+		GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiNoStats,
+				   GPOS_WSZ_LIT("CPartialPlan"));
+	}
 
 	stats->AddRef();
 	ICostModel::SCostingInfo ci(mp, exprhdl.UlNonScalarChildren(),

--- a/src/backend/gporca/libgpopt/src/exception.cpp
+++ b/src/backend/gporca/libgpopt/src/exception.cpp
@@ -106,6 +106,11 @@ gpopt::EresExceptionInit(CMemoryPool *mp)
 			1,
 			GPOS_WSZ_WSZLEN(
 				"CTE Producer-Consumer execution locality mismatch")),
+
+		CMessage(CException(gpopt::ExmaGPOPT, gpopt::ExmiNoStats),
+				 CException::ExsevError,
+				 GPOS_WSZ_WSZLEN("Missing group stats in %ls"), 1,
+				 GPOS_WSZ_WSZLEN("Missing group stats")),
 	};
 
 	GPOS_RESULT eres = GPOS_FAILED;

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -43,7 +43,8 @@ const ULONG expected_opt_fallback[] = {
 	gpopt::ExmiUnexpectedOp,
 	gpopt::ExmiUnsatisfiedRequiredProperties,
 	gpopt::ExmiEvalUnsupportedScalarExpr,
-	gpopt::ExmiCTEProducerConsumerMisAligned};
+	gpopt::ExmiCTEProducerConsumerMisAligned,
+	gpopt::ExmiNoStats};
 
 // array of DXL minor exception types that trigger expected fallback to the planner
 // refer naucrates/exception.cpp for explanation of errors

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1046,6 +1046,11 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 	// extract part table base stats from passed handle
 	IStatistics *base_table_stats = exprhdl.Pstats();
 	GPOS_ASSERT(nullptr != base_table_stats);
+	if (nullptr == base_table_stats)
+	{
+		GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiNoStats,
+				   GPOS_WSZ_LIT("CPhysicalDynamicScan"));
+	}
 
 	if (!GPOS_FTRACE(EopttraceDeriveStatsForDPE))
 	{


### PR DESCRIPTION
This is a forward port of https://github.com/greenplum-db/gpdb/pull/12491.

In some edge cases in Orca, groups may not have had statistics derived
during the exploration stage. This is ok in many cases, as these groups
may not be used during implementation or their stats may not be accessed
during implementation. However, there are some cases where we do need
these stats, and trying to access them resulted in a crash.

This commit adds a defensive check to fall back to planner if we
encounter such a scenario, similar to checks added in
a6f92be1b8327aadc7l.

Co-authored-by: Chris Hajas <chajas@vmware.com>
Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>