### PR TITLE
WIP: Alter Table Alter Column Type AOCO table optimization, backport from pull #9595

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3694,6 +3694,7 @@ _copyAlterTableCmd(const AlterTableCmd *from)
 	COPY_NODE_FIELD(def);
 	COPY_SCALAR_FIELD(behavior);
 	COPY_SCALAR_FIELD(missing_ok);
+	COPY_SCALAR_FIELD(aoco_alter_type_norewrite);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3356,6 +3356,7 @@ _outAlterTableCmd(StringInfo str, const AlterTableCmd *node)
 	WRITE_NODE_FIELD(transform);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
 	WRITE_BOOL_FIELD(missing_ok);
+	WRITE_BOOL_FIELD(aoco_alter_type_norewrite);
 
 	WRITE_INT_FIELD(backendId);
 	WRITE_NODE_FIELD(policy);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -917,6 +917,7 @@ _readAlterTableCmd(void)
 	READ_NODE_FIELD(transform);
 	READ_ENUM_FIELD(behavior, DropBehavior);
 	READ_BOOL_FIELD(missing_ok);
+	READ_BOOL_FIELD(aoco_alter_type_norewrite);
 
 	READ_INT_FIELD(backendId);
 	READ_NODE_FIELD(policy);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -36,6 +36,7 @@
 #include "catalog/index.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_am.h"
+#include "catalog/pg_attribute_encoding.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_opclass.h"
@@ -61,6 +62,7 @@
 #include "parser/parse_type.h"
 #include "parser/parse_utilcmd.h"
 #include "parser/parser.h"
+#include "rewrite/rewriteHandler.h"
 #include "rewrite/rewriteManip.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
@@ -4068,6 +4070,122 @@ transformRuleStmt(RuleStmt *stmt, const char *queryString,
 }
 
 /*
+ * If there exists only only ONE command
+ * and the command is AT_AlterColumnType and the relation is AOCO
+ *
+ * Then
+ * Add two extra commands, i.e. drop column and add column.
+ *
+ * During the Alter table preparation, then we will check, if we
+ * can optimise and not re-write the whole relation but use the newly
+ * added commands. These commands have to be added here and not during
+ * execution, because we need to fail early, i.e. during preparation of the
+ * newly added commands also. Meaning if we have commited to perform the
+ * composite action, we should not fail after removing the original column.
+ *
+ * There are a couple of caveats here, regarding default values and constraints
+ * It is very possible that we will have to perform that step during the add
+ * column command, try here for now though... This is a big XXX
+ */
+static void
+aoco_optimize_alter_type(Relation rel, List *commands)
+{
+	AlterTableCmd *cmd;
+	AlterTableCmd *dropColumn;
+	AlterTableCmd *addColumn;
+	ColumnDef	  *def;
+	Form_pg_attribute attribute;
+
+	if (!RelationIsAoCols(rel) || list_length(commands) != 1)
+		return;
+
+	cmd = (AlterTableCmd *) linitial(commands);
+	Assert(IsA(cmd, AlterTableCmd));
+	if (cmd->subtype != AT_AlterColumnType)
+		return;
+
+	attribute = NULL;
+	for (int i = 0; i < RelationGetDescr(rel)->natts && !attribute; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(RelationGetDescr(rel), i);
+		if (strcmp(NameStr(attr->attname), cmd->name) != 0)
+			continue;
+
+		attribute = attr;
+	}
+
+	if (!attribute || attribute->attinhcount || attribute->attisdropped)
+		return;
+
+	cmd->aoco_alter_type_norewrite = true;
+
+	dropColumn = makeNode(AlterTableCmd);
+	dropColumn->subtype = AT_DropColumn;
+	dropColumn->behavior = DROP_RESTRICT;
+	dropColumn->name = pstrdup(cmd->name);
+	dropColumn->missing_ok = false;
+	dropColumn->aoco_alter_type_norewrite = true;
+
+	commands = lappend(commands, dropColumn);
+
+	addColumn = makeNode(AlterTableCmd);
+	addColumn->subtype = AT_AddColumn;
+	addColumn->name = pstrdup(cmd->name);
+	addColumn->missing_ok = false;
+	addColumn->aoco_alter_type_norewrite = true;
+
+	addColumn->def = copyObject(cmd->def);
+	def = (ColumnDef *)addColumn->def;
+
+	if (!def->colname)
+		def->colname = pstrdup(NameStr(attribute->attname));
+
+	Assert(def->typeName);
+
+	if (!def->is_local)
+		def->is_local = attribute->attislocal;
+
+	if (!def->is_not_null)
+		def->is_not_null = attribute->attnotnull;
+
+	if (!def->constraints)
+			;	/* other constraints on column */
+
+	if (!def->raw_default && attribute->atthasdef)
+	{
+#if 0
+		/* XXX: This has to be done in Add column, no way around it */
+		Node	   *defaultexpr;
+		Oid			targettype;
+		int32		targettypmod;
+
+		typenameTypeIdAndMod(NULL, def->typeName, &targettype, &targettypmod);
+
+		defaultexpr = build_column_default(rel, attribute->attnum);
+		Assert(defaultexpr);
+
+		defaultexpr = strip_implicit_coercions(defaultexpr);
+		defaultexpr = coerce_to_target_type(NULL,		/* no UNKNOWN params */
+										  defaultexpr, exprType(defaultexpr),
+										  targettype, targettypmod,
+										  COERCION_ASSIGNMENT,
+										  COERCE_IMPLICIT_CAST,
+										  -1);
+
+		if (defaultexpr == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATATYPE_MISMATCH),
+					 errmsg("default for column \"%s\" cannot be cast automatically to type %s",
+						def->colname, format_type_be(targettype))));
+
+		def->raw_default = defaultexpr;
+#endif
+	}
+
+	commands = lappend(commands, addColumn);
+}
+
+/*
  * transformAlterTableStmt -
  *		parse analysis for ALTER TABLE
  *
@@ -4105,6 +4223,9 @@ transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 	/* Caller is responsible for locking the relation */
 	rel = relation_open(relid, NoLock);
 	tupdesc = RelationGetDescr(rel);
+
+	/* Try if can optimize alter column type command */
+	aoco_optimize_alter_type(rel, stmt->cmds);
 
 	/* Set up pstate */
 	pstate = make_parsestate(NULL);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2027,6 +2027,8 @@ typedef struct AlterTableCmd	/* one subcommand of an ALTER TABLE */
 	DropBehavior behavior;		/* RESTRICT or CASCADE for DROP cases */
 	bool		missing_ok;		/* skip error if missing? */
 
+	bool		aoco_alter_type_norewrite;		/* GPDB: do not re-write aoco table if possible */
+
 	/*
 	 * Extra information dispatched from QD to QEs in AT_SetDistributedBy and
 	 * AT_ExpandTable

--- a/src/test/regress/expected/aoco_alter_opt.out
+++ b/src/test/regress/expected/aoco_alter_opt.out
@@ -1,0 +1,99 @@
+DROP TABLE IF EXISTS aoco_opt;
+CREATE TABLE aoco_opt (
+    a integer,
+    b integer default 3 NOT NULL encoding(compresstype=zlib,compresslevel=2),
+    c integer,
+    default column encoding (compresstype=RLE_TYPE)
+) WITH (
+    appendonly=true,
+    orientation=column
+) DISTRIBUTED BY (a);
+PREPARE attopts AS SELECT
+    attname,
+    atttypid,
+    pga.attnum,
+    attisdropped,
+    attislocal,
+    attstorage,
+    attinhcount,
+    pge.attoptions
+FROM
+    pg_attribute_encoding pge,
+    pg_attribute pga,
+    pg_class pgc
+WHERE
+    pga.attrelid = pgc.oid AND
+    pga.attnum = pge.attnum AND
+    pge.attrelid = pgc.oid AND
+    pgc.relname = 'aoco_opt'; 
+SELECT relfilenode AS origfilenode FROM pg_class WHERE relname = 'aoco_opt' \gset
+EXECUTE attopts;
+ attname | atttypid | attnum | attisdropped | attislocal | attstorage | attinhcount |                       attoptions                        
+---------+----------+--------+--------------+------------+------------+-------------+---------------------------------------------------------
+ a       |       23 |      1 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ c       |       23 |      3 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ b       |       23 |      2 | f            | t          | p          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+(3 rows)
+
+INSERT INTO aoco_opt SELECT a, a AS b, a AS c FROM generate_series(0, 9) a;
+BEGIN;
+ALTER TABLE aoco_opt ALTER COLUMN b SET DATA TYPE text;
+EXECUTE attopts;
+           attname            | atttypid | attnum | attisdropped | attislocal | attstorage | attinhcount |                       attoptions                        
+------------------------------+----------+--------+--------------+------------+------------+-------------+---------------------------------------------------------
+ a                            |       23 |      1 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ c                            |       23 |      3 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ........pg.dropped.2........ |        0 |      2 | t            | t          | p          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ b                            |       25 |      4 | f            | t          | x          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+(4 rows)
+
+SELECT relname FROM pg_class WHERE relfilenode = :origfilenode;
+ relname  
+----------
+ aoco_opt
+(1 row)
+
+TABLE aoco_opt;
+ a | c | b 
+---+---+---
+ 5 | 5 | 5
+ 6 | 6 | 6
+ 9 | 9 | 9
+ 2 | 2 | 2
+ 3 | 3 | 3
+ 4 | 4 | 4
+ 7 | 7 | 7
+ 8 | 8 | 8
+ 0 | 0 | 0
+ 1 | 1 | 1
+(10 rows)
+
+-- This will fail due to silently dropped default
+INSERT INTO aoco_opt (a, c) VALUES (10, 10);
+ERROR:  null value in column "b" violates not-null constraint  (seg2 127.0.1.1:7004 pid=13130)
+DETAIL:  Failing row contains (10, 10, null).
+ROLLBACK;
+EXECUTE attopts;
+ attname | atttypid | attnum | attisdropped | attislocal | attstorage | attinhcount |                       attoptions                        
+---------+----------+--------+--------------+------------+------------+-------------+---------------------------------------------------------
+ a       |       23 |      1 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ c       |       23 |      3 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ b       |       23 |      2 | f            | t          | p          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+(3 rows)
+
+TABLE aoco_opt;
+ a | b | c 
+---+---+---
+ 5 | 5 | 5
+ 6 | 6 | 6
+ 9 | 9 | 9
+ 2 | 2 | 2
+ 3 | 3 | 3
+ 4 | 4 | 4
+ 7 | 7 | 7
+ 8 | 8 | 8
+ 0 | 0 | 0
+ 1 | 1 | 1
+(10 rows)
+
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -122,7 +122,7 @@ test: db_size_functions
 
 ignore: gp_portal_error
 test: external_table external_table_union_all external_table_create_privs external_table_persistent_error_log column_compression eagerfree alter_table_aocs alter_table_aocs2 alter_distribution_policy aoco_privileges
-test: alter_table_set alter_table_gp alter_table_ao subtransaction_visibility oid_consistency udf_exception_blocks
+test: alter_table_set alter_table_gp alter_table_ao subtransaction_visibility oid_consistency udf_exception_blocks aoco_alter_opt
 # below test(s) inject faults so each of them need to be in a separate group
 test: aocs
 test: ic

--- a/src/test/regress/sql/aoco_alter_opt.sql
+++ b/src/test/regress/sql/aoco_alter_opt.sql
@@ -1,0 +1,49 @@
+DROP TABLE IF EXISTS aoco_opt;
+CREATE TABLE aoco_opt (
+    a integer,
+    b integer default 3 NOT NULL encoding(compresstype=zlib,compresslevel=2),
+    c integer,
+    default column encoding (compresstype=RLE_TYPE)
+) WITH (
+    appendonly=true,
+    orientation=column
+) DISTRIBUTED BY (a);
+
+PREPARE attopts AS SELECT
+    attname,
+    atttypid,
+    pga.attnum,
+    attisdropped,
+    attislocal,
+    attstorage,
+    attinhcount,
+    pge.attoptions
+FROM
+    pg_attribute_encoding pge,
+    pg_attribute pga,
+    pg_class pgc
+WHERE
+    pga.attrelid = pgc.oid AND
+    pga.attnum = pge.attnum AND
+    pge.attrelid = pgc.oid AND
+    pgc.relname = 'aoco_opt'; 
+
+SELECT relfilenode AS origfilenode FROM pg_class WHERE relname = 'aoco_opt' \gset
+
+EXECUTE attopts;
+
+INSERT INTO aoco_opt SELECT a, a AS b, a AS c FROM generate_series(0, 9) a;
+
+BEGIN;
+ALTER TABLE aoco_opt ALTER COLUMN b SET DATA TYPE text;
+EXECUTE attopts;
+SELECT relname FROM pg_class WHERE relfilenode = :origfilenode;
+TABLE aoco_opt;
+
+-- This will fail due to silently dropped default
+INSERT INTO aoco_opt (a, c) VALUES (10, 10);
+ROLLBACK;
+
+EXECUTE attopts;
+TABLE aoco_opt;
+


### PR DESCRIPTION
Alter Table Alter Column Type AOCO table optimization, backport from pull [#9595](https://github.com/greenplum-db/gpdb/pull/9595)

>  **gkokolatos commented on 20 Feb 2020**

> Append-optimised column oriented (AOCO) tables are organised as one file per
> column at storage layer. This layout is amenable to optimisation in case of
> ALTER TABLE ALTER COLUMN command where rewriting the entire table being altered
> can be avoided. The ADD COLUMN subcommand of ALTER TABLE is already optimised
> like this for AOCO tables.
> 
> There is a catch. The file names on disk are semantically significant.
> 
> Bypass this by converting the ALTER COLUMN subcommand into DROP COLUMN and ADD
> COLUMN subcommands during preparation step of ALTER TABLE. The altered column
> gets a new attribute number in catalog, new entry in pg_aoseg table and a new
> file on disk.
> 
> This works great because the magic of MVCC can allow two versions of the
> relation to exist as long as there are open transactions referring to them.
> 
> The current implementaiton is trying to limit the diversion with upstream and
> some operation might have been fitted better in a different layer, though they
> are grouped together to limit the foot print.
> 
> A bug was found that DROP column does not remove segment files from dropped
> columns. This should be fixed in a different PR.
> 
> There are a couple TODOs:
> * deal with default values / constraints when coercing to the type.
> According to the postgres documentation: PostgreSQL will attempt to convert the column's default value (if any) to the new type, as well as any constraints that involve the column. But these conversions might fail, or might produce surprising results. It's often best to drop any constraints on the column before altering its type, and then add back suitably modified constraints afterwards.
> Maybe emiting a message that defaults will be silently dropped or aborting the
> optimization is also fine...
> * deal with existing indexes. Now the indexes are silently dropped. Same as
> above.
> 
> Co-authored-by: Asim R P apraveen@pivotal.io


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
