### PR TITLE
Docs: Removed otherprops value op-help from xml files

### DIFF
--- a/gpdb-doc/dita/admin_guide/highavail/topics/g-recovering-a-failed-segment.xml
+++ b/gpdb-doc/dita/admin_guide/highavail/topics/g-recovering-a-failed-segment.xml
@@ -25,8 +25,8 @@
         <title>Segment Failure Troubleshooting Matrix</title>
         <image otherprops="op-print" href="../../graphics/recovermatrix.png" placement="break"
           width="460" id="image_cdg_nfp_35"/>
-        <image otherprops="op-help" href="../../graphics/recovermatrix.png" placement="break"
-          width="680" id="image_cdg_nfp_34"/>
+        <image href="../../graphics/recovermatrix.png" placement="break" width="680"
+          id="image_cdg_nfp_34"/>
 
       </fig></p>
   </body>

--- a/gpdb-doc/dita/admin_guide/intro/arch_overview.xml
+++ b/gpdb-doc/dita/admin_guide/intro/arch_overview.xml
@@ -64,7 +64,7 @@
       <image height="316px" href="../graphics/highlevel_arch.jpg" placement="break" width="397px"/>
     </fig>
     <p>The following topics describe the components that make up a Greenplum Database system and how
-      they work together. <ul id="ul_cz4_xhy_dq" otherprops="op-help">
+      they work together. <ul id="ul_cz4_xhy_dq">
         <!-- hack for HTML/PDF -->
         <li><xref href="#arch_master" format="dita"/></li>
         <li><xref href="#arch_segments" format="dita"/></li>

--- a/gpdb-doc/dita/admin_guide/managing/monitor.xml
+++ b/gpdb-doc/dita/admin_guide/managing/monitor.xml
@@ -353,14 +353,14 @@ Distributed by: (sale_id)
           Greenplum Database. The view contains session information and information such as the
           database that the session is connected to, the query that the session is currently
           running, and memory consumed by the session processes. </p>
-        <ul id="ul_hwv_bbb_dq" otherprops="op-help">
-          <li>
-            <xref href="#topic_nby_j1b_dq" format="dita"/>
-          </li>
-          <li>
-            <xref href="#topic7" format="dita"/>
-          </li>
-        </ul>
+        <ul id="ul_hwv_bbb_dq">
+        <li>
+          <xref href="#topic_nby_j1b_dq" format="dita"/>
+        </li>
+        <li>
+          <xref href="#topic7" format="dita"/>
+        </li>
+      </ul>
       </body>
       <topic id="topic_nby_j1b_dq">
         <title>Creating the session_level_memory_consumption View</title>

--- a/gpdb-doc/dita/install_guide/install_modules.xml
+++ b/gpdb-doc/dita/install_guide/install_modules.xml
@@ -20,7 +20,7 @@
         Database will notify you of these dependencies when you attempt to drop the module
         extension.</note>
       <p>You can register the following modules in this manner:</p>
-      <simpletable frame="all" relcolwidth="1.0* 1.0* 1.0*" otherprops="op-help">
+      <simpletable frame="all" relcolwidth="1.0* 1.0* 1.0*">
         <strow>
           <stentry>
             <ul id="ul_tc3_nlx_wp">

--- a/gpdb-doc/dita/utility_guide/ref/analyzedb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/analyzedb.xml
@@ -277,7 +277,7 @@ LANGUAGE plpythonu VOLATILE;</codeblock></p>
       <p>
         <ph otherprops="op-print"><cmdname>ANALYZE</cmdname> in the <cite>Greenplum Database
             Reference Guide</cite></ph>
-        <ph otherprops="op-help">
+        <ph>
           <codeph>
             <xref href="../../ref_guide/sql_commands/ANALYZE.xml#topic1"/>
           </codeph>

--- a/gpdb-doc/dita/utility_guide/ref/clusterdb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/clusterdb.xml
@@ -48,5 +48,6 @@ batch jobs and scripts where no user is present to enter a password.</pd></plent
             <pd> Specifies the name of the database to connect to discover what other databases
               should be clustered. If not specified, the <codeph>postgres</codeph> database will
               be used, and if that does not exist, <codeph>template1</codeph> will be used. </pd>
-          </plentry></parml></sectiondiv></section><section id="section6"><title>Examples</title><p>To cluster the database <codeph>test</codeph>:</p><codeblock>clusterdb test</codeblock><p>To cluster a single table <codeph>foo</codeph> in a database named <codeph>xyzzy</codeph>:</p><codeblock>clusterdb --table foo xyzzyb</codeblock></section><section id="section7"><title>See Also</title><p><ph otherprops="op-print"><codeph>CLUSTER</codeph> in the <i>Greenplum Database Reference
-            Guide</i></ph><ph otherprops="op-help"><codeph><xref href="../../ref_guide/sql_commands/CLUSTER.xml#topic1"/></codeph></ph></p></section></body></topic>
+          </plentry></parml></sectiondiv></section><section id="section6"><title>Examples</title><p>To cluster the database <codeph>test</codeph>:</p><codeblock>clusterdb test</codeblock><p>To cluster a single table <codeph>foo</codeph> in a database named <codeph>xyzzy</codeph>:</p><codeblock>clusterdb --table foo xyzzyb</codeblock></section><section id="section7"><title>See Also</title><p><ph><codeph>CLUSTER</codeph> in the <i>Greenplum Database Reference
+              Guide</i></ph><ph><codeph><xref href="../../ref_guide/sql_commands/CLUSTER.xml#topic1"
+            /></codeph></ph></p></section></body></topic>

--- a/gpdb-doc/dita/utility_guide/ref/createdb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/createdb.xml
@@ -55,12 +55,12 @@ privileges.</p><p><codeph>createdb</codeph> is a wrapper around the SQL command 
           <pd>Show help about <codeph>createdb</codeph> command line arguments, and exit.</pd>
         </plentry>
         </parml>
-      <p>The options <codeph>-D</codeph>, <codeph>-l</codeph>, <codeph>-E</codeph>, 
-          <codeph>-O</codeph>, and <codeph>-T</codeph> correspond to options of the underlying
-        SQL command <codeph>CREATE DATABASE</codeph>; see <ph><codeph><xref
-            href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1" otherprops="op-help"
-          /></codeph></ph><ph otherprops="op-print"><codeph>CREATE DATABASE</codeph> in the <i>Greenplum
-            Database Reference Guide</i></ph> for more information about them. </p><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host=<varname>host</varname></pt><pd>The host name of the machine on which the Greenplum coordinator database
+      <p>The options <codeph>-D</codeph>, <codeph>-l</codeph>, <codeph>-E</codeph>,
+          <codeph>-O</codeph>, and <codeph>-T</codeph> correspond to options of the underlying SQL
+        command <codeph>CREATE DATABASE</codeph>; see <ph><codeph><xref
+              href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1"
+            /></codeph></ph><ph><codeph>CREATE DATABASE</codeph> in the <i>Greenplum Database
+            Reference Guide</i></ph> for more information about them. </p><sectiondiv id="section5"><b>Connection Options</b><parml><plentry><pt>-h <varname>host</varname> | --host=<varname>host</varname></pt><pd>The host name of the machine on which the Greenplum coordinator database
               server is running. If not specified, reads from the environment variable
                 <codeph>PGHOST</codeph> or defaults to localhost.</pd></plentry><plentry><pt>-p <varname>port</varname> | --port=<varname>port</varname></pt><pd>The TCP port on which the Greenplum coordinator database server is
               listening for connections. If not specified, reads from the environment variable
@@ -74,7 +74,7 @@ batch jobs and scripts where no user is present to enter a password.</pd></plent
           <codeph>LATIN1</codeph> encoding scheme:</p><codeblock>createdb -p 54321 -h gpmaster -E LATIN1 demo</codeblock></section><section id="section7">
       <title>See Also</title>
       <p><ph otherprops="op-print"><codeph>CREATE DATABASE</codeph> in the <i>Greenplum Database
-            Reference Guide</i></ph><ph otherprops="op-help"><codeph><xref
+            Reference Guide</i></ph><ph><codeph><xref
               href="../../ref_guide/sql_commands/CREATE_DATABASE.xml#topic1"/></codeph>,
-            <codeph><xref href="dropdb.xml#topic1"/></codeph></ph></p>
+              <codeph><xref href="dropdb.xml#topic1"/></codeph></ph></p>
     </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/ref/createuser.xml
+++ b/gpdb-doc/dita/utility_guide/ref/createuser.xml
@@ -85,10 +85,7 @@ CREATE ROLE</codeblock><p>In the above example, the new password is not actually
         the <codeph>-e</codeph> option is used.</p></section><section id="section7">
                         <title>See Also</title>
                         <p><ph otherprops="op-print"><codeph>CREATE ROLE</codeph> in the
-                                                <i>Greenplum Database Reference Guide</i></ph><ph
-                                        otherprops="op-help"><codeph><xref
-                                                  href="../../ref_guide/sql_commands/CREATE_ROLE.xml#topic1"
-                                                /></codeph>,
-                        <codeph><xref
-                                                  href="dropuser.xml#topic1"/></codeph></ph></p>
+            <i>Greenplum Database Reference Guide</i></ph><ph><codeph><xref
+              href="../../ref_guide/sql_commands/CREATE_ROLE.xml#topic1"/></codeph>, <codeph><xref
+              href="dropuser.xml#topic1"/></codeph></ph></p>
                 </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/ref/dropdb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/dropdb.xml
@@ -50,9 +50,7 @@ DROP DATABASE "demo"
 DROP DATABASE</codeblock></section><section id="section7">
                         <title>See Also</title>
                         <p><ph otherprops="op-print"><codeph>DROP DATABASE</codeph> in the
-                                                <i>Greenplum Database Reference Guide</i></ph><ph
-                                        otherprops="op-help"><codeph><xref
-                                                  href="createdb.xml#topic1"/></codeph>, <codeph><xref
-                                                  href="../../ref_guide/sql_commands/DROP_DATABASE.xml#topic1"
-                                                /></codeph></ph></p>
+            <i>Greenplum Database Reference Guide</i></ph><ph><codeph><xref
+              href="createdb.xml#topic1"/></codeph>, <codeph><xref
+              href="../../ref_guide/sql_commands/DROP_DATABASE.xml#topic1"/></codeph></ph></p>
                 </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/ref/dropuser.xml
+++ b/gpdb-doc/dita/utility_guide/ref/dropuser.xml
@@ -43,7 +43,6 @@ DROP ROLE "joe"
 DROP ROLE</codeblock></section><section id="section7">
       <title>See Also</title>
       <p><ph otherprops="op-print"><codeph>DROP ROLE</codeph> in the <i>Greenplum Database Reference
-            Guide</i></ph><ph otherprops="op-help"><codeph><xref
-              href="createuser.xml#topic1"/></codeph>, <codeph><xref
+            Guide</i></ph><ph><codeph><xref href="createuser.xml#topic1"/></codeph>, <codeph><xref
               href="../../ref_guide/sql_commands/DROP_ROLE.xml#topic1"/></codeph></ph></p>
     </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/ref/reindexdb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/reindexdb.xml
@@ -50,6 +50,6 @@ batch jobs and scripts where no user is present to enter a password.</pd></plent
           <codeph>abcd</codeph>:</p><codeblock>reindexdb --table foo --index bar abcd</codeblock></section><section id="section8">
       <title>See Also</title>
       <p><ph otherprops="op-print"><codeph>REINDEX</codeph> in the <i>Greenplum Database Reference
-            Guide</i></ph><ph otherprops="op-help"><codeph><xref
-              href="../../ref_guide/sql_commands/REINDEX.xml#topic1"/></codeph></ph></p>
+            Guide</i></ph><ph><codeph><xref href="../../ref_guide/sql_commands/REINDEX.xml#topic1"
+            /></codeph></ph></p>
     </section></body></topic>

--- a/gpdb-doc/dita/utility_guide/ref/vacuumdb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/vacuumdb.xml
@@ -150,11 +150,10 @@
     <section id="section8">
       <title>See Also</title>
       <p>
-        <ph otherprops="op-print"><codeph>VACUUM</codeph> and <codeph>ANALYZE</codeph> in the
-            <i>Greenplum Database Reference Guide</i></ph>
-        <ph otherprops="op-help"><codeph><xref href="../../ref_guide/sql_commands/VACUUM.xml#topic1"
-            /></codeph>, <codeph><xref href="../../ref_guide/sql_commands/ANALYZE.xml#topic1"
-            /></codeph></ph>
+        <ph><codeph>VACUUM</codeph> and <codeph>ANALYZE</codeph> in the <i>Greenplum Database
+            Reference Guide</i></ph>
+        <ph><codeph><xref href="../../ref_guide/sql_commands/VACUUM.xml#topic1"/></codeph>,
+              <codeph><xref href="../../ref_guide/sql_commands/ANALYZE.xml#topic1"/></codeph></ph>
       </p>
     </section>
   </body>

--- a/gpdb-doc/dita/utility_guide/utility-programs.xml
+++ b/gpdb-doc/dita/utility_guide/utility-programs.xml
@@ -35,7 +35,7 @@
                     Packages. (See the Note following the table.) All utilities are installed when
                     you install the Greenplum Database server, unless specifically identified by a
                     superscript.</ph></p>
-            <simpletable frame="all" relcolwidth="1.0* 1.0* 1.0*" otherprops="op-help">
+            <simpletable frame="all" relcolwidth="1.0* 1.0* 1.0*">
                 <strow>
                     <stentry>
                         <p><xref href="ref/analyzedb.xml" type="topic" format="dita"/></p>
@@ -71,7 +71,8 @@
                             /></p>
                         <p><xref href="ref/gpinitsystem.xml#topic1" type="topic" format="dita"/></p>
                         <p otherprops="pivotal">
-                            <xref href="https://greenplum.docs.pivotal.io/streaming-server/1-5/ref/gpss-ref.html"
+                            <xref
+                                href="https://greenplum.docs.pivotal.io/streaming-server/1-5/ref/gpss-ref.html"
                                 format="html" scope="external">gpkafka</xref><sup>4</sup></p>
                         <p><xref href="ref/gpload.xml#topic1" type="topic" format="dita"/><sup
                                 otherprops="pivotal">3</sup></p>
@@ -104,12 +105,13 @@
                             >3</sup></p>
                         <p><xref href="ref/pg_restore.xml#topic1"/></p>
                         <p><xref href="ref/plcontainer.xml#topic1" type="topic" format="dita"/></p>
-                        <p><xref href="ref/plcontainer-configuration.xml#topic1" type="topic" format="dita"/></p>
+                        <p><xref href="ref/plcontainer-configuration.xml#topic1" type="topic"
+                                format="dita"/></p>
                         <p><xref href="ref/psql.xml#topic1"/><sup otherprops="pivotal">3</sup></p>
                         <p><xref href="../../pxf/5-15/ref/pxf.html" format="html" scope="external"
-                            >pxf</xref></p>
+                                >pxf</xref></p>
                         <p><xref href="../../pxf/5-15/ref/pxf-cluster.html" format="html"
-                            scope="external">pxf cluster</xref></p>
+                                scope="external">pxf cluster</xref></p>
                         <p><xref href="ref/reindexdb.xml#topic1"/></p>
                         <p><xref href="ref/vacuumdb.xml#topic1"/></p>
                     </stentry>


### PR DESCRIPTION
Some paragraphs/tables had the property otherprops="op-help" set. This was causing issues when viewing the PDF version of the documentation, some text was being hidden.
Removed all references to this property for all xml files. I didn't change some ditamap/ditaval files. 
