### PR TITLE
Use text type in output of array type

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -132,7 +132,7 @@ def dumpStats(cur, inclHLL):
         # determine the actual types of stavalues[1-5], the columns are defined as "anyarray"
         if vals[4][0] == '_':
             # column is an array type, use as is
-            rowTypes = types + [typename] * 5
+            rowTypes = types + ["_text"] * 5
         else:
             # non-array type, make an array type out of it
             rowTypes = types + [typename + '[]'] * 5

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -271,7 +271,7 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
         # determine the actual types of stavalues[1-5], the columns are defined as "anyarray"
         if vals[4][0] == '_':
             # column is an array type, use as is
-            rowTypes = types + [typename] * 5
+            rowTypes = types + ["_text"] * 5
         else:
             # non-array type, make an array type out of it
             rowTypes = types + [typename + '[]'] * 5

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -1,0 +1,50 @@
+-- start_ignore
+drop database if exists gpsd_db_with_hll;
+-- end_ignore
+create database gpsd_db_with_hll;
+\c gpsd_db_with_hll
+create table minirepro_foo(a int, b int[]);
+insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
+insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
+insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
+analyze minirepro_foo;
+\! echo "select * from minirepro_foo;" > ./data/minirepro_q.sql
+-- start_ignore
+\! minirepro gpsd_db_with_hll -q data/minirepro_q.sql -f data/minirepro.sql
+Connecting to database: host=localhost.localdomain, port=16000, user=gpadmin, db=gpsd_db_with_hll ...
+Extracting metadata from query file data/minirepro_q.sql ...
+psql gpsd_db_with_hll --pset footer --no-psqlrc -Atq -h localhost.localdomain -p 16000 -U gpadmin -f /tmp/20210908204808/toolkit.sql
+Invoking pg_dump to dump DDL ...
+pg_dump -h localhost.localdomain -p 16000 -U gpadmin -sxO gpsd_db_with_hll --relation-oids 16634 --function-oids 0 -f /tmp/20210908204808/pg_dump_out.sql
+Writing schema DDLs ...
+Writing relation and function DDLs ...
+Writing table statistics ...
+Writing column statistics ...
+Attaching raw query text ...
+--- MiniRepro completed! ---
+WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.
+Please review output file to ensure it is within corporate policy to transport the output file.
+-- end_ignore
+drop table minirepro_foo;
+\! psql -f data/minirepro.sql gpsd_db_with_hll
+You are now connected to database "gpsd_db_with_hll" as user "gpadmin".
+SET
+SET
+SET
+SET
+SET
+ set_config 
+------------
+ 
+(1 row)
+
+SET
+SET
+SET
+SET
+SET
+CREATE TABLE
+SET
+UPDATE 1
+INSERT 0 1
+INSERT 0 1

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -1,0 +1,24 @@
+-- start_ignore
+drop database if exists gpsd_db_with_hll;
+-- end_ignore
+create database gpsd_db_with_hll;
+\c gpsd_db_with_hll
+create table minirepro_foo(a int, b int[]);
+
+insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
+insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
+insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
+analyze minirepro_foo;
+
+\! echo "select * from minirepro_foo;" > ./data/minirepro_q.sql
+-- start_ignore
+\! minirepro gpsd_db_with_hll -q data/minirepro_q.sql -f data/minirepro.sql
+-- end_ignore
+
+drop table minirepro_foo;
+
+\! psql -f data/minirepro.sql gpsd_db_with_hll
+
+
+
+


### PR DESCRIPTION
If the field type is array, then the type of statistical information
will be array[array]. But now we use One-dimensional array like
array[float].

Since we have output in a good format, if it is considered to be of text
type, it will be automatically converted to array[array]

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
