### PR TITLE
gpinitsystem behave tests fix flakes

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -38,12 +38,13 @@ Feature: gpinitsystem tests
         Given the user runs "gpstate"
          Then gpstate should return a return code of 0
 
-    Scenario Outline: gpinitsystem creates a backout file when process terminated
+    Scenario: gpinitsystem creates a backout file when gpinitsystem process terminated
         Given create demo cluster config
         And all files in gpAdminLogs directory are deleted
         When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-        And the user asynchronously sets up to end <terminated_process> process when "Waiting for parallel processes" is printed in gpinitsystem logs
-        And the user waits 30 second
+        And the user asynchronously sets up to end gpinitsystem process when "Waiting for parallel processes" is printed in the logs
+        And the user waits until saved async process is completed
+        And the user waits until gpcreateseg process is completed
         Then gpintsystem logs should contain lines about running backout script
         And the user runs the gpinitsystem backout script
         And all files in gpAdminLogs directory are deleted
@@ -51,18 +52,27 @@ Feature: gpinitsystem tests
         And gpinitsystem should return a return code of 0
         And gpintsystem logs should not contain lines about running backout script
 
-    Examples:
-        | terminated_process |
-        | bin/gpinitsystem   |
-        | gpcreateseg        |
+    Scenario: gpinitsystem creates a backout file when gpcreateseg process terminated
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end gpcreateseg process when it starts
+        And the user waits until saved async process is completed
+        Then gpintsystem logs should contain lines about running backout script
+        And the user runs the gpinitsystem backout script
+        And all files in gpAdminLogs directory are deleted
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And gpinitsystem should return a return code of 0
+        And gpintsystem logs should not contain lines about running backout script
 
     Scenario: gpinitsystem does not create or need backout file when user terminated very early
         Given create demo cluster config
         And all files in gpAdminLogs directory are deleted
         When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
         And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
-        And the user waits 10 second
+        And the user waits until saved async process is completed
         Then gpintsystem logs should not contain lines about running backout script
+        And all files in gpAdminLogs directory are deleted
         And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
 


### PR DESCRIPTION
The behave tests added for gpinitsystem backout scripts are timing
dependent, since they involve asynchronous killing of processes.
This was causing failures on pipeline if the kill is executed too
early/late.

This commit aims at reducing this flaky behavior by
- making the kill condition more accurate for gpcreateseg- by monitoring
  process instead of logs. We monitor the process using ps/grep and want
  to kill it after it has setup the trap for ERROR_EXIT. Added test step
  for the same.
- for scenario of killing gpinitsystem, gpcreateseg processes can still
  run in the background after gpinitsystem has been killed. We want to
  wait for these processes to complete to successfully run backout
  script. Added test step for the same.
- changing the 'waiting to complete' step to monitor processes, instead
  of time.
- clearing out logs so subsequent runs don't affect each other.