### PR TITLE
Mark n-th children of redistribute-redistribute hash joins plans as unsatisfiable by singleton

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/3WayJoinOnMultiDistributionColumnsTables.mdp
+++ b/src/backend/gporca/data/dxl/minidump/3WayJoinOnMultiDistributionColumnsTables.mdp
@@ -2759,7 +2759,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="72">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1304.753547" Rows="10000.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/3WayJoinOnMultiDistributionColumnsTablesNoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/3WayJoinOnMultiDistributionColumnsTablesNoMotion.mdp
@@ -2759,7 +2759,7 @@ t1.a = t2.a and t2.a = t3.a and t1.b = t3.b and t2.b = t3.b;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="52">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.035547" Rows="10000.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/3WayJoinUsingOperatorsOfNonDefaultOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/3WayJoinUsingOperatorsOfNonDefaultOpfamily.mdp
@@ -396,7 +396,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.445645" Rows="3.413333" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
@@ -4649,7 +4649,7 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="104185">
+    <dxl:Plan Id="0" SpaceSize="245494">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1725.989618" Rows="129.961520" Width="44"/>

--- a/src/backend/gporca/data/dxl/minidump/AddPredsInSubqueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddPredsInSubqueries.mdp
@@ -392,7 +392,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="141">
+    <dxl:Plan Id="0" SpaceSize="139">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001677" Rows="1.000000" Width="104"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubqueryWithAllSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubqueryWithAllSubqueryInScalar.mdp
@@ -442,7 +442,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="356">
+    <dxl:Plan Id="0" SpaceSize="504">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="8620.003395" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
@@ -353,7 +353,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="420">
+    <dxl:Plan Id="0" SpaceSize="600">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6896.001505" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
@@ -1563,7 +1563,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="50">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="75.123853" Rows="337.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -313,7 +313,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000126" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
@@ -3456,7 +3456,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="15">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1070.584957" Rows="992059.668838" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/BroadcastSkewedHashjoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BroadcastSkewedHashjoin.mdp
@@ -3111,7 +3111,7 @@ Intent: The join should pick up a Broadcast over Redistribute. The hashjoin is s
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="871.634495" Rows="77880.861751" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithOutDP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithOutDP.mdp
@@ -1764,7 +1764,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="197120">
+    <dxl:Plan Id="0" SpaceSize="326264">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.369590" Rows="100.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -705,7 +705,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="17">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="10" VarTypeModList="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="438.394467" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
@@ -271,7 +271,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="61">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.003882" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Join-Redistribute-Producer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Join-Redistribute-Producer.mdp
@@ -410,7 +410,7 @@ with v as (select * from t1) select * from v v1, v v2 where v1.b=v2.b;
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="42">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.388166" Rows="1000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
@@ -1726,7 +1726,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="85">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.483722" Rows="1000.000000" Width="26"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
@@ -1755,7 +1755,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="80">
+    <dxl:Plan Id="0" SpaceSize="190">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.388623" Rows="400.000000" Width="26"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
@@ -410,7 +410,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="60">
+    <dxl:Plan Id="0" SpaceSize="124">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.050688" Rows="100.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp
@@ -251,7 +251,7 @@
         <dxl:LogicalCTEConsumer CTEId="1" Columns="19,20,21,22"/>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000587" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="106430584528">
+    <dxl:Plan Id="0" SpaceSize="83789749800">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250696.455244" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEinlining.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEinlining.mdp
@@ -198,7 +198,7 @@ explain with v as (select x,y from bar) select v1.x from v v1, v v2 where v1.x =
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="44">
+    <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000443" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10888,7 +10888,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="188">
+    <dxl:Plan Id="0" SpaceSize="222">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="102938.691528" Rows="13.696907" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -852,7 +852,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5302">
+    <dxl:Plan Id="0" SpaceSize="4780">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="38915.797885" Rows="4.000000" Width="269"/>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -1931,7 +1931,7 @@ SELECT * FROM information_schema.tables;
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.080500" Rows="2.800000" Width="96"/>

--- a/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
@@ -642,7 +642,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:DMLInsert Columns="0,6" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="877.746838" Rows="1000.000000" Width="7"/>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
@@ -711,7 +711,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalDelete>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="156">
+    <dxl:Plan Id="0" SpaceSize="96">
       <dxl:DMLDelete Columns="0" ActionCol="23" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.570616" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -360,7 +360,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="25">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0" VarTypeModList="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.010884" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
@@ -971,7 +971,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.284504" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -963,7 +963,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.294061" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2371,7 +2371,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="137">
+    <dxl:Plan Id="0" SpaceSize="150">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324807.970884" Rows="2844.444444" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/DPv2GreedyOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPv2GreedyOnly.mdp
@@ -5921,7 +5921,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="15">
       <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="228670.202313" Rows="2010720827.932932" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/DPv2MinCardOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPv2MinCardOnly.mdp
@@ -5921,7 +5921,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="15">
       <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="228670.202313" Rows="2010720827.932932" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/DPv2QueryOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPv2QueryOnly.mdp
@@ -5921,7 +5921,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="58">
+    <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="300474.867137" Rows="205295483.329566" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -721,10 +721,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalDelete>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="238">
+    <dxl:Plan Id="0" SpaceSize="242">
       <dxl:DMLDelete Columns="0" ActionCol="21" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.965580" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.965234" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -746,7 +746,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.942142" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.941796" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -764,9 +764,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:HashJoin JoinType="In">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.942136" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.941790" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -816,37 +816,34 @@
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.941257" Rows="10.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.940911" Rows="10.000000" Width="4"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="8"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="a">
                   <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr>
+                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.941236" Rows="10.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.940807" Rows="10.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="a">
                     <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.941105" Rows="10.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.940767" Rows="10.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="a">
@@ -855,27 +852,18 @@
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.941063" Rows="10.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.940618" Rows="10.000000" Width="4"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="8"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="8" Alias="a">
                         <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.941042" Rows="10.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.693671" Rows="99570.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="8" Alias="a">
@@ -883,95 +871,35 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.940911" Rows="10.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="8" Alias="a">
-                            <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Limit>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.940807" Rows="10.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="8" Alias="a">
-                              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.940767" Rows="10.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="8" Alias="a">
-                                <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Limit>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.940618" Rows="10.000000" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="8" Alias="a">
-                                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.693671" Rows="99570.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="8" Alias="a">
-                                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.49342.1.0" TableName="test1">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="10"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:GatherMotion>
-                          <dxl:LimitCount>
-                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="10"/>
-                          </dxl:LimitCount>
-                          <dxl:LimitOffset>
-                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                          </dxl:LimitOffset>
-                        </dxl:Limit>
-                      </dxl:RandomMotion>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
-            </dxl:Aggregate>
+                      <dxl:TableDescriptor Mdid="0.49342.1.0" TableName="test1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="10"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:GatherMotion>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:RedistributeMotion>
           </dxl:HashJoin>
         </dxl:Result>
       </dxl:DMLDelete>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -324,7 +324,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="96">
+    <dxl:Plan Id="0" SpaceSize="72">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Supported.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Supported.mdp
@@ -1238,7 +1238,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7257">
+    <dxl:Plan Id="0" SpaceSize="2649">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2796.936115" Rows="140203.000000" Width="78"/>

--- a/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Unsupported.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Unsupported.mdp
@@ -1176,7 +1176,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="58837188745941401600.000000" Rows="258611551791821375930368.000000" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -1934,7 +1934,7 @@
         </dxl:UnionAll>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="66">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34972.709569" Rows="19097.637457" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -1936,7 +1936,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="484">
+    <dxl:Plan Id="0" SpaceSize="1176">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34974.557438" Rows="9548.818729" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
@@ -371,7 +371,7 @@
         </dxl:UnionAll>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000573" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/EstimateJoinRowsForCastPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EstimateJoinRowsForCastPredicates.mdp
@@ -515,7 +515,7 @@ explain select * from A,B where A.j=B.j;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.541395" Rows="10000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/ExceptAllCompatibleDataType.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExceptAllCompatibleDataType.mdp
@@ -413,7 +413,7 @@
         </dxl:LogicalGet>
       </dxl:DifferenceAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="140">
+    <dxl:Plan Id="0" SpaceSize="99">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.003180" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
@@ -221,7 +221,7 @@ select * from t full join s on t1 = s1;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="256">
+    <dxl:Plan Id="0" SpaceSize="248">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.001789" Rows="3.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -865,7 +865,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3249">
+    <dxl:Plan Id="0" SpaceSize="3639">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="31120.116045" Rows="100.000000" Width="128"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
@@ -3934,7 +3934,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="100041">
+    <dxl:Plan Id="0" SpaceSize="67132">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.168979" Rows="10.000001" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -15774,7 +15774,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7020">
+    <dxl:Plan Id="0" SpaceSize="7960">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5944.261371" Rows="20169.272000" Width="76"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -454,7 +454,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7695">
+    <dxl:Plan Id="0" SpaceSize="8635">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-NonDefaultOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-NonDefaultOpfamily.mdp
@@ -349,7 +349,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="288">
+    <dxl:Plan Id="0" SpaceSize="227">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.001617" Rows="10.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -487,7 +487,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2048">
+    <dxl:Plan Id="0" SpaceSize="2400">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1299.001542" Rows="3.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/GreedyNAryJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GreedyNAryJoin.mdp
@@ -1144,7 +1144,7 @@ EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON a =b INNER JOIN t3 ON b = c;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="88">
+    <dxl:Plan Id="0" SpaceSize="85">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.748028" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
@@ -320,10 +320,10 @@ where t.a in (select count(s.i) from s);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
-      <dxl:HashJoin JoinType="In">
+    <dxl:Plan Id="0" SpaceSize="102">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000729" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000717" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -334,18 +334,10 @@ where t.a in (select count(s.i) from s);
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-            <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:Cast>
-            <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000151" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000663" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -356,10 +348,18 @@ where t.a in (select count(s.i) from s);
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:TableScan>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+              <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:Cast>
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -370,85 +370,124 @@ where t.a in (select count(s.i) from s);
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.839942.1.1" TableName="t">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:GatherMotion>
-        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:GroupingColumns/>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="18" Alias="count">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
-                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
-              </dxl:AggFunc>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Cast>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.839942.1.1" TableName="t">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+          <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="18" Alias="count">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
-                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="18" Alias="count">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final">
+                    <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
                   </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableScan>
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="i">
-                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                    <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.839968.1.1" TableName="s">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
+                <dxl:SortingColumnList/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="i">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.839968.1.1" TableName="s">
+                      <dxl:Columns>
+                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:Aggregate>
+              </dxl:GatherMotion>
             </dxl:Aggregate>
-          </dxl:GatherMotion>
-        </dxl:Aggregate>
-      </dxl:HashJoin>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6362,7 +6362,7 @@ ORDER BY s_name;
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1863552">
+    <dxl:Plan Id="0" SpaceSize="2868496">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="24583535.993774" Rows="49.989277" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -1917,7 +1917,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28">
+    <dxl:Plan Id="0" SpaceSize="34">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="829.034339" Rows="35.148716" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -356,7 +356,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1219">
+    <dxl:Plan Id="0" SpaceSize="1213">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001398" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -4551,7 +4551,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="11941.357050" Rows="1.000000" Width="275"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -824,7 +824,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="23">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -830,7 +830,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="31">
+    <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="864.151759" Rows="1000.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -824,7 +824,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="23">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -816,7 +816,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="25">
+    <dxl:Plan Id="0" SpaceSize="27">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.780122" Rows="100.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
@@ -489,7 +489,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22893">
+    <dxl:Plan Id="0" SpaceSize="22449">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324469.354209" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
@@ -285,7 +285,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="27">
+    <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000677" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -290,7 +290,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="27">
+    <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="822.296104" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
@@ -273,7 +273,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="25">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="822.295674" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -260,7 +260,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="44">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.001095" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
@@ -273,7 +273,7 @@ a < 2 should also be outside the limit but not below.
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="52">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000626" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForProcessedColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForProcessedColumn.mdp
@@ -370,7 +370,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="104">
+    <dxl:Plan Id="0" SpaceSize="102">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001317" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -816,7 +816,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="257">
+    <dxl:Plan Id="0" SpaceSize="237">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000804" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InferredPredicatesConstraintSimplification.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferredPredicatesConstraintSimplification.mdp
@@ -399,7 +399,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="108">
+    <dxl:Plan Id="0" SpaceSize="104">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001072" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExcept.mdp
@@ -295,7 +295,7 @@ ON (a.col = b.col);
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1248">
+    <dxl:Plan Id="0" SpaceSize="1222">
       <dxl:DMLInsert Columns="0" ActionCol="32" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.011396" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExceptAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExceptAll.mdp
@@ -333,7 +333,7 @@ ON (a.col = b.col);
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1127">
+    <dxl:Plan Id="0" SpaceSize="987">
       <dxl:DMLInsert Columns="0" ActionCol="34" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.011735" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -503,7 +503,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1180">
+    <dxl:Plan Id="0" SpaceSize="1120">
       <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="48" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="867.119333" Rows="96.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1413,7 +1413,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13920">
+    <dxl:Plan Id="0" SpaceSize="15360">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.065290" Rows="77.229878" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-NonRedistributableCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-NonRedistributableCol.mdp
@@ -270,7 +270,7 @@ explain select * from foo, testhstore where foo.b = testhstore.h;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000526" Rows="1.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
@@ -649,7 +649,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.566515" Rows="10000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
@@ -474,7 +474,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.031867" Rows="100.000000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
@@ -352,7 +352,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022512" Rows="100.000000" Width="6"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -985,7 +985,7 @@ OR
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="375168">
+    <dxl:Plan Id="0" SpaceSize="269612">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9921.832259" Rows="521.833333" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4044,7 +4044,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="323272">
+    <dxl:Plan Id="0" SpaceSize="443272">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>
@@ -4269,7 +4269,7 @@
                           </dxl:Cast>
                         </dxl:Comparison>
                       </dxl:HashCondList>
-                      <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="10">
+                      <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="9">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="96421.988429" Rows="5288759693.059181" Width="26"/>
                         </dxl:Properties>
@@ -4473,7 +4473,7 @@
                         </dxl:TableScan>
                       </dxl:BroadcastMotion>
                     </dxl:HashJoin>
-                    <dxl:PartitionSelector RelationMdid="0.328475.1.1" SelectorId="10" ScanId="1" Partitions="0,1,2,3">
+                    <dxl:PartitionSelector RelationMdid="0.328475.1.1" SelectorId="9" ScanId="1" Partitions="0,1,2,3">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="1552.578227" Rows="607744.000000" Width="30"/>
                       </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAboveLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAboveLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2488">
+    <dxl:Plan Id="0" SpaceSize="4966">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001370" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5270">
+    <dxl:Plan Id="0" SpaceSize="10480">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001370" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityBelowLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityBelowLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="415">
+    <dxl:Plan Id="0" SpaceSize="293">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001389" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp.mdp
@@ -333,7 +333,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000704" Rows="4.800000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
@@ -3155,7 +3155,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="911.682395" Rows="1061.180292" Width="969"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
@@ -2868,7 +2868,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="617">
+    <dxl:Plan Id="0" SpaceSize="543">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.848201" Rows="10.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelQueryNonPartTblInnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelQueryNonPartTblInnerJoin.mdp
@@ -2868,7 +2868,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="102">
+    <dxl:Plan Id="0" SpaceSize="55">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1725.015494" Rows="9.990009" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -3144,7 +3144,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="644">
+    <dxl:Plan Id="0" SpaceSize="602">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.264890" Rows="95315.069401" Width="24"/>
@@ -3223,7 +3223,7 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="3" SelectorIds="11">
+            <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="3" SelectorIds="10">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.003571" Rows="156.000000" Width="8"/>
               </dxl:Properties>
@@ -3282,7 +3282,7 @@
                 </dxl:TableDescriptor>
               </dxl:TableScan>
             </dxl:Append>
-            <dxl:PartitionSelector RelationMdid="0.245931.1.0" SelectorId="11" ScanId="3" Partitions="3">
+            <dxl:PartitionSelector RelationMdid="0.245931.1.0" SelectorId="10" ScanId="3" Partitions="3">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000166" Rows="3.000003" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/JoinTinterval.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinTinterval.mdp
@@ -311,7 +311,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="54">
+    <dxl:Plan Id="0" SpaceSize="64">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000771" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
@@ -287,7 +287,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000934" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MasterOnly-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MasterOnly-Table.mdp
@@ -803,7 +803,7 @@ union all
         </dxl:LogicalJoin>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Append IsTarget="false" IsZapped="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="874.433340" Rows="1.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
@@ -355,7 +355,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="461.001441" Rows="5.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
@@ -374,7 +374,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="461.001661" Rows="5.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -288,7 +288,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="822.295778" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
@@ -273,7 +273,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="822.295752" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
@@ -283,7 +283,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000351" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
@@ -287,7 +287,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000597" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IsNullPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IsNullPred.mdp
@@ -12159,7 +12159,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="8890.464428" Rows="2818278.671879" Width="251"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJNullRejectingPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJNullRejectingPredicates.mdp
@@ -429,7 +429,7 @@ explain select * from t1 left join t2 on t1.a=t2.a left join t3 on t2.a=t3.a lef
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2170">
+    <dxl:Plan Id="0" SpaceSize="2014">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.002274" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
@@ -1619,7 +1619,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2778615">
+    <dxl:Plan Id="0" SpaceSize="8024302">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.297294" Rows="6.196244" Width="56"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithComplexPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithComplexPredicate.mdp
@@ -1957,7 +1957,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="95">
+    <dxl:Plan Id="0" SpaceSize="104">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.153370" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="95">
+    <dxl:Plan Id="0" SpaceSize="104">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.153459" Rows="1.200000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithNestedLOJAndFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithNestedLOJAndFilter.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="57">
+    <dxl:Plan Id="0" SpaceSize="54">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.154254" Rows="4.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
@@ -1954,7 +1954,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765474.620713" Rows="4.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithSimplePredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithSimplePredicate.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="449">
+    <dxl:Plan Id="0" SpaceSize="463">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.210199" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5768,7 +5768,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19655804">
+    <dxl:Plan Id="0" SpaceSize="18357990">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2587.327973" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -352,7 +352,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="15">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -360,7 +360,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="15">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-UnsupportedFilter-Cardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-UnsupportedFilter-Cardinality.mdp
@@ -787,7 +787,7 @@ explain select * from foo left join bar on foo.a=bar.a left join zoo on foo.a::i
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="59">
+    <dxl:Plan Id="0" SpaceSize="51">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.520466" Rows="2000.000000" Width="22"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -2110,10 +2110,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1028">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="8413">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="69941.373160" Rows="896.720000" Width="238"/>
+          <dxl:Cost StartupCost="0" TotalCost="69897.543704" Rows="896.720000" Width="238"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="36" Alias="tableoid">
@@ -2138,68 +2138,7 @@
             <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="100" Alias="rolname">
-            <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-              </dxl:ParamList>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.059266" Rows="1.000000" Width="64"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="74" Alias="rolname">
-                    <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.059266" Rows="1.000000" Width="64"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="99" Alias="rolpassword">
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWI=" LintValue="160449068"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="74" Alias="rolname">
-                      <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.059202" Rows="1.000000" Width="64"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="74" Alias="rolname">
-                        <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                        <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
-                        <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
-                      <dxl:Columns>
-                        <dxl:Column ColId="74" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                        <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="92" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="93" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="94" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="95" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="96" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="97" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="98" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="100" ColName="rolname" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="18" Alias="relchecks">
             <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
@@ -2217,10 +2156,7 @@
             <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="101" Alias="relistoasted">
-            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.608.1.0">
-              <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
-              <dxl:ConstValue TypeMdid="0.26.1.0" Value="0"/>
-            </dxl:Comparison>
+            <dxl:Ident ColId="101" ColName="relistoasted" TypeMdid="0.16.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="42" Alias="owning_tab">
             <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
@@ -2229,73 +2165,32 @@
             <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="117" Alias="reltablespace">
-            <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-              </dxl:ParamList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.131851" Rows="1.000000" Width="64"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="102" Alias="spcname">
-                    <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                    <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.1213.1.1" TableName="pg_tablespace">
-                  <dxl:Columns>
-                    <dxl:Column ColId="102" Attno="1" ColName="spcname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="109" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="110" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="111" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="112" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="113" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="114" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="115" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="116" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="117" ColName="reltablespace" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="118" Alias="reloptions">
-            <dxl:FuncExpr FuncId="0.395.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-              <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUI=" LintValue="160711212"/>
-            </dxl:FuncExpr>
+            <dxl:Ident ColId="118" ColName="reloptions" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Sort SortDiscardDuplicates="false">
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="31" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="69941.159741" Rows="1000.000000" Width="241"/>
+            <dxl:Cost StartupCost="0" TotalCost="69896.585452" Rows="896.720000" Width="238"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="36" Alias="tableoid">
+              <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="31" Alias="oid">
+              <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="relname">
               <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="relnamespace">
-              <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="relowner">
-              <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="6" Alias="reltablespace">
-              <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="reltoastrelid">
-              <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="13" Alias="relhasindex">
-              <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+            <dxl:ProjElem ColId="28" Alias="relacl">
+              <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="15" Alias="relkind">
               <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
@@ -2303,29 +2198,137 @@
             <dxl:ProjElem ColId="16" Alias="relstorage">
               <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="relnamespace">
+              <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="100" Alias="rolname">
+              <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                </dxl:ParamList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.063108" Rows="2.000000" Width="64"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="74" Alias="rolname">
+                      <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.063108" Rows="2.000000" Width="64"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="99" Alias="rolpassword">
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWI=" LintValue="160449068"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="74" Alias="rolname">
+                        <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.063044" Rows="2.000000" Width="64"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="74" Alias="rolname">
+                          <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                          <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.004039" Rows="2.000000" Width="72"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="74" Alias="rolname">
+                            <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="92" Alias="oid">
+                            <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.003967" Rows="2.000000" Width="72"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="74" Alias="rolname">
+                              <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="92" Alias="oid">
+                              <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="74" Alias="rolname">
+                                <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="92" Alias="oid">
+                                <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
+                              <dxl:Columns>
+                                <dxl:Column ColId="74" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                                <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="92" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="93" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="94" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="95" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="96" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="97" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="98" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:Result>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="18" Alias="relchecks">
               <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="19" Alias="reltriggers">
               <dxl:Ident ColId="19" ColName="reltriggers" TypeMdid="0.21.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="23" Alias="relhasoids">
-              <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+            <dxl:ProjElem ColId="13" Alias="relhasindex">
+              <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="25" Alias="relhasrules">
               <dxl:Ident ColId="25" ColName="relhasrules" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="28" Alias="relacl">
-              <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
+            <dxl:ProjElem ColId="23" Alias="relhasoids">
+              <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="29" Alias="reloptions">
-              <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="31" Alias="oid">
-              <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="36" Alias="tableoid">
-              <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:ProjElem ColId="101" Alias="relistoasted">
+              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.608.1.0">
+                <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                <dxl:ConstValue TypeMdid="0.26.1.0" Value="0"/>
+              </dxl:Comparison>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="42" Alias="refobjid">
               <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
@@ -2333,16 +2336,99 @@
             <dxl:ProjElem ColId="43" Alias="refobjsubid">
               <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="117" Alias="reltablespace">
+              <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                </dxl:ParamList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.139667" Rows="2.000000" Width="64"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="102" Alias="spcname">
+                      <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                      <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
+                      <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.008067" Rows="4.000000" Width="72"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="102" Alias="spcname">
+                        <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="110" Alias="oid">
+                        <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.007923" Rows="4.000000" Width="72"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="102" Alias="spcname">
+                          <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="110" Alias="oid">
+                          <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000117" Rows="2.000000" Width="72"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="102" Alias="spcname">
+                            <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="110" Alias="oid">
+                            <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.1213.1.1" TableName="pg_tablespace">
+                          <dxl:Columns>
+                            <dxl:Column ColId="102" Attno="1" ColName="spcname" TypeMdid="0.19.1.0"/>
+                            <dxl:Column ColId="109" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="110" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="111" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="112" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="113" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="114" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="115" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="116" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="118" Alias="reloptions">
+              <dxl:FuncExpr FuncId="0.395.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUI=" LintValue="160711212"/>
+              </dxl:FuncExpr>
+            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList>
-            <dxl:SortingColumn ColId="31" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-          </dxl:SortingColumnList>
-          <dxl:LimitCount/>
-          <dxl:LimitOffset/>
-          <dxl:HashJoin JoinType="Right">
+          <dxl:OneTimeFilter/>
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1295.347540" Rows="896.720000" Width="145"/>
+              <dxl:Cost StartupCost="0" TotalCost="69896.478742" Rows="1000.000000" Width="241"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="relname">
@@ -2401,81 +2487,14 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
-                <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
-                <dxl:ConstValue TypeMdid="0.18.1.0" Value="Uw=="/>
-              </dxl:Comparison>
-            </dxl:JoinFilter>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="31" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:HashJoin JoinType="Right">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.642269" Rows="2240.800000" Width="20"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="38" Alias="classid">
-                  <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="39" Alias="objid">
-                  <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="refclassid">
-                  <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="refobjid">
-                  <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="refobjsubid">
-                  <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:And>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="40" ColName="objsubid" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
-                    <dxl:Ident ColId="44" ColName="deptype" TypeMdid="0.18.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.18.1.0" Value="YQ=="/>
-                  </dxl:Comparison>
-                </dxl:And>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.2608.1.1" TableName="pg_depend">
-                <dxl:Columns>
-                  <dxl:Column ColId="38" Attno="1" ColName="classid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="39" Attno="2" ColName="objid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="40" Attno="3" ColName="objsubid" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="41" Attno="4" ColName="refclassid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="42" Attno="5" ColName="refobjid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="43" Attno="6" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="44" Attno="7" ColName="deptype" TypeMdid="0.18.1.0"/>
-                  <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.051129" Rows="1.000000" Width="137"/>
+                <dxl:Cost StartupCost="0" TotalCost="1294.644951" Rows="896.720000" Width="145"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="relname">
@@ -2526,18 +2545,124 @@
                 <dxl:ProjElem ColId="36" Alias="tableoid">
                   <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="refobjid">
+                  <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="43" Alias="refobjsubid">
+                  <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
+              <dxl:JoinFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
+                  <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.18.1.0" Value="Uw=="/>
+                </dxl:Comparison>
+              </dxl:JoinFilter>
               <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
                   <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                  <dxl:Ident ColId="53" ColName="parchildrelid" TypeMdid="0.26.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:TableScan>
+              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.049779" Rows="2.000000" Width="137"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.764617" Rows="2240.800000" Width="20"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="38" Alias="classid">
+                    <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="39" Alias="objid">
+                    <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="41" Alias="refclassid">
+                    <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="42" Alias="refobjid">
+                    <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="43" Alias="refobjsubid">
+                    <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.642269" Rows="2240.800000" Width="20"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="38" Alias="classid">
+                      <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="39" Alias="objid">
+                      <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="41" Alias="refclassid">
+                      <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="42" Alias="refobjid">
+                      <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="43" Alias="refobjsubid">
+                      <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:And>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="40" ColName="objsubid" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                      </dxl:Comparison>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
+                        <dxl:Ident ColId="44" ColName="deptype" TypeMdid="0.18.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.18.1.0" Value="YQ=="/>
+                      </dxl:Comparison>
+                    </dxl:And>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.2608.1.1" TableName="pg_depend">
+                    <dxl:Columns>
+                      <dxl:Column ColId="38" Attno="1" ColName="classid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="39" Attno="2" ColName="objid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="40" Attno="3" ColName="objsubid" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="41" Attno="4" ColName="refclassid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="42" Attno="5" ColName="refobjid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="43" Attno="6" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="44" Attno="7" ColName="deptype" TypeMdid="0.18.1.0"/>
+                      <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.051558" Rows="1.000000" Width="137"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="relname">
@@ -2589,72 +2714,203 @@
                     <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:ArrayComp OperatorName="=" OperatorMdid="0.92.1.0" OperatorType="Any">
-                    <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
-                    <dxl:Array ArrayType="0.1002.1.0" ElementType="0.18.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.18.1.0" Value="cg=="/>
-                      <dxl:ConstValue TypeMdid="0.18.1.0" Value="Uw=="/>
-                      <dxl:ConstValue TypeMdid="0.18.1.0" Value="dg=="/>
-                      <dxl:ConstValue TypeMdid="0.18.1.0" Value="Yw=="/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.1259.1.1" TableName="pg_class">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="relname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="relnamespace" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="3" Attno="4" ColName="relowner" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="6" Attno="7" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="9" Attno="10" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="13" Attno="14" ColName="relhasindex" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="15" Attno="16" ColName="relkind" TypeMdid="0.18.1.0"/>
-                    <dxl:Column ColId="16" Attno="17" ColName="relstorage" TypeMdid="0.18.1.0"/>
-                    <dxl:Column ColId="18" Attno="19" ColName="relchecks" TypeMdid="0.21.1.0"/>
-                    <dxl:Column ColId="19" Attno="20" ColName="reltriggers" TypeMdid="0.21.1.0"/>
-                    <dxl:Column ColId="23" Attno="24" ColName="relhasoids" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="25" Attno="26" ColName="relhasrules" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="28" Attno="29" ColName="relacl" TypeMdid="0.1034.1.0"/>
-                    <dxl:Column ColId="29" Attno="30" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-                    <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="31" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="53" Alias="parchildrelid">
-                    <dxl:Ident ColId="53" ColName="parchildrelid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.5011.1.1" TableName="pg_partition_rule">
-                  <dxl:Columns>
-                    <dxl:Column ColId="53" Attno="2" ColName="parchildrelid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="66" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="67" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="68" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="69" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="70" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="71" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="72" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="73" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.051129" Rows="1.000000" Width="137"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="relname">
+                      <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="relnamespace">
+                      <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="3" Alias="relowner">
+                      <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="6" Alias="reltablespace">
+                      <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="reltoastrelid">
+                      <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="13" Alias="relhasindex">
+                      <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="15" Alias="relkind">
+                      <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="16" Alias="relstorage">
+                      <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="relchecks">
+                      <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="reltriggers">
+                      <dxl:Ident ColId="19" ColName="reltriggers" TypeMdid="0.21.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="23" Alias="relhasoids">
+                      <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="25" Alias="relhasrules">
+                      <dxl:Ident ColId="25" ColName="relhasrules" TypeMdid="0.16.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="28" Alias="relacl">
+                      <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="29" Alias="reloptions">
+                      <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="31" Alias="oid">
+                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="36" Alias="tableoid">
+                      <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                      <dxl:Ident ColId="53" ColName="parchildrelid" TypeMdid="0.26.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.049779" Rows="2.000000" Width="137"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="relname">
+                        <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="relnamespace">
+                        <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="3" Alias="relowner">
+                        <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="reltablespace">
+                        <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="reltoastrelid">
+                        <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="13" Alias="relhasindex">
+                        <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="relkind">
+                        <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="relstorage">
+                        <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="18" Alias="relchecks">
+                        <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="19" Alias="reltriggers">
+                        <dxl:Ident ColId="19" ColName="reltriggers" TypeMdid="0.21.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="23" Alias="relhasoids">
+                        <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="25" Alias="relhasrules">
+                        <dxl:Ident ColId="25" ColName="relhasrules" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="relacl">
+                        <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="29" Alias="reloptions">
+                        <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="31" Alias="oid">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="36" Alias="tableoid">
+                        <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:ArrayComp OperatorName="=" OperatorMdid="0.92.1.0" OperatorType="Any">
+                        <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+                        <dxl:Array ArrayType="0.1002.1.0" ElementType="0.18.1.0" MultiDimensional="false">
+                          <dxl:ConstValue TypeMdid="0.18.1.0" Value="cg=="/>
+                          <dxl:ConstValue TypeMdid="0.18.1.0" Value="Uw=="/>
+                          <dxl:ConstValue TypeMdid="0.18.1.0" Value="dg=="/>
+                          <dxl:ConstValue TypeMdid="0.18.1.0" Value="Yw=="/>
+                        </dxl:Array>
+                      </dxl:ArrayComp>
+                    </dxl:Filter>
+                    <dxl:TableDescriptor Mdid="0.1259.1.1" TableName="pg_class">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="relname" TypeMdid="0.19.1.0"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="3" Attno="4" ColName="relowner" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="6" Attno="7" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="9" Attno="10" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="13" Attno="14" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+                        <dxl:Column ColId="15" Attno="16" ColName="relkind" TypeMdid="0.18.1.0"/>
+                        <dxl:Column ColId="16" Attno="17" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                        <dxl:Column ColId="18" Attno="19" ColName="relchecks" TypeMdid="0.21.1.0"/>
+                        <dxl:Column ColId="19" Attno="20" ColName="reltriggers" TypeMdid="0.21.1.0"/>
+                        <dxl:Column ColId="23" Attno="24" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+                        <dxl:Column ColId="25" Attno="26" ColName="relhasrules" TypeMdid="0.16.1.0"/>
+                        <dxl:Column ColId="28" Attno="29" ColName="relacl" TypeMdid="0.1034.1.0"/>
+                        <dxl:Column ColId="29" Attno="30" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                        <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="31" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="53" Alias="parchildrelid">
+                        <dxl:Ident ColId="53" ColName="parchildrelid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.5011.1.1" TableName="pg_partition_rule">
+                      <dxl:Columns>
+                        <dxl:Column ColId="53" Attno="2" ColName="parchildrelid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="66" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="67" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="68" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="69" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="70" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="71" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="72" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="73" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:HashJoin>
+              </dxl:RedistributeMotion>
             </dxl:HashJoin>
-          </dxl:HashJoin>
-        </dxl:Sort>
-      </dxl:Result>
+          </dxl:Sort>
+        </dxl:Result>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11631,7 +11631,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="176674">
+    <dxl:Plan Id="0" SpaceSize="210462">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5904.512295" Rows="5.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
@@ -301,7 +301,7 @@ and ei.entity_id  = i.ad_id;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5008">
+    <dxl:Plan Id="0" SpaceSize="7612">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003103" Rows="2.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -588,7 +588,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13648900">
+    <dxl:Plan Id="0" SpaceSize="12660800">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003419" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-MaterializeUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-MaterializeUnderResult.mdp
@@ -412,7 +412,7 @@ Optimizer status: PQO version 2.67.0
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="166192.837038" Rows="4994000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeGatherUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeGatherUnderResult.mdp
@@ -408,7 +408,7 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="166192.837038" Rows="4994000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
@@ -447,7 +447,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="150">
+    <dxl:Plan Id="0" SpaceSize="120">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="199109.213873" Rows="9846.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeSortUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeSortUnderResult.mdp
@@ -433,7 +433,7 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="166193.741134" Rows="4994000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiDistKeyJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiDistKeyJoinCardinality.mdp
@@ -1162,7 +1162,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.346837" Rows="1000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiDistKeyWithOtherPredsJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiDistKeyWithOtherPredsJoinCardinality.mdp
@@ -687,7 +687,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.740340" Rows="1368.264678" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -686,7 +686,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4866">
+    <dxl:Plan Id="0" SpaceSize="4845">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.489763" Rows="999.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleDampedPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleDampedPredJoinCardinality.mdp
@@ -4718,7 +4718,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.346837" Rows="1000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleIndependentPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleIndependentPredJoinCardinality.mdp
@@ -5753,7 +5753,7 @@ explain select * from t1, t2, t3 where t1.a = t2.a and t2.a = t3.a and t1.b = t3
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="29">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.651422" Rows="1000.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
@@ -252,7 +252,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000614" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NaryWithLojAndNonLojChilds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NaryWithLojAndNonLojChilds.mdp
@@ -1729,7 +1729,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="665">
+    <dxl:Plan Id="0" SpaceSize="575">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.770115" Rows="17.263546" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -597,7 +597,7 @@
         </dxl:LogicalProject>
       </dxl:Difference>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1423008000">
+    <dxl:Plan Id="0" SpaceSize="1388016000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NoDistKeyMultiPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoDistKeyMultiPredJoinCardinality.mdp
@@ -1584,7 +1584,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="26">
+    <dxl:Plan Id="0" SpaceSize="34">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.448529" Rows="1000.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
@@ -443,7 +443,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="274176">
+    <dxl:Plan Id="0" SpaceSize="182784">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5297852.190616" Rows="3.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
@@ -425,7 +425,7 @@ GROUP BY b;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28999731200">
+    <dxl:Plan Id="0" SpaceSize="28712517632">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.000796" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/NonSingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonSingleton.mdp
@@ -282,7 +282,7 @@ EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000381" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/OneDistKeyMultiPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneDistKeyMultiPredJoinCardinality.mdp
@@ -1220,7 +1220,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.423489" Rows="1000.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -2264,7 +2264,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="898.322204" Rows="73705.404960" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
@@ -541,7 +541,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="34">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001167" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -1926,7 +1926,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="415">
+    <dxl:Plan Id="0" SpaceSize="455">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.013245" Rows="3.000000" Width="4"/>
@@ -1976,7 +1976,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
               <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="31">
+          <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="24">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000149" Rows="21.333333" Width="8"/>
             </dxl:Properties>
@@ -2597,7 +2597,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:Append>
-          <dxl:PartitionSelector RelationMdid="0.247422.1.0" SelectorId="31" ScanId="1" Partitions="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21">
+          <dxl:PartitionSelector RelationMdid="0.247422.1.0" SelectorId="24" ScanId="1" Partitions="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="862.003395" Rows="12.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -828,7 +828,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1118">
+    <dxl:Plan Id="0" SpaceSize="1116">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.020922" Rows="100.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
@@ -782,7 +782,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="64">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.043086" Rows="100.000000" Width="46"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
@@ -468,7 +468,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000831" Rows="1.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="196">
+    <dxl:Plan Id="0" SpaceSize="228">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1298.385913" Rows="4000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1604,7 +1604,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="31">
+    <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.027662" Rows="101.010101" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2124">
+    <dxl:Plan Id="0" SpaceSize="3404">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.575209" Rows="10000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1297.273809" Rows="20000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -1137,7 +1137,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.717330" Rows="5431.276543" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp
@@ -368,7 +368,7 @@ select * from t2 left outer join t1 on t1.b = t2.d where t1.b is null;
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000687" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -513,7 +513,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="820798">
+    <dxl:Plan Id="0" SpaceSize="4647157">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.012321" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -2566,7 +2566,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1077">
+    <dxl:Plan Id="0" SpaceSize="1185">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="23515.903551" Rows="12277684.984863" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4765,7 +4765,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="53564">
+    <dxl:Plan Id="0" SpaceSize="76032">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1548186.589494" Rows="321694266.492042" Width="355"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
@@ -734,7 +734,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="54">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000898" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -883,10 +883,10 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:HashJoin JoinType="Inner">
+    <dxl:Plan Id="0" SpaceSize="32">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="952.936690" Rows="10000.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="933.563639" Rows="10000.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -903,30 +903,36 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
-            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1082.1.0"/>
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.538100" Rows="10000.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="932.665639" Rows="10000.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="count">
+              <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="a">
               <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="b">
-              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1082.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:TableScan>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
+              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1082.1.0"/>
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.304100" Rows="10000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -937,40 +943,43 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.71822.1.1" TableName="jpat">
-              <dxl:Columns>
-                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.1082.1.0"/>
-                <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:GatherMotion>
-        <dxl:Window PartitionColumns="">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="472.587702" Rows="100009.000000" Width="16"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="9" Alias="count">
-              <dxl:WindowFunc Mdid="0.2803.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1082.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="a">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="b">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1082.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.71822.1.1" TableName="jpat">
+                <dxl:Columns>
+                  <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.1082.1.0"/>
+                  <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+          <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="471.787630" Rows="100009.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="476.956095" Rows="100009.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -979,14 +988,20 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="count">
+                <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="468.195306" Rows="100009.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="472.587702" Rows="100009.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -995,31 +1010,20 @@
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="count">
+                  <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList>
-                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              </dxl:SortingColumnList>
-              <dxl:LimitCount/>
-              <dxl:LimitOffset/>
-              <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+              <dxl:OneTimeFilter/>
+              <dxl:Window PartitionColumns="">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="472.587702" Rows="100009.000000" Width="16"/>
                 </dxl:Properties>
-                <dxl:TableDescriptor Mdid="0.71316.1.1" TableName="pat">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1082.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="count">
+                    <dxl:WindowFunc Mdid="0.2803.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="0" Alias="a">
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
@@ -1028,134 +1032,197 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableScan>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="471.787630" Rows="100009.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="19" Alias="a">
-                      <dxl:Ident ColId="19" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="20" Alias="b">
-                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.1082.1.0"/>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.71316001.1.1" TableName="pat_prt_1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="28" Alias="a">
-                      <dxl:Ident ColId="28" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="b">
-                      <dxl:Ident ColId="29" ColName="b" TypeMdid="0.1082.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.71316002.1.1" TableName="pat_prt_2">
-                    <dxl:Columns>
-                      <dxl:Column ColId="28" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="29" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="31" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="32" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="33" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="34" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="35" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="36" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="37" Alias="a">
-                      <dxl:Ident ColId="37" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="38" Alias="b">
-                      <dxl:Ident ColId="38" ColName="b" TypeMdid="0.1082.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.71316003.1.1" TableName="pat_prt_3">
-                    <dxl:Columns>
-                      <dxl:Column ColId="37" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="38" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="39" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="40" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="41" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="42" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="43" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="44" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="45" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="46" Alias="a">
-                      <dxl:Ident ColId="46" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="47" Alias="b">
-                      <dxl:Ident ColId="47" ColName="b" TypeMdid="0.1082.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.71316004.1.1" TableName="pat_prt_4">
-                    <dxl:Columns>
-                      <dxl:Column ColId="46" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="47" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="48" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="49" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="50" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="51" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="52" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="53" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="54" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Append>
-            </dxl:Sort>
-          </dxl:GatherMotion>
-          <dxl:WindowKeyList>
-            <dxl:WindowKey>
-              <dxl:SortingColumnList>
-                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              </dxl:SortingColumnList>
-              <dxl:WindowFrame FrameSpec="Row" ExclusionStrategy="Nulls">
-                <dxl:TrailingEdge TrailingBoundary="BoundedPreceding">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:TrailingEdge>
-                <dxl:LeadingEdge LeadingBoundary="BoundedFollowing">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:LeadingEdge>
-              </dxl:WindowFrame>
-            </dxl:WindowKey>
-          </dxl:WindowKeyList>
-        </dxl:Window>
-      </dxl:HashJoin>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="468.195306" Rows="100009.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:TableDescriptor Mdid="0.71316.1.1" TableName="pat">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1082.1.0"/>
+                          <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="a">
+                            <dxl:Ident ColId="19" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="20" Alias="b">
+                            <dxl:Ident ColId="20" ColName="b" TypeMdid="0.1082.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.71316001.1.1" TableName="pat_prt_1">
+                          <dxl:Columns>
+                            <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="28" Alias="a">
+                            <dxl:Ident ColId="28" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="b">
+                            <dxl:Ident ColId="29" ColName="b" TypeMdid="0.1082.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.71316002.1.1" TableName="pat_prt_2">
+                          <dxl:Columns>
+                            <dxl:Column ColId="28" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="29" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="31" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="32" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="33" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="34" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="35" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="36" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="37" Alias="a">
+                            <dxl:Ident ColId="37" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="38" Alias="b">
+                            <dxl:Ident ColId="38" ColName="b" TypeMdid="0.1082.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.71316003.1.1" TableName="pat_prt_3">
+                          <dxl:Columns>
+                            <dxl:Column ColId="37" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="38" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="39" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="40" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="41" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="42" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="43" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="44" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="45" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="46" Alias="a">
+                            <dxl:Ident ColId="46" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="47" Alias="b">
+                            <dxl:Ident ColId="47" ColName="b" TypeMdid="0.1082.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.71316004.1.1" TableName="pat_prt_4">
+                          <dxl:Columns>
+                            <dxl:Column ColId="46" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="47" Attno="2" ColName="b" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="48" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="49" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="50" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="51" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="52" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="53" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="54" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Append>
+                  </dxl:Sort>
+                </dxl:GatherMotion>
+                <dxl:WindowKeyList>
+                  <dxl:WindowKey>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:WindowFrame FrameSpec="Row" ExclusionStrategy="Nulls">
+                      <dxl:TrailingEdge TrailingBoundary="BoundedPreceding">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:TrailingEdge>
+                      <dxl:LeadingEdge LeadingBoundary="BoundedFollowing">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:LeadingEdge>
+                    </dxl:WindowFrame>
+                  </dxl:WindowKey>
+                </dxl:WindowKeyList>
+              </dxl:Window>
+            </dxl:Result>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -386,7 +386,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18240">
+    <dxl:Plan Id="0" SpaceSize="16680">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/RemoveImpliedPredOnBCCPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RemoveImpliedPredOnBCCPredicates.mdp
@@ -275,7 +275,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="414">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12725.266667" Rows="10000000.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
@@ -1437,7 +1437,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -916,7 +916,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.005845" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
@@ -1039,7 +1039,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
@@ -1437,7 +1437,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
@@ -1039,7 +1039,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableCTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableCTE.mdp
@@ -1443,7 +1443,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -389,7 +389,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="544">
+    <dxl:Plan Id="0" SpaceSize="520">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.000816" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -889,10 +889,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="72144">
+    <dxl:Plan Id="0" SpaceSize="94028">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="891.087839" Rows="3009.000000" Width="64"/>
+          <dxl:Cost StartupCost="0" TotalCost="888.268997" Rows="3009.000000" Width="64"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="proname">
@@ -905,7 +905,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="890.223173" Rows="3009.000000" Width="64"/>
+            <dxl:Cost StartupCost="0" TotalCost="887.404330" Rows="3009.000000" Width="64"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="proname">
@@ -920,7 +920,7 @@
           <dxl:LimitOffset/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="884.460602" Rows="3009.000000" Width="64"/>
+              <dxl:Cost StartupCost="0" TotalCost="881.641760" Rows="3009.000000" Width="64"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="proname">
@@ -935,9 +935,9 @@
                 <dxl:Ident ColId="35" ColName="oid" TypeMdid="0.26.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
+            <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="877.795162" Rows="3009.000000" Width="68"/>
+                <dxl:Cost StartupCost="0" TotalCost="874.976320" Rows="3009.000000" Width="68"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="proname">
@@ -948,10 +948,16 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                  <dxl:Ident ColId="0" ColName="proname" TypeMdid="0.19.1.0"/>
+                  <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="877.236572" Rows="3009.000000" Width="68"/>
+                  <dxl:Cost StartupCost="0" TotalCost="432.496887" Rows="3009.000000" Width="68"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="proname">
@@ -962,13 +968,12 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="0" ColName="proname" TypeMdid="0.19.1.0"/>
-                    <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
                 <dxl:TableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.557718" Rows="3009.000000" Width="68"/>
@@ -997,9 +1002,26 @@
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
+              </dxl:RedistributeMotion>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="439.461388" Rows="3009.000000" Width="64"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="42" Alias="proname">
+                    <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="439.262185" Rows="3009.000000" Width="64"/>
+                    <dxl:Cost StartupCost="0" TotalCost="439.160006" Rows="3009.000000" Width="64"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="42" Alias="proname">
@@ -1014,9 +1036,9 @@
                       <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:TableScan>
+                  <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.557718" Rows="3009.000000" Width="68"/>
+                      <dxl:Cost StartupCost="0" TotalCost="432.496887" Rows="3009.000000" Width="68"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="42" Alias="proname">
@@ -1027,94 +1049,131 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.1255.1.1" TableName="pg_proc">
-                      <dxl:Columns>
-                        <dxl:Column ColId="42" Attno="1" ColName="proname" TypeMdid="0.19.1.0"/>
-                        <dxl:Column ColId="43" Attno="2" ColName="pronamespace" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="66" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="67" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="68" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="69" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="70" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="71" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="72" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                  <dxl:Assert ErrorCode="P0003">
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="43" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.557718" Rows="3009.000000" Width="68"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="42" Alias="proname">
+                          <dxl:Ident ColId="42" ColName="proname" TypeMdid="0.19.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="43" Alias="pronamespace">
+                          <dxl:Ident ColId="43" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.1255.1.1" TableName="pg_proc">
+                        <dxl:Columns>
+                          <dxl:Column ColId="42" Attno="1" ColName="proname" TypeMdid="0.19.1.0"/>
+                          <dxl:Column ColId="43" Attno="2" ColName="pronamespace" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="66" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="67" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="68" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="69" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="70" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="71" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="72" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                  <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6.002018" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="6.002043" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="77" Alias="oid">
                         <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:AssertConstraintList>
-                      <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                          <dxl:Ident ColId="89" ColName="row_number" TypeMdid="0.20.1.0"/>
-                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Cast>
-                        </dxl:Comparison>
-                      </dxl:AssertConstraint>
-                    </dxl:AssertConstraintList>
-                    <dxl:Window PartitionColumns="">
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:Assert ErrorCode="P0003">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.002010" Rows="2.800000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="6.002018" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="89" Alias="row_number">
-                          <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="77" Alias="oid">
                           <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:IndexScan IndexScanDirection="Forward">
+                      <dxl:AssertConstraintList>
+                        <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                            <dxl:Ident ColId="89" ColName="row_number" TypeMdid="0.20.1.0"/>
+                            <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:Cast>
+                          </dxl:Comparison>
+                        </dxl:AssertConstraint>
+                      </dxl:AssertConstraintList>
+                      <dxl:Window PartitionColumns="">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="6.001968" Rows="2.800000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="6.002010" Rows="2.800000" Width="16"/>
                         </dxl:Properties>
                         <dxl:ProjList>
+                          <dxl:ProjElem ColId="89" Alias="row_number">
+                            <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="77" Alias="oid">
                             <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:IndexCondList>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                            <dxl:Ident ColId="73" ColName="nspname" TypeMdid="0.19.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="cGdfY2F0YWxvZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                          </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.2684.1.0" IndexName="pg_namespace_nspname_index"/>
-                        <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace">
-                          <dxl:Columns>
-                            <dxl:Column ColId="73" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
-                            <dxl:Column ColId="76" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="77" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="78" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="79" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="80" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="81" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="82" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="83" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:IndexScan>
-                      <dxl:WindowKeyList>
-                        <dxl:WindowKey>
-                          <dxl:SortingColumnList/>
-                        </dxl:WindowKey>
-                      </dxl:WindowKeyList>
-                    </dxl:Window>
-                  </dxl:Assert>
+                        <dxl:IndexScan IndexScanDirection="Forward">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="6.001968" Rows="2.800000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="77" Alias="oid">
+                              <dxl:Ident ColId="77" ColName="oid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:IndexCondList>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                              <dxl:Ident ColId="73" ColName="nspname" TypeMdid="0.19.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.19.1.0" Value="cGdfY2F0YWxvZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                            </dxl:Comparison>
+                          </dxl:IndexCondList>
+                          <dxl:IndexDescriptor Mdid="0.2684.1.0" IndexName="pg_namespace_nspname_index"/>
+                          <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace">
+                            <dxl:Columns>
+                              <dxl:Column ColId="73" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
+                              <dxl:Column ColId="76" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="77" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="78" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="79" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="80" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="81" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="82" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="83" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:IndexScan>
+                        <dxl:WindowKeyList>
+                          <dxl:WindowKey>
+                            <dxl:SortingColumnList/>
+                          </dxl:WindowKey>
+                        </dxl:WindowKeyList>
+                      </dxl:Window>
+                    </dxl:Assert>
+                  </dxl:RedistributeMotion>
                 </dxl:HashJoin>
-              </dxl:HashJoin>
-            </dxl:RandomMotion>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
             <dxl:Assert ErrorCode="P0003">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="6.004363" Rows="2.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
@@ -492,7 +492,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="534472">
+    <dxl:Plan Id="0" SpaceSize="514764">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003056" Rows="1.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/SpoolShouldInvalidateUnresolvedDynamicScans.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SpoolShouldInvalidateUnresolvedDynamicScans.mdp
@@ -756,7 +756,7 @@ And instead have a plan like
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="19">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.014148" Rows="43.698859" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -827,7 +827,7 @@ AND
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="668">
+    <dxl:Plan Id="0" SpaceSize="244">
       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1373.906987" Rows="512.000000" Width="106"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -532,7 +532,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3124">
+    <dxl:Plan Id="0" SpaceSize="3108">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.005263" Rows="10.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2CorrSQInLOJOn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2CorrSQInLOJOn.mdp
@@ -2430,7 +2430,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="568384082185.659546" Rows="1000.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -676,7 +676,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1680">
+    <dxl:Plan Id="0" SpaceSize="1152">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.003881" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,10 +456,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="62302">
-      <dxl:HashJoin JoinType="Inner">
+    <dxl:Plan Id="0" SpaceSize="579354">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.001435" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -470,16 +470,10 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.001399" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -490,7 +484,13 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
@@ -518,23 +518,9 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:GatherMotion>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000967" Rows="1.000000" Width="4"/>
-          </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="27"/>
-          </dxl:GroupingColumns>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="27" Alias="i">
-              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000980" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="27" Alias="i">
@@ -542,130 +528,107 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000967" Rows="1.000000" Width="4"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="27"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="i">
                   <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="i">
                     <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="j">
-                    <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000961" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="27" Alias="i">
                       <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="j">
-                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                    <dxl:Columns>
-                      <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000437" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="j">
-                    <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashJoin JoinType="Inner">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000419" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="19" Alias="j">
-                      <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:JoinFilter/>
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                       <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:TableScan>
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="10" Alias="j">
-                        <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="27" Alias="i">
+                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="j">
+                        <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                      <dxl:Columns>
-                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                  <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="27" Alias="i">
+                          <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="28" Alias="j">
+                          <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                          <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                        <dxl:Columns>
+                          <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000437" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="19" Alias="j">
@@ -674,9 +637,9 @@
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
-                    <dxl:TableScan>
+                    <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000419" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="j">
@@ -684,27 +647,81 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.1159276.1.1" TableName="a">
-                        <dxl:Columns>
-                          <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:BroadcastMotion>
+                      <dxl:JoinFilter/>
+                      <dxl:HashCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:HashCondList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="10" Alias="j">
+                            <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="j">
+                            <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="19" Alias="j">
+                              <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.1159276.1.1" TableName="a">
+                            <dxl:Columns>
+                              <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:BroadcastMotion>
+                    </dxl:HashJoin>
+                  </dxl:GatherMotion>
                 </dxl:HashJoin>
-              </dxl:GatherMotion>
-            </dxl:HashJoin>
-          </dxl:Sort>
-        </dxl:Aggregate>
-      </dxl:HashJoin>
+              </dxl:Sort>
+            </dxl:Aggregate>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="384581">
+    <dxl:Plan Id="0" SpaceSize="699288">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -520,7 +520,7 @@ ON a = c
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48688">
+    <dxl:Plan Id="0" SpaceSize="59852">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2206721.811317" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -4043,7 +4043,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="225448">
+    <dxl:Plan Id="0" SpaceSize="355038">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2343319.893955" Rows="10325183.250315" Width="697"/>

--- a/src/backend/gporca/data/dxl/minidump/TranslateFilterDisjunctQuals.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateFilterDisjunctQuals.mdp
@@ -384,7 +384,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765384.377240" Rows="2.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
@@ -612,7 +612,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="616">
+    <dxl:Plan Id="0" SpaceSize="896">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1852062876647.470947" Rows="10.000001" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/TranslateOneTimeFilterConjunctQuals.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateOneTimeFilterConjunctQuals.mdp
@@ -387,7 +387,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765384.376489" Rows="2.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
@@ -288,7 +288,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
         </dxl:LogicalProject>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1488">
+    <dxl:Plan Id="0" SpaceSize="1760">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001805" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1277,10 +1277,10 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="128412">
+    <dxl:Plan Id="0" SpaceSize="155547">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1306.824501" Rows="199.680000" Width="148"/>
+          <dxl:Cost StartupCost="0" TotalCost="1306.228645" Rows="199.680000" Width="148"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="oid">
@@ -1303,7 +1303,7 @@ WHERE
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1306.714368" Rows="199.680000" Width="148"/>
+            <dxl:Cost StartupCost="0" TotalCost="1306.118512" Rows="199.680000" Width="148"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="oid">
@@ -1334,7 +1334,7 @@ WHERE
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1306.698971" Rows="702.000000" Width="150"/>
+              <dxl:Cost StartupCost="0" TotalCost="1306.103115" Rows="702.000000" Width="150"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="ColRef_0073">
@@ -1363,7 +1363,7 @@ WHERE
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1306.663871" Rows="702.000000" Width="158"/>
+                <dxl:Cost StartupCost="0" TotalCost="1306.068015" Rows="702.000000" Width="158"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="amname">
@@ -1400,9 +1400,9 @@ WHERE
                   <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="875.127646" Rows="702.000000" Width="150"/>
+                  <dxl:Cost StartupCost="0" TotalCost="874.520071" Rows="702.000000" Width="150"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="amname">
@@ -1425,18 +1425,16 @@ WHERE
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
                     <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:HashExpr>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:HashJoin JoinType="Inner">
+                    <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="874.854217" Rows="702.000000" Width="150"/>
+                    <dxl:Cost StartupCost="0" TotalCost="443.276576" Rows="141.000000" Width="146"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="amname">
@@ -1454,18 +1452,14 @@ WHERE
                     <dxl:ProjElem ColId="41" Alias="oid">
                       <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                      <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
                   <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="443.223121" Rows="141.000000" Width="146"/>
@@ -1569,6 +1563,26 @@ WHERE
                       </dxl:TableDescriptor>
                     </dxl:IndexScan>
                   </dxl:NestedLoopJoin>
+                </dxl:RedistributeMotion>
+                <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.042403" Rows="702.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="48" Alias="amopclaid">
+                      <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="49" Alias="amopsubtype">
+                      <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
@@ -1596,33 +1610,33 @@ WHERE
                       </dxl:Columns>
                     </dxl:TableDescriptor>
                   </dxl:TableScan>
-                </dxl:HashJoin>
-              </dxl:RedistributeMotion>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                </dxl:RedistributeMotion>
+              </dxl:HashJoin>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.184039" Rows="702.000000" Width="16"/>
                 </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="60"/>
-                  <dxl:GroupingColumn ColId="61"/>
-                </dxl:GroupingColumns>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="72" Alias="count">
-                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
-                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
-                    </dxl:AggFunc>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="60" Alias="amopclaid">
                     <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="61" Alias="amopsubtype">
                     <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="72" Alias="count">
+                    <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.113221" Rows="702.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1631,60 +1645,62 @@ WHERE
                     <dxl:ProjElem ColId="61" Alias="amopsubtype">
                       <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="74" Alias="ColRef_0074">
-                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="72" Alias="count">
+                      <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="60"/>
+                      <dxl:GroupingColumn ColId="61"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="72" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                          <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="60" Alias="amopclaid">
                         <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="61" Alias="amopsubtype">
                         <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="74" Alias="ColRef_0074">
-                        <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.113221" Rows="702.000000" Width="16"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="60"/>
-                        <dxl:GroupingColumn ColId="61"/>
-                      </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="74" Alias="ColRef_0074">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="60" Alias="amopclaid">
                           <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="61" Alias="amopsubtype">
                           <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                          <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.042403" Rows="702.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1693,14 +1709,24 @@ WHERE
                           <dxl:ProjElem ColId="61" Alias="amopsubtype">
                             <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                            <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="60"/>
+                            <dxl:GroupingColumn ColId="61"/>
+                          </dxl:GroupingColumns>
                           <dxl:ProjList>
+                            <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="60" Alias="amopclaid">
                               <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
                             </dxl:ProjElem>
@@ -1709,25 +1735,54 @@ WHERE
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
-                            <dxl:Columns>
-                              <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RandomMotion>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Aggregate>
+                          <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.042403" Rows="702.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="60" Alias="amopclaid">
+                                <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="61" Alias="amopsubtype">
+                                <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="60" Alias="amopclaid">
+                                  <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="61" Alias="amopsubtype">
+                                  <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:RandomMotion>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:RedistributeMotion>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
             </dxl:HashJoin>
           </dxl:Result>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -1016,7 +1016,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.173205" Rows="136.148000" Width="132"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
@@ -269,7 +269,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="40">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1880.351554" Rows="10000.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/cte-duplicate-columns-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/cte-duplicate-columns-2.mdp
@@ -245,7 +245,7 @@ where x1.b = x2.b;
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001043" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -790,7 +790,14 @@ CPhysicalHashJoin::PdshashedRequired(CMemoryPool *,	 // mp
 	CDistributionSpec *pds = (*m_pdrgpdsRedistributeRequests)[ulReqIndex];
 
 	pds->AddRef();
-	return CDistributionSpecHashed::PdsConvert(pds);
+	CDistributionSpecHashed *pdsChild =
+		CDistributionSpecHashed::PdsConvert(pds);
+	if (pdsChild->FSatisfiedBySingleton())
+	{
+		pdsChild->MarkUnsatisfiableBySingleton();
+	}
+
+	return pdsChild;
 }
 
 //---------------------------------------------------------------------------

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -355,23 +355,24 @@ INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL c
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id = (select max(id2) from direct_dispatch_bar where id1 = 5);
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id * id = (select max(id2) from direct_dispatch_bar where id1 = 5) AND id = 3;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 3) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- Known_opt_diff: MPP-21346
 delete from direct_dispatch_foo where id * id = (select max(id2) from direct_dispatch_bar) AND id = 3;
 INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 3) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- tests with subplans (MPP-22019)
 CREATE TABLE MPP_22019_a ( i INT, j INT) DISTRIBUTED BY (i);
@@ -392,7 +393,7 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 EXPLAIN SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHERE a.j NOT IN (SELECT j FROM MPP_22019_a a2 where a2.j = b.j) and a.i = 1;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1765376.88 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1765376.88 rows=1 width=8)
    ->  Result  (cost=0.00..1765376.88 rows=1 width=8)
          Filter: (SubPlan 1)
          ->  Hash Join  (cost=0.00..862.00 rows=1 width=12)
@@ -406,7 +407,7 @@ EXPLAIN SELECT a.* FROM MPP_22019_a a INNER JOIN MPP_22019_b b ON a.i = b.i WHER
            ->  Result  (cost=0.00..431.00 rows=1 width=4)
                  Filter: (mpp_22019_a_1.j = mpp_22019_b.j)
                  ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                              ->  Seq Scan on mpp_22019_a mpp_22019_a_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (17 rows)

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -141,30 +141,29 @@ set optimizer_nestloop_factor = 1.0;
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=1.743..2.097 rows=16 loops=1)
+ Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=2.443..2.651 rows=16 loops=1)
    Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
-   Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.282..0.291 rows=64 loops=1)
-         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.949..1.287 rows=32 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.010..0.047 rows=64 loops=1)
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=1.708..1.867 rows=32 loops=1)
                Join Filter: true
-               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.005..0.006 rows=4 loops=1)
-               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.187..0.253 rows=7 loops=5)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=0.897..1.264 rows=8 loops=1)
-                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.012..0.134 rows=4 loops=1)
-   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=0.137..0.137 rows=1 loops=1)
-         Buckets: 262144  Batches: 1  Memory Usage: 1kB
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.133..0.133 rows=1 loops=1)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=0.004..0.097 rows=8 loops=1)
-                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.008..0.009 rows=4 loops=1)
- Planning time: 109.024 ms
-   (slice0)    Executor memory: 2216K bytes.  Work_mem: 1K bytes max.
-   (slice1)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
-   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.116..0.119 rows=4 loops=1)
+               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.315..0.341 rows=7 loops=5)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=1.421..1.598 rows=8 loops=1)
+                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.163..0.166 rows=4 loops=1)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=2.291..2.291 rows=1 loops=1)
+         Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=2.276..2.277 rows=1 loops=1)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=1.758..2.215 rows=8 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.179..0.182 rows=4 loops=1)
+ Planning Time: 24.615 ms
+   (slice0)    Executor memory: 2137K bytes.  Work_mem: 2049K bytes max.
+   (slice1)    Executor memory: 41K bytes avg x 3 workers, 41K bytes max (seg0).  Work_mem: 17K bytes max.
+   (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 17.954 ms
-(23 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 27.504 ms
+(22 rows)
 
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                QUERY PLAN                                                
@@ -214,20 +213,20 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
 -----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12)
    ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12)
-         Hash Cond: ((max(gpd1.c1)) = gpd1_1.c1)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8)
-               Hash Key: (max(gpd1.c1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
-         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14)
-               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14)
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=14 width=12)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12)
-                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+         Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=14 width=12)
+                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12)
+               ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=8)
+                     Hash Key: (max(gpd1_2.c1))
+                     ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
@@ -252,33 +251,33 @@ select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
 (16 rows)
 
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=11.226..13.705 rows=16 loops=1)
-   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=5.349..10.009 rows=16 loops=1)
-         Hash Cond: ((max(gpd1.c1)) = gpd1_1.c1)
-         Extra Text: (seg0)   Hash chain length 16.0 avg, 16 max, using 1 of 524288 buckets.
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.007..0.007 rows=1 loops=1)
-               Hash Key: (max(gpd1.c1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.384..1.384 rows=1 loops=1)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.216..1.339 rows=3 loops=1)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.056..0.056 rows=1 loops=1)
-                                 ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.038..0.045 rows=4 loops=1)
-         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14) (actual time=0.287..0.287 rows=32 loops=1)
-               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.089..0.223 rows=32 loops=1)
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.019..0.043 rows=8 loops=1)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12) (actual time=0.042..0.047 rows=4 loops=1)
-                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.006..0.014 rows=4 loops=9)
- Planning time: 63.479 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 4208K bytes avg x 3 workers, 4208K bytes max (seg0).  Work_mem: 4098K bytes max.
-   (slice2)    Executor memory: 79K bytes (seg0).
-   (slice3)    Executor memory: 75K bytes avg x 3 workers, 75K bytes max (seg0).
-   (slice4)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=4.975..4.980 rows=16 loops=1)
+   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=3.278..4.340 rows=16 loops=1)
+         Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.196..0.253 rows=16 loops=1)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.007..0.016 rows=8 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.134..0.137 rows=4 loops=1)
+               ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.019..0.022 rows=2 loops=9)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=0.025..0.025 rows=1 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.011..0.012 rows=1 loops=1)
+                     Hash Key: (max(gpd1_2.c1))
+                     ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.741..1.742 rows=1 loops=1)
+                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.616..1.716 rows=3 loops=1)
+                                 ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.154..0.154 rows=1 loops=1)
+                                       ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.134..0.137 rows=4 loops=1)
+ Planning Time: 21.696 ms
+   (slice0)    Executor memory: 64K bytes.
+   (slice1)    Executor memory: 4135K bytes avg x 3 workers, 4159K bytes max (seg0).  Work_mem: 4097K bytes max.
+   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+   (slice3)    Executor memory: 49K bytes (entry db).
+   (slice4)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
- Execution time: 16.006 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 6.374 ms
 (25 rows)
 
 --

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -1862,33 +1862,27 @@ select * from int4_tbl i4, tenk1 a
 where exists(select * from tenk1 b
              where a.twothousand = b.twothousand and a.fivethous <> b.fivethous)
       and i4.f1 = a.tenthous;
-                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  HashAggregate
          Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-         ->  Sort
-               Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-                           ->  Sort
-                                 Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-                                 ->  Hash Join
-                                       Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
-                                       Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
-                                       ->  Seq Scan on tenk1
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Nested Loop
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                               ->  Seq Scan on int4_tbl
-                                                         ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
-                                                               Index Cond: (tenthous = int4_tbl.f1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+               ->  Hash Join
+                     Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
+                     Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
+                     ->  Seq Scan on tenk1
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Nested Loop
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                             ->  Seq Scan on int4_tbl
+                                       ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
+                                             Index Cond: (tenthous = int4_tbl.f1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(18 rows)
 
 --
 -- More complicated constructs
@@ -2263,26 +2257,31 @@ explain (costs off)
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
 order by 1, 2;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Sort
-   Sort Key: int8_tbl.q1, int8_tbl.q2
-   ->  Hash Left Join
-         Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on int8_tbl
-         ->  Hash
-               ->  Hash Join
-                     Hash Cond: (int8_tbl_1.q1 = ((123))::bigint)
-                     ->  Gather Motion 3:1  (slice2; segments: 3)
-                           ->  Seq Scan on int8_tbl int8_tbl_1
-                                 Filter: (q1 = 123)
-                     ->  Hash
-                           ->  Result
-                                 Filter: ((123) = 123)
-                                 ->  Result
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: int8_tbl.q1, int8_tbl.q2
+   ->  Sort
+         Sort Key: int8_tbl.q1, int8_tbl.q2
+         ->  Hash Left Join
+               Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int8_tbl.q2
+                     ->  Seq Scan on int8_tbl
+               ->  Hash
+                     ->  Redistribute Motion 1:3  (slice3)
+                           Hash Key: int8_tbl_1.q2
+                           ->  Hash Join
+                                 Hash Cond: (int8_tbl_1.q1 = ((123))::bigint)
+                                 ->  Gather Motion 3:1  (slice4; segments: 3)
+                                       ->  Seq Scan on int8_tbl int8_tbl_1
+                                             Filter: (q1 = 123)
+                                 ->  Hash
+                                       ->  Result
+                                             Filter: ((123) = 123)
+                                             ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(22 rows)
 
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
@@ -3821,20 +3820,21 @@ explain (costs off)
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
   where (case when unique2 is null then f1 else 0 end) = 0;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Result
-         Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
-         ->  Hash Right Join
-               Hash Cond: (tenk1.unique2 = int4_tbl.f1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: tenk1.unique2
-                     ->  Seq Scan on tenk1
-               ->  Hash
-                     ->  Seq Scan on int4_tbl
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Result
+               Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
+               ->  Hash Right Join
+                     Hash Cond: (tenk1.unique2 = int4_tbl.f1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1.unique2
+                           ->  Seq Scan on tenk1
+                     ->  Hash
+                           ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(12 rows)
 
 select f1, unique2, case when unique2 is null then f1 else 0 end
   from int4_tbl a left join tenk1 b on f1 = unique2
@@ -3967,6 +3967,7 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
+               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4000,12 +4001,14 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl.f1
-               ->  Broadcast Motion 3:3  (slice6; segments: 3)
+               ->  Redistribute Motion 3:3  (slice6; segments: 3)
                      Output: int4_tbl.f1
+                     Hash Key: (int4_tbl.f1)::bigint
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(45 rows)
+ Settings: optimizer=on
+(48 rows)
 
 select t1.* from
   text_tbl t1
@@ -4043,6 +4046,7 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl_1.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
+               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4082,12 +4086,14 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
-               ->  Broadcast Motion 3:3  (slice7; segments: 3)
+               ->  Redistribute Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
+                     Hash Key: (int4_tbl_1.f1)::bigint
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(51 rows)
+ Settings: optimizer=on
+(54 rows)
 
 select t1.* from
   text_tbl t1
@@ -4126,6 +4132,7 @@ select t1.* from
          Hash Cond: (int8_tbl.q2 = (int4_tbl_1.f1)::bigint)
          ->  Redistribute Motion 1:3  (slice2)
                Output: text_tbl.f1, int8_tbl.q2
+               Hash Key: int8_tbl.q2
                ->  Hash Right Join
                      Output: text_tbl.f1, int8_tbl.q2
                      Hash Cond: (('***'::text) = text_tbl.f1)
@@ -4148,8 +4155,9 @@ select t1.* from
                                                          Output: int8_tbl_1.q1
                                                    ->  Hash
                                                          Output: int4_tbl.f1
-                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                                                Output: int4_tbl.f1
+                                                               Hash Key: (int4_tbl.f1)::bigint
                                                                ->  Seq Scan on public.int4_tbl
                                                                      Output: int4_tbl.f1
                            ->  Hash
@@ -4168,12 +4176,14 @@ select t1.* from
                                        Output: text_tbl.f1
          ->  Hash
                Output: int4_tbl_1.f1
-               ->  Broadcast Motion 3:3  (slice7; segments: 3)
+               ->  Redistribute Motion 3:3  (slice7; segments: 3)
                      Output: int4_tbl_1.f1
+                     Hash Key: (int4_tbl_1.f1)::bigint
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(54 rows)
+ Settings: optimizer=on
+(58 rows)
 
 select t1.* from
   text_tbl t1
@@ -4716,14 +4726,15 @@ select i8.* from int8_tbl i8 left join (select f1 from int4_tbl group by f1) i4
          Hash Cond: (int8_tbl.q1 = (int4_tbl.f1)::bigint)
          ->  Seq Scan on int8_tbl
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (int4_tbl.f1)::bigint
                      ->  GroupAggregate
                            Group Key: int4_tbl.f1
                            ->  Sort
                                  Sort Key: int4_tbl.f1
                                  ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 -- check join removal with lateral references
 explain (costs off)

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -750,19 +750,19 @@ explain select * from table_a where a0=3;
 (5 rows)
 
 explain select a0 from table_a where a0 in (select max(a1) from table_a);
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               Hash Key: (max(table_a.a1))
-               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (table_a.a0 = (max(table_a_1.a1)))
+         ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-               ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+               ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: (max(table_a_1.a1))
+                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
@@ -788,20 +788,20 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 (1 row)
 
 explain select a0 from table_a where a0 in (select max(a1) from table_a where a0=1);
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               Hash Key: (max(table_a.a1))
-               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
-                                 Filter: (a0 = 1)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (table_a.a0 = (max(table_a_1.a1)))
+         ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-               ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+               ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: (max(table_a_1.a1))
+                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: (a0 = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 reset test_print_direct_dispatch_info;
@@ -817,18 +817,18 @@ select rank from ( select rank() over ( order by dist_key asc ) as rank , * from
 (1 row)
 
 explain select rank from ( select rank() over ( order by dist_key asc ) as rank , * from foo_direct_dispatch )a where 10 = dist_key;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Result  (cost=0.00..431.01 rows=1 width=8)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.00 rows=1 width=8)
    Filter: (dist_key = 10)
-   ->  WindowAgg  (cost=0.00..431.01 rows=34 width=12)
+   ->  WindowAgg  (cost=0.00..431.00 rows=1 width=12)
          Order By: dist_key
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                Merge Key: dist_key
-               ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                      Sort Key: dist_key
-                     ->  Seq Scan on foo_direct_dispatch  (cost=0.00..431.00 rows=34 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+                     ->  Seq Scan on foo_direct_dispatch  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
By default, hashed being satisfied by singleton is allowed, but the plans we
attempt to generate should generate redistribution motions. Forcing
non-satisfaction by singleton allows these hash redistribute plans to be
generated.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
