### PR TITLE
Make pg_relation_filenode() working for AO auxiliary tables

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -1122,6 +1122,9 @@ pg_relation_filenode(PG_FUNCTION_ARGS)
 		case RELKIND_INDEX:
 		case RELKIND_SEQUENCE:
 		case RELKIND_TOASTVALUE:
+		case RELKIND_AOSEGMENTS:
+		case RELKIND_AOBLOCKDIR:
+		case RELKIND_AOVISIMAP:
 			/* okay, these have storage */
 			if (relform->relfilenode)
 				result = relform->relfilenode;


### PR DESCRIPTION
AO auxiliary tables using different relkind poses problem as requires
explicit effort to add those values to switch
blocks. pg_relation_filenode() is missing RELKIND_AOSEGMENTS,
RELKIND_AOBLOCKDIR and RELKIND_AOVISIMAP. Hence, used to report NULL
when run against those. With this change, works fine for AO auxiliary
tables as well.

Fixes https://github.com/greenplum-db/gpdb/issues/12409.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
