### PR TITLE
Improve memory accounting logging for VMEM

### DIFF
--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -515,14 +515,19 @@ MemoryAccounting_SaveToFile(int currentSliceId)
 void
 MemoryAccounting_SaveToLog()
 {
-	int64 vmem_reserved = VmemTracker_GetMaxReservedVmemBytes();
+	int64 max_vmem_reserved = VmemTracker_GetMaxReservedVmemBytes();
+	int64 vmem_reserved = VmemTracker_GetReservedVmemBytes();
 
 	/* Write the header for the subsequent lines of memory usage information */
 	write_stderr("memory: account_name, account_id, parent_account_id, quota, peak, allocated, freed, current\n");
 
-	write_stderr("memory: %s, %d, %d, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", "Vmem",
+	write_stderr("memory: %s, %d, %d, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", "CurrentVmem",
 			MEMORY_STAT_TYPE_VMEM_RESERVED /* Id */, MEMORY_STAT_TYPE_VMEM_RESERVED /* Parent Id */,
 			(int64) 0 /* Quota */, vmem_reserved /* Peak */, vmem_reserved /* Allocated */, (int64) 0 /* Freed */, vmem_reserved /* Current */);
+
+	write_stderr("memory: %s, %d, %d, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", "MaxVmem",
+			MEMORY_STAT_TYPE_VMEM_RESERVED /* Id */, MEMORY_STAT_TYPE_VMEM_RESERVED /* Parent Id */,
+			(int64) 0 /* Quota */, max_vmem_reserved /* Peak */, max_vmem_reserved /* Allocated */, (int64) 0 /* Freed */, max_vmem_reserved /* Current */);
 
 	write_stderr("memory: %s, %d, %d, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", "Peak",
 			MEMORY_STAT_TYPE_MEMORY_ACCOUNTING_PEAK /* Id */, MEMORY_STAT_TYPE_MEMORY_ACCOUNTING_PEAK /* Parent Id */,

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -1089,7 +1089,8 @@ test__MemoryAccounting_SaveToLog__GeneratesCorrectString(void **state)
 {
 	char *templateString =
 "memory: account_name, account_id, parent_account_id, quota, peak, allocated, freed, current\n\
-memory: Vmem, -1, -1, 0, 0, 0, 0, 0\n\
+memory: CurrentVmem, -1, -1, 0, 0, 0, 0, 0\n\
+memory: MaxVmem, -1, -1, 0, 0, 0, 0, 0\n\
 memory: Peak, -2, -2, 0, %" PRIu64 ", %" PRIu64 ", 0, %" PRIu64 "\n\
 memory: Root, 1, 1, 0, 0, 0, 0, 0\n\
 memory: SharedHeader, 2, 1, 0, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n\


### PR DESCRIPTION
Previously, we used the max vmem and called this "Vmem". Now, we report
both the reserved and max vmem, which hopefully will be a bit clearer for debugging.

This memory accounting framework does not exist on the master branch, so this change only applies to 6X.

Co-authored-by: Chris Hajas <chajas@vmware.com>
Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>