### PR TITLE
Fix incorrect fallback behavior for invalid function return types

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2907,13 +2907,15 @@ TempTablespacesAreSet(void)
 int
 GetTempTablespaces(Oid *tableSpaces, int numSpaces)
 {
-	int			i;
+    if (TempTablespacesAreSet()) {
+        int            i;
+        for (i = 0; i < numTempTableSpaces && i < numSpaces; ++i)
+            tableSpaces[i] = tempTableSpaces[i];
 
-	Assert(TempTablespacesAreSet());
-	for (i = 0; i < numTempTableSpaces && i < numSpaces; ++i)
-		tableSpaces[i] = tempTableSpaces[i];
-
-	return i;
+        return i;
+    } else {
+        return 0;
+    }
 }
 
 /*


### PR DESCRIPTION
This changes some assertions to if-else cases to prevent falling back when the number
of entries in a function's return tuple is different than expected.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
