### PR TITLE
[Minor] Fix ic-proxy logging not work due to outdated api.

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -31,7 +31,7 @@
 
 
 #ifndef IC_PROXY_LOG_LEVEL
-#define IC_PROXY_LOG_LEVEL LOG
+#define IC_PROXY_LOG_LEVEL WARNING
 #endif
 
 #define ic_proxy_alloc(size) palloc(size)

--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -31,7 +31,7 @@
 
 
 #ifndef IC_PROXY_LOG_LEVEL
-#define IC_PROXY_LOG_LEVEL WARNING
+#define IC_PROXY_LOG_LEVEL LOG
 #endif
 
 #define ic_proxy_alloc(size) palloc(size)

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -193,7 +193,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 				int			family;
 				int			ret;
 
-				ret = ic_proxy_extract_addr(iter->ai_addr, name, sizeof(name),
+				ret = ic_proxy_extract_sockaddr(iter->ai_addr, name, sizeof(name),
 											&port, &family);
 				if (ret == 0)
 					ic_proxy_log(LOG,

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -166,7 +166,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 		int			family;
 		int			ret;
 
-		ret = ic_proxy_extract_addr((struct sockaddr *) &addr->addr,
+		ret = ic_proxy_extract_sockaddr((struct sockaddr *) &addr->sockaddr,
 									name, sizeof(name), &port, &family);
 		if (ret == 0)
 			ic_proxy_log(LOG,


### PR DESCRIPTION
Fix ic-proxy logging not work due to outdated api.

In the logging enabled code block, `ic_proxy_extract_addr` is deprecated instead of `ic_proxy_extract_sockaddr`, with minor changes in parameters also.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
