### PR TITLE
5X: Disable the log_lock_waits feature

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -929,7 +929,7 @@ static struct config_bool ConfigureNamesBool[] =
 #endif
 
 	{
-		{"log_lock_waits", PGC_SUSET, LOGGING_WHAT,
+		{"log_lock_waits", PGC_SUSET, DEFUNCT_OPTIONS,
 			gettext_noop("Logs long lock waits."),
 			NULL
 		},

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -701,3 +701,12 @@ select myfunc(1), current_setting('regex_flavor');
  extended | extended
 (1 row)
 
+-- GP: assert that we don't support turning on log_lock_waits
+SET log_lock_waits TO on;
+WARNING:  "log_lock_waits": setting is ignored because it is defunct
+SHOW log_lock_waits;
+ log_lock_waits 
+----------------
+ off
+(1 row)
+

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -251,3 +251,7 @@ set regex_flavor = basic;
 select myfunc(0);
 select current_setting('regex_flavor');
 select myfunc(1), current_setting('regex_flavor');
+
+-- GP: assert that we don't support turning on log_lock_waits
+SET log_lock_waits TO on;
+SHOW log_lock_waits;


### PR DESCRIPTION
This is a backport of 6X commit 3763cc7379b with minor changes.

log_lock_waits was never officially supported and it was missing from
our official documentation. This commit disallows the GUC from being
set. Setting the GUC to on will be a no-op with a WARNING emitted.

The reason why we can't support this GUC boils down to inconsistencies
between ResProcSleep() and its upstream equivalent ProcSleep().
ResProcSleep() clearly did not get the memo about log_lock_waits.
(introduced in e52c4a6e26f, much after resource queues were incepted)

The way the GUC works is simple: When anything other than a hard
deadlock is detected in CheckDeadlock(), the waiting process wakes up
inside ProcSleep(), logs the lock wait, and then goes back to sleep.

Unlike ProcSleep(), if a process is waiting on a resource queue in
ResProcSleep(), after waking up, we don't log the lock wait. That's not
all - the code flow leads to a spurious and possibly empty (no errdetail
capturing deadlock info) deadlock report. This is because
MyProc->waitStatus is still set to STATUS_ERROR after the wakeup in
ResProcSleep().

The spurious deadlock report has further ramifications.

(1) Unlike we would in a hard deadlock report, we don't call
ResRemoveFromWaitQueue(). This has adverse consequences:

(a) The PGPROC entry for the backend is not removed from the resource
queue lock's wait queue (waitProcs). Now, the same PGPROC entry will be
recycled and used for another backend after this backend exits. So, the
waitProcs link will be dangling and segfaults can result whenever the
waitProcs list is traversed (such as ResProcLockRemoveSelfAndWakeup(),
FindLockCycleRecurse() etc).

(b) The portal increment is not removed. This can lead to:
WARNING: duplicate portal id <> for proc <>
and a misleading ERROR which follows immediately after:
ERROR: out of shared memory adding portal increments
for the same process, on a subsequent ResLockAcquire().

(2) We don't clean up the locallock, opening up a possibility for the
same memory corruption scenario as the one fixed in f8348f911b1.

Note: Fixing the misleading out of shared memory message is left for a
later commit.