### PR TITLE
Add test case for hashagg and sisc across slices to honor temp_tablespaces

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -239,6 +239,20 @@ init_tuplestore_state(ShareInputScanState *node)
 				tuplestore_make_shared(ts,
 									   get_shareinput_fileset(),
 									   rwfile_prefix);
+#ifdef FAULT_INJECTOR
+				if (SIMPLE_FAULT_INJECTOR("sisc_xslice_temp_files") == FaultInjectorTypeSkip)
+				{
+					const char *filename = tuplestore_get_buffilename(ts);
+					if (!filename)
+						ereport(NOTICE, (errmsg("sisc_xslice: buffilename is null")));
+					else if (strstr(filename, "base/" PG_TEMP_FILES_DIR) == filename)
+						ereport(NOTICE, (errmsg("sisc_xslice: Use default tablespace")));
+					else if (strstr(filename, "pg_tblspc/") == filename)
+						ereport(NOTICE, (errmsg("sisc_xslice: Use temp tablespace")));
+					else
+						ereport(NOTICE, (errmsg("sisc_xslice: Unexpected prefix of the tablespace path")));
+				}
+#endif
 			}
 			else
 			{

--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -226,6 +226,11 @@ static void ltsConcatWorkerTapes(LogicalTapeSet *lts, TapeShare *shared,
 static void ltsInitTape(LogicalTape *lt);
 static void ltsInitReadBuffer(LogicalTapeSet *lts, LogicalTape *lt);
 
+char *
+LogicalTapeGetBufFilename(const LogicalTapeSet *lts)
+{
+	return lts->pfile ? pstrdup(BufFileGetFilename(lts->pfile)) : NULL;
+}
 
 /*
  * Write a block-sized buffer to the specified block of the underlying file.

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -296,6 +296,12 @@ static void writetup_heap(Tuplestorestate *state, void *tup);
 static void *readtup_heap(Tuplestorestate *state, unsigned int len);
 
 
+char *
+tuplestore_get_buffilename(Tuplestorestate *state)
+{
+	return state->myfile ? pstrdup(BufFileGetFilename(state->myfile)) : NULL;
+}
+
 /*
  *		tuplestore_begin_xxx
  *

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -160,11 +160,8 @@ extern int gp_retry_close(int fd);
 #define PG_TEMP_FILES_DIR "pgsql_tmp"
 #define PG_TEMP_FILE_PREFIX "pgsql_tmp"
 
-extern char *GetTempFilePath(const char *filename, bool createdir);
-
 extern const char *FileGetFilename(File file);
 
 extern void FileSetIsWorkfile(File file);
-extern void FileSetIsTempFile(File file, bool isTempFile);
 
 #endif							/* FD_H */

--- a/src/include/utils/logtape.h
+++ b/src/include/utils/logtape.h
@@ -54,6 +54,7 @@ typedef struct TapeShare
  * prototypes for functions in logtape.c
  */
 
+extern char * LogicalTapeGetBufFilename(const LogicalTapeSet *lts);
 extern LogicalTapeSet *LogicalTapeSetCreate(int ntapes, TapeShare *shared,
 											SharedFileSet *fileset, int worker);
 extern void LogicalTapeSetClose(LogicalTapeSet *lts);

--- a/src/include/utils/tuplestore.h
+++ b/src/include/utils/tuplestore.h
@@ -42,6 +42,8 @@ struct Instrumentation;                 /* #include "executor/instrument.h" */
  */
 typedef struct Tuplestorestate Tuplestorestate;
 
+extern char * tuplestore_get_buffilename(Tuplestorestate *state);
+
 /*
  * Currently we only need to store MinimalTuples, but it would be easy
  * to support the same behavior for IndexTuples and/or bare Datums.

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -161,6 +161,11 @@ tablespace-setup:
         ./testtablespace_1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000/ \
 	./testtablespace_default_tablespace \
 	./testtablespace_temp_tablespace \
+	./testtablespace_mytempsp0 \
+	./testtablespace_mytempsp1 \
+	./testtablespace_mytempsp2 \
+	./testtablespace_mytempsp3 \
+	./testtablespace_mytempsp4 \
 	./testtablespace_database_tablespace
 
 

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -26,3 +26,115 @@ drop tablespace some_temp_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;
 reset temp_tablespaces;
+
+
+-- When the GUC temp_tablespaces is set, one of the temp tablespaces is used instead of the default tablespace.
+-- create several tablespaces and use them as temp tablespaces
+-- all QD/QEs in one session should have the same temp tablespace
+create tablespace mytempsp0 location '@testtablespace@_mytempsp0';
+create tablespace mytempsp1 location '@testtablespace@_mytempsp1';
+create tablespace mytempsp2 location '@testtablespace@_mytempsp2';
+create tablespace mytempsp3 location '@testtablespace@_mytempsp3';
+create tablespace mytempsp4 location '@testtablespace@_mytempsp4';
+
+CREATE TABLE tts_foo (i int, j int) distributed by(i);
+insert into tts_foo select i, i from generate_series(1,80000)i;
+ANALYZE tts_foo;
+set gp_cte_sharing=on;
+
+-- CASE 1: when temp_tablespaces is set, hashagg and share-input-scan
+-- should honor the GUC and creates temp files under the specified tablespaces.
+
+-- temp_tablespaces will synchronized to all segments
+set temp_tablespaces=mytempsp0,mytempsp1,mytempsp2,mytempsp3,mytempsp4;
+set statement_mem='2MB';
+
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+CREATE TEMP TABLE tts_bar as
+WITH a1 as (select * from tts_foo),
+     a2 as (select * from tts_foo)
+    SELECT a1.i xx
+       FROM a1
+         INNER JOIN a2 ON a2.i = a1.i
+         UNION ALL
+         SELECT count(a1.i)
+           FROM a1
+             INNER JOIN a2 ON a2.i = a1.i
+distributed by(xx);
+
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('sisc_xslice_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+-- test for hash agg
+set statement_mem='1MB';
+
+select gp_inject_fault('hashagg_spill_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+create temp table tts_hashagg as
+select * from tts_foo group by i, j
+distributed by(i);
+
+-- hashagg should spill on the temp tablespaces specified by temp_tablespaces
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('hashagg_spill_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+select gp_inject_fault('hashagg_spill_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+-- CASE 2: when temp_tablespaces is not set, hashagg and share-input-scan
+-- should create temp files under the default tablespaces.
+drop table tts_bar, tts_hashagg;
+set temp_tablespaces='';
+set statement_mem='2MB';
+
+-- The following CTAS query should generate share input scan cross slices.
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+CREATE TEMP TABLE tts_bar as
+WITH a1 as (select * from tts_foo),
+     a2 as (select * from tts_foo)
+    SELECT a1.i xx
+       FROM a1
+         INNER JOIN a2 ON a2.i = a1.i
+         UNION ALL
+         SELECT count(a1.i)
+           FROM a1
+             INNER JOIN a2 ON a2.i = a1.i
+distributed by(xx);
+
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('sisc_xslice_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+-- test for hash agg
+set statement_mem='1MB';
+
+select gp_inject_fault('hashagg_spill_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+create temp table tts_hashagg as
+select * from tts_foo group by i, j
+distributed by(i);
+
+-- hashagg should spill on the default tablespaces.
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('hashagg_spill_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+select gp_inject_fault('hashagg_spill_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+
+
+drop table tts_foo, tts_bar, tts_hashagg;
+drop tablespace mytempsp0;
+drop tablespace mytempsp1;
+drop tablespace mytempsp2;
+drop tablespace mytempsp3;
+drop tablespace mytempsp4;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -40,3 +40,190 @@ drop tablespace some_temp_tablespace;
 drop tablespace some_default_tablespace;
 reset default_tablespace;
 reset temp_tablespaces;
+-- When the GUC temp_tablespaces is set, one of the temp tablespaces is used instead of the default tablespace.
+-- create several tablespaces and use them as temp tablespaces
+-- all QD/QEs in one session should have the same temp tablespace
+create tablespace mytempsp0 location '@testtablespace@_mytempsp0';
+create tablespace mytempsp1 location '@testtablespace@_mytempsp1';
+create tablespace mytempsp2 location '@testtablespace@_mytempsp2';
+create tablespace mytempsp3 location '@testtablespace@_mytempsp3';
+create tablespace mytempsp4 location '@testtablespace@_mytempsp4';
+CREATE TABLE tts_foo (i int, j int) distributed by(i);
+insert into tts_foo select i, i from generate_series(1,80000)i;
+ANALYZE tts_foo;
+set gp_cte_sharing=on;
+-- CASE 1: when temp_tablespaces is set, hashagg and share-input-scan
+-- should honor the GUC and creates temp files under the specified tablespaces.
+-- temp_tablespaces will synchronized to all segments
+set temp_tablespaces=mytempsp0,mytempsp1,mytempsp2,mytempsp3,mytempsp4;
+set statement_mem='2MB';
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+CREATE TEMP TABLE tts_bar as
+WITH a1 as (select * from tts_foo),
+     a2 as (select * from tts_foo)
+    SELECT a1.i xx
+       FROM a1
+         INNER JOIN a2 ON a2.i = a1.i
+         UNION ALL
+         SELECT count(a1.i)
+           FROM a1
+             INNER JOIN a2 ON a2.i = a1.i
+distributed by(xx);
+NOTICE:  sisc_xslice: Use temp tablespace  (seg0 slice1 172.17.0.2:7002 pid=2944771)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg1 slice1 172.17.0.2:7003 pid=2944772)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg2 slice1 172.17.0.2:7004 pid=2944773)
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('sisc_xslice_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- test for hash agg
+set statement_mem='1MB';
+select gp_inject_fault('hashagg_spill_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+create temp table tts_hashagg as
+select * from tts_foo group by i, j
+distributed by(i);
+NOTICE:  hashagg: Use temp tablespace  (seg1 slice1 172.17.0.2:7003 pid=2944795)
+NOTICE:  hashagg: Use temp tablespace  (seg2 slice1 172.17.0.2:7004 pid=2944796)
+NOTICE:  hashagg: Use temp tablespace  (seg0 slice1 172.17.0.2:7002 pid=2944794)
+-- hashagg should spill on the temp tablespaces specified by temp_tablespaces
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('hashagg_spill_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+select gp_inject_fault('hashagg_spill_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- CASE 2: when temp_tablespaces is not set, hashagg and share-input-scan
+-- should create temp files under the default tablespaces.
+drop table tts_bar, tts_hashagg;
+set temp_tablespaces='';
+set statement_mem='2MB';
+-- The following CTAS query should generate share input scan cross slices.
+select gp_inject_fault('sisc_xslice_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+CREATE TEMP TABLE tts_bar as
+WITH a1 as (select * from tts_foo),
+     a2 as (select * from tts_foo)
+    SELECT a1.i xx
+       FROM a1
+         INNER JOIN a2 ON a2.i = a1.i
+         UNION ALL
+         SELECT count(a1.i)
+           FROM a1
+             INNER JOIN a2 ON a2.i = a1.i
+distributed by(xx);
+NOTICE:  sisc_xslice: Use default tablespace  (seg0 slice1 172.17.0.2:7002 pid=2945819)
+NOTICE:  sisc_xslice: Use default tablespace  (seg1 slice1 172.17.0.2:7003 pid=2945820)
+NOTICE:  sisc_xslice: Use default tablespace  (seg2 slice1 172.17.0.2:7004 pid=2945821)
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('sisc_xslice_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+select gp_inject_fault('sisc_xslice_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- test for hash agg
+set statement_mem='1MB';
+select gp_inject_fault('hashagg_spill_temp_files', 'skip', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+create temp table tts_hashagg as
+select * from tts_foo group by i, j
+distributed by(i);
+NOTICE:  hashagg: Use default tablespace  (seg0 172.17.0.2:7002 pid=2945760)
+NOTICE:  hashagg: Use default tablespace  (seg1 172.17.0.2:7003 pid=2945761)
+NOTICE:  hashagg: Use default tablespace  (seg2 172.17.0.2:7004 pid=2945762)
+-- hashagg should spill on the default tablespaces.
+-- Make sure the following fault injector is triggered.
+select gp_wait_until_triggered_fault('hashagg_spill_temp_files', 1, dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+select gp_inject_fault('hashagg_spill_temp_files', 'reset', dbid)
+  from gp_segment_configuration where role='p' and content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table tts_foo, tts_bar, tts_hashagg;
+drop tablespace mytempsp0;
+drop tablespace mytempsp1;
+drop tablespace mytempsp2;
+drop tablespace mytempsp3;
+drop tablespace mytempsp4;


### PR DESCRIPTION
NB: The current code has already correctly used temp_tablespaces for
hash aggregate and sisc(share input scan) across slices. This commit
only adds test cases for them to constraint future code break.

The `temp_tablespaces` defines the temp tablespaces that are used
when spill file happens. Using wrong tablespaces usually doesn't
have errors or even warnings, but we want to ensure that the GUC
`temp_tablespaces` is honored if it was set.
When `temp_tablespaces` is set, usually any tablespace can be chosen
for temp files, but we need to take care of one case that uses
temp file(s) across slices. The producer backend must use the same
tablespace as the consumer backend(s), or they refer to different
path for the expected temp file(s).


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
