### PR TITLE
Use the segment address for WAL-replication in gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -660,7 +660,7 @@ class SegmentTemplate:
         try:
             coordinatorSeg = self.gparray.coordinator
             cmd = PgBaseBackup(pgdata=self.tempDir,
-                               host=coordinatorSeg.getSegmentHostName(),
+                               host=coordinatorSeg.getSegmentAddress(),
                                port=str(coordinatorSeg.getSegmentPort()),
                                recovery_mode=False,
                                target_gp_dbid=dummyDBID)


### PR DESCRIPTION
The address for WAL-replication should be the primary's `address`
in gp_segment_configuration. When running pg_basebackup,
the destination address for pg_basebackup is resolved to
the address in WAL replication by its mirror.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
