### PR TITLE
Add test cases for SET with quoted string

### DIFF
--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -371,3 +371,40 @@ FETCH c2;
 
 END;
 DROP TABLE guc_gp_t1;
+-- test for string guc is quoted correctly
+SET search_path = "'";
+SHOW search_path;
+ search_path 
+-------------
+ "'"
+(1 row)
+
+SET search_path = '"';
+SHOW search_path;
+ search_path 
+-------------
+ """"
+(1 row)
+
+SET search_path = '''';
+SHOW search_path;
+ search_path 
+-------------
+ "'"
+(1 row)
+
+SET search_path = '''abc''';
+SHOW search_path;
+ search_path 
+-------------
+ "'abc'"
+(1 row)
+
+SET search_path = '\path';
+SHOW search_path;
+ search_path 
+-------------
+ "\path"
+(1 row)
+
+RESET search_path;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -230,3 +230,16 @@ FETCH c2;
 END;
 
 DROP TABLE guc_gp_t1;
+
+-- test for string guc is quoted correctly
+SET search_path = "'";
+SHOW search_path;
+SET search_path = '"';
+SHOW search_path;
+SET search_path = '''';
+SHOW search_path;
+SET search_path = '''abc''';
+SHOW search_path;
+SET search_path = '\path';
+SHOW search_path;
+RESET search_path;


### PR DESCRIPTION
6X_stable has a bug with single quote `'` in the string GUC value, which
will cause a incorrect quoted string gets dispatched to QEs. e.g.:

> SET search_path = "'";
ERROR:  unterminated quoted string at or near "'"

"SET search_path = '" will be dispatched instead of the correct one
"SET search_path = ''''"

Luckily the bug has been fixed on master by 320af40b31f5.
This commit adds test cases to prepare to be backported to 6X with
the original fix together.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
