### PR TITLE
6X backport: gpinitsystem behave tests fix flakes

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -55,12 +55,13 @@ Feature: gpinitsystem tests
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
-    Scenario Outline: gpinitsystem creates a backout file when process terminated
+    Scenario: gpinitsystem creates a backout file when gpinitsystem process terminated
         Given create demo cluster config
         And all files in gpAdminLogs directory are deleted
         When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-        And the user asynchronously sets up to end <terminated_process> process when "Waiting for parallel processes" is printed in gpinitsystem logs
-        And the user waits 30 second
+        And the user asynchronously sets up to end gpinitsystem process when "Waiting for parallel processes" is printed in the logs
+        And the user waits until saved async process is completed
+        And the user waits until gpcreateseg process is completed
         Then gpintsystem logs should contain lines about running backout script
         And the user runs the gpinitsystem backout script
         And all files in gpAdminLogs directory are deleted
@@ -68,18 +69,27 @@ Feature: gpinitsystem tests
         And gpinitsystem should return a return code of 0
         And gpintsystem logs should not contain lines about running backout script
 
-    Examples:
-        | terminated_process |
-        | bin/gpinitsystem   |
-        | gpcreateseg        |
+    Scenario: gpinitsystem creates a backout file when gpcreateseg process terminated
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end gpcreateseg process when it starts
+        And the user waits until saved async process is completed
+        Then gpintsystem logs should contain lines about running backout script
+        And the user runs the gpinitsystem backout script
+        And all files in gpAdminLogs directory are deleted
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And gpinitsystem should return a return code of 0
+        And gpintsystem logs should not contain lines about running backout script
 
     Scenario: gpinitsystem does not create or need backout file when user terminated very early
         Given create demo cluster config
         And all files in gpAdminLogs directory are deleted
         When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
         And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
-        And the user waits 10 second
+        And the user waits until saved async process is completed
         Then gpintsystem logs should not contain lines about running backout script
+        And all files in gpAdminLogs directory are deleted
         And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -381,10 +381,26 @@ def impl(context, process_name, secs):
     run_async_command(context, command)
 
 
-@when('the user asynchronously sets up to end {process_name} process when {log_msg} is printed in gpinitsystem logs')
-def impl(context, process_name, log_msg):
-    command = "while sleep 3; do if egrep --quiet %s  ~/gpAdminLogs/gpinitsystem*log ; then ps ux | grep %s |awk '{print $2}' | xargs kill ;break 2; fi; done" % (log_msg, process_name)
+@when('the user asynchronously sets up to end gpinitsystem process when {log_msg} is printed in the logs')
+def impl(context, log_msg):
+    command = "while sleep 0.1; " \
+              "do if egrep --quiet %s  ~/gpAdminLogs/gpinitsystem*log ; " \
+              "then ps ux | grep bin/gpinitsystem |awk '{print $2}' | xargs kill ;break 2; " \
+              "fi; done" % (log_msg)
     run_async_command(context, command)
+
+
+@when('the user asynchronously sets up to end gpcreateseg process when it starts')
+def impl(context):
+    # We keep trying to find the gpcreateseg process using ps,grep
+    # and when we find it, we want to kill it only after the trap for ERROR_EXIT is setup (hence the sleep 1)
+    command = """timeout 10m
+    bash -c "while sleep 0.1;
+    do if ps ux | grep [g]pcreateseg ;
+    then sleep 1 && ps ux | grep [g]pcreateseg |awk '{print \$2}' | xargs kill ;
+    break 2; fi; done" """
+    run_async_command(context, command)
+
 
 @given('the user asynchronously runs "{command}" and the process is saved')
 @when('the user asynchronously runs "{command}" and the process is saved')
@@ -403,6 +419,17 @@ def impl(context, ret_code):
                         "rc: %s\n"
                         "stdout: %s\n"
                         "stderr: %s" % (rc, stdout_value, stderr_value))
+
+
+@when('the user waits until saved async process is completed')
+def impl(context):
+    context.asyncproc.communicate2()
+
+
+@when('the user waits until {process_name} process is completed')
+def impl(context, process_name):
+    wait_process_command = "while ps ux | grep %s | grep -v grep; do sleep 0.1; done;" % process_name
+    run_cmd(wait_process_command)
 
 
 @given('a user runs "{command}" with gphome "{gphome}"')


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/12514
The behave tests added for gpinitsystem backout scripts are timing
dependent, since they involve asynchronous killing of processes.
This was causing failures on pipeline if the kill is executed too
early/late.

This commit aims at reducing this flaky behavior by
- making the kill condition more accurate for gpcreateseg- by monitoring
  process instead of logs. We monitor the process using ps/grep and want
  to kill it after it has setup the trap for ERROR_EXIT. Added test step
  for the same.
- for scenario of killing gpinitsystem, gpcreateseg processes can still
  run in the background after gpinitsystem has been killed. We want to
  wait for these processes to complete to successfully run backout
  script. Added test step for the same.
- changing the 'waiting to complete' step to monitor processes, instead
  of time.
- clearing out logs so subsequent runs don't affect each other.

Co-authored-by: Denis Smirnov <darthunix@gmail.com>

(cherry picked from commit 5dc8a32ffb1b41bbfbd9e45532a35495ae26e1f7)
