### PR TITLE
[5X] VACUUM FULL should do permissions check during relation list creation

### DIFF
--- a/src/test/isolation/expected/vacuum-full-permissions.out
+++ b/src/test/isolation/expected/vacuum-full-permissions.out
@@ -1,0 +1,38 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2_sr s1_in s2_in s1_ct s2_ct s2_r s1_r s1_d s2_d s2_r s1_r s1_b s1_l s2_sw s2_vf s2_r s1_r
+step s2_sr: SET ROLE testrole_vacuum_full;
+step s1_in: SET gp_select_invisible=on;
+step s2_in: SET gp_select_invisible=on;
+step s1_ct: CREATE TABLE testtable_vacuum_full_to_skip AS SELECT generate_series(1,10);
+step s2_ct: CREATE TABLE testtable_vacuum_full AS SELECT generate_series(1,10);
+step s2_r: SELECT COUNT(*) FROM testtable_vacuum_full;
+count          
+
+10             
+step s1_r: SELECT COUNT(*) FROM testtable_vacuum_full_to_skip;
+count          
+
+10             
+step s1_d: DELETE FROM testtable_vacuum_full_to_skip;
+step s2_d: DELETE FROM testtable_vacuum_full;
+step s2_r: SELECT COUNT(*) FROM testtable_vacuum_full;
+count          
+
+10             
+step s1_r: SELECT COUNT(*) FROM testtable_vacuum_full_to_skip;
+count          
+
+10             
+step s1_b: BEGIN;
+step s1_l: LOCK TABLE pg_database IN ACCESS SHARE MODE;
+step s2_sw: SET client_min_messages TO ERROR;
+step s2_vf: VACUUM FULL;
+step s2_r: SELECT COUNT(*) FROM testtable_vacuum_full;
+count          
+
+0              
+step s1_r: SELECT COUNT(*) FROM testtable_vacuum_full_to_skip;
+count          
+
+10             

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -5,5 +5,6 @@ test: heap-serializable-vacuum
 test: ao-serializable-read
 test: ao-serializable-vacuum
 test: ao-insert-eof
+test: vacuum-full-permissions
 test: create_index_hot
 test: udf-insert-deadlock

--- a/src/test/isolation/specs/vacuum-full-permissions.spec
+++ b/src/test/isolation/specs/vacuum-full-permissions.spec
@@ -1,0 +1,48 @@
+# Test validates VACUUM FULL is not blocked on a table
+# that the role doesn't have permission to vacuum.
+
+setup
+{
+	CREATE ROLE testrole_vacuum_full;
+}
+
+teardown
+{
+	DROP ROLE testrole_vacuum_full;
+}
+
+session "s1"
+step "s1_in"	{ SET gp_select_invisible=on; }
+step "s1_ct"	{ CREATE TABLE testtable_vacuum_full_to_skip AS SELECT generate_series(1,10); }
+step "s1_d"	{ DELETE FROM testtable_vacuum_full_to_skip; }
+step "s1_r"	{ SELECT COUNT(*) FROM testtable_vacuum_full_to_skip; }
+step "s1_b"	{ BEGIN; }
+step "s1_l"	{ LOCK TABLE pg_database IN ACCESS SHARE MODE; }
+
+teardown
+{
+	END;
+	DROP TABLE testtable_vacuum_full_to_skip;
+	RESET gp_select_invisible;
+}
+
+session "s2"
+step "s2_sr"	{ SET ROLE testrole_vacuum_full; }
+step "s2_in"	{ SET gp_select_invisible=on; }
+step "s2_sw"	{ SET client_min_messages TO ERROR; }
+step "s2_ct"	{ CREATE TABLE testtable_vacuum_full AS SELECT generate_series(1,10); }
+step "s2_r"	{ SELECT COUNT(*) FROM testtable_vacuum_full; }
+step "s2_d"	{ DELETE FROM testtable_vacuum_full; }
+step "s2_vf"	{ VACUUM FULL; }
+
+teardown
+{
+	DROP TABLE testtable_vacuum_full;
+	RESET client_min_messages;
+	RESET gp_select_invisible;
+}
+
+# This permutation asserts that s2, running VACUUM FULL, is not blocked on s1 which has an active lock on catalog table.
+# s2 should skip catalog tables as well as user tables that it doesn't have access rights to.
+# To check if a table has been vacuumed we ensure that no dead rows are returned on a select with gp_select_invisible=on.
+permutation "s2_sr" "s1_in" "s2_in" "s1_ct" "s2_ct" "s2_r" "s1_r" "s1_d" "s2_d" "s2_r" "s1_r" "s1_b" "s1_l" "s2_sw" "s2_vf" "s2_r" "s1_r"


### PR DESCRIPTION
If non superuser runs VACUUM FULL, it could block on a table that the user
doesn't have permissions to if someone else is running a transaction on the same
table at the same time. In fact, in this case the table would have been skipped,
but the permissions check currently happens after AccessExclusiveLock is
acquired. Until the AccessExclusiveLock is acquired and VACUUM FULL skips the
table, all other transactions touching the table would be blocked on the
AccessExclusiveLock request.  This is especially troublesome when the table is a
system catalog table such as pg_class or pg_database.

This commit adds the permission check to get_rel_oids() to filter out the tables
that the user doesn't have permissions to during relation list creation. In this
case, if such a table is locked VACUUM FULL will not try to obtain the
AccessExclusiveLock and will just skip it.

Inspired by upstream Postgres commit:
https://github.com/postgres/postgres/commit/a556549d7e6dce15fe216bd4130ea64239f4d83f

Co-authored-by: Jimmy Yih <jyih@vmware.com>
Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>

Cherry-picked and modified from GPDB 6X PR:
https://github.com/greenplum-db/gpdb/pull/12527

Modifications made:
    - VACUUM FULL second pass to do heap_truncate was getting an invalid
    RangeVar in its VacuumStmt. This is because the first pass clobbers
    the memory context when it commits transaction and the RangeVar is
    not properly cleaned up for the second pass. There was an old
    assumption that VACUUM FULL on the database would always have a
    relation list length greater than 1 because the catalog tables were
    always included. With this VACUUM FULL patch this assumption no
    longer is valid because we filter early now on permissions.