### PR TITLE
Set bitmap to NULL after freeing it to avoid freeing twice

### DIFF
--- a/src/backend/access/appendonly/appendonly_visimap_entry.c
+++ b/src/backend/access/appendonly/appendonly_visimap_entry.c
@@ -150,6 +150,16 @@ AppendOnlyVisiMapEnty_ReadData(
 	}
 
 	bms_free(visiMapEntry->bitmap);
+	/*
+	 * After we free visiMapEntry->bitmap, In gpdb4 before resetting to a new value,
+	 * Some error may be thrown out (e.g. palloc fail), then when we catch this error in
+	 * PostgresMain we will rollback the transaction by AbortCurrentTransaction, then call
+	 * PortalCleanup-->ExecutorEnd to close resource, In AppendOnlyVisimapEntry_Finish
+	 * visiMapEntry->bitmap is not null, we free it the second time.
+	 * However, Since gpdb5 PortalCleanup logic is refactored, do not have this issue,
+	 * but I think it is reasonable to set it to NULLL to avoid similar issues.
+	 */
+	visiMapEntry->bitmap = NULL;
 
 	newWordCount =
 		BitmapDecompress_GetBlockCount(&decompressState);
@@ -163,11 +173,7 @@ AppendOnlyVisiMapEnty_ReadData(
 									visiMapEntry->bitmap->words,
 									newWordCount);
 	}
-	else if (newWordCount == 0)
-	{
-		visiMapEntry->bitmap = NULL;
-	}
-	else
+	else if (newWordCount != 0)
 	{
 		elog(ERROR,
 			 "illegal visimap block count: visimap block count %d", newWordCount);


### PR DESCRIPTION
In gpdb4，visiMapEntry->bitmap is not set to NULL after freeing in AppendOnlyVisiMapEnty_ReadData, before it is assigned new values, we get cancel signal and throw an error, When we catch the error and process AbortCurrentTransaction to rollback, we call PortalCleanup->ExecutorEnd to release the resource, In AppendOnlyVisimapEntry_Finish visiMapEntry->bitmap is not null, It is freed the second time.

I did not reproduce this issue in master, because the logic of AbortCurrentTransaction is different from gpdb4,
However, we should set visiMapEntry->bitmap to null after we free it to avoid other similar issues.

This issue occurs, when segment free bitmap in AppendOnlyVisiMapEnty_ReadData, Then when we palloc memory we receive a cancel signal and throw an error, this occurs randomly, So the test case is difficult to construct.