### PR TITLE
Fix assertion failure for AO table.

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1895,7 +1895,12 @@ _mdfd_openseg(SMgrRelation reln, ForkNumber forknum, BlockNumber segno,
 	v->mdfd_vfd = fd;
 	v->mdfd_segno = segno;
 	v->mdfd_chain = NULL;
-	Assert(_mdnblocks(reln, forknum, v) <= ((BlockNumber) RELSEG_SIZE));
+	/*
+	 * Skip the assertion check, it'll cause assertion failure if aocs table
+	 * exceeds 1G. Comment this line for now to avoid future pg merge adds
+	 * back the code.
+	 */
+	/*Assert(_mdnblocks(reln, forknum, v) <= ((BlockNumber) RELSEG_SIZE));*/
 
 	/* all done */
 	return v;


### PR DESCRIPTION
If the AO table exceeds 1G, it will cause an assertion failure when called _mdfd_openseg().
Fix issue https://github.com/greenplum-db/gpdb/issues/12408.

As PostgreSQL upstream also has the assertion, comment this line for now.
Comment this line, for now, to avoid future pg merge adds back the code.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
