### PR TITLE
Revive legacy one-argument string_agg() aggregate

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -19,11 +19,13 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_debug_numsegments \
                gp_inject_fault \
                gp_exttable_fdw \
+               gp_legacy_string_agg \
                gp_replica_check
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
                gp_internal_tools \
+               gp_legacy_string_agg \
                gp_exttable_fdw
 endif
 

--- a/gpcontrib/gp_legacy_string_agg/Makefile
+++ b/gpcontrib/gp_legacy_string_agg/Makefile
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------------------
+#
+# Makefile--
+#    Makefile for legacy one-argument string_agg
+#
+# By default, this builds against an existing PostgreSQL installation
+# (the one identified by whichever pg_config is first in your path).
+# Within a configured source tree, you can say "make NO_PGXS=1 all"
+# to build using the surrounding source tree.
+#
+# IDENTIFICATION
+#    gpcontrib/gp_legacy_string_agg/Makefile
+#
+#-------------------------------------------------------------------------
+
+MODULES = gp_legacy_string_agg
+EXTENSION = gp_legacy_string_agg
+DATA = gp_legacy_string_agg--1.0.0.sql
+
+REGRESS = gp_legacy_string_agg_tests
+PG_CPPFLAGS = -I$(libpq_srcdir)
+
+ifdef USE_PGXS
+	PG_CONFIG = pg_config
+	PGXS := $(shell $(PG_CONFIG) --pgxs)
+	include $(PGXS)
+else
+	subdir = gpcontrib/gp_legacy_string_agg
+	top_builddir = ../..
+	include $(top_builddir)/src/Makefile.global
+	include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_legacy_string_agg/expected/gp_legacy_string_agg_tests.out
+++ b/gpcontrib/gp_legacy_string_agg/expected/gp_legacy_string_agg_tests.out
@@ -1,0 +1,24 @@
+CREATE EXTENSION gp_legacy_string_agg;
+SELECT string_agg('a') FROM generate_series(1, 10);
+WARNING:  Deprecated call to string_agg(text), use string_agg(text, text) instead
+ string_agg 
+------------
+ aaaaaaaaaa
+(1 row)
+
+SELECT string_agg(a) FROM (VALUES('aaaa'),('bbbb'),('cccc'),(NULL)) g(a);
+WARNING:  Deprecated call to string_agg(text), use string_agg(text, text) instead
+  string_agg  
+--------------
+ aaaabbbbcccc
+(1 row)
+
+CREATE TABLE foo(a int, b text);
+INSERT INTO foo VALUES(1, 'aaaa'),(2, 'bbbb'),(3, 'cccc'), (4, NULL);
+SELECT string_agg(b ORDER BY a) FROM foo;
+WARNING:  Deprecated call to string_agg(text), use string_agg(text, text) instead
+  string_agg  
+--------------
+ aaaabbbbcccc
+(1 row)
+

--- a/gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg--1.0.0.sql
+++ b/gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg--1.0.0.sql
@@ -1,0 +1,42 @@
+---------------------------------------------------------------------------
+--
+-- gp_legacy_string_agg--1.0.0.sql-
+--    This file creates a string_agg(text) which is deprecated in GPDB6 server.
+--    Instead, users should convert their SQL to use string_agg(text, text).
+--
+--    E.g. string_agg('a') should converted to string_agg('a', '')
+--
+--
+-- Portions Copyright (c) 1996-2014, PostgreSQL Global Development Group
+-- Portions Copyright (c) 1994, Regents of the University of California
+--
+-- gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg--1.0.0.sql
+--
+---------------------------------------------------------------------------
+
+-- Assume the user defined functions are in $libdir/gp_legacy_string_agg
+-- (we do not want to assume this is in the dynamic loader search path).
+-- Look at gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg.c for the
+-- source.  Note we mark them IMMUTABLE, since they always return the same
+-- outputs given the same inputs.
+
+
+-- first, define a function gp_legacy_string_agg_transfn (also in gp_legacy_string_agg.c)
+CREATE FUNCTION gp_legacy_string_agg_transfn(internal, text)
+   RETURNS internal
+   AS '$libdir/gp_legacy_string_agg'
+   LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION gp_legacy_string_agg_finalfn(internal)
+   RETURNS text
+   AS '$libdir/gp_legacy_string_agg'
+   LANGUAGE C IMMUTABLE;
+
+
+-- Creating aggregate functions
+CREATE AGGREGATE string_agg(text)
+(
+     sfunc= gp_legacy_string_agg_transfn,
+     stype= internal,
+     finalfunc= gp_legacy_string_agg_finalfn
+);

--- a/gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg.c
+++ b/gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg.c
@@ -1,0 +1,124 @@
+/*
+ * gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg.c
+ *
+ ******************************************************************************
+  This file contains routines that can be bound to a Postgres backend and
+  called by the backend in the process of processing queries.  The calling
+  format for these routines is dictated by Postgres architecture.
+******************************************************************************/
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "libpq/pqformat.h"		/* needed for send/recv functions */
+
+
+PG_MODULE_MAGIC;
+
+/*
+* string_agg - Concatenates values and returns string.
+*
+* Syntax: string_agg(value text, delimiter text) RETURNS text
+*
+* Note: Any NULL values are ignored. The first-call delimiter isn't
+* actually used at all, and on subsequent calls the delimiter precedes
+* the associated value.
+*/
+
+/* subroutine to initialize state */
+static StringInfo
+makeStringAggState(FunctionCallInfo fcinfo)
+{
+	StringInfo	state;
+	MemoryContext aggcontext;
+	MemoryContext oldcontext;
+
+	if (!AggCheckCallContext(fcinfo, &aggcontext))
+	{
+		/* cannot be called directly because of internal-type argument */
+		elog(ERROR, "gp_legacy_string_agg_transfn called in non-aggregate context");
+	}
+
+	/*
+	 * Create state in aggregate context.  It'll stay there across subsequent
+	 * calls.
+	 */
+	oldcontext = MemoryContextSwitchTo(aggcontext);
+	state = makeStringInfo();
+	MemoryContextSwitchTo(oldcontext);
+
+	return state;
+}
+
+static void
+appendStringInfoText(StringInfo str, const text *t)
+{
+	appendBinaryStringInfo(str, VARDATA_ANY((void *) t), VARSIZE_ANY_EXHDR((void *) t));
+}
+
+/*
+ * cstring_to_text_with_len
+ *
+ * Same as cstring_to_text except the caller specifies the string length;
+ * the string need not be null_terminated.
+ */
+static text *
+cstring_to_text_with_len(const char *s, int len)
+{
+	text	   *result = (text *) palloc(len + VARHDRSZ);
+
+	SET_VARSIZE(result, len + VARHDRSZ);
+	memcpy(VARDATA(result), s, len);
+
+	return result;
+}
+
+/*
+ * Since we use V1 function calling convention, all these functions have
+ * the same signature as far as C is concerned.  We provide these prototypes
+ * just to forestall warnings when compiled with gcc -Wmissing-prototypes.
+ */
+PG_FUNCTION_INFO_V1(gp_legacy_string_agg_transfn);
+PG_FUNCTION_INFO_V1(gp_legacy_string_agg_finalfn);
+
+Datum		gp_legacy_string_agg_transfn(PG_FUNCTION_ARGS);
+Datum		gp_legacy_string_agg_finalfn(PG_FUNCTION_ARGS);
+
+
+Datum
+gp_legacy_string_agg_transfn(PG_FUNCTION_ARGS)
+{
+	StringInfo state = NULL;
+	state = PG_ARGISNULL(0) ? NULL : (StringInfo) PG_GETARG_POINTER(0);
+	/* Append the value unless null. */
+
+	if (!PG_ARGISNULL(1))
+	{
+		/* On the first time through, we ignore the delimiter. */
+		if (state == NULL)
+			state = makeStringAggState(fcinfo);
+		appendStringInfoText(state, PG_GETARG_TEXT_PP(1));          /* value */
+	}
+
+	/*
+	* The transition type for string_agg() is declared to be "internal",
+	* which is a pass-by-value type the same size as a pointer.
+	*/
+	PG_RETURN_POINTER(state);
+}
+
+Datum
+gp_legacy_string_agg_finalfn(PG_FUNCTION_ARGS)
+{
+	StringInfo state;
+	/* cannot be called directly because of internal-type argument */
+	Assert(AggCheckCallContext(fcinfo, NULL));
+	state = PG_ARGISNULL(0) ? NULL : (StringInfo) PG_GETARG_POINTER(0);
+
+	elog(WARNING, "Deprecated call to string_agg(text), use string_agg(text, text) instead");
+
+	if (state != NULL)
+		PG_RETURN_TEXT_P(cstring_to_text_with_len(state->data, state->len));
+	else
+		PG_RETURN_NULL();
+}

--- a/gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg.control
+++ b/gpcontrib/gp_legacy_string_agg/gp_legacy_string_agg.control
@@ -1,0 +1,3 @@
+comment = 'Legacy one-argument string_agg implementation for Greenplum'
+default_version = '1.0.0'
+relocatable = true

--- a/gpcontrib/gp_legacy_string_agg/sql/gp_legacy_string_agg_tests.sql
+++ b/gpcontrib/gp_legacy_string_agg/sql/gp_legacy_string_agg_tests.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION gp_legacy_string_agg;
+
+SELECT string_agg('a') FROM generate_series(1, 10);
+
+SELECT string_agg(a) FROM (VALUES('aaaa'),('bbbb'),('cccc'),(NULL)) g(a);
+
+CREATE TABLE foo(a int, b text);
+INSERT INTO foo VALUES(1, 'aaaa'),(2, 'bbbb'),(3, 'cccc'), (4, NULL);
+SELECT string_agg(b ORDER BY a) FROM foo;


### PR DESCRIPTION
In GPDB6 the one-argument version of string_agg() was removed (Postgres
removed it in 9.1 commit b0c451e). This commit brings back the
one-argument version string agg in a user-defined aggregate extension.

A simpler approach is to use a SQL user-defined function like so:

    ```SQL
    CREATE FUNCTION aggs_trans(text,text) RETURNS text
    AS 'SELECT concat($1,$2)' LANGUAGE SQL STRICT IMMUTABLE;

    CREATE AGGREGATE string_agg(text) (
       sfunc = aggs_trans, stype = text,
       initcond = ''
    );
    ```

Issue with that implementation is that it is significantly slower:

    ```SQL
    \timing

    -- UDF version of one-argument string_agg()
    SELECT string_agg('a') FROM generate_series(1, 5000);
    Time: 77.713 ms

    -- built-in two-argument version of string_agg()
    SELECT string_agg('a', '') FROM generate_series(1, 5000);
    Time: 11.101 ms
    ```

Using this commit, we can achieve similar performance as built-in
string_agg function through an extension.

    ```SQL
    CREATE EXTENSION legacy_string_agg;

    \timing

    -- gpconrib module user-defined C-function aggregate
    SELECT string_agg('a') FROM generate_series(1, 5000);
    Time: 9.688 ms
    ```

Co-authored-by: Ekta Khanna <ekhanna@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
