### PR TITLE
Add NULL pointer check when creating memory pool manager in Orca

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -102,12 +102,14 @@ protected:
 		// raw allocation of memory for internal memory pools
 		void *alloc_internal = gpos::clib::Malloc(sizeof(PoolType));
 
-		// create internal memory pool
-		CMemoryPool *internal = ::new (alloc_internal) PoolType();
+		GPOS_OOM_CHECK(alloc_internal);
 
-		// instantiate manager
 		GPOS_TRY
 		{
+			// create internal memory pool
+			CMemoryPool *internal = ::new (alloc_internal) PoolType();
+
+			// instantiate manager
 			m_memory_pool_mgr = ::new ManagerType(internal, EMemoryPoolTracker);
 			m_memory_pool_mgr->Setup();
 		}


### PR DESCRIPTION
When initially creating the memory pools in Orca, there is a Malloc call
that is not properly handled if Malloc returns a null pointer. Since
Orca is also initialized on the segments, it is possible that this could
cause a segment OOM to be improperly handled if OOM occurs at this time.

Now, we raise an exception if we fail to allocate here.

Co-authored-by: Chris Hajas <chajas@vmware.com>
Co-authored-by: Shreedhar Hardikar <shardikar@vmware.com>