### PR TITLE
Fix gpstart master only without maintenance mode

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -100,6 +100,7 @@ class GpStart:
                 if self.interactive:
                     if not userinput.ask_yesno(None, "\nContinue with coordinator-only startup", 'N'):
                         raise UserAbortedException()
+            self.specialMode = 'maintenance'
 
         try:
             # Disable Ctrl-C

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1192,8 +1192,9 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	 * gp_maintenance_conn GUC is set.  We cannot check it until
 	 * process_startup_options parses the GUC.
 	 */
-	if (gp_maintenance_mode && Gp_role == GP_ROLE_DISPATCH &&
-		!(am_superuser && gp_maintenance_conn))
+	if (gp_maintenance_mode && !am_superuser &&
+		((Gp_role == GP_ROLE_DISPATCH && gp_maintenance_conn)
+		|| Gp_role == GP_ROLE_UTILITY))
 		ereport(FATAL,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("maintenance mode: connected by superuser only")));


### PR DESCRIPTION
Made following changes:

1.  Enter maintenance mode at the same time when Gpstart a coordinator in master-only mode;
2. If client pass a `PGOPTIONS="-c gp_role=utility" ` option in maintenance mode, check for superuser access.

It solved #12217 .


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
