### PR TITLE
docs - no spaces between column names in analyzedb -i, -x option values

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/analyzedb.xml
+++ b/gpdb-doc/dita/utility_guide/ref/analyzedb.xml
@@ -12,8 +12,8 @@
       <codeblock><b>analyzedb</b> <b>-d</b> <varname>dbname</varname>
    { <b>-s</b> <varname>schema</varname>  | 
    { <b>-t</b> <varname>schema</varname>.<varname>table</varname> 
-     [ <b>-i</b> <varname>col1</varname>[, <varname>col2</varname>, ...] | 
-       <b>-x</b> <varname>col1</varname>[, <varname>col2</varname>, ...] ] } |
+     [ <b>-i</b> <varname>col1</varname>[,<varname>col2</varname>, ...] | 
+       <b>-x</b> <varname>col1</varname>[,<varname>col2</varname>, ...] ] } |
      { <b>-f</b> | <b>--file</b>} <varname>config-file</varname> }
    [ <b>-l</b> | <b>--list</b> ]
    [ <b>--gen_profile_only</b> ]   
@@ -128,7 +128,7 @@
               <cmdname>ANALYZE</cmdname> operation only on the columns <codeph>l_shipdate</codeph>
             and <codeph>l_receiptdate</codeph> in the table
             <codeph>public.lineitem</codeph>.<codeblock>public.nation
-public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
+public.lineitem -i l_shipdate,l_receiptdate </codeblock></pd>
         </plentry>
         <plentry>
           <pt>--full</pt>
@@ -144,7 +144,7 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
             and you want to update the <codeph>analyzedb</codeph> snapshot for the tables. </pd>
         </plentry>
         <plentry>
-          <pt>-i <varname>col1</varname>, <varname>col2</varname>, ...</pt>
+          <pt>-i <varname>col1</varname>,<varname>col2</varname>, ...</pt>
           <pd>Optional. Must be specified with the <cmdname>-t</cmdname> option. For the table
             specified with the <cmdname>-t</cmdname> option, collect statistics only for the
             specified columns. </pd>
@@ -194,7 +194,7 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
               <codeph>-s</codeph>.</pd>
         </plentry>
         <plentry>
-          <pt>-x <varname>col1</varname>, <varname>col2</varname>, ...</pt>
+          <pt>-x <varname>col1</varname>,<varname>col2</varname>, ...</pt>
           <pd>Optional. Must be specified with the <cmdname>-t</cmdname> option. For the table
             specified with the <cmdname>-t</cmdname> option, exclude statistics collection for the
             specified columns. Statistics are collected only on the columns that are not
@@ -229,12 +229,12 @@ public.lineitem -i l_shipdate, l_receiptdate </codeblock></pd>
       <p>An example that collects statistics only on a set of table columns. In the database
           <codeph>mytest</codeph>, collect statistics on the columns <codeph>shipdate</codeph> and
           <codeph>receiptdate</codeph> in the table <codeph>public.orders</codeph>:</p>
-      <codeblock>analyzedb -d mytest -t public.orders -i shipdate, receiptdate</codeblock>
+      <codeblock>analyzedb -d mytest -t public.orders -i shipdate,receiptdate</codeblock>
       <p>An example that collects statistics on a table and exclude a set of columns. In the
         database <codeph>mytest</codeph>, collect statistics on the table
           <codeph>public.foo</codeph>, and do not collect statistics on the columns
           <codeph>bar</codeph> and <codeph>test2</codeph>.</p>
-      <codeblock>analyzedb -d mytest -t public.foo -x bar, test2</codeblock>
+      <codeblock>analyzedb -d mytest -t public.foo -x bar,test2</codeblock>
       <p>An example that specifies a file that contains a list of tables. This command collect
         statistics on the tables listed in the file <codeph>analyze-tables</codeph> in the database
         named <codeph>mytest</codeph>.</p>


### PR DESCRIPTION
the analyzedb ref page synopsis and examples for -i and -x option/values specify spaces between column names.  this is incorrect, there must be no spaces.
