### PR TITLE
Fix mis-planning of repeated application of a projection.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2036,6 +2036,7 @@ create_projection_plan(PlannerInfo *root, ProjectionPath *best_path, int flags)
 		 */
 		subplan = create_plan_recurse(root, best_path->subpath,
 									  CP_IGNORE_TLIST);
+		Assert(is_projection_capable_plan(subplan));
 		tlist = build_path_tlist(root, &best_path->path);
 	}
 	else


### PR DESCRIPTION
Let's consider backpatching fix for CVE-2021-3677. The original vulnerability was not reproduced in PG12. However, the fix for this was backpatched. Maybe we should do the same?