### PR TITLE
[5X] Miscellaneous fixes to the ERROR path for ResLockAcquire

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -379,6 +379,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in cdbdisp_finishCommand */
 	_("before_auto_stats"),
 		/* inject fault in auto_stats before running autostats logic */
+	_("res_increment_add_oosm"),
+		/* inject fault in ResIncrementAdd to simulate an out-of-shared-memory ERROR */
 	_("not recognized"),
 };
 
@@ -1091,6 +1093,8 @@ FaultInjector_NewHashEntry(
 			case ProcessStartupPacketFault:
 			case DynamicIndexScanContextReset:
 			case AbortAfterProcarrayEnd:
+
+			case ResIncrementAddOOSM:
 
 				break;
 			default:

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1474,6 +1474,15 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 
 	Assert(LWLockHeldExclusiveByMe(ResQueueLock));
 
+#ifdef FAULT_INJECTOR
+	/* Simulate an out-of-shared-memory error by bypassing the increment hash. */
+	if (FaultInjector_InjectFaultIfSet(ResIncrementAddOOSM,
+									   DDLNotSpecified,
+									   "",
+									   "") == FaultInjectorTypeSkip)
+		return NULL;
+#endif
+
 	/* Set up the key. */
 	MemSet(&portaltag, 0, sizeof(ResPortalTag));
 	portaltag.pid = incSet->pid;

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -45,7 +45,10 @@
 
 static void ResCleanUpLock(LOCK *lock, PROCLOCK *proclock, uint32 hashcode, bool wakeupNeeded);
 
-static ResPortalIncrement *ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner owner);
+static ResPortalIncrement *ResIncrementAdd(ResPortalIncrement *incSet,
+										   PROCLOCK *proclock,
+										   ResourceOwner owner,
+										   ResIncrementAddStatus *status);
 static bool ResIncrementRemove(ResPortalTag *portaltag);
 
 static void ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *incrementSet);
@@ -135,6 +138,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 	ResourceOwner owner;
 	ResQueue	queue;
 	int			status;
+	ResIncrementAddStatus addStatus;
 
 	/* Setup the lock method bits. */
 	Assert(locktag->locktag_lockmethodid == RESOURCE_LOCKMETHOD);
@@ -339,17 +343,27 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 	 * Otherwise, we are going to take a lock, Add an increment to the
 	 * increment hash for this process.
 	 */
-	incrementSet = ResIncrementAdd(incrementSet, proclock, owner);
-	if (!incrementSet)
+	incrementSet = ResIncrementAdd(incrementSet, proclock, owner, &addStatus);
+	if (addStatus != RES_INCREMENT_ADD_OK)
 	{
+		/*
+		 * We have failed to add the increment. So decrement the requested
+		 * counters, relinquish locks and raise the appropriate error.
+		 */
 		lock->nRequested--;
 		lock->requested[lockmode]--;
 		LWLockRelease(ResQueueLock);
 		LWLockRelease(partitionLock);
-		ereport(ERROR,
-				(errcode(ERRCODE_OUT_OF_MEMORY),
-				 errmsg("out of shared memory adding portal increments"),
-				 errhint("You may need to increase max_resource_portals_per_transaction.")));
+		if (addStatus == RES_INCREMENT_ADD_OOSM)
+			ereport(ERROR,
+					(errcode(ERRCODE_OUT_OF_MEMORY),
+						errmsg("out of shared memory adding portal increments"),
+						errhint("You may need to increase max_resource_portals_per_transaction.")));
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("duplicate portal id %u for proc %d",
+							   incrementSet->portalId, incrementSet->pid)));
 	}
 
 	/*
@@ -1457,15 +1471,20 @@ ResPortalIncrementHashTableInit(void)
 /*
  * ResIncrementAdd -- Add a new increment element to the increment hash.
  *
- * Notes:
- *	Return a pointer to where the new increment is stored, or NULL if we
- *	are out of memory (or if we find a duplicate portalid).
+ * We return the increment added. We return NULL if we are run out of shared
+ * memory. In case there is an existing increment element in the hash table,
+ * we have encountered a duplicate portal - so we return the existing increment
+ * for ERROR reporting purposes. The status output argument is updated to
+ * indicate the outcome of the routine.
  *
  *	The resource queue lightweight lock (ResQueueLock) *must* be held for
  *	this operation.
  */
 static ResPortalIncrement *
-ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner owner)
+ResIncrementAdd(ResPortalIncrement *incSet,
+				PROCLOCK *proclock,
+				ResourceOwner owner,
+				ResIncrementAddStatus *status)
 {
 	ResPortalIncrement *incrementSet;
 	ResPortalTag portaltag;
@@ -1480,7 +1499,10 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 									   DDLNotSpecified,
 									   "",
 									   "") == FaultInjectorTypeSkip)
+	{
+		*status = RES_INCREMENT_ADD_OOSM;
 		return NULL;
+	}
 #endif
 
 	/* Set up the key. */
@@ -1494,6 +1516,7 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 
 	if (!incrementSet)
 	{
+		*status = RES_INCREMENT_ADD_OOSM;
 		return NULL;
 	}
 
@@ -1514,10 +1537,11 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 	{
 		/* We have added this portId before - something has gone wrong! */
 		ResIncrementRemove(&portaltag);
-		elog(WARNING, "duplicate portal id %u for proc %d", incSet->portalId, incSet->pid);
-		incrementSet = NULL;
+		*status = RES_INCREMENT_ADD_DUPLICATE_PORTAL;
+		return incrementSet;
 	}
 
+	*status = RES_INCREMENT_ADD_OK;
 	return incrementSet;
 }
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -259,6 +259,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	BeforeAutoStats,
 
+	ResIncrementAddOOSM,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -103,6 +103,13 @@ typedef struct ResPortalIncrement
 	Cost		increments[NUM_RES_LIMIT_TYPES];
 } ResPortalIncrement;
 
+typedef enum
+{
+	RES_INCREMENT_ADD_OK,
+	RES_INCREMENT_ADD_OOSM,
+	RES_INCREMENT_ADD_DUPLICATE_PORTAL
+} ResIncrementAddStatus;
+
 typedef struct ResPortalTag
 {
 	int			pid;

--- a/src/test/regress/expected/resource_queue.out
+++ b/src/test/regress/expected/resource_queue.out
@@ -512,3 +512,45 @@ DROP OWNED BY rq_test_u CASCADE;
 DROP USER rq_test_u;
 DROP RESOURCE QUEUE rq_test_q;
 DROP TABLE rq_product;
+-- Coverage for resource queue error conditions
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE ROLE rq_test_oosm_role;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SET ROLE rq_test_oosm_role;
+CREATE TABLE rq_test_oosm_table(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO rq_test_oosm_table VALUES(1);
+-- Simulate an out-of-shared-memory condition during the course of grabbing a
+-- resource queue lock (in ResLockAcquire()).
+SELECT gp_inject_fault('res_increment_add_oosm', 'skip', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+-- Queries should error out indicating that we have no shared memory left.
+SELECT * FROM rq_test_oosm_table;
+ERROR:  out of shared memory adding portal increments
+HINT:  You may need to increase max_resource_portals_per_transaction.
+-- Temporarily switch role to reset the fault.
+RESET role;
+SELECT gp_inject_fault('res_increment_add_oosm', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SET ROLE rq_test_oosm_role;
+-- Queries should succeed now.
+SELECT * FROM rq_test_oosm_table;
+ i 
+---
+ 1
+(1 row)
+
+DROP TABLE rq_test_oosm_table;
+RESET ROLE;
+DROP ROLE rq_test_oosm_role;

--- a/src/test/regress/sql/resource_queue.sql
+++ b/src/test/regress/sql/resource_queue.sql
@@ -345,3 +345,23 @@ DROP USER rq_test_u;
 DROP RESOURCE QUEUE rq_test_q;
 DROP TABLE rq_product;
 
+-- Coverage for resource queue error conditions
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE ROLE rq_test_oosm_role;
+SET ROLE rq_test_oosm_role;
+CREATE TABLE rq_test_oosm_table(i int);
+INSERT INTO rq_test_oosm_table VALUES(1);
+-- Simulate an out-of-shared-memory condition during the course of grabbing a
+-- resource queue lock (in ResLockAcquire()).
+SELECT gp_inject_fault('res_increment_add_oosm', 'skip', 1);
+-- Queries should error out indicating that we have no shared memory left.
+SELECT * FROM rq_test_oosm_table;
+-- Temporarily switch role to reset the fault.
+RESET role;
+SELECT gp_inject_fault('res_increment_add_oosm', 'reset', 1);
+SET ROLE rq_test_oosm_role;
+-- Queries should succeed now.
+SELECT * FROM rq_test_oosm_table;
+DROP TABLE rq_test_oosm_table;
+RESET ROLE;
+DROP ROLE rq_test_oosm_role;


### PR DESCRIPTION
This is a backport of #12528.

1. The first commit is a partial backport for test coverage (the associated fix was already present in 5X from commit: a7f8e8c275). Some minor changes to the test and test infrastructure was necessary due to differences in the fault injector framework between 5X and 7X.
2. The second commit is a straight-forward backport without any conflict resolution necessary.