### PR TITLE
6X ORCA Backport DbgStr

### DIFF
--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
@@ -32,7 +32,8 @@ using namespace gpos;
 //		Parameters in GPDB cost model
 //
 //---------------------------------------------------------------------------
-class CCostModelParamsGPDB : public ICostModelParams
+class CCostModelParamsGPDB : public ICostModelParams,
+							 public DbgPrintMixin<CCostModelParamsGPDB>
 {
 public:
 	// enumeration of cost model params

--- a/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
@@ -16,6 +16,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CCostModelParamsGPDB);
+
 // sequential i/o bandwidth
 const CDouble CCostModelParamsGPDB::DSeqIOBandwidthVal = 1024.0;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
@@ -50,7 +50,7 @@ class CCTEReq;
 //		CTE map that is derived as part of plan properties
 //
 //---------------------------------------------------------------------------
-class CCTEMap : public CRefCount
+class CCTEMap : public CRefCount, public DbgPrintMixin<CCTEMap>
 {
 public:
 	// CTE types
@@ -73,7 +73,7 @@ private:
 	//		the plan rooted by producer node.
 	//
 	//---------------------------------------------------------------------------
-	class CCTEMapEntry : public CRefCount
+	class CCTEMapEntry : public CRefCount, public DbgPrintMixin<CCTEMapEntry>
 	{
 	private:
 		// cte id

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
@@ -35,7 +35,7 @@ using namespace gpos;
 //		CTE requirements
 //
 //---------------------------------------------------------------------------
-class CCTEReq : public CRefCount
+class CCTEReq : public CRefCount, public DbgPrintMixin<CCTEReq>
 {
 private:
 	//---------------------------------------------------------------------------
@@ -46,7 +46,7 @@ private:
 	//		A single entry in the CTE requirement
 	//
 	//---------------------------------------------------------------------------
-	class CCTEReqEntry : public CRefCount
+	class CCTEReqEntry : public CRefCount, public DbgPrintMixin<CCTEReqEntry>
 	{
 	private:
 		// cte id

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -15,6 +15,7 @@
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CHashMap.h"
 #include "gpos/common/CList.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/metadata/CName.h"
 #include "naucrates/md/IMDType.h"
@@ -51,7 +52,7 @@ typedef CHashMapIter<ULONG, CColRef, gpos::HashValue<ULONG>,
 //		factory object
 //
 //---------------------------------------------------------------------------
-class CColRef
+class CColRef : public gpos::DbgPrintMixin<CColRef>
 {
 public:
 	enum EUsedStatus
@@ -227,10 +228,6 @@ public:
 	{
 		m_mdid_table = mdid_table;
 	}
-
-#ifdef GPOS_DEBUG
-	void DbgPrint() const;
-#endif	// GPOS_DEBUG
 
 };	// class CColRef
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
@@ -48,7 +48,7 @@ typedef CHashMap<INT, CColRef, gpos::HashValue<INT>, gpos::Equals<INT>,
 //		member functions inaccessible
 //
 //---------------------------------------------------------------------------
-class CColRefSet : public CBitSet
+class CColRefSet : public CBitSet, public DbgPrintMixin<CColRefSet>
 {
 	// bitset iter needs to access internals
 	friend class CColRefSetIter;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -58,7 +58,7 @@ typedef CHashMap<ULONG, CConstraint, gpos::HashValue<ULONG>,
 //		Base class for representing constraints
 //
 //---------------------------------------------------------------------------
-class CConstraint : public CRefCount
+class CConstraint : public CRefCount, public DbgPrintMixin<CConstraint>
 {
 public:
 	enum EConstraintType

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
@@ -51,7 +51,7 @@ typedef const CCostContext *CONST_COSTCTXT_PTR;
 //		Cost context
 //
 //---------------------------------------------------------------------------
-class CCostContext : public CRefCount
+class CCostContext : public CRefCount, public DbgPrintMixin<CCostContext>
 {
 public:
 	// states of cost context

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CRefCount.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 
 namespace gpopt
@@ -62,7 +63,7 @@ typedef CDynamicPtrArray<CDrvdProp, CleanupRelease> CDrvdPropArray;
 //		CExpressionHandle::DeriveProps().
 //
 //---------------------------------------------------------------------------
-class CDrvdProp : public CRefCount
+class CDrvdProp : public CRefCount, public DbgPrintMixin<CDrvdProp>
 {
 public:
 	// types of derived properties

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtRelational.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtRelational.h
@@ -64,13 +64,6 @@ public:
 	{
 	}
 
-	// print
-	virtual IOstream &
-	OsPrint(IOstream &os) const
-	{
-		return os;
-	}
-
 #ifdef GPOS_DEBUG
 
 	// is it a relational property context?

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
@@ -35,7 +35,7 @@ class CReqdPropPlan;
 //		Abstract base class for all enforceable properties.
 //
 //---------------------------------------------------------------------------
-class CEnfdProp : public CRefCount
+class CEnfdProp : public CRefCount, public DbgPrintMixin<CEnfdProp>
 {
 public:
 	// Definition of property enforcing type for a given operator.

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionProp.h
@@ -29,7 +29,7 @@ using namespace gpmd;
 //		Representation of function properties
 //
 //---------------------------------------------------------------------------
-class CFunctionProp : public CRefCount
+class CFunctionProp : public CRefCount, public DbgPrintMixin<CFunctionProp>
 {
 private:
 	// function stability

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
@@ -37,7 +37,8 @@ using namespace gpos;
 //		Functional dependency representation
 //
 //---------------------------------------------------------------------------
-class CFunctionalDependency : public CRefCount
+class CFunctionalDependency : public CRefCount,
+							  public DbgPrintMixin<CFunctionalDependency>
 {
 private:
 	// the left hand side of the FD

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
@@ -30,7 +30,7 @@ using namespace gpos;
 //		Captures sets of keys for a relation
 //
 //---------------------------------------------------------------------------
-class CKeyCollection : public CRefCount
+class CKeyCollection : public CRefCount, public DbgPrintMixin<CKeyCollection>
 {
 private:
 	// memory pool

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptCtxt.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptCtxt.h
@@ -281,10 +281,6 @@ public:
 	// return true if all enforcers are enabled
 	static BOOL FAllEnforcersEnabled();
 
-#ifdef GPOS_DEBUG
-	virtual IOstream &OsPrint(IOstream &) const;
-#endif	// GPOS_DEBUG
-
 };	// class COptCtxt
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
@@ -13,6 +13,7 @@
 #define GPOPT_COptimizationContext_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/task/CAutoTraceFlag.h"
 
 #include "gpopt/base/CReqdPropPlan.h"
@@ -48,7 +49,8 @@ typedef CDynamicPtrArray<COptimizationContext, CleanupRelease>
 //		Optimization context
 //
 //---------------------------------------------------------------------------
-class COptimizationContext : public CRefCount
+class COptimizationContext : public CRefCount,
+							 public DbgPrintMixin<COptimizationContext>
 {
 public:
 	// states of optimization context

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COrderSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COrderSpec.h
@@ -13,11 +13,11 @@
 #define GPOPT_COrderSpec_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CColRef.h"
 #include "gpopt/base/CPropSpec.h"
 #include "naucrates/md/IMDId.h"
-
 
 namespace gpopt
 {
@@ -64,7 +64,7 @@ private:
 	//			3. definition of NULL treatment
 	//
 	//---------------------------------------------------------------------------
-	class COrderExpression
+	class COrderExpression : public gpos::DbgPrintMixin<COrderExpression>
 	{
 	private:
 		// MD id of sort operator
@@ -113,11 +113,6 @@ private:
 
 		// print
 		IOstream &OsPrint(IOstream &os) const;
-
-#ifdef GPOS_DEBUG
-		// debug print for interactive debugging sessions only
-		void DbgPrint() const;
-#endif	// GPOS_DEBUG
 
 	};	// class COrderExpression
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
@@ -38,7 +38,7 @@ class CPartConstraint;
 //		Derived partition information at the logical level
 //
 //---------------------------------------------------------------------------
-class CPartInfo : public CRefCount
+class CPartInfo : public CRefCount, public DbgPrintMixin<CPartInfo>
 {
 private:
 	//---------------------------------------------------------------------------
@@ -49,7 +49,8 @@ private:
 	//		A single entry of the CPartInfo
 	//
 	//---------------------------------------------------------------------------
-	class CPartInfoEntry : public CRefCount
+	class CPartInfoEntry : public CRefCount,
+						   public DbgPrintMixin<CPartInfoEntry>
 	{
 	private:
 		// scan id

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
@@ -34,7 +34,7 @@ typedef CDynamicPtrArray<CPartKeys, CleanupRelease> CPartKeysArray;
 //		A collection of partitioning keys for a partitioned table
 //
 //---------------------------------------------------------------------------
-class CPartKeys : public CRefCount
+class CPartKeys : public CRefCount, public DbgPrintMixin<CPartKeys>
 {
 private:
 	// partitioning keys

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPropConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPropConstraint.h
@@ -33,7 +33,7 @@ class CExpression;
 //		Representation of constraint property
 //
 //---------------------------------------------------------------------------
-class CPropConstraint : public CRefCount
+class CPropConstraint : public CRefCount, public DbgPrintMixin<CPropConstraint>
 {
 private:
 	// array of equivalence classes

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h
@@ -31,7 +31,7 @@ class CReqdPropPlan;
 //		Property specification
 //
 //---------------------------------------------------------------------------
-class CPropSpec : public CRefCount
+class CPropSpec : public CRefCount, public DbgPrintMixin<CPropSpec>
 {
 public:
 	// property type
@@ -87,6 +87,8 @@ operator<<(IOstream &os, const CPropSpec &ospec)
 }
 
 }  // namespace gpopt
+
+FORCE_GENERATE_DBGSTR(gpopt::CPropSpec);
 
 #endif	// !GPOPT_CPropSpec_H
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
@@ -48,7 +48,7 @@ using namespace gpos;
 //
 //
 //---------------------------------------------------------------------------
-class CQueryContext
+class CQueryContext : public DbgPrintMixin<CQueryContext>
 {
 private:
 	// required plan properties in optimizer's produced plan

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
@@ -12,6 +12,7 @@
 #define GPOPT_CQueryContext_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CReqdPropPlan.h"
 #include "gpopt/base/CReqdPropRelational.h"
@@ -50,9 +51,6 @@ using namespace gpos;
 class CQueryContext
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// required plan properties in optimizer's produced plan
 	CReqdPropPlan *m_prpp;
 
@@ -142,8 +140,6 @@ public:
 #ifdef GPOS_DEBUG
 	// debug print
 	virtual IOstream &OsPrint(IOstream &) const;
-
-	void DbgPrint() const;
 #endif	// GPOS_DEBUG
 
 	// walk the expression and add the mapping between computed column

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
@@ -44,7 +44,7 @@ class IComparator;
 //		Representation of a range of values
 //
 //---------------------------------------------------------------------------
-class CRange : public CRefCount
+class CRange : public CRefCount, public DbgPrintMixin<CRange>
 {
 public:
 	enum ERangeInclusion

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CRefCount.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CDrvdProp.h"
 
@@ -64,7 +65,7 @@ typedef CDynamicPtrArray<CReqdProp, CleanupRelease> CReqdPropArray;
 //		children.
 //
 //---------------------------------------------------------------------------
-class CReqdProp : public CRefCount
+class CReqdProp : public CRefCount, public DbgPrintMixin<CReqdProp>
 {
 public:
 	// types of required properties

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
@@ -34,7 +34,7 @@ using namespace gpos;
 //		Description of window frame
 //
 //---------------------------------------------------------------------------
-class CWindowFrame : public CRefCount
+class CWindowFrame : public CRefCount, public DbgPrintMixin<CWindowFrame>
 {
 public:
 	// specification method

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CEngine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CEngine.h
@@ -42,7 +42,7 @@ class CEnumeratorConfig;
 //		Optimization engine; owns entire optimization workflow
 //
 //---------------------------------------------------------------------------
-class CEngine
+class CEngine : public DbgPrintMixin<CEngine>
 {
 private:
 	// memory pool

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
@@ -31,7 +31,8 @@ using namespace gpmd;
 //		column descriptor;
 //
 //---------------------------------------------------------------------------
-class CColumnDescriptor : public CRefCount
+class CColumnDescriptor : public CRefCount,
+						  public DbgPrintMixin<CColumnDescriptor>
 {
 private:
 	// type information

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
@@ -33,7 +33,8 @@ using namespace gpmd;
 //		Base class for index descriptor
 //
 //---------------------------------------------------------------------------
-class CIndexDescriptor : public CRefCount
+class CIndexDescriptor : public CRefCount,
+						 public DbgPrintMixin<CIndexDescriptor>
 {
 private:
 	// mdid of the index

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CName.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CName.h
@@ -13,6 +13,7 @@
 #define GPOPT_CName_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/string/CWStringConst.h"
 
 #define GPOPT_NAME_QUOTE_BEGIN "\""
@@ -34,7 +35,7 @@ using namespace gpos;
 //		enforced is zero termination of string;
 //
 //---------------------------------------------------------------------------
-class CName
+class CName : public DbgPrintMixin<CName>
 {
 private:
 	// actual name

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
@@ -46,7 +46,7 @@ typedef CHashMapIter<ULONG, CPartConstraint, gpos::HashValue<ULONG>,
 //		metadata abstraction for tables
 //
 //---------------------------------------------------------------------------
-class CPartConstraint : public CRefCount
+class CPartConstraint : public CRefCount, public DbgPrintMixin<CPartConstraint>
 {
 private:
 	// constraints for different levels

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -41,7 +41,8 @@ typedef CDynamicPtrArray<CBitSet, CleanupRelease> CBitSetArray;
 //		metadata abstraction for tables
 //
 //---------------------------------------------------------------------------
-class CTableDescriptor : public CRefCount
+class CTableDescriptor : public CRefCount,
+						 public DbgPrintMixin<CTableDescriptor>
 {
 private:
 	// memory pool

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CRefCount.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CColRef.h"
 #include "gpopt/base/CCostContext.h"
@@ -53,7 +54,7 @@ using namespace gpnaucrates;
 //		Simply dynamic array for pointer types
 //
 //---------------------------------------------------------------------------
-class CExpression : public CRefCount
+class CExpression : public CRefCount, public gpos::DbgPrintMixin<CExpression>
 {
 	friend class CExpressionHandle;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -46,7 +46,7 @@ typedef CHashMap<CColRef, CColRef, CColRef::HashValue, CColRef::Equals,
 //		base class for all operators
 //
 //---------------------------------------------------------------------------
-class COperator : public CRefCount
+class COperator : public CRefCount, public DbgPrintMixin<COperator>
 {
 private:
 	// private copy ctor

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -70,7 +70,7 @@ enum EOptimizationLevel
 //		Group of equivalent expressions in the Memo structure
 //
 //---------------------------------------------------------------------------
-class CGroup : public CRefCount
+class CGroup : public CRefCount, public DbgPrintMixin<CGroup>
 {
 	friend class CGroupProxy;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -71,9 +71,6 @@ public:
 		ShtCC;
 
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// definition of context hash table accessor
 	typedef CSyncHashtableAccessByKey<CCostContext,	 // entry
 									  OPTCTXT_PTR>
@@ -182,8 +179,7 @@ private:
 
 	//private dummy ctor; used for creating invalid gexpr
 	CGroupExpression()
-		: m_mp(NULL),
-		  m_id(GPOPT_INVALID_GEXPR_ID),
+		: m_id(GPOPT_INVALID_GEXPR_ID),
 		  m_pop(NULL),
 		  m_pdrgpgroup(NULL),
 		  m_pdrgpgroupSorted(NULL),

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -34,7 +34,8 @@ using namespace gpos;
 //		Expression representation inside Memo structure
 //
 //---------------------------------------------------------------------------
-class CGroupExpression : public CRefCount
+class CGroupExpression : public CRefCount,
+						 public DbgPrintMixin<CGroupExpression>
 {
 public:
 #ifdef GPOS_DEBUG

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
@@ -13,6 +13,7 @@
 
 #include "gpos/base.h"
 #include "gpos/common/CList.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/task/ITask.h"
 
 namespace gpopt
@@ -78,7 +79,7 @@ class CSchedulerContext;
 //		about how job are scheduled.
 //
 //---------------------------------------------------------------------------
-class CJob
+class CJob : public DbgPrintMixin<CJob>
 {
 	// friends
 	friend class CJobFactory;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
@@ -303,7 +303,7 @@ public:
 
 #ifdef GPOS_DEBUG
 	// print job description
-	virtual IOstream &OsPrint(IOstream &os);
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 	// link for running job list
 	SLink m_linkRunning;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroup.h
@@ -73,7 +73,7 @@ protected:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os) = 0;
+	virtual IOstream &OsPrint(IOstream &os) const = 0;
 
 #endif	// GPOS_DEBUG
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExploration.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExploration.h
@@ -103,7 +103,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os);
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpression.h
@@ -105,7 +105,7 @@ protected:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os) = 0;
+	virtual IOstream &OsPrint(IOstream &os) const = 0;
 
 #endif	// GPOS_DEBUG
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionExploration.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionExploration.h
@@ -104,7 +104,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os);
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionImplementation.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionImplementation.h
@@ -107,7 +107,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	IOstream &OsPrint(IOstream &os);
+	IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionOptimization.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionOptimization.h
@@ -187,7 +187,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	IOstream &OsPrint(IOstream &os);
+	IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupImplementation.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupImplementation.h
@@ -105,7 +105,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os);
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupOptimization.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupOptimization.h
@@ -137,7 +137,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os);
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobTest.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobTest.h
@@ -85,7 +85,7 @@ public:
 
 #ifdef GPOS_DEBUG
 	// printer
-	virtual IOstream &OsPrint(IOstream &);
+	virtual IOstream &OsPrint(IOstream &) const;
 #endif	// GPOS_DEBUG
 
 	// set execution parameters

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobTransformation.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobTransformation.h
@@ -91,7 +91,7 @@ public:
 #ifdef GPOS_DEBUG
 
 	// print function
-	virtual IOstream &OsPrint(IOstream &os);
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 	// dump state machine diagram in graphviz format
 	virtual IOstream &

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
@@ -158,7 +158,7 @@ public:
 	void ResetStats();
 
 	// print driver
-	IOstream &OsPrint(IOstream &os);
+	IOstream &OsPrint(IOstream &os) const;
 
 	// derive stats when no stats not present for the group
 	void DeriveStatsIfAbsent(CMemoryPool *mp);

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
@@ -15,6 +15,7 @@
 #include "gpos/common/CRefCount.h"
 #include "gpos/common/CSyncHashtable.h"
 #include "gpos/common/CSyncList.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/search/CGroupExpression.h"
 
@@ -41,7 +42,7 @@ using namespace gpos;
 //		Dynamic programming table
 //
 //---------------------------------------------------------------------------
-class CMemo
+class CMemo : public gpos::DbgPrintMixin<CMemo>
 {
 private:
 	// definition of hash table key accessor
@@ -176,8 +177,6 @@ public:
 	// get group by id
 	CGroup *Pgroup(ULONG id);
 
-	// debug print for interactive debugging sessions only
-	void DbgPrint();
 #endif	// GPOS_DEBUG
 
 };	// class CMemo

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
@@ -38,7 +38,7 @@ typedef CDynamicPtrArray<CSearchStage, CleanupDelete> CSearchStageArray;
 //		Search stage
 //
 //---------------------------------------------------------------------------
-class CSearchStage
+class CSearchStage : public DbgPrintMixin<CSearchStage>
 {
 private:
 	// set of xforms to be applied during stage

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
@@ -34,7 +34,7 @@ using namespace gpos;
 //		Helper class for creating compact join orders
 //
 //---------------------------------------------------------------------------
-class CJoinOrder
+class CJoinOrder : public DbgPrintMixin<CJoinOrder>
 {
 public:
 	enum EPosition
@@ -53,7 +53,7 @@ public:
 	//		Struct to capture edge
 	//
 	//---------------------------------------------------------------------------
-	struct SEdge : public CRefCount
+	struct SEdge : public CRefCount, public DbgPrintMixin<SEdge>
 	{
 		// cover of edge
 		CBitSet *m_pbs;
@@ -90,7 +90,7 @@ public:
 	//		Struct to capture component
 	//
 	//---------------------------------------------------------------------------
-	struct SComponent : public CRefCount
+	struct SComponent : public CRefCount, public DbgPrintMixin<SComponent>
 	{
 		// cover
 		CBitSet *m_pbs;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"
 #include "gpos/common/CHashMap.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/io/IOstream.h"
 
 #include "gpopt/base/CUtils.h"
@@ -33,7 +34,7 @@ using namespace gpos;
 //		Helper class for creating join orders using dynamic programming
 //
 //---------------------------------------------------------------------------
-class CJoinOrderDP : public CJoinOrder
+class CJoinOrderDP : public CJoinOrder, public gpos::DbgPrintMixin<CJoinOrderDP>
 {
 private:
 	//---------------------------------------------------------------------------
@@ -196,9 +197,6 @@ public:
 		return CXform::ExfExpandNAryJoinDP;
 	}
 
-#ifdef GPOS_DEBUG
-	void DbgPrint();
-#endif
 
 };	// class CJoinOrderDP
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"
 #include "gpos/common/CHashMap.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/io/IOstream.h"
 
 #include "gpopt/base/CKHeap.h"
@@ -44,7 +45,8 @@ using namespace gpos;
 //				a result expression, each of these sets will be associated
 //				with a CGroup in MEMO.
 //---------------------------------------------------------------------------
-class CJoinOrderDPv2 : public CJoinOrder
+class CJoinOrderDPv2 : public CJoinOrder,
+					   public gpos::DbgPrintMixin<CJoinOrderDPv2>
 {
 private:
 	// Data structures for DPv2 join enumeration:
@@ -568,10 +570,6 @@ public:
 	{
 		return CXform::ExfExpandNAryJoinDPv2;
 	}
-
-#ifdef GPOS_DEBUG
-	void DbgPrint();
-#endif
 
 };	// class CJoinOrderDPv2
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -44,7 +44,7 @@ using namespace gpos;
 //		base class for all transformations
 //
 //---------------------------------------------------------------------------
-class CXform : public CRefCount
+class CXform : public CRefCount, public DbgPrintMixin<CXform>
 {
 private:
 	// pattern

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
@@ -27,7 +27,7 @@ using namespace gpos;
 //		result container
 //
 //---------------------------------------------------------------------------
-class CXformResult : public CRefCount
+class CXformResult : public CRefCount, public DbgPrintMixin<CXformResult>
 {
 private:
 	// set of alternatives

--- a/src/backend/gporca/libgpopt/src/base/CCTEMap.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEMap.cpp
@@ -17,6 +17,9 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CCTEMap);
+FORCE_GENERATE_DBGSTR(CCTEMap::CCTEMapEntry);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CCTEMap::CCTEMap

--- a/src/backend/gporca/libgpopt/src/base/CCTEReq.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEReq.cpp
@@ -17,6 +17,9 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CCTEReq);
+FORCE_GENERATE_DBGSTR(CCTEReq::CCTEReqEntry);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CCTEReq::CCTEReqEntry::CCTEReqEntry

--- a/src/backend/gporca/libgpopt/src/base/CColRef.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRef.cpp
@@ -176,15 +176,3 @@ CColRef::Equals(const CColRef2dArray *pdrgdrgpcr1,
 
 	return true;
 }
-
-#ifdef GPOS_DEBUG
-void
-CColRef::DbgPrint() const
-{
-	CMemoryPool *pmp = COptCtxt::PoctxtFromTLS()->Pmp();
-	CAutoTrace at(pmp);
-	(void) this->OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/base/CColRef.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRef.cpp
@@ -93,6 +93,8 @@ CColRef::HashValue(const CColRef *colref)
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::CColRef);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CColRef::OsPrint

--- a/src/backend/gporca/libgpopt/src/base/CColRefSet.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRefSet.cpp
@@ -19,6 +19,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CColRefSet);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
@@ -35,6 +35,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CConstraint);
+
 // initialize constant true
 BOOL CConstraint::m_fTrue(true);
 

--- a/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
@@ -35,6 +35,8 @@
 using namespace gpopt;
 using namespace gpnaucrates;
 
+FORCE_GENERATE_DBGSTR(CCostContext);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CCostContext::CCostContext

--- a/src/backend/gporca/libgpopt/src/base/CDrvdProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdProp.cpp
@@ -21,6 +21,8 @@
 #include "gpopt/base/COptCtxt.h"
 #endif	// GPOS_DEBUG
 
+FORCE_GENERATE_DBGSTR(gpopt::CDrvdProp);
+
 namespace gpopt
 {
 CDrvdProp::CDrvdProp()

--- a/src/backend/gporca/libgpopt/src/base/CEnfdProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CEnfdProp.cpp
@@ -19,6 +19,8 @@
 #include "gpopt/base/COptCtxt.h"
 #endif	// GPOS_DEBUG
 
+FORCE_GENERATE_DBGSTR(gpopt::CEnfdProp);
+
 namespace gpopt
 {
 IOstream &

--- a/src/backend/gporca/libgpopt/src/base/CFunctionProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CFunctionProp.cpp
@@ -15,6 +15,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CFunctionProp);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CFunctionProp::CFunctionProp

--- a/src/backend/gporca/libgpopt/src/base/CFunctionalDependency.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CFunctionalDependency.cpp
@@ -18,6 +18,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CFunctionalDependency);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
@@ -17,6 +17,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CKeyCollection);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CKeyCollection::CKeyCollection

--- a/src/backend/gporca/libgpopt/src/base/COptCtxt.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COptCtxt.cpp
@@ -148,24 +148,3 @@ COptCtxt::FAllEnforcersEnabled()
 
 	return !fEnforcerDisabled;
 }
-
-
-#ifdef GPOS_DEBUG
-//---------------------------------------------------------------------------
-//	@function:
-//		COptCtxt::OsPrint
-//
-//	@doc:
-//		debug print -- necessary to override abstract function in base class
-//
-//---------------------------------------------------------------------------
-IOstream &
-COptCtxt::OsPrint(IOstream &os) const
-{
-	// NOOP
-	return os;
-}
-
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/base/COptimizationContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COptimizationContext.cpp
@@ -27,6 +27,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(COptimizationContext);
 
 // invalid optimization context
 const COptimizationContext COptimizationContext::m_ocInvalid;

--- a/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
@@ -75,6 +75,8 @@ COrderSpec::COrderExpression::Matches(const COrderExpression *poe) const
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::COrderSpec::COrderExpression);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		COrderSpec::COrderExpression::OsPrint

--- a/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
@@ -95,15 +95,6 @@ COrderSpec::COrderExpression::OsPrint(IOstream &os) const
 	return os;
 }
 
-#ifdef GPOS_DEBUG
-void
-COrderSpec::COrderExpression::DbgPrint() const
-{
-	CMemoryPool *mp = COptCtxt::PoctxtFromTLS()->Pmp();
-	CAutoTrace at(mp);
-	(void) this->OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CPartInfo.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartInfo.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPartInfo);
+FORCE_GENERATE_DBGSTR(CPartInfo::CPartInfoEntry);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CPartKeys.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartKeys.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPartKeys);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPartKeys::CPartKeys

--- a/src/backend/gporca/libgpopt/src/base/CPropConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPropConstraint.cpp
@@ -20,6 +20,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPropConstraint);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPropConstraint::CPropConstraint

--- a/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
@@ -34,8 +34,7 @@ using namespace gpopt;
 CQueryContext::CQueryContext(CMemoryPool *mp, CExpression *pexpr,
 							 CReqdPropPlan *prpp, CColRefArray *colref_array,
 							 CMDNameArray *pdrgpmdname, BOOL fDeriveStats)
-	: m_mp(mp),
-	  m_prpp(prpp),
+	: m_prpp(prpp),
 	  m_pdrgpcr(colref_array),
 	  m_pdrgpcrSystemCols(NULL),
 	  m_pdrgpmdname(pdrgpmdname),
@@ -267,13 +266,6 @@ IOstream &
 CQueryContext::OsPrint(IOstream &os) const
 {
 	return os << *m_pexpr << std::endl << *m_prpp;
-}
-
-void
-CQueryContext::DbgPrint() const
-{
-	CAutoTrace at(m_mp);
-	(void) this->OsPrint(at.Os());
 }
 #endif	// GPOS_DEBUG
 

--- a/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
@@ -22,6 +22,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CQueryContext);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CRange.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CRange.cpp
@@ -21,6 +21,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CRange);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CRange::CRange

--- a/src/backend/gporca/libgpopt/src/base/CReqdProp.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CReqdProp.cpp
@@ -23,6 +23,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CReqdProp);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CReqdProp::CReqdProp

--- a/src/backend/gporca/libgpopt/src/base/CWindowFrame.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CWindowFrame.cpp
@@ -17,6 +17,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CWindowFrame);
+
 // string encoding of frame specification
 const CHAR rgszFrameSpec[][10] = {"Rows", "Range"};
 GPOS_CPL_ASSERT(CWindowFrame::EfsSentinel == GPOS_ARRAY_SIZE(rgszFrameSpec));

--- a/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
@@ -64,6 +64,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CEngine);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CEngine::CEngine

--- a/src/backend/gporca/libgpopt/src/metadata/CColumnDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CColumnDescriptor.cpp
@@ -18,6 +18,8 @@
 using namespace gpopt;
 using namespace gpmd;
 
+FORCE_GENERATE_DBGSTR(CColumnDescriptor);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CColumnDescriptor::CColumnDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CIndexDescriptor);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CIndexDescriptor::CIndexDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CName.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CName.cpp
@@ -19,6 +19,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CName);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CName::CName

--- a/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
@@ -20,6 +20,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPartConstraint);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPartConstraint::CPartConstraint

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -24,6 +24,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CTableDescriptor);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CTableDescriptor::CTableDescriptor

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -37,7 +37,6 @@
 #include "naucrates/statistics/CStatistics.h"
 #include "naucrates/traceflags/traceflags.h"
 
-
 using namespace gpnaucrates;
 using namespace gpopt;
 
@@ -1122,6 +1121,8 @@ CExpression::DbgPrintWithProperties() const
 }
 
 #endif	// GPOS_DEBUG
+
+FORCE_GENERATE_DBGSTR(gpopt::CExpression);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/COperator.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/COperator.cpp
@@ -20,6 +20,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(COperator);
+
 // generate unique operator ids
 ULONG COperator::m_aulOpIdCounter(0);
 

--- a/src/backend/gporca/libgpopt/src/search/CGroup.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroup.cpp
@@ -37,6 +37,8 @@
 using namespace gpnaucrates;
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CGroup);
+
 #define GPOPT_OPTCTXT_HT_BUCKETS 100
 
 

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -48,8 +48,7 @@ CGroupExpression::CGroupExpression(CMemoryPool *mp, COperator *pop,
 								   CXform::EXformId exfid,
 								   CGroupExpression *pgexprOrigin,
 								   BOOL fIntermediate)
-	: m_mp(mp),
-	  m_id(GPOPT_INVALID_GEXPR_ID),
+	: m_id(GPOPT_INVALID_GEXPR_ID),
 	  m_pgexprDuplicate(NULL),
 	  m_pop(pop),
 	  m_pdrgpgroup(pdrgpgroup),
@@ -1204,7 +1203,7 @@ void
 CGroupExpression::DbgPrintWithProperties()
 {
 	CAutoTraceFlag atf(EopttracePrintGroupProperties, true);
-	CAutoTrace at(m_mp);
+	CAutoTrace at(CTask::Self()->Pmp());
 	(void) this->OsPrint(at.Os());
 }
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -29,6 +29,8 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CGroupExpression);
+
 #define GPOPT_COSTCTXT_HT_BUCKETS 100
 
 // invalid group expression

--- a/src/backend/gporca/libgpopt/src/search/CJob.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJob.cpp
@@ -19,6 +19,7 @@
 using namespace gpopt;
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CJob);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/search/CJob.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJob.cpp
@@ -75,7 +75,7 @@ CJob::FResumeParent() const
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJob::OsPrint(IOstream &os)
+CJob::OsPrint(IOstream &os) const
 {
 	os << "ID=" << Id();
 

--- a/src/backend/gporca/libgpopt/src/search/CJobGroupExploration.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobGroupExploration.cpp
@@ -286,7 +286,7 @@ CJobGroupExploration::ScheduleJob(CSchedulerContext *psc, CGroup *pgroup,
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobGroupExploration::OsPrint(IOstream &os)
+CJobGroupExploration::OsPrint(IOstream &os) const
 {
 	return m_jsm.OsHistory(os);
 }

--- a/src/backend/gporca/libgpopt/src/search/CJobGroupExpressionExploration.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobGroupExpressionExploration.cpp
@@ -334,7 +334,7 @@ CJobGroupExpressionExploration::ScheduleJob(CSchedulerContext *psc,
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobGroupExpressionExploration::OsPrint(IOstream &os)
+CJobGroupExpressionExploration::OsPrint(IOstream &os) const
 {
 	return m_jsm.OsHistory(os);
 }

--- a/src/backend/gporca/libgpopt/src/search/CJobGroupExpressionImplementation.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobGroupExpressionImplementation.cpp
@@ -336,7 +336,7 @@ CJobGroupExpressionImplementation::ScheduleJob(CSchedulerContext *psc,
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobGroupExpressionImplementation::OsPrint(IOstream &os)
+CJobGroupExpressionImplementation::OsPrint(IOstream &os) const
 {
 	return m_jsm.OsHistory(os);
 }

--- a/src/backend/gporca/libgpopt/src/search/CJobGroupExpressionOptimization.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobGroupExpressionOptimization.cpp
@@ -798,7 +798,7 @@ CJobGroupExpressionOptimization::FScheduleCTEOptimization(
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobGroupExpressionOptimization::OsPrint(IOstream &os)
+CJobGroupExpressionOptimization::OsPrint(IOstream &os) const
 {
 	os << "Group expr: ";
 	m_pgexpr->OsPrint(os);

--- a/src/backend/gporca/libgpopt/src/search/CJobGroupImplementation.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobGroupImplementation.cpp
@@ -309,7 +309,7 @@ CJobGroupImplementation::ScheduleJob(CSchedulerContext *psc, CGroup *pgroup,
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobGroupImplementation::OsPrint(IOstream &os)
+CJobGroupImplementation::OsPrint(IOstream &os) const
 {
 	return m_jsm.OsHistory(os);
 }

--- a/src/backend/gporca/libgpopt/src/search/CJobGroupOptimization.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobGroupOptimization.cpp
@@ -379,7 +379,7 @@ CJobGroupOptimization::ScheduleJob(CSchedulerContext *psc, CGroup *pgroup,
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobGroupOptimization::OsPrint(IOstream &os)
+CJobGroupOptimization::OsPrint(IOstream &os) const
 {
 	return m_jsm.OsHistory(os);
 }

--- a/src/backend/gporca/libgpopt/src/search/CJobTest.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobTest.cpp
@@ -274,7 +274,7 @@ CJobTest::Loop()
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobTest::OsPrint(IOstream &os)
+CJobTest::OsPrint(IOstream &os) const
 {
 	os << "Test job, ";
 	return CJob::OsPrint(os);

--- a/src/backend/gporca/libgpopt/src/search/CJobTransformation.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobTransformation.cpp
@@ -196,7 +196,7 @@ CJobTransformation::ScheduleJob(CSchedulerContext *psc,
 //
 //---------------------------------------------------------------------------
 IOstream &
-CJobTransformation::OsPrint(IOstream &os)
+CJobTransformation::OsPrint(IOstream &os) const
 {
 	return m_jsm.OsHistory(os);
 }

--- a/src/backend/gporca/libgpopt/src/search/CMemo.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CMemo.cpp
@@ -806,14 +806,3 @@ CMemo::UlGrpExprs()
 
 	return ulGExprs;
 }
-
-#ifdef GPOS_DEBUG
-void
-CMemo::DbgPrint()
-{
-	CAutoTrace at(m_mp);
-	(void) this->OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/search/CMemo.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CMemo.cpp
@@ -610,6 +610,8 @@ CMemo::Trace()
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::CMemo);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMemo::OsPrint

--- a/src/backend/gporca/libgpopt/src/search/CMemo.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CMemo.cpp
@@ -619,20 +619,18 @@ CMemo::Trace()
 //
 //---------------------------------------------------------------------------
 IOstream &
-CMemo::OsPrint(IOstream &os)
+CMemo::OsPrint(IOstream &os) const
 {
 	CGroup *pgroup = m_listGroups.PtFirst();
 
 	while (NULL != pgroup)
 	{
-		CAutoTrace at(m_mp);
-
 		if (m_pgroupRoot == pgroup)
 		{
-			at.Os() << std::endl << "ROOT ";
+			os << std::endl << "ROOT ";
 		}
 
-		pgroup->OsPrint(at.Os());
+		pgroup->OsPrint(os);
 		pgroup = m_listGroups.Next(pgroup);
 
 		GPOS_CHECK_ABORT;

--- a/src/backend/gporca/libgpopt/src/search/CSearchStage.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSearchStage.cpp
@@ -16,6 +16,8 @@
 using namespace gpopt;
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CSearchStage);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CSearchStage::CSearchStage

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
@@ -27,6 +27,10 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CJoinOrder);
+FORCE_GENERATE_DBGSTR(CJoinOrder::SEdge);
+FORCE_GENERATE_DBGSTR(CJoinOrder::SComponent);
+
 
 // ctor
 CJoinOrder::SComponent::SComponent(CMemoryPool *mp, CExpression *pexpr,

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
@@ -993,16 +993,3 @@ CJoinOrderDP::OsPrint(IOstream &os) const
 
 	return os;
 }
-
-
-#ifdef GPOS_DEBUG
-void
-CJoinOrderDP::DbgPrint()
-{
-	CAutoTrace at(m_mp);
-
-	OsPrint(at.Os());
-}
-#endif
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
@@ -937,6 +937,8 @@ CJoinOrderDP::PexprExpand()
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::CJoinOrderDP);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CJoinOrderDP::OsPrint

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -32,7 +32,6 @@
 #include "naucrates/md/IMDRelStats.h"
 #include "naucrates/statistics/CJoinStatsProcessor.h"
 
-
 using namespace gpopt;
 
 // how many expressions will we return at the end of the DP phase?
@@ -1805,6 +1804,8 @@ CJoinOrderDPv2::LevelIsFull(ULONG level)
 	return li->m_top_k_groups->IsLimitExceeded();
 }
 
+
+FORCE_GENERATE_DBGSTR(gpopt::CJoinOrderDPv2);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1979,17 +1979,3 @@ CJoinOrderDPv2::OsPrintProperty(IOstream &os,
 
 	return os;
 }
-
-
-#ifdef GPOS_DEBUG
-void
-CJoinOrderDPv2::DbgPrint()
-{
-	CAutoTrace at(m_mp);
-
-	OsPrint(at.Os());
-}
-#endif
-
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXform.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXform.cpp
@@ -18,6 +18,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CXform);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/xforms/CXformResult.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformResult.cpp
@@ -15,6 +15,7 @@
 
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CXformResult);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpos/include/gpos/attributes.h
+++ b/src/backend/gporca/libgpos/include/gpos/attributes.h
@@ -1,0 +1,16 @@
+#ifndef GPOS_attributes_H
+#define GPOS_attributes_H
+
+#ifdef __GNUC__
+#define GPOS_UNUSED __attribute__((unused))
+#else
+#define GPOS_UNUSED
+#endif
+
+#ifndef GPOS_DEBUG
+#define GPOS_ASSERTS_ONLY GPOS_UNUSED
+#else
+#define GPOS_ASSERTS_ONLY
+#endif
+
+#endif	// !GPOS_attributes_H

--- a/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
@@ -15,6 +15,7 @@
 #include "gpos/common/CBitVector.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CList.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 
 namespace gpos
@@ -27,7 +28,7 @@ namespace gpos
 //		Linked list of CBitSetLink's
 //
 //---------------------------------------------------------------------------
-class CBitSet : public CRefCount
+class CBitSet : public CRefCount, public DbgPrintMixin<CBitSet>
 {
 	// bitset iter needs to access internals
 	friend class CBitSetIter;

--- a/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
@@ -396,13 +396,6 @@ public:
 		return result;
 	}
 
-	virtual IOstream &
-	OsPrint(IOstream &os) const
-	{
-		// do nothing, for now
-		return os;
-	}
-
 };	// class CDynamicPtrArray
 }  // namespace gpos
 

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -128,11 +128,6 @@ public:
 		}
 	}
 
-#ifdef GPOS_DEBUG
-	// debug print for interactive debugging sessions only
-	void DbgPrint() const;
-#endif	// GPOS_DEBUG
-
 	// print function
 	virtual IOstream &
 	OsPrint(IOstream &os) const

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncList.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncList.h
@@ -64,70 +64,29 @@ public:
 	void
 	Push(T *elem)
 	{
-		GPOS_ASSERT(NULL != elem);
-		GPOS_ASSERT(m_list.First() != elem);
-
-		SLink &link = m_list.Link(elem);
-
-#ifdef GPOS_DEBUG
-		void *next_head = link.m_next;
-#endif	// GPOS_DEBUG
-
-		GPOS_ASSERT(NULL == link.m_next);
-
-		T *head = m_list.First();
-
-		GPOS_ASSERT(elem != head && "Element is already inserted");
-		GPOS_ASSERT(next_head == link.m_next &&
-					"Element is concurrently accessed");
-
-		// set current head as next element
-		link.m_next = head;
-#ifdef GPOS_DEBUG
-		next_head = link.m_next;
-#endif	// GPOS_DEBUG
-
-		// set element as head
-		GPOS_ASSERT(m_list.m_head == head);
-		m_list.m_head = elem;
+		m_list.Prepend(elem);
 	}
 
 	// remove element from the head of the list;
 	T *
 	Pop()
 	{
-		T *old_head = NULL;
-
-		// get current head
-		old_head = m_list.First();
-		if (NULL != old_head)
-		{
-			// second element becomes the new head
-			SLink &link = m_list.Link(old_head);
-			T *new_head = static_cast<T *>(link.m_next);
-
-			GPOS_ASSERT(m_list.m_head == old_head);
-			m_list.m_head = new_head;
-			// reset link
-			link.m_next = NULL;
-		}
-
-		return old_head;
+		if (!m_list.IsEmpty())
+			return m_list.RemoveHead();
+		return NULL;
 	}
 
 	// get first element
 	T *
-	PtFirst()
+	PtFirst() const
 	{
-		m_list.m_tail = m_list.m_head;
 		return m_list.First();
 	}
 
 	// get next element
 	T *
-	Next(T *elem)
+	Next(T *elem) const
 	{
-		m_list.m_tail = m_list.m_head;
 		return m_list.Next(elem);
 	}
 
@@ -143,9 +102,8 @@ public:
 	// lookup a given element in the stack
 	// this works only when no elements are removed
 	GPOS_RESULT
-	Find(T *elem)
+	Find(T *elem) const
 	{
-		m_list.m_tail = m_list.m_head;
 		return m_list.Find(elem);
 	}
 

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -6,7 +6,9 @@
 #define GPDB_DbgPrintMixin_H
 
 #include "gpos/error/CAutoTrace.h"
+#include "gpos/io/COstreamStdString.h"
 #include "gpos/task/CTask.h"
+
 namespace gpos
 {
 template <class T>
@@ -19,6 +21,14 @@ struct DbgPrintMixin
 	{
 		CAutoTrace at(CTask::Self()->Pmp());
 		static_cast<const T *>(this)->OsPrint(at.Os());
+	}
+
+	std::wstring
+	DbgStr() const __attribute__((used))
+	{
+		COstreamStdString oss;
+		static_cast<const T *>(this)->OsPrint(oss);
+		return oss.Str();
 	}
 #endif
 };

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2020-Present VMware, Inc. or its affiliates
+//---------------------------------------------------------------------------
+#ifndef GPDB_DbgPrintMixin_H
+#define GPDB_DbgPrintMixin_H
+
+#include "gpos/error/CAutoTrace.h"
+#include "gpos/task/CTask.h"
+namespace gpos
+{
+template <class T>
+struct DbgPrintMixin
+{
+#ifdef GPOS_DEBUG
+	// debug print for interactive debugging sessions only
+	void
+	DbgPrint() const __attribute__((used))
+	{
+		CAutoTrace at(CTask::Self()->Pmp());
+		static_cast<const T *>(this)->OsPrint(at.Os());
+	}
+#endif
+};
+}  // namespace gpos
+
+#endif

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -2,8 +2,8 @@
 //	Greenplum Database
 //	Copyright (c) 2020-Present VMware, Inc. or its affiliates
 //---------------------------------------------------------------------------
-#ifndef GPDB_DbgPrintMixin_H
-#define GPDB_DbgPrintMixin_H
+#ifndef GPOS_DbgPrintMixin_H
+#define GPOS_DbgPrintMixin_H
 
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/io/COstreamStdString.h"
@@ -11,20 +11,36 @@
 
 namespace gpos
 {
+/// A Mixin class that adds debug printing to a type.
+///
+/// To use it to add DbgStr() and friends to a type U, simply add this as a
+/// public base:
+/// \code
+/// namespace ns {
+/// class U : public gpos::DbgPrintMixin<U> { ... };
+/// }
+/// \endcode
+///
+/// Also drop this snippet into the U.cpp file at the top level:
+///
+/// \code FORCE_GENERATE_DBGSTR(ns::U); \endcode
+///
+/// The FORCE_GENERATE_DBGSTR macro ensures code generation for the unused
+/// functions so that we can call them in a debugger
 template <class T>
 struct DbgPrintMixin
 {
 #ifdef GPOS_DEBUG
 	// debug print for interactive debugging sessions only
 	void
-	DbgPrint() const __attribute__((used))
+	DbgPrint() const
 	{
 		CAutoTrace at(CTask::Self()->Pmp());
 		static_cast<const T *>(this)->OsPrint(at.Os());
 	}
 
 	std::wstring
-	DbgStr() const __attribute__((used))
+	DbgStr() const GPOS_UNUSED
 	{
 		COstreamStdString oss;
 		static_cast<const T *>(this)->OsPrint(oss);
@@ -33,5 +49,32 @@ struct DbgPrintMixin
 #endif
 };
 }  // namespace gpos
+
+// DbgStr() is designed to be unused until evaluated in a debugger. The "used"
+// attribute usually does the trick to convince a mainstream compiler (GCC and
+// upstream LLVM Clang) to generate code for DbgStr(). There are two issues with
+// the "used" attribute, however:
+//
+// 1. It slows down compilation. Every translation unit that includes the
+// declaration of a derived class will take a hit generating DbgPrint() and
+// DbgStr(). But we really only need one copy of them. This is a fairly minor
+// issue.
+//
+// 2. Not so minor, However, is that AppleClang insists to omit code generation
+// for unused functions in a class template (this is borderline bug, and there
+// isn't a flag to disable such a "feature").
+//
+// The best remedy is for each derived type, explicitly instantiate the base
+// template in the translation unit. This forces code generation even in Apple
+// Clang, and it speeds up compilation because we only emit code for each
+// explicit instantiation once.
+#if defined(GPOS_DEBUG)
+#define FORCE_GENERATE_DBGSTR(Type) template struct ::gpos::DbgPrintMixin<Type>
+#else
+#define FORCE_GENERATE_DBGSTR(Type) \
+	template <bool>                 \
+	struct StaticAssert
+#endif
+
 
 #endif

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -7,26 +7,30 @@
 
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/io/COstreamStdString.h"
-#include "gpos/task/CTask.h"
 
 namespace gpos
 {
-/// A Mixin class that adds debug printing to a type.
-///
-/// To use it to add DbgStr() and friends to a type U, simply add this as a
-/// public base:
-/// \code
-/// namespace ns {
-/// class U : public gpos::DbgPrintMixin<U> { ... };
-/// }
-/// \endcode
-///
-/// Also drop this snippet into the U.cpp file at the top level:
-///
-/// \code FORCE_GENERATE_DBGSTR(ns::U); \endcode
-///
-/// The FORCE_GENERATE_DBGSTR macro ensures code generation for the unused
-/// functions so that we can call them in a debugger
+// A Mixin class that adds debug printing to a type.
+//
+// To use it to add DbgStr() and friends to a type U, simply add this as a
+// public base:
+// namespace ns {
+// class U : public gpos::DbgPrintMixin<U> { ... };
+// }
+//
+// Also drop this snippet into the U.cpp file at the top level:
+//
+// FORCE_GENERATE_DBGSTR(ns::U);
+//
+// The FORCE_GENERATE_DBGSTR macro ensures code generation for the unused
+// functions so that we can call them in a debugger
+//
+// Use the following printing multi-line messages in your favorite debugger:
+//
+// (lldb) setting set escape-non-printables false
+// (lldb) p x->DbgStr()
+//
+// (gdb) printf x->DbgStr()
 template <class T>
 struct DbgPrintMixin
 {
@@ -35,7 +39,9 @@ struct DbgPrintMixin
 	void
 	DbgPrint() const
 	{
-		CAutoTrace at(CTask::Self()->Pmp());
+		CMemoryPool *mp =
+			CMemoryPoolManager::GetMemoryPoolMgr()->GetGlobalMemoryPool();
+		CAutoTrace at(mp);
 		static_cast<const T *>(this)->OsPrint(at.Os());
 	}
 

--- a/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
@@ -19,6 +19,7 @@
 
 #include <unistd.h>
 
+#include "gpos/attributes.h"
 #include "gpos/common/clibtypes.h"
 #include "gpos/types.h"
 

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessage.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessage.h
@@ -17,6 +17,7 @@
 
 #include "gpos/assert.h"
 #include "gpos/common/CSyncHashtable.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/common/clibwrapper.h"
 #include "gpos/types.h"
 
@@ -34,7 +35,7 @@ namespace gpos
 //		Corresponds to individual message as defined in config file
 //
 //---------------------------------------------------------------------------
-class CMessage
+class CMessage : public DbgPrintMixin<CMessage>
 {
 private:
 	// severity
@@ -91,7 +92,7 @@ public:
 
 #ifdef GPOS_DEBUG
 	// debug print function
-	IOstream &OsPrint(IOstream &);
+	IOstream &OsPrint(IOstream &) const;
 #endif	// GPOS_DEBUG
 
 };	// class CMessage

--- a/src/backend/gporca/libgpos/include/gpos/io/COstreamStdString.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/COstreamStdString.h
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------------
+// Greenplum Database
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+//---------------------------------------------------------------------------
+#ifndef COstreamStdString_H
+#define COstreamStdString_H
+
+#include <sstream>
+#include <string>
+
+#include "gpos/io/COstreamBasic.h"
+
+namespace gpos
+{
+class COstreamStdString : public gpos::COstreamBasic
+{
+public:
+	COstreamStdString();
+	std::wstring Str() const;
+
+private:
+	std::wostringstream m_oss;
+};
+}  // namespace gpos
+
+#endif

--- a/src/backend/gporca/libgpos/include/gpos/task/CTaskLocalStorageObject.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CTaskLocalStorageObject.h
@@ -58,11 +58,6 @@ public:
 	// key
 	const CTaskLocalStorage::Etlsidx m_etlsidx;
 
-#ifdef GPOS_DEBUG
-	// debug print
-	virtual IOstream &OsPrint(IOstream &os) const = 0;
-#endif	// GPOS_DEBUG
-
 };	// class CTaskLocalStorageObject
 }  // namespace gpos
 

--- a/src/backend/gporca/libgpos/src/common/CBitSet.cpp
+++ b/src/backend/gporca/libgpos/src/common/CBitSet.cpp
@@ -24,6 +24,7 @@
 
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CBitSet);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpos/src/common/CRefCount.cpp
+++ b/src/backend/gporca/libgpos/src/common/CRefCount.cpp
@@ -15,16 +15,3 @@
 #include "gpos/task/CTask.h"
 
 using namespace gpos;
-
-#ifdef GPOS_DEBUG
-// debug print for interactive debugging sessions only
-void
-CRefCount::DbgPrint() const
-{
-	CAutoTrace at(CTask::Self()->Pmp());
-
-	OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpos/src/error/CMessage.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessage.cpp
@@ -16,6 +16,8 @@
 
 using namespace gpos;
 
+FORCE_GENERATE_DBGSTR(CMessage);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMessage::CMessage
@@ -114,7 +116,7 @@ CMessage::FormatMessage(CWStringStatic *str, ULONG major, ULONG minor, ...)
 //
 //---------------------------------------------------------------------------
 IOstream &
-CMessage::OsPrint(IOstream &os)
+CMessage::OsPrint(IOstream &os) const
 {
 	os << "Message No: " << m_exception.Major() << "-" << m_exception.Minor()
 	   << std::endl

--- a/src/backend/gporca/libgpos/src/io/COstreamStdString.cpp
+++ b/src/backend/gporca/libgpos/src/io/COstreamStdString.cpp
@@ -1,0 +1,20 @@
+//---------------------------------------------------------------------------
+// Greenplum Database
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+//---------------------------------------------------------------------------
+
+#include "gpos/io/COstreamStdString.h"
+
+namespace gpos
+{
+COstreamStdString::COstreamStdString() : COstreamBasic(&m_oss)
+{
+}
+
+std::wstring
+COstreamStdString::Str() const
+{
+	return m_oss.str();
+}
+
+}  // namespace gpos

--- a/src/backend/gporca/libgpos/src/io/Makefile
+++ b/src/backend/gporca/libgpos/src/io/Makefile
@@ -16,6 +16,7 @@ OBJS        = CFileDescriptor.o \
               COstream.o \
               COstreamBasic.o \
               COstreamFile.o \
+              COstreamStdString.o \
               COstreamString.o \
               ioutils.o
 

--- a/src/backend/gporca/libgpos/src/test/CUnittest.cpp
+++ b/src/backend/gporca/libgpos/src/test/CUnittest.cpp
@@ -533,9 +533,6 @@ CUnittest::Init(CUnittest *rgut, ULONG ulUtCnt, void (*pfConfig)(),
 	m_ulTests = ulUtCnt;
 	m_pfConfig = pfConfig;
 	m_pfCleanup = pfCleanup;
-
-	// disable allocations using global new operator
-	CMemoryPoolManager::GetMemoryPoolMgr()->DisableGlobalNew();
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDouble.h"
 #include "gpos/common/CHashMap.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/string/CWStringConst.h"
 
 #include "naucrates/md/IMDId.h"
@@ -39,7 +40,7 @@ typedef CHashMap<ULONG, IDatum, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 //		Base abstract class for datum representation inside optimizer
 //
 //---------------------------------------------------------------------------
-class IDatum : public CRefCount
+class IDatum : public CRefCount, public DbgPrintMixin<IDatum>
 {
 private:
 	// private copy ctor

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -18,6 +18,7 @@
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CHashSet.h"
 #include "gpos/common/CHashSetIter.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/string/CWStringConst.h"
 
 #include "naucrates/dxl/gpdb_types.h"
@@ -48,7 +49,7 @@ static const INT default_type_modifier = -1;
 //		Abstract class for representing metadata objects ids
 //
 //---------------------------------------------------------------------------
-class IMDId : public CRefCount
+class IMDId : public CRefCount, public DbgPrintMixin<IMDId>
 {
 private:
 	// number of deletion locks -- each MDAccessor adds a new deletion lock if it uses
@@ -177,7 +178,7 @@ typedef CHashSetIter<IMDId, IMDId::MDIdHash, IMDId::MDIdCompare,
 	MdidHashSetIter;
 }  // namespace gpmd
 
-
+FORCE_GENERATE_DBGSTR(gpmd::IMDId);
 
 #endif	// !GPMD_IMDId_H
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
@@ -13,6 +13,7 @@
 #define GPNAUCRATES_CBucket_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/task/CTask.h"
 
@@ -42,7 +43,7 @@ typedef CDynamicPtrArray<CBucket, CleanupDelete> CBucketArray;
 //
 //---------------------------------------------------------------------------
 
-class CBucket : public IBucket
+class CBucket : public IBucket, public gpos::DbgPrintMixin<CBucket>
 {
 private:
 	// lower bound of bucket
@@ -167,10 +168,6 @@ public:
 
 	// print function
 	virtual IOstream &OsPrint(IOstream &os) const;
-
-#ifdef GPOS_DEBUG
-	void DbgPrint() const;
-#endif
 
 	// construct new bucket with lower bound greater than given point
 	CBucket *MakeBucketGreaterThan(CMemoryPool *mp, CPoint *point) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -12,6 +12,7 @@
 #define GPNAUCRATES_CHistogram_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CKHeap.h"
 #include "naucrates/statistics/CBucket.h"
@@ -37,7 +38,7 @@ typedef CDynamicPtrArray<CDouble, CleanupDelete> CDoubleArray;
 //	@doc:
 //
 //---------------------------------------------------------------------------
-class CHistogram
+class CHistogram : public gpos::DbgPrintMixin<CHistogram>
 {
 	// hash map from column id to a histogram
 	typedef CHashMap<ULONG, CHistogram, gpos::HashValue<ULONG>,
@@ -345,10 +346,6 @@ public:
 
 	// print function
 	virtual IOstream &OsPrint(IOstream &os) const;
-
-#ifdef GPOS_DEBUG
-	void DbgPrint() const;
-#endif
 
 	// total frequency from buckets and null fraction
 	CDouble GetFrequency() const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
@@ -34,7 +34,7 @@ using namespace gpopt;
 //	@doc:
 //		One dimensional point in the datum space
 //---------------------------------------------------------------------------
-class CPoint : public CRefCount
+class CPoint : public CRefCount, public DbgPrintMixin<CPoint>
 {
 private:
 	// private copy ctor

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -56,7 +56,7 @@ typedef CHashMapIter<ULONG, ULongPtrArray, gpos::HashValue<ULONG>,
 //	@doc:
 //		Abstract statistics API
 //---------------------------------------------------------------------------
-class CStatistics : public IStatistics
+class CStatistics : public IStatistics, public DbgPrintMixin<CStatistics>
 {
 public:
 	// method used to compute for columns of each source it corresponding

--- a/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
@@ -17,6 +17,8 @@
 using namespace gpnaucrates;
 using namespace gpmd;
 
+FORCE_GENERATE_DBGSTR(gpmd::IDatum);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		IDatum::StatsAreEqual

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -247,15 +247,6 @@ CBucket::OsPrint(IOstream &os) const
 	return os;
 }
 
-#ifdef GPOS_DEBUG
-void
-CBucket::DbgPrint() const
-{
-	CAutoTrace at(CTask::Self()->Pmp());
-	OsPrint(at.Os());
-}
-#endif
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CBucket::MakeBucketGreaterThan

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -205,6 +205,8 @@ CBucket::GetOverlapPercentage(const CPoint *point, BOOL include_point) const
 	return CDouble(std::min(res.Get(), DOUBLE(1.0)));
 }
 
+FORCE_GENERATE_DBGSTR(gpnaucrates::CBucket);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CBucket::OsPrint

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -117,6 +117,8 @@ CHistogram::SetNullFrequency(CDouble null_freq)
 	m_null_freq = null_freq;
 }
 
+FORCE_GENERATE_DBGSTR(gpnaucrates::CHistogram);
+
 //	print function
 IOstream &
 CHistogram::OsPrint(IOstream &os) const

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -153,15 +153,6 @@ CHistogram::OsPrint(IOstream &os) const
 	return os;
 }
 
-#ifdef GPOS_DEBUG
-void
-CHistogram::DbgPrint() const
-{
-	CAutoTrace at(CTask::Self()->Pmp());
-	OsPrint(at.Os());
-}
-#endif
-
 // check if histogram is empty
 BOOL
 CHistogram::IsEmpty() const

--- a/src/backend/gporca/libnaucrates/src/statistics/CPoint.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CPoint.cpp
@@ -19,6 +19,8 @@
 using namespace gpnaucrates;
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CPoint);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPoint::CPoint

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -36,6 +36,8 @@ using namespace gpmd;
 using namespace gpdxl;
 using namespace gpopt;
 
+FORCE_GENERATE_DBGSTR(CStatistics);
+
 // default number of rows in relation
 const CDouble CStatistics::DefaultRelationRows(1000.0);
 


### PR DESCRIPTION
This helps in debugging 6X, as issues must often be worked directly on 6X branch.  I think following are the minimal commits required:

- Make CMemo::OsPrint const by fixing CSyncList. cc7fa71bdf513488e5db173b56e58e432248e995
- Make CJob::OsPrint const. 420f3eb00c204ea8a6329fdb8ab3cbbfbc560917
- Replace repeated definitions with a Mixin. 1d140333ec9458bf7f85000af3cd61d2a2f5e42d
- Add DbgStr() wherever we support DbgPrint(). 162d0d247fa442b369c6db1758404ad800917230
- Add GPOS_UNUSED attribute 26ae898a151de55868138806657d2279666c7adb
- Exciting hack to work around an Apple Clang bug 914445a5a62bff4d99bd11543cd853e568d7de2a
- Extend use of DbgPrintMixin to more classes 234bc4e613c9cae5c7c11980370556b7ad3ded27

```
(gdb) b PexprOptimize
(gdb) c
(gdb) printf "%ls", pexprPlan->DbgStr().c_str()                                                                                                                                                                                                                                                                             
+--CPhysicalMotionGather(master)   rows:1   width:34  rebinds:1   cost:6.000114   origin: [Grp:4, GrpExpr:5]                                                                                                                                                                                                                
   +--CPhysicalIndexScan   Index Name: ("i"), Table Name: ("t"), Columns: ["a" (0), "ctid" (1), "xmin" (2), "cmin" (3), "xmax" (4), "cmax" (5), "tableoid" (6), "gp_segment_id" (7)]   rows:1   width:34  rebinds:1   cost:6.000096   origin: [Grp:4, GrpExpr:3]                                                            
      +--CScalarCmp (>)   origin: [Grp:3, GrpExpr:0]                                                                                                                                                                                                                                                                        
         |--CScalarIdent "a" (0)   origin: [Grp:1, GrpExpr:0]                                                                                                                                                                                                                                                               
         +--CScalarConst (42)   origin: [Grp:2, GrpExpr:0]
```

NOTE: There were some merge conflicts related to C++11 commits that cannot be backported (e.g. aedfd1f5e3bb8a0ee53a7dd3a6857ce2ce2edf0d)