### PR TITLE
Protect ResCleanupLock callsite with partitionLock

### DIFF
--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -582,11 +582,11 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	 */
 	if (!(proclock->holdMask & LOCKBIT_ON(lockmode)) || proclock->nLocks <= 0)
 	{
-		LWLockRelease(partitionLock);
 		elog(DEBUG1, "Resource queue %d: proclock not held", locktag->locktag_field1);
 		RemoveLocalLock(locallock);
 		ResCleanUpLock(lock, proclock, hashcode, false);
 		LWLockRelease(ResQueueLock);
+		LWLockRelease(partitionLock);
 		return false;
 	}
 


### PR DESCRIPTION
This is inspired from PR #12185

This change was already backported to 5X (https://github.com/greenplum-db/gpdb/pull/12233) and 6X (https://github.com/greenplum-db/gpdb/pull/12267). It wasn't committed to master, since the associated test wasn't passing due to problems with the deadlock check code not getting invoked from resource queue code (See https://github.com/greenplum-db/gpdb/issues/9651). 

Adding this change for code consistency between 5x, 6x and 7x and overall stability until we remove resource queues from 7X.