### PR TITLE
[6X backport] gpstate: mirror sync progress

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -366,6 +366,9 @@ class GpRecoverSegmentProgram:
             self.logger.info("Segments successfully recovered.")
             self.logger.info("********************************")
 
+            self.logger.info("Recovered mirror segments need to sync WAL with primary segments.")
+            self.logger.info("Use 'gpstate -e' to check progress of WAL sync remaining bytes")
+
         sys.exit(0)
 
     def trigger_fts_probe(self, port=0):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
@@ -4,6 +4,7 @@ import mock
 from pygresql import pgdb
 
 from gppylib import gparray
+from .gp_unittest import GpTestCase
 from gppylib.programs.clsSystemState import *
 from gppylib.commands.unix import CommandNotFoundException
 
@@ -393,6 +394,49 @@ class ReplicationInfoTestCase(unittest.TestCase):
             pass
         self.assertFalse(port_active, "PgPortIsActive.local should be false")
 
+
+class SegmentsReqAttentionTestCase(GpTestCase):
+
+    def setUp(self):
+        coordinator = create_segment(content=-1, dbid=0)
+        self.primary1 = create_primary(content=0, dbid=1)
+        self.primary2 = create_primary(content=1, dbid=2)
+        mirror1 = create_mirror(content=0, dbid=3)
+        mirror2 = create_mirror(content=1, dbid=4)
+        self.gpArray = gparray.GpArray([coordinator, self.primary1, self.primary2, mirror1, mirror2])
+
+        self.data = GpStateData()
+        self.data.beginSegment(self.primary1)
+        self.data.beginSegment(self.primary2)
+
+        self.apply_patches([mock.patch('gppylib.db.dbconn.connect', autospec=True)])
+
+    def test_WalSyncRemainingBytes_multiple_segments_both_catchup(self):
+        m = mock.Mock()
+        m.fetchall.side_effect = [[[100, 'async']], [[10, 'async']]]
+        with mock.patch('gppylib.db.dbconn.execSQL', return_value=m) as mock_execSQL:
+            GpSystemStateProgram._get_unsync_segs_add_wal_remaining_bytes(self.data, self.gpArray)
+            self.assertEqual(mock_execSQL.call_count, 2)
+            self.assertEqual('100', self.data.getStrValue(self.primary1, VALUE__REPL_SYNC_REMAINING_BYTES))
+            self.assertEqual('10', self.data.getStrValue(self.primary2, VALUE__REPL_SYNC_REMAINING_BYTES))
+
+    def test_WalSyncRemainingBytes_multiple_segments_one_sync(self):
+        m = mock.Mock()
+        m.fetchall.side_effect = [[[100, 'async']], [[10, 'sync']]]
+        with mock.patch('gppylib.db.dbconn.execSQL', return_value=m) as mock_execSQL:
+            GpSystemStateProgram._get_unsync_segs_add_wal_remaining_bytes(self.data, self.gpArray)
+            self.assertEqual(mock_execSQL.call_count, 2)
+            self.assertEqual('100', self.data.getStrValue(self.primary1, VALUE__REPL_SYNC_REMAINING_BYTES))
+            self.assertEqual('', self.data.getStrValue(self.primary2, VALUE__REPL_SYNC_REMAINING_BYTES))
+
+    def test_WalSyncRemainingBytes_multiple_segments_one_down(self):
+        m = mock.Mock()
+        m.fetchall.side_effect = [[[100, 'async']], []]
+        with mock.patch('gppylib.db.dbconn.execSQL', return_value=m) as mock_execSQL:
+            GpSystemStateProgram._get_unsync_segs_add_wal_remaining_bytes(self.data, self.gpArray)
+            self.assertEqual(mock_execSQL.call_count, 2)
+            self.assertEqual('100', self.data.getStrValue(self.primary1, VALUE__REPL_SYNC_REMAINING_BYTES))
+            self.assertEqual('Unknown', self.data.getStrValue(self.primary2, VALUE__REPL_SYNC_REMAINING_BYTES))
 
 class GpStateDataTestCase(unittest.TestCase):
     def test_switchSegment_sets_current_segment_correctly(self):

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -5,7 +5,7 @@ import behave
 
 from test.behave_utils.utils import drop_database_if_exists, start_database_if_not_started,\
                                             create_database, \
-                                            run_command, check_user_permissions, run_gpcommand
+                                            run_command, check_user_permissions, run_gpcommand, execute_sql
 from steps.mirrors_mgmt_utils import MirrorMgmtContext
 from steps.gpconfig_mgmt_utils import GpConfigContext
 from steps.gpssh_exkeys_mgmt_utils import GpsshExkeysMgmtContext
@@ -132,7 +132,7 @@ def after_scenario(context, scenario):
             ''')
 
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
-    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpinitstandby',
+    tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpinitstandby',
                     'gpconfig', 'gpstop', 'gpinitsystem', 'cross_subnet']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
@@ -167,3 +167,9 @@ def after_scenario(context, scenario):
     elif hasattr(context, 'permissions_to_restore_path_to'):
         raise Exception('Missing path_for_which_to_restore_the_permissions despite the specified permission %o' %
                         context.permissions_to_restore_path_to)
+
+    if 'gpstate' in context.feature.tags:
+        create_fault_query = "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"
+        execute_sql('postgres', create_fault_query)
+        reset_fault_query = "SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration WHERE status='u';"
+        execute_sql('postgres', reset_fault_query)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1056,7 +1056,7 @@ def impl(context, dbname):
     sql = context.text
     execute_sql(dbname, sql)
 
-
+@given('sql "{sql}" is executed in "{dbname}" db')
 @when('sql "{sql}" is executed in "{dbname}" db')
 @then('sql "{sql}" is executed in "{dbname}" db')
 def impl(context, sql, dbname):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -356,6 +356,50 @@ def impl(context, env_var):
 
     del context.orig_env[env_var]
 
+@given('the user {action} the walsender on the {segment} on content {content}')
+@then('the user {action} the walsender on the {segment} on content {content}')
+def impl(context, action, segment, content):
+    if segment == 'mirror':
+        role = "'m'"
+    elif segment == 'primary':
+        role = "'p'"
+    else:
+        raise Exception('segment role can only be primary or mirror')
+
+    create_fault_query = "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"
+    execute_sql('postgres', create_fault_query)
+
+    inject_fault_query = "SELECT gp_inject_fault_infinite('wal_sender_loop', '%s', dbid) FROM gp_segment_configuration WHERE content=%s AND role=%s;" % (action, content, role)
+    execute_sql('postgres', inject_fault_query)
+    return
+
+
+@given('the user skips walreceiver flushing on the {segment} on content {content}')
+@then('the user skips walreceiver flushing on the {segment} on content {content}')
+def impl(context, segment, content):
+    if segment == 'mirror':
+        role = "'m'"
+    elif segment == 'primary':
+        role = "'p'"
+    else:
+        raise Exception('segment role can only be primary or mirror')
+
+    create_fault_query = "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"
+    execute_sql('postgres', create_fault_query)
+
+    inject_fault_query = "SELECT gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) FROM gp_segment_configuration WHERE content=%s AND role=%s;" % (content, role)
+    execute_sql('postgres', inject_fault_query)
+    return
+
+
+@given('the user waits until all bytes are sent to mirror on content {content}')
+@then('the user waits until all bytes are sent to mirror on content {content}')
+def impl(context, content):
+    host, port = get_primary_segment_host_port_for_content(content)
+    query = "SELECT pg_current_xlog_location() - sent_location FROM pg_stat_replication;"
+    desired_result = 0
+    wait_for_desired_query_result_on_segment(host, port, query, desired_result)
+
 
 @given('the user runs "{command}"')
 @when('the user runs "{command}"')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -799,3 +799,26 @@ def wait_for_unblocked_transactions(context, num_retries=150):
 
     if attempt == num_retries:
         raise Exception('Unable to establish a connection to database !!!')
+
+
+def wait_for_desired_query_result_on_segment(host, port, query, desired_result, num_retries=150):
+    """
+    Tries once a second to check for the desired query result on the segment.
+    Raises an Exception after failing <num_retries> times.
+    """
+    attempt = 0
+    actual_result = None
+    url = dbconn.DbURL(hostname=host, port=port, dbname='template1')
+    while (attempt < num_retries) and (actual_result != desired_result):
+        attempt += 1
+        try:
+            with dbconn.connect(url, utility=True) as conn:
+                cursor = dbconn.execSQL(conn, query)
+                rows = cursor.fetchall()
+                actual_result = rows[0][0]
+        except Exception as e:
+            print('could not query segment (%s:%s) %s' % (host, port, e))
+        time.sleep(1)
+
+    if attempt == num_retries:
+        raise Exception('Timed out after %s retries' % num_retries)

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -723,6 +723,19 @@ def get_primary_segment_host_port():
     return primary_seg_host, primary_seg_port
 
 
+def get_primary_segment_host_port_for_content(content='0'):
+    """
+    return host, port of primary segment for the content id
+    """
+    get_psegment_sql = "SELECT hostname, port FROM gp_segment_configuration WHERE content=%s AND role='p';" % content
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+        cur = dbconn.execSQL(conn, get_psegment_sql)
+        rows = cur.fetchall()
+        primary_seg_host = rows[0][0]
+        primary_seg_port = rows[0][1]
+    return primary_seg_host, primary_seg_port
+
+
 def remove_local_path(dirname):
     list = glob.glob(os.path.join(os.path.curdir, dirname))
     for dir in list:


### PR DESCRIPTION
This PR is a combination of changes for enhancing gpstate output on showing mirror sync progress. (More technical details in commit message)

[1] gpstate -e: Add `WAL sync remaining bytes` field for unsyncronized segment
pairs catching up to get to sync. 

- This is only required when walsender starts for the first time (after mirror
recovery) and is in catchup state.

- Sample output:
```
----------------------------------------------------
Unsynchronized Segment Pairs
Current Primary           Port    WAL sync remaining bytes   Mirror                    Port
vanjared-a01.vmware.com   15434   2802320                    vanjared-a01.vmware.com   15437
```

[2] gpstate -s: Add WAL fields for commit queue/delay for tracking delays on
commit queue. This change aims at giving the user additional tool for
troubleshooting network or I/O delays for a segment pair

- On primary segment's output, we added fields for: `current write location` and `Bytes remaining to send to mirror` 
- On mirror segment's output, we refined the output for `Bytes received but remain to flush` and `Bytes received but remain to replay` and make it static.

-Sample output
```
----------------------------------------------------
Segment Instance Status Report
----------------------------------------------------
   Segment Info
      Hostname                              = vanjared-a01.vmware.com
      Address                               = vanjared-a01.vmware.com
      Datadir                               = /Users/vanjared/gpdb7/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
      Port                                  = 7002
   Mirroring Info
      Current role                          = Primary
      Preferred role                        = Primary
      Mirror status                         = Synchronized
   Replication Info
      Current write location                = 0/C0B4548
      Bytes remaining to send to mirror     = 82336
   Status
      PID                                   = 59223
      Configuration reports status as       = Up
      Database status                       = Up
----------------------------------------------------
   Segment Info
      Hostname                              = vanjared-a01.vmware.com
      Address                               = vanjared-a01.vmware.com
      Datadir                               = /Users/vanjared/gpdb7/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
      Port                                  = 7005
   Mirroring Info
      Current role                          = Mirror
      Preferred role                        = Mirror
      Mirror status                         = Streaming
   Replication Info
      WAL Sent Location                     = 0/C0A03A8
      WAL Flush Location                    = 0/C062B88
      WAL Replay Location                   = 0/C062B88
      Bytes received but remain to flush    = 251936
      Bytes received but remain to replay   = 251936
   Status
      PID                                   = 60298
      Configuration reports status as       = Up
      Segment status                        = Up
```
This is a backport of https://github.com/greenplum-db/gpdb/pull/12388
With some differences in the upstream names
```
master              : 6X
pg_current_wal_lsn  : pg_current_xlog_location
sent_lsn            : sent_location
flush_lsn           : flush_location
replay_lsn          : replay_location
pg_wal_lsn_diff     : pg_xlog_location_diff
```