### PR TITLE
Limit number of bindings per group expression in Orca

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -373,6 +373,7 @@ COptTasks::CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model)
 	ULONG broadcast_threshold = (ULONG) optimizer_penalize_broadcast_threshold;
 	ULONG push_group_by_below_setop_threshold =
 		(ULONG) optimizer_push_group_by_below_setop_threshold;
+	ULONG xform_bind_threshold = (ULONG) optimizer_xform_bind_threshold;
 
 	return GPOS_NEW(mp) COptimizerConfig(
 		GPOS_NEW(mp)
@@ -388,7 +389,7 @@ COptTasks::CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model)
 				  broadcast_threshold,
 				  false, /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
-				  push_group_by_below_setop_threshold),
+				  push_group_by_below_setop_threshold, xform_bind_threshold),
 		GPOS_NEW(mp) CWindowOids(OID(F_WINDOW_ROW_NUMBER), OID(F_WINDOW_RANK)));
 }
 

--- a/src/backend/gporca/data/dxl/minidump/NestedSubqLimitBindings.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedSubqLimitBindings.mdp
@@ -1,0 +1,1096 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+
+Objective: Orca should generate a plan reasonably fast when `optimizer_xform_bind_threshold` is set to 100. By default, this query will take much longer since it generates many more groups.
+
+create table t (a int) distributed by (a);
+set optimizer_xform_bind_threshold=100;
+
+explain select a in (
+select a from t as t1 where a in (
+    select a from t as t2 where a in (
+	select a from t as t3 where a in (
+	    select a from t as t4 join t as t5 using(a) group by t4.a
+	    union
+	    select a from t as t4 join t as t5 using(a) group by t4.a
+	    union
+	    select a from t as t4 join t as t5 using(a) group by t4.a
+	)
+    )
+)
+) from t;
+
+]]></dxl:Comment>
+ <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="100"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16385.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.65.1.0" Name="int4eq" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.16.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="81" ColName="?column?" TypeMdid="0.16.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="81" Alias="?column?">
+            <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="9">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:LogicalSelect>
+                <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="17">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:LogicalSelect>
+                    <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="25">
+                      <dxl:Ident ColId="17" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:LogicalSelect>
+                        <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="33">
+                          <dxl:Ident ColId="25" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Union InputColumns="33;65" CastAcrossInputs="false">
+                            <dxl:Columns>
+                              <dxl:Column ColId="33" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                            <dxl:Union InputColumns="33;49" CastAcrossInputs="false">
+                              <dxl:Columns>
+                                <dxl:Column ColId="33" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                              <dxl:LogicalGroupBy>
+                                <dxl:GroupingColumns>
+                                  <dxl:GroupingColumn ColId="33"/>
+                                </dxl:GroupingColumns>
+                                <dxl:ProjList/>
+                                <dxl:LogicalJoin JoinType="Inner">
+                                  <dxl:LogicalGet>
+                                    <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="33" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="35" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="36" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="37" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="38" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="39" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="40" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:LogicalGet>
+                                  <dxl:LogicalGet>
+                                    <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="41" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="42" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="43" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="44" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="45" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="46" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="47" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="48" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:LogicalGet>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="33" ColName="a" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="41" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:LogicalJoin>
+                              </dxl:LogicalGroupBy>
+                              <dxl:LogicalGroupBy>
+                                <dxl:GroupingColumns>
+                                  <dxl:GroupingColumn ColId="49"/>
+                                </dxl:GroupingColumns>
+                                <dxl:ProjList/>
+                                <dxl:LogicalJoin JoinType="Inner">
+                                  <dxl:LogicalGet>
+                                    <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="49" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="50" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="51" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="52" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="53" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="54" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="55" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="56" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:LogicalGet>
+                                  <dxl:LogicalGet>
+                                    <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="57" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="59" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="60" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="61" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="62" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="63" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="64" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:LogicalGet>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="49" ColName="a" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="57" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:LogicalJoin>
+                              </dxl:LogicalGroupBy>
+                            </dxl:Union>
+                            <dxl:LogicalGroupBy>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="65"/>
+                              </dxl:GroupingColumns>
+                              <dxl:ProjList/>
+                              <dxl:LogicalJoin JoinType="Inner">
+                                <dxl:LogicalGet>
+                                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="65" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="66" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="67" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="68" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="69" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="70" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="71" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="72" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:LogicalGet>
+                                <dxl:LogicalGet>
+                                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="73" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="74" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="75" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="76" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="77" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="78" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="79" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="80" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:LogicalGet>
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                  <dxl:Ident ColId="65" ColName="a" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="73" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:LogicalJoin>
+                            </dxl:LogicalGroupBy>
+                          </dxl:Union>
+                        </dxl:SubqueryAny>
+                        <dxl:LogicalGet>
+                          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="25" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="27" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="28" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="29" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="30" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="31" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="32" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:LogicalGet>
+                      </dxl:LogicalSelect>
+                    </dxl:SubqueryAny>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                  </dxl:LogicalSelect>
+                </dxl:SubqueryAny>
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+              </dxl:LogicalSelect>
+            </dxl:SubqueryAny>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7046592">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="4165951483148.106445" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="80" Alias="?column?">
+            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+              <dxl:TestExpr>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:TestExpr>
+              <dxl:ParamList/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="4068311133.248707" Rows="1.000000" Width="5"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="a">
+                    <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="4068311133.248707" Rows="1.000000" Width="5"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="85" Alias="ColRef_0085">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="a">
+                      <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="4068311133.248702" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="8" Alias="a">
+                        <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="4068311133.248698" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="8" Alias="a">
+                          <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                          <dxl:TestExpr>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:TestExpr>
+                          <dxl:ParamList/>
+                          <dxl:Materialize Eager="true">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="3972098.090727" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="16" Alias="a">
+                                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:Result>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="3972098.090723" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="16" Alias="a">
+                                  <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                                  <dxl:TestExpr>
+                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                      <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:Comparison>
+                                  </dxl:TestExpr>
+                                  <dxl:ParamList/>
+                                  <dxl:Materialize Eager="true">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="3017.001705" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="24" Alias="a">
+                                        <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="3017.001701" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="24" Alias="a">
+                                          <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:HashJoin JoinType="Inner">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="3017.001686" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="24" Alias="a">
+                                            <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:JoinFilter/>
+                                        <dxl:HashCondList>
+                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                            <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
+                                            <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                          </dxl:Comparison>
+                                        </dxl:HashCondList>
+                                        <dxl:TableScan>
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="24" Alias="a">
+                                              <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                            <dxl:Columns>
+                                              <dxl:Column ColId="24" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                              <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                              <dxl:Column ColId="26" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                              <dxl:Column ColId="27" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                              <dxl:Column ColId="28" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                              <dxl:Column ColId="29" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                              <dxl:Column ColId="30" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                              <dxl:Column ColId="31" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                            </dxl:Columns>
+                                          </dxl:TableDescriptor>
+                                        </dxl:TableScan>
+                                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="2586.001288" Rows="1.000000" Width="4"/>
+                                          </dxl:Properties>
+                                          <dxl:GroupingColumns>
+                                            <dxl:GroupingColumn ColId="32"/>
+                                          </dxl:GroupingColumns>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="32" Alias="a">
+                                              <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:Sort SortDiscardDuplicates="false">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="2586.001282" Rows="1.000000" Width="4"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="32" Alias="a">
+                                                <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:SortingColumnList>
+                                              <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                            </dxl:SortingColumnList>
+                                            <dxl:LimitCount/>
+                                            <dxl:LimitOffset/>
+                                            <dxl:Append IsTarget="false" IsZapped="false">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="2586.001282" Rows="1.000000" Width="4"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="32" Alias="a">
+                                                  <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="862.000426" Rows="1.000000" Width="4"/>
+                                                </dxl:Properties>
+                                                <dxl:GroupingColumns>
+                                                  <dxl:GroupingColumn ColId="32"/>
+                                                </dxl:GroupingColumns>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="32" Alias="a">
+                                                    <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:Sort SortDiscardDuplicates="false">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="4"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="32" Alias="a">
+                                                      <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:SortingColumnList>
+                                                    <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                  </dxl:SortingColumnList>
+                                                  <dxl:LimitCount/>
+                                                  <dxl:LimitOffset/>
+                                                  <dxl:HashJoin JoinType="Inner">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="4"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="32" Alias="a">
+                                                        <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:JoinFilter/>
+                                                    <dxl:HashCondList>
+                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                        <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+                                                      </dxl:Comparison>
+                                                    </dxl:HashCondList>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="32" Alias="a">
+                                                          <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="32" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="34" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="35" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="36" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="37" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="38" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="39" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="40" Alias="a">
+                                                          <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="40" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="42" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="43" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="44" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="45" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="46" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="47" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                  </dxl:HashJoin>
+                                                </dxl:Sort>
+                                              </dxl:Aggregate>
+                                              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="862.000426" Rows="1.000000" Width="4"/>
+                                                </dxl:Properties>
+                                                <dxl:GroupingColumns>
+                                                  <dxl:GroupingColumn ColId="48"/>
+                                                </dxl:GroupingColumns>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="48" Alias="a">
+                                                    <dxl:Ident ColId="48" ColName="a" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:Sort SortDiscardDuplicates="false">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="4"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="48" Alias="a">
+                                                      <dxl:Ident ColId="48" ColName="a" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:SortingColumnList>
+                                                    <dxl:SortingColumn ColId="48" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                  </dxl:SortingColumnList>
+                                                  <dxl:LimitCount/>
+                                                  <dxl:LimitOffset/>
+                                                  <dxl:HashJoin JoinType="Inner">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="4"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="48" Alias="a">
+                                                        <dxl:Ident ColId="48" ColName="a" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:JoinFilter/>
+                                                    <dxl:HashCondList>
+                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                        <dxl:Ident ColId="48" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        <dxl:Ident ColId="56" ColName="a" TypeMdid="0.23.1.0"/>
+                                                      </dxl:Comparison>
+                                                    </dxl:HashCondList>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="48" Alias="a">
+                                                          <dxl:Ident ColId="48" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="48" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="50" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="51" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="52" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="53" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="54" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="55" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="56" Alias="a">
+                                                          <dxl:Ident ColId="56" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="56" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="58" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="59" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="60" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="61" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="62" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="63" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                  </dxl:HashJoin>
+                                                </dxl:Sort>
+                                              </dxl:Aggregate>
+                                              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="862.000426" Rows="1.000000" Width="4"/>
+                                                </dxl:Properties>
+                                                <dxl:GroupingColumns>
+                                                  <dxl:GroupingColumn ColId="64"/>
+                                                </dxl:GroupingColumns>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="64" Alias="a">
+                                                    <dxl:Ident ColId="64" ColName="a" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:Sort SortDiscardDuplicates="false">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="4"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="64" Alias="a">
+                                                      <dxl:Ident ColId="64" ColName="a" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:SortingColumnList>
+                                                    <dxl:SortingColumn ColId="64" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                  </dxl:SortingColumnList>
+                                                  <dxl:LimitCount/>
+                                                  <dxl:LimitOffset/>
+                                                  <dxl:HashJoin JoinType="Inner">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="862.000424" Rows="1.000000" Width="4"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="64" Alias="a">
+                                                        <dxl:Ident ColId="64" ColName="a" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:JoinFilter/>
+                                                    <dxl:HashCondList>
+                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                        <dxl:Ident ColId="64" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        <dxl:Ident ColId="72" ColName="a" TypeMdid="0.23.1.0"/>
+                                                      </dxl:Comparison>
+                                                    </dxl:HashCondList>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="64" Alias="a">
+                                                          <dxl:Ident ColId="64" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="64" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="66" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="67" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="68" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="69" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="70" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="71" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="72" Alias="a">
+                                                          <dxl:Ident ColId="72" ColName="a" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="72" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="73" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="74" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="75" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="76" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="77" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="78" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="79" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                  </dxl:HashJoin>
+                                                </dxl:Sort>
+                                              </dxl:Aggregate>
+                                            </dxl:Append>
+                                          </dxl:Sort>
+                                        </dxl:Aggregate>
+                                      </dxl:HashJoin>
+                                    </dxl:GatherMotion>
+                                  </dxl:Materialize>
+                                </dxl:SubPlan>
+                              </dxl:Filter>
+                              <dxl:OneTimeFilter/>
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="16" Alias="a">
+                                    <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="16" Alias="a">
+                                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:GatherMotion>
+                            </dxl:Result>
+                          </dxl:Materialize>
+                        </dxl:SubPlan>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="8" Alias="a">
+                            <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="8" Alias="a">
+                              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Result>
+                  </dxl:Materialize>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:SubPlan>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
@@ -18,6 +18,7 @@
 #define JOIN_ORDER_DP_THRESHOLD ULONG(10)
 #define BROADCAST_THRESHOLD ULONG(10000000)
 #define PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD ULONG(10)
+#define XFORM_BIND_THRESHOLD ULONG(0)
 
 
 namespace gpopt
@@ -49,6 +50,8 @@ private:
 
 	ULONG m_ulPushGroupByBelowSetopThreshold;
 
+	ULONG m_ulXform_bind_threshold;
+
 public:
 	CHint(const CHint &) = delete;
 
@@ -57,7 +60,7 @@ public:
 		  ULONG join_arity_for_associativity_commutativity,
 		  ULONG array_expansion_threshold, ULONG ulJoinOrderDPLimit,
 		  ULONG broadcast_threshold, BOOL enforce_constraint_on_dml,
-		  ULONG push_group_by_below_setop_threshold)
+		  ULONG push_group_by_below_setop_threshold, ULONG xform_bind_threshold)
 		: m_ulMinNumOfPartsToRequireSortOnInsert(
 			  min_num_of_parts_to_require_sort_on_insert),
 		  m_ulJoinArityForAssociativityCommutativity(
@@ -67,7 +70,8 @@ public:
 		  m_ulBroadcastThreshold(broadcast_threshold),
 		  m_fEnforceConstraintsOnDML(enforce_constraint_on_dml),
 		  m_ulPushGroupByBelowSetopThreshold(
-			  push_group_by_below_setop_threshold)
+			  push_group_by_below_setop_threshold),
+		  m_ulXform_bind_threshold(xform_bind_threshold)
 	{
 	}
 
@@ -133,6 +137,13 @@ public:
 		return m_ulPushGroupByBelowSetopThreshold;
 	}
 
+	// Stop generating alternatives for group expression if bindings exceed this threshold
+	ULONG
+	UlXformBindThreshold() const
+	{
+		return m_ulXform_bind_threshold;
+	}
+
 	// generate default hint configurations, which disables sort during insert on
 	// append only row-oriented partitioned tables by default
 	static CHint *
@@ -142,10 +153,11 @@ public:
 			gpos::int_max, /* min_num_of_parts_to_require_sort_on_insert */
 			gpos::int_max, /* join_arity_for_associativity_commutativity */
 			gpos::int_max, /* array_expansion_threshold */
-			JOIN_ORDER_DP_THRESHOLD,			/*ulJoinOrderDPLimit*/
-			BROADCAST_THRESHOLD,				/*broadcast_threshold*/
-			true,								/* enforce_constraint_on_dml */
-			PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD /* push_group_by_below_setop_threshold */
+			JOIN_ORDER_DP_THRESHOLD,			 /*ulJoinOrderDPLimit*/
+			BROADCAST_THRESHOLD,				 /*broadcast_threshold*/
+			true,								 /* enforce_constraint_on_dml */
+			PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD, /* push_group_by_below_setop_threshold */
+			XFORM_BIND_THRESHOLD				 /* xform_bind_threshold */
 		);
 	}
 

--- a/src/backend/gporca/libgpopt/src/optimizer/COptimizerConfig.cpp
+++ b/src/backend/gporca/libgpopt/src/optimizer/COptimizerConfig.cpp
@@ -207,6 +207,9 @@ COptimizerConfig::Serialize(CMemoryPool *mp, CXMLSerializer *xml_serializer,
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenPushGroupByBelowSetopThreshold),
 		m_hint->UlPushGroupByBelowSetopThreshold());
+	xml_serializer->AddAttribute(
+		CDXLTokens::GetDXLTokenStr(EdxltokenXformBindThreshold),
+		m_hint->UlXformBindThreshold());
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 		CDXLTokens::GetDXLTokenStr(EdxltokenHint));

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -65,6 +65,7 @@ enum Edxltoken
 	EdxltokenBroadcastThreshold,
 	EdxltokenEnforceConstraintsOnDML,
 	EdxltokenPushGroupByBelowSetopThreshold,
+	EdxltokenXformBindThreshold,
 	EdxltokenMaxStatsBuckets,
 	EdxltokenWindowOids,
 	EdxltokenOidRowNumber,

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHint.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHint.cpp
@@ -109,12 +109,17 @@ CParseHandlerHint::StartElement(const XMLCh *const,	 //element_uri,
 			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
 			EdxltokenPushGroupByBelowSetopThreshold, EdxltokenHint, true,
 			PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD);
+	ULONG xform_bind_threshold =
+		CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+			EdxltokenXformBindThreshold, EdxltokenHint, true,
+			XFORM_BIND_THRESHOLD);
 
 	m_hint = GPOS_NEW(m_mp) CHint(
 		min_num_of_parts_to_require_sort_on_insert,
 		join_arity_for_associativity_commutativity, array_expansion_threshold,
 		join_order_dp_threshold, broadcast_threshold, enforce_constraint_on_dml,
-		push_group_by_below_setop_threshold);
+		push_group_by_below_setop_threshold, xform_bind_threshold);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -87,6 +87,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		 GPOS_WSZ_LIT("EnforceConstraintsOnDML")},
 		{EdxltokenPushGroupByBelowSetopThreshold,
 		 GPOS_WSZ_LIT("PushGroupByBelowSetopThreshold")},
+		{EdxltokenXformBindThreshold, GPOS_WSZ_LIT("XformBindThreshold")},
 		{EdxltokenWindowOids, GPOS_WSZ_LIT("WindowOids")},
 		{EdxltokenOidRowNumber, GPOS_WSZ_LIT("RowNumber")},
 		{EdxltokenOidRank, GPOS_WSZ_LIT("Rank")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -338,7 +338,7 @@ Distinct-LegacyOpfamily;
 
 CSubquery2Test:
 Subq2PartialDecorrelate Subq2CorrSQInLOJOn Subq2NotInWhereLOJ Subq2OuterRef2InJoin Subq2OuterRefMultiLevelInOn
-Index-Join-With-Subquery-In-Pred;
+Index-Join-With-Subquery-In-Pred NestedSubqLimitBindings;
 
 CIndexOnlyScanTest:
 IndexOnlyScan-NoDistKeyInIndex;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -360,6 +360,7 @@ int         optimizer_join_order_threshold;
 int			optimizer_join_order;
 int			optimizer_cte_inlining_bound;
 int			optimizer_push_group_by_below_setop_threshold;
+int			optimizer_xform_bind_threshold;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
 bool		optimizer_force_expanded_distinct_aggs;
@@ -3845,6 +3846,17 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&optimizer_push_group_by_below_setop_threshold,
 		10, 0, INT_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_xform_bind_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Maximum number bindings per xform per group expression"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_xform_bind_threshold,
+		0, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -545,6 +545,7 @@ extern int optimizer_join_order;
 extern int optimizer_join_arity_for_associativity_commutativity;
 extern int optimizer_cte_inlining_bound;
 extern int optimizer_push_group_by_below_setop_threshold;
+extern int optimizer_xform_bind_threshold;
 extern bool optimizer_force_multistage_agg;
 extern bool optimizer_force_three_stage_scalar_dqa;
 extern bool optimizer_force_expanded_distinct_aggs;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -101,6 +101,7 @@
 		"optimizer_partition_selection_log",
 		"optimizer_plan_id",
 		"optimizer_push_group_by_below_setop_threshold",
+		"optimizer_xform_bind_threshold",
 		"optimizer_samples_number",
 		"parallel_setup_cost",
 		"parallel_tuple_cost",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13916,3 +13916,28 @@ SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS D
   
 (1 row)
 
+--- optimizer_xform_bind_threshold should limit the search space and quickly
+--- generate a plan (<100ms, but if this GUC is not set it will take minutes to
+--- optimize)
+create table binding (a int) distributed by (a);
+set optimizer_xform_bind_threshold=100;
+set statement_timeout = '15s';
+select a in (
+       select a from binding as t1 where a in (
+           select a from binding as t2 where a in (
+               select a from binding as t3 where a in (
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+               )
+           )
+       )
+   ) from binding;
+ ?column? 
+----------
+(0 rows)
+
+reset optimizer_xform_bind_threshold;
+reset statement_timeout;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14281,3 +14281,28 @@ SELECT b FROM tt1 WHERE NOT EXISTS (SELECT * FROM tt2 WHERE (tt1.b = tt2.d) IS D
   
 (1 row)
 
+--- optimizer_xform_bind_threshold should limit the search space and quickly
+--- generate a plan (<100ms, but if this GUC is not set it will take minutes to
+--- optimize)
+create table binding (a int) distributed by (a);
+set optimizer_xform_bind_threshold=100;
+set statement_timeout = '15s';
+select a in (
+       select a from binding as t1 where a in (
+           select a from binding as t2 where a in (
+               select a from binding as t3 where a in (
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+               )
+           )
+       )
+   ) from binding;
+ ?column? 
+----------
+(0 rows)
+
+reset optimizer_xform_bind_threshold;
+reset statement_timeout;


### PR DESCRIPTION
This reopens https://github.com/greenplum-db/gpdb/pull/11866. The intention is to backport to this 
to 6X (and possibly 5X).

In some cases with deeply nested subqueries, an expression can end up being binded
many times. The expression is decorrelated, and the new expression
generated continuously is decorrelated over and over. While this does
work and will properly decorrelate complex trees, it also results in high
optimization times/OOM in severe cases.

Looking at the memo, we are generating new and unique plans. However,
the vast majority of the groups generated are duplicates. I'm not sure
if there's a relatively simple way to prune these away in the current
way we do decorrelation.

This commit adds a guc, optimizer_xform_bind_threshold, to limit the
number of bindings for each group expression to a certain value. By
default, this is set to 0 (unlimited).

Example query affected by this change:

```
create table t (a int) distributed by (a);

explain select a in (
    select a from t as t1 where a in (
        select a from t as t2 where a in (
            select a from t as t3 where a in (
                select a from t as t4 join t as t5 using(a) group by t4.a
                union
                select a from t as t4 join t as t5 using(a) group by t4.a
                union
                select a from t as t4 join t as t5 using(a) group by t4.a
            )
        )
    )
) from t;

```

Previously this was binded hundreds of thousands of times with an
optimization time of 40s+:
```
CXformLeftOuterApply2LeftOuterJoin: 5 calls, 433071 total bindings, 136085 alternatives generated, 34598ms
CXformLeftSemiApplyIn2LeftSemiJoin: 3 calls, 23345 total bindings, 9075 alternatives generated, 2073ms
```