### PR TITLE
gpstate mirror-sync tests bugfixes

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -1069,6 +1069,9 @@ class GpSystemStateProgram:
 
         data.addValue(VALUE__REPL_CURRENT_LSN, current_wal_lsn if current_wal_lsn else 'Unknown', isWarning=(not current_wal_lsn))
 
+        # Set SENT_LEFT to unknown, and if we find a valid WAL connection, set it to correct value
+        data.addValue(VALUE__REPL_SENT_LEFT, 'Unknown', isWarning=True)
+
         # Now fill in the information for the standby connection. There should
         # be exactly one such entry; otherwise we bail.
         standby_connections = [r for r in rows if r[0] == 'gp_walreceiver']
@@ -1083,9 +1086,7 @@ class GpSystemStateProgram:
 
         sent_left = row[8]
         if sent_left is not None:
-            data.addValue(VALUE__REPL_SENT_LEFT, sent_left)
-        else:
-            data.addValue(VALUE__REPL_SENT_LEFT, 'Unknown', isWarning=True)
+            data.addValue(VALUE__REPL_SENT_LEFT, sent_left, isWarning=False)
 
         GpSystemStateProgram._set_mirror_replication_values(data, mirror,
             state=row[1],

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
@@ -72,6 +72,8 @@ class ReplicationInfoTestCase(unittest.TestCase):
         rows = None
 
         # Try to match the query() query against one of our stored fragments.
+        # If there is an overlap in fragments, we can get wrong results.
+        # Make sure none of the fragments in a test is a subset of another fragment.
         for fragment in self._pg_rows:
             if fragment in query:
                 rows = self._pg_rows[fragment]
@@ -98,7 +100,7 @@ class ReplicationInfoTestCase(unittest.TestCase):
         mock_query.side_effect = self._get_rows_for_query
 
     def mock_pg_current_wal_lsn(self, mock_query, rows):
-        self._pg_rows['pg_current_wal_lsn'] = rows
+        self._pg_rows['SELECT pg_current_wal_lsn'] = rows
         mock_query.side_effect = self._get_rows_for_query
 
     def stub_replication_entry(self, **kwargs):

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -170,7 +170,7 @@ def after_scenario(context, scenario):
                         context.permissions_to_restore_path_to)
 
     if 'gpstate' in context.feature.tags:
-        create_fault_query = "CREATE extension IF NOT EXISTS gp_inject_fault;"
+        create_fault_query = "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"
         execute_sql('postgres', create_fault_query)
         reset_fault_query = "SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration WHERE status='u';"
         execute_sql('postgres', reset_fault_query)

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -688,7 +688,7 @@ def get_primary_segment_host_port_for_content(content='0'):
     """
     return host, port of primary segment for the content id
     """
-    get_psegment_sql = 'select hostname, port from gp_segment_configuration where content=%s;' % content
+    get_psegment_sql = "SELECT hostname, port FROM gp_segment_configuration WHERE content=%s AND role='p';" % content
     with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
         cur = dbconn.query(conn, get_psegment_sql)
         rows = cur.fetchall()


### PR DESCRIPTION
This change is a combination of few bugfixes 

- The function to get primary host/port should filter on role='p'
- sent_left field should be static if mirror isn't up
- mock for query should use unique non-overlapping fragments
