### PR TITLE
gpstate throws cosmetic errors when gpadmin database is not present

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -11,7 +11,7 @@
                       {'name': 'gpinitsystem',
                        'use_concourse_cluster': false},
                       {'name': 'gpstate',
-                       'use_concourse_cluster': false},
+                       'use_concourse_cluster': true},
                       {'name': 'replication_slots',
                        'use_concourse_cluster': false},
                       {'name': 'gpactivatestandby',

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -514,6 +514,8 @@ class GpGetStatusUsingTransitionArgs(CmdArgs):
         @param status_request
         """
         CmdArgs.__init__(self, [
+            "env",
+            "pgdatabase=%s" % os.getenv('PGDATABASE'),
             "$GPHOME/sbin/gpgetstatususingtransition.py",
             "-s", str(status_request)
         ])

--- a/gpMgmt/sbin/gpgetstatususingtransition.py
+++ b/gpMgmt/sbin/gpgetstatususingtransition.py
@@ -34,8 +34,13 @@ PQPING_MIRROR_READY = 64
 POSTMASTER_MIRROR_VERSION_DETAIL_MSG = "- VERSION:"
 
 def _get_segment_status(segment):
-    cmd = base.Command('pg_isready for segment',
+    PGDATABASE = os.getenv('pgdatabase')
+    if (PGDATABASE == 'None'):
+        cmd = base.Command('pg_isready for segment',
                        "pg_isready -q -h %s -p %d" % (segment.hostname, segment.port))
+    else:
+        cmd = base.Command('pg_isready for segment',
+                           "pg_isready -q -h %s -p %d -d %s" % (segment.hostname, segment.port, PGDATABASE))
     cmd.run()
 
     rc = cmd.get_return_code()

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -546,3 +546,21 @@ Feature: gpstate tests
          When the user runs "gpstate -x"
          Then gpstate output looks like
              | Cluster Expansion State = No Expansion Detected |
+
+    Scenario: gpstate -e -v logs no errors when the user sets PGDATABASE
+        Given a standard local demo cluster is running
+        And the user runs command "export PGDATABASE=postgres && $GPHOME/bin/gpstate -e -v"
+        Then command should print "pg_isready -q -h .* -p .* -d postgres" to stdout
+        And command should print "All segments are running normally" to stdout
+
+
+########################### @concourse_cluster tests ###########################
+# The @concourse_cluster tag denotes the scenario that requires a remote cluster
+
+    @concourse_cluster
+    Scenario: gpstate -e -v logs no errors when the user unsets PGDATABASE
+        Given the database is running
+        And all the segments are running
+        And the user runs command "unset PGDATABASE && $GPHOME/bin/gpstate -e -v"
+        Then command should print "pg_isready -q -h .* -p .*" to stdout
+        And command should print "All segments are running normally" to stdout


### PR DESCRIPTION
when the environment does not has a $HOSTNAME database present,
gpstate command throwing FATAL error on master logs

solution: Try to utilize the default DB defined in PGDATABASE from
gpstate

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
