### PR TITLE
Resolve leftover PostgreSQL 12 merge conflicts in doc

### DIFF
--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -52,28 +52,33 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] <replaceable class="parameter">table_name</replaceable>
     OF <replaceable class="parameter">type_name</replaceable> [ (
   { <replaceable class="parameter">column_name</replaceable> [ WITH OPTIONS ] [ <replaceable class="parameter">column_constraint</replaceable> [ ... ] ]
+[ ENCODING ( storage_directive [,...] ) ]
     | <replaceable>table_constraint</replaceable> }
+    | [<replaceable>column_reference_storage_directive</replaceable> [, ... ]
     [, ... ]
 ) ]
 [ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ USING <replaceable class="parameter">method</replaceable> ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
-<<<<<<< HEAD
-[ TABLESPACE <replaceable class="PARAMETER">tablespace_name</replaceable> ]
+[ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 [ DISTRIBUTED BY (column [opclass], [ ... ] ) | DISTRIBUTED RANDOMLY | DISTRIBUTED REPLICATED]
-[ PARTITION BY partition_type (column)
-       [ SUBPARTITION BY partition_type (column) ]
-          [ SUBPARTITION TEMPLATE ( template_spec ) ]
-       [...]
-    ( partition_spec )
-        | [ SUBPARTITION BY partition_type (column) ]
-          [...]
-    ( partition_spec
-      [ ( subpartition_spec
-           [(...)]
-         ) ]
-    ) ]
+
+CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] <replaceable class="parameter">table_name</replaceable>
+    PARTITION OF <replaceable class="parameter">parent_table</replaceable> [ (
+  { <replaceable class="parameter">column_name</replaceable> [ WITH OPTIONS ] [ <replaceable class="parameter">column_constraint</replaceable> [ ... ] ]
+[ ENCODING ( storage_directive [,...] ) ]
+    | <replaceable>table_constraint</replaceable> }
+    | [<replaceable>column_reference_storage_directive</replaceable> [, ... ]
+    [, ... ]
+) ] { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+[ USING <replaceable class="parameter">method</replaceable> ]
+[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS ]
+[ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
+[ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
+[ DISTRIBUTED BY (column [opclass], [ ... ] ) | DISTRIBUTED RANDOMLY | DISTRIBUTED REPLICATED]
+
 where storage_parameter is:
    APPENDONLY={TRUE|FALSE}
    BLOCKSIZE={8192-2097152}
@@ -83,24 +88,8 @@ where storage_parameter is:
    CHECKSUM={TRUE|FALSE}
    FILLFACTOR={10-100}
    OIDS[=TRUE|FALSE]
-<phrase>where <replaceable class="PARAMETER">column_constraint</replaceable> is:</phrase>
-=======
-[ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
-
-CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] <replaceable class="parameter">table_name</replaceable>
-    PARTITION OF <replaceable class="parameter">parent_table</replaceable> [ (
-  { <replaceable class="parameter">column_name</replaceable> [ WITH OPTIONS ] [ <replaceable class="parameter">column_constraint</replaceable> [ ... ] ]
-    | <replaceable>table_constraint</replaceable> }
-    [, ... ]
-) ] { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }
-[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
-[ USING <replaceable class="parameter">method</replaceable> ]
-[ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITHOUT OIDS ]
-[ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
-[ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 
 <phrase>where <replaceable class="parameter">column_constraint</replaceable> is:</phrase>
->>>>>>> 9e1c9f959422192bbe1b842a2a1ffaf76b080196
 
 [ CONSTRAINT <replaceable class="parameter">constraint_name</replaceable> ]
 { NOT NULL |
@@ -147,9 +136,11 @@ WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REM
 <phrase><replaceable class="parameter">exclude_element</replaceable> in an <literal>EXCLUDE</literal> constraint is:</phrase>
 
 { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ <replaceable class="parameter">opclass</replaceable> ] [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
+
 where partition_type is:
     LIST
   | RANGE
+
 where partition_specification is:
 partition_element [, ...]
 and partition_element is:
@@ -165,6 +156,7 @@ and partition_element is:
 [ WITH ( partition_storage_parameter=value [, ... ] ) ]
 [column_reference_storage_directive [, ...] ]
 [ TABLESPACE tablespace ]
+
 where subpartition_spec or template_spec is:
 subpartition_element [, ...]
 and subpartition_element is:
@@ -180,10 +172,12 @@ and subpartition_element is:
 [ WITH ( partition_storage_parameter=value [, ... ] ) ]
 [column_reference_storage_directive [, ...] ]
 [ TABLESPACE tablespace ]
+
 where storage_directive is:
    COMPRESSTYPE={ZLIB | QUICKLZ | RLE_TYPE | NONE} 
  | COMPRESSLEVEL={0-9} 
  | BLOCKSIZE={8192-2097152}
+
 Where column_reference_storage_directive is:
    COLUMN column_name ENCODING ( storage_directive [, ... ] ), ... 
  | DEFAULT COLUMN ENCODING ( storage_directive [, ... ] )

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -1363,39 +1363,13 @@ testdb=&gt;
 
 
       <varlistentry>
-<<<<<<< HEAD
-        <term><literal>\dD[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <listitem>
-        <para>
-        Lists domains. If <replaceable
-        class="parameter">pattern</replaceable>
-        is specified, only domains whose names match the pattern are shown.
-        By default, only user-created objects are shown;  supply a
-        pattern or the <literal>S</literal> modifier to include system
-        objects.
-        If <literal>+</literal> is appended to the command name, each object
-        is listed with its associated permissions and description.
-        </para>
-        </listitem>
-      </varlistentry>
-
-
-      <varlistentry>
-        <term><literal>\dE[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <term><literal>\di[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <term><literal>\dP[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <term><literal>\dm[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <term><literal>\ds[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <term><literal>\dt[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-        <term><literal>\dv[S+] [ <link linkend="APP-PSQL-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
-=======
         <term><literal>\dE[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
         <term><literal>\di[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
+        <term><literal>\dP[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
         <term><literal>\dm[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
         <term><literal>\ds[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
         <term><literal>\dt[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
         <term><literal>\dv[S+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">pattern</replaceable></link> ]</literal></term>
->>>>>>> 9e1c9f959422192bbe1b842a2a1ffaf76b080196
 
         <listitem>
         <para>
@@ -4403,24 +4377,6 @@ $endif
    </varlistentry>
 
    <varlistentry>
-<<<<<<< HEAD
-    <term><envar>PAGER</envar></term>
-
-    <listitem>
-     <para>
-      If the query results do not fit on the screen, they are piped
-      through this command.  Typical values are
-      <literal>more</literal> or <literal>less</literal>.  The default
-      is platform-dependent.  Use of the pager can be disabled by setting
-      <envar>PAGER</envar> to empty, or by using pager-related options of
-      the <command>\pset</command> command.
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-=======
->>>>>>> 9e1c9f959422192bbe1b842a2a1ffaf76b080196
     <term><envar>PGDATABASE</envar></term>
     <term><envar>PGHOST</envar></term>
     <term><envar>PGPORT</envar></term>


### PR DESCRIPTION
Keep the Greenplum extra command `\dP` because it still exists.

```
gpadmin=# \dP
    List of partitioned relations
 Schema | Name | Owner | Type | Table
--------+------+-------+------+-------
(0 rows)
```
