### PR TITLE
Fix an assert failure that slice table is incorrect

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -409,8 +409,9 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 	ctl.keysize = sizeof(int);
 	ctl.entrysize = sizeof(InitPlanItem);
 	ctl.hash = tag_hash;
+	ctl.hcxt = CurrentMemoryContext;
 	state.planid_subplans = hash_create("plan_id to subplans", 8, &ctl,
-										 HASH_ELEM | HASH_FUNCTION);
+										 HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
 
 	Assert(is_plan_node((Node *) plan) && IsA(query, Query));
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4756,7 +4756,11 @@ typedef struct
 {
 	plan_tree_base_prefix prefix;
 	EState	   *estate;
-	Bitmapset *unique_init_plans;
+	/*
+	 * record the visited subplans that refer to an init plan,
+	 * to avoid re-visit the motion that is under an init plan.
+	 */
+	Bitmapset *unique_init_plans; 
 	int			currentSliceId;
 } FillSliceTable_cxt;
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4958,10 +4958,10 @@ FillSliceTable_walker(Node *node, void *context)
 
 		if (subplan->is_initplan)
 		{
-      /* do not re-visit the init plan */
+			/* do not re-visit the init plan */
 			if (bms_is_member(subplan->plan_id, unique_init_plans))
 				return false;
-			bms_add_member(unique_init_plans, subplan->plan_id);
+			cxt->unique_init_plans = bms_add_member(unique_init_plans, subplan->plan_id);
 			cxt->currentSliceId = subplan->qDispSliceId;
 			result = plan_tree_walker(node, FillSliceTable_walker, cxt);
 			cxt->currentSliceId = parentSliceIndex;
@@ -4992,9 +4992,8 @@ FillSliceTable(EState *estate, PlannedStmt *stmt)
 
 	cxt.prefix.node = (Node *) stmt;
 	cxt.estate = estate;
-	cxt.unique_init_plans = bms_make_singleton(0);
+	cxt.unique_init_plans = NULL;
 	cxt.currentSliceId = 0;
-	bms_del_member(cxt.unique_init_plans, 0);
 
 	if (stmt->intoClause != NULL || stmt->copyIntoClause != NULL || stmt->refreshClause)
 	{

--- a/src/test/regress/expected/initplan.out
+++ b/src/test/regress/expected/initplan.out
@@ -1,0 +1,200 @@
+-- test cases for init plan
+-- prepare tables
+-- start_ignore
+-- end_ignore
+create table issue_12543_foo(a int, b int, c int) distributed randomly
+partition by range(a)
+(
+   start (1) end (2) every (1),
+   default partition extra
+);
+NOTICE:  CREATE TABLE will create partition "issue_12543_foo_1_prt_extra" for table "issue_12543_foo"
+NOTICE:  CREATE TABLE will create partition "issue_12543_foo_1_prt_2" for table "issue_12543_foo"
+create table issue_12543_bar(a int, b int, c int) distributed randomly;
+insert into issue_12543_bar values(1,4,3),(2,4,3);
+insert into issue_12543_foo values(5,4,3),(7,4,3),(7,5,3),(7,6,4);
+-- CASE 1: single initplan that is not re-used
+explain (costs off)
+select * from issue_12543_bar
+where b < (select count(*) from pg_class);
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on issue_12543_bar
+         Filter: (b < $0)
+         InitPlan 1 (returns $0)  (slice2)
+           ->  Aggregate
+                 ->  Seq Scan on pg_class
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- should print all tuples in issue_12543_bar
+select * from issue_12543_bar
+where b < (select count(*) from pg_class);
+ a | b | c 
+---+---+---
+ 1 | 4 | 3
+ 2 | 4 | 3
+(2 rows)
+
+-- CASE 2: single init-plan that is re-used by several sub-plans
+explain (costs off)
+select * from issue_12543_foo
+where b < (select count(*) from pg_class);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         InitPlan 1 (returns $0)  (slice2)
+           ->  Aggregate
+                 ->  Seq Scan on pg_class
+         ->  Seq Scan on issue_12543_foo_1_prt_extra
+               Filter: (b < $0)
+         ->  Seq Scan on issue_12543_foo_1_prt_2
+               Filter: (b < $0)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- should print all tuples in issue_12543_foo
+select * from issue_12543_foo
+where b < (select count(*) from pg_class);
+ a | b | c 
+---+---+---
+ 5 | 4 | 3
+ 7 | 5 | 3
+ 7 | 6 | 4
+ 7 | 4 | 3
+(4 rows)
+
+-- INIT PLAN that has motion(s)
+-- CASE 3: single init-plan that is re-used by several sub-plans
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar);
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Append
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Aggregate
+                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                       ->  Aggregate
+                             ->  Seq Scan on issue_12543_bar
+         ->  Seq Scan on issue_12543_foo_1_prt_extra
+               Filter: (b > $0)
+         ->  Seq Scan on issue_12543_foo_1_prt_2
+               Filter: (b > $0)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar);
+ a | b | c 
+---+---+---
+ 7 | 6 | 4
+ 7 | 5 | 3
+(2 rows)
+
+-- CASE 4: two init-plans that are both re-used by several sub-plans
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar)
+   or c = (select max(c) from issue_12543_bar);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Append
+         InitPlan 1 (returns $0)  (slice4)
+           ->  Aggregate
+                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                       ->  Aggregate
+                             ->  Seq Scan on issue_12543_bar
+         InitPlan 2 (returns $1)  (slice5)
+           ->  Aggregate
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  Aggregate
+                             ->  Seq Scan on issue_12543_bar issue_12543_bar_1
+         ->  Seq Scan on issue_12543_foo_1_prt_extra
+               Filter: ((b > $0) OR (c = $1))
+         ->  Seq Scan on issue_12543_foo_1_prt_2
+               Filter: ((b > $0) OR (c = $1))
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar)
+   or c = (select max(c) from issue_12543_bar);
+ a | b | c 
+---+---+---
+ 7 | 6 | 4
+ 5 | 4 | 3
+ 7 | 5 | 3
+ 7 | 4 | 3
+(4 rows)
+
+-- CASE from Github issue 12543
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo foo
+where foo.a in
+(select b+c from issue_12543_bar bar
+  where a > (select max(b) from issue_12543_bar)
+)
+or
+foo.a in (select b+b from issue_12543_bar);
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_12543_foo_1_prt_extra foo
+               Filter: ((hashed SubPlan 2) OR (hashed SubPlan 3))
+               SubPlan 2  (slice6; segments: 3)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Seq Scan on issue_12543_bar bar
+                                   Filter: (a > $0)
+                                   InitPlan 1 (returns $0)  (slice7)
+                                     ->  Aggregate
+                                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                 ->  Aggregate
+                                                       ->  Seq Scan on issue_12543_bar
+               SubPlan 3  (slice6; segments: 3)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                             ->  Seq Scan on issue_12543_bar issue_12543_bar_1
+         ->  Seq Scan on issue_12543_foo_1_prt_2 foo_1
+               Filter: ((hashed SubPlan 2) OR (hashed SubPlan 3))
+               SubPlan 2  (slice6; segments: 3)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                             ->  Seq Scan on issue_12543_bar bar_1
+                                   Filter: (a > $0)
+                                   InitPlan 1 (returns $0)  (slice7)
+                                     ->  Aggregate
+                                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                 ->  Aggregate
+                                                       ->  Seq Scan on issue_12543_bar
+               SubPlan 3  (slice6; segments: 3)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                             ->  Seq Scan on issue_12543_bar issue_12543_bar_2
+ Optimizer: Postgres query optimizer
+(35 rows)
+
+select * from issue_12543_foo foo
+where foo.a in
+(select b+c from issue_12543_bar bar
+  where a > (select max(b) from issue_12543_bar)
+)
+or
+foo.a in (select b+b from issue_12543_bar);
+ a | b | c 
+---+---+---
+(0 rows)
+
+drop table issue_12543_foo, issue_12543_bar;

--- a/src/test/regress/expected/initplan_optimizer.out
+++ b/src/test/regress/expected/initplan_optimizer.out
@@ -1,0 +1,217 @@
+-- test cases for init plan
+-- prepare tables
+-- start_ignore
+-- end_ignore
+create table issue_12543_foo(a int, b int, c int) distributed randomly
+partition by range(a)
+(
+   start (1) end (2) every (1),
+   default partition extra
+);
+NOTICE:  CREATE TABLE will create partition "issue_12543_foo_1_prt_extra" for table "issue_12543_foo"
+NOTICE:  CREATE TABLE will create partition "issue_12543_foo_1_prt_2" for table "issue_12543_foo"
+create table issue_12543_bar(a int, b int, c int) distributed randomly;
+insert into issue_12543_bar values(1,4,3),(2,4,3);
+insert into issue_12543_foo values(5,4,3),(7,4,3),(7,5,3),(7,6,4);
+-- CASE 1: single initplan that is not re-used
+explain (costs off)
+select * from issue_12543_bar
+where b < (select count(*) from pg_class);
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on issue_12543_bar
+         Filter: (b < $0)
+         InitPlan 1 (returns $0)  (slice2)
+           ->  Aggregate
+                 ->  Seq Scan on pg_class
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- should print all tuples in issue_12543_bar
+select * from issue_12543_bar
+where b < (select count(*) from pg_class);
+ a | b | c 
+---+---+---
+ 2 | 4 | 3
+ 1 | 4 | 3
+(2 rows)
+
+-- CASE 2: single init-plan that is re-used by several sub-plans
+explain (costs off)
+select * from issue_12543_foo
+where b < (select count(*) from pg_class);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         InitPlan 1 (returns $0)  (slice2)
+           ->  Aggregate
+                 ->  Seq Scan on pg_class
+         ->  Seq Scan on issue_12543_foo_1_prt_extra
+               Filter: (b < $0)
+         ->  Seq Scan on issue_12543_foo_1_prt_2
+               Filter: (b < $0)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- should print all tuples in issue_12543_foo
+select * from issue_12543_foo
+where b < (select count(*) from pg_class);
+ a | b | c 
+---+---+---
+ 7 | 5 | 3
+ 5 | 4 | 3
+ 7 | 6 | 4
+ 7 | 4 | 3
+(4 rows)
+
+-- INIT PLAN that has motion(s)
+-- CASE 3: single init-plan that is re-used by several sub-plans
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Result
+         Filter: (issue_12543_foo.b > (SubPlan 1))
+         ->  Sequence
+               ->  Partition Selector for issue_12543_foo (dynamic scan id: 1)
+                     Partitions selected: 2 (out of 2)
+               ->  Dynamic Seq Scan on issue_12543_foo (dynamic scan id: 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice2)
+                       ->  Aggregate
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Aggregate
+                                         ->  Seq Scan on issue_12543_bar
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar);
+ a | b | c 
+---+---+---
+ 7 | 6 | 4
+ 7 | 5 | 3
+(2 rows)
+
+-- CASE 4: two init-plans that are both re-used by several sub-plans
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar)
+   or c = (select max(c) from issue_12543_bar);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)
+   ->  Result
+         Filter: ((issue_12543_foo.b > (max((max(issue_12543_bar_1.b))))) OR (issue_12543_foo.c = (max((max(issue_12543_bar.c))))))
+         ->  Nested Loop Left Join
+               Join Filter: true
+               ->  Nested Loop Left Join
+                     Join Filter: true
+                     ->  Sequence
+                           ->  Partition Selector for issue_12543_foo (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on issue_12543_foo (dynamic scan id: 1)
+                     ->  Materialize
+                           ->  Broadcast Motion 1:3  (slice4)
+                                 ->  Aggregate
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             ->  Aggregate
+                                                   ->  Seq Scan on issue_12543_bar issue_12543_bar_1
+               ->  Materialize
+                     ->  Broadcast Motion 1:3  (slice2)
+                           ->  Aggregate
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                                       ->  Aggregate
+                                             ->  Seq Scan on issue_12543_bar
+ Optimizer: Pivotal Optimizer (GPORCA)
+(24 rows)
+
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar)
+   or c = (select max(c) from issue_12543_bar);
+ a | b | c 
+---+---+---
+ 7 | 5 | 3
+ 7 | 4 | 3
+ 5 | 4 | 3
+ 7 | 6 | 4
+(4 rows)
+
+-- CASE from Github issue 12543
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo foo
+where foo.a in
+(select b+c from issue_12543_bar bar
+  where a > (select max(b) from issue_12543_bar)
+)
+or
+foo.a in (select b+b from issue_12543_bar);
+                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  Result
+         Filter: (CASE WHEN ((count("inner".ColRef_0043)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((issue_12543_foo.a = ((issue_12543_bar_1.b + issue_12543_bar_1.c))) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0043))) THEN NULL::boolean ELSE true END ELSE false END OR CASE WHEN ((count("inner".ColRef_0047)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((issue_12543_foo.a = ((issue_12543_bar.b + issue_12543_bar.b))) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0047))) THEN NULL::boolean ELSE true END ELSE false END)
+         ->  GroupAggregate
+               Group Key: issue_12543_foo.a, issue_12543_foo.b, issue_12543_foo.c, issue_12543_foo.ctid, issue_12543_foo.tableoid, issue_12543_foo.gp_segment_id, (count("inner".ColRef_0043)), (sum((CASE WHEN ((issue_12543_foo.a = ((issue_12543_bar_1.b + issue_12543_bar_1.c))) IS NULL) THEN 1 ELSE 0 END)))
+               ->  Sort
+                     Sort Key: issue_12543_foo.a, issue_12543_foo.b, issue_12543_foo.c, issue_12543_foo.ctid, issue_12543_foo.tableoid, issue_12543_foo.gp_segment_id, (count("inner".ColRef_0043)), (sum((CASE WHEN ((issue_12543_foo.a = ((issue_12543_bar_1.b + issue_12543_bar_1.c))) IS NULL) THEN 1 ELSE 0 END)))
+                     ->  Result
+                           ->  Nested Loop Left Join
+                                 Join Filter: ((issue_12543_foo.a = ((issue_12543_bar.b + issue_12543_bar.b))) IS NOT FALSE)
+                                 ->  GroupAggregate
+                                       Group Key: issue_12543_foo.a, issue_12543_foo.b, issue_12543_foo.c, issue_12543_foo.ctid, issue_12543_foo.tableoid, issue_12543_foo.gp_segment_id
+                                       ->  Sort
+                                             Sort Key: issue_12543_foo.a, issue_12543_foo.b, issue_12543_foo.c, issue_12543_foo.ctid, issue_12543_foo.tableoid, issue_12543_foo.gp_segment_id
+                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                                   Hash Key: issue_12543_foo.a, issue_12543_foo.b, issue_12543_foo.c, issue_12543_foo.ctid, issue_12543_foo.tableoid, issue_12543_foo.gp_segment_id
+                                                   ->  Result
+                                                         ->  Result
+                                                               ->  Nested Loop Left Join
+                                                                     Join Filter: ((issue_12543_foo.a = ((issue_12543_bar_1.b + issue_12543_bar_1.c))) IS NOT FALSE)
+                                                                     ->  Sequence
+                                                                           ->  Partition Selector for issue_12543_foo (dynamic scan id: 1)
+                                                                                 Partitions selected: 2 (out of 2)
+                                                                           ->  Dynamic Seq Scan on issue_12543_foo (dynamic scan id: 1)
+                                                                     ->  Result
+                                                                           ->  Materialize
+                                                                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                                                       ->  Result
+                                                                                             ->  Seq Scan on issue_12543_bar issue_12543_bar_1
+                                                                                                   Filter: (a > (SubPlan 1))
+                                                                                                   SubPlan 1  (slice4; segments: 3)
+                                                                                                     ->  Materialize
+                                                                                                           ->  Broadcast Motion 1:3  (slice3)
+                                                                                                                 ->  Aggregate
+                                                                                                                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                                                                                             ->  Aggregate
+                                                                                                                                   ->  Seq Scan on issue_12543_bar issue_12543_bar_2
+                                 ->  Result
+                                       ->  Materialize
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                   ->  Seq Scan on issue_12543_bar
+ Optimizer: Pivotal Optimizer (GPORCA)
+(42 rows)
+
+select * from issue_12543_foo foo
+where foo.a in
+(select b+c from issue_12543_bar bar
+  where a > (select max(b) from issue_12543_bar)
+)
+or
+foo.a in (select b+b from issue_12543_bar);
+ a | b | c 
+---+---+---
+(0 rows)
+
+drop table issue_12543_foo, issue_12543_bar;

--- a/src/test/regress/sql/initplan.sql
+++ b/src/test/regress/sql/initplan.sql
@@ -1,0 +1,74 @@
+-- test cases for init plan
+
+-- prepare tables
+-- start_ignore
+drop table if exists issue_12543_foo, issue_12543_bar;
+-- end_ignore
+create table issue_12543_foo(a int, b int, c int) distributed randomly
+partition by range(a)
+(
+   start (1) end (2) every (1),
+   default partition extra
+);
+create table issue_12543_bar(a int, b int, c int) distributed randomly;
+insert into issue_12543_bar values(1,4,3),(2,4,3);
+insert into issue_12543_foo values(5,4,3),(7,4,3),(7,5,3),(7,6,4);
+
+-- CASE 1: single initplan that is not re-used
+explain (costs off)
+select * from issue_12543_bar
+where b < (select count(*) from pg_class);
+-- should print all tuples in issue_12543_bar
+select * from issue_12543_bar
+where b < (select count(*) from pg_class);
+
+-- CASE 2: single init-plan that is re-used by several sub-plans
+explain (costs off)
+select * from issue_12543_foo
+where b < (select count(*) from pg_class);
+-- should print all tuples in issue_12543_foo
+select * from issue_12543_foo
+where b < (select count(*) from pg_class);
+
+-- INIT PLAN that has motion(s)
+-- CASE 3: single init-plan that is re-used by several sub-plans
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar);
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar);
+
+-- CASE 4: two init-plans that are both re-used by several sub-plans
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar)
+   or c = (select max(c) from issue_12543_bar);
+select * from issue_12543_foo
+where b > (select max(b) from issue_12543_bar)
+   or c = (select max(c) from issue_12543_bar);
+
+-- CASE from Github issue 12543
+-- GPORCA falls back to postgres planner, but keep it here to
+-- compare the results
+explain (costs off)
+select * from issue_12543_foo foo
+where foo.a in
+(select b+c from issue_12543_bar bar
+  where a > (select max(b) from issue_12543_bar)
+)
+or
+foo.a in (select b+b from issue_12543_bar);
+
+select * from issue_12543_foo foo
+where foo.a in
+(select b+c from issue_12543_bar bar
+  where a > (select max(b) from issue_12543_bar)
+)
+or
+foo.a in (select b+b from issue_12543_bar);
+
+drop table issue_12543_foo, issue_12543_bar;


### PR DESCRIPTION
The slice table is incorrect when the following conditions are met:
1. An init plan is re-used some two or more sub-plans
2. The re-used init-plan contains motion

The root cause is that the number of motion slices and init-plans
are wrongly calculated in apply_motion/apply_motion_mutator.
Assume that there are 2 sub-plans(P1 and P2) that refer to the same
init-plan(I1), i.e. P1.plan_id == P2.plan_id, the number of motion
slice is calculated by walking the plan tree from top to bottom.
When it sees the sub-plan P1 or P2, it walks the referred init-plan,
so the motion under the init plan is re-counted. The number of
init-plans is counted by the number of sub-plans that refer to an
init plan. Both of the P1 and P2 refer to the same init-plan, the
number of init-plan is wrongly counted.

The fix is simply to use a hash table or bitmapset to de-duplicate
sub-plans that refer to the same init plan.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
