### PR TITLE
gpstart -m -R allows non-super user connections

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -1,3 +1,4 @@
+#Test
 # Concourse Pipeline Generation
 
 To facilitate pipeline maintenance, a Python utility `gen_pipeline.py`

--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -1,4 +1,3 @@
-#Test
 # Concourse Pipeline Generation
 
 To facilitate pipeline maintenance, a Python utility `gen_pipeline.py`

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -193,6 +193,37 @@ class GpStart(GpTestCase):
         self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
         self.assertEqual(return_code, 4)
 
+    def test_option_coordinator_restricted_success_with_auto_accept(self):
+        sys.argv = ["gpstart", "-m", "-R", "-a"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 0)
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin and RESTRICTED mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+        self.assertEqual(return_code, 0)
+
+    def test_option_coordinator_restricted_success_without_auto_accept(self):
+        sys.argv = ["gpstart", "-m", "-R"]
+        self.mock_userinput.ask_yesno.return_value = True
+        self.subject.unix.PgPortIsActive.local.return_value = False
+
+        self.mock_os_path_exists.side_effect = os_exists_check
+
+        gpstart = self.setup_gpstart()
+        return_code = gpstart.run()
+
+        self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
+        self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin and RESTRICTED mode')
+        self.subject.logger.info.assert_any_call('Coordinator Started...')
+        self.assertEqual(return_code, 0)
+
     def test_gpstart_success_without_auto_accept(self):
         self.mock_userinput.ask_yesno.return_value = True
         self.subject.unix.PgPortIsActive.local.return_value = False

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -397,13 +397,25 @@ class GpStart:
 
     ######
     def _startCoordinator(self):
-        logger.info("Starting Coordinator instance in admin mode")
 
-        cmd = gp.CoordinatorStart('coordinator in utility mode', self.coordinator_datadir,
-                             self.port, self.era,
-                             wrapper=self.wrapper, wrapper_args=self.wrapper_args,
-                             specialMode=self.specialMode, timeout=self.timeout, utilityMode=True
-                             )
+        if self.restricted and self.coordinatoronly:
+            logger.info("Starting Coordinator instance in admin and RESTRICTED mode")
+
+            # attempt to start coordinator in utility & restricted mode
+            cmd = gp.CoordinatorStart('Coordinator in utility and restricted mode', self.coordinator_datadir,
+                                 self.port, self.era,
+                                 wrapper=self.wrapper, wrapper_args=self.wrapper_args,
+                                 specialMode=self.specialMode, restrictedMode=self.restricted, timeout=self.timeout,
+                                 utilityMode=True, max_connections=self.max_connections
+                                 )
+        else:
+            logger.info("Starting Coordinator instance in admin mode")
+
+            cmd = gp.CoordinatorStart('coordinator in utility mode', self.coordinator_datadir,
+                                 self.port, self.era,
+                                 wrapper=self.wrapper, wrapper_args=self.wrapper_args,
+                                 specialMode=self.specialMode, timeout=self.timeout, utilityMode=True
+                                 )
         cmd.run()
 
         if cmd.get_results().rc != 0:


### PR DESCRIPTION
gpstart -mR doesn't respect the -R at all and actually allows non-su connections in master only mode, observed in both 6x and 7x.

Non-super users could connect to master-only mode along with restricted mode

> PGOPTIONS="-c gp_session_role=utility" psql -U foouser postgres
psql (9.4.24)
Type "help" for help.
postgres=> create table baz(i int);
CREATE TABLE

The fix would respect -R(restricted mode) along with -m (master-only) and allow only super users to connect.

> PGOPTIONS="-c gp_session_role=utility" psql -U foouser postgres
psql: FATAL:  remaining connection slots are reserved for non-replication superuser connections

> PGOPTIONS="-c gp_session_role=utility" psql
psql (9.4.24)
Type "help" for help.

Co-authored-by: M Hari krishna hmaddileti@vmware.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
