### PR TITLE
Fix copy command EOL

### DIFF
--- a/src/test/regress/expected/copy_eol.out
+++ b/src/test/regress/expected/copy_eol.out
@@ -1,0 +1,71 @@
+--
+-- copy data from file with different EOL and NEWLINE option.
+-- Using /usr/bin/printf in case of different behaviours on
+-- different OS, especially on ubuntu18.
+--
+CREATE TABLE copy_eol(id int, seq text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+--- EOL: '\n'
+\!/usr/bin/printf '1\x1es1\x5c\n2\x1es2\x5c\n' > /tmp/copy_lf.file;
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
+SELECT * FROM copy_eol ORDER BY id ASC;
+ id | seq 
+----+-----
+  1 | s1\
+  1 | s1\
+  2 | s2\
+  2 | s2\
+(4 rows)
+
+TRUNCATE copy_eol;
+--- EOL: '\r'
+--- produce '\r' step by step on linux
+\!/usr/bin/printf '1\x1es1\' > /tmp/copy_cr.file;
+\!/usr/bin/printf '\r' >> /tmp/copy_cr.file;
+\!/usr/bin/printf '2\x1es2\' >> /tmp/copy_cr.file;
+\!/usr/bin/printf '\r' >> /tmp/copy_cr.file;
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+SELECT * FROM copy_eol ORDER BY id ASC;
+ id | seq 
+----+-----
+  1 | s1\
+  1 | s1\
+  2 | s2\
+  2 | s2\
+(4 rows)
+
+TRUNCATE copy_eol;
+--- EOL: '\r\n'
+\!/usr/bin/printf '1\x1es1\\\r\n2\x1es2\\\r\n' > /tmp/copy_crlf.file;
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+SELECT * FROM copy_eol ORDER BY id ASC;
+ id | seq 
+----+-----
+  1 | s1\
+  1 | s1\
+  2 | s2\
+  2 | s2\
+(4 rows)
+
+TRUNCATE copy_eol;
+--- EOL: '\r\n' with a '\r' in data
+\!/usr/bin/printf '1\x1es1\\\r\n2\x1es2\\\r\r\n3\x1es3\\\r\n' > /tmp/copy_crlf_1.file;
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+SELECT * FROM copy_eol ORDER BY id ASC;
+ id |  seq  
+----+-------
+  1 | s1\
+  1 | s1\
+  2 | s2\\r
+  2 | s2\\r
+  3 | s3\
+  3 | s3\
+(6 rows)
+
+TRUNCATE copy_eol;
+DROP TABLE copy_eol;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,10 @@
 #   hitting max_connections limit on segments.
 #
 
+# copy command
+# copy form a file with different EOL
+test: copy_eol
+
 # gp_toolkit performs a vacuum and checks that it truncated the relation. That
 # might not happen if other backends are holding transactions open, preventing
 # vacuum from removing dead tuples. And run gp_toolkit early to make some log

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -260,10 +260,6 @@ COPY copy_regression_text3 from stdin with delimiter '|';
 the at sign: \100|6|c text data|d text data|e text data
 a single backslash \\ in col a|8|c text data|d text data|e text data
 \.
--- This works in PostgreSQL, and these days in GPDB as well, but used to not
--- work until GPDB 6. This is just one line, because the newlines are
--- escaped. (Even on PostgreSQL, the COPY documentation recommends not to do
--- this, but let's test it.)
 COPY copy_regression_text3 from stdin with delimiter '|';
 an embedded linefeed \
 and another one\

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -226,11 +226,9 @@ SELECT * FROM copy_regression_text2;
 COPY copy_regression_text3 from stdin with delimiter '|' escape '#';
 COPY copy_regression_text3 from stdin with delimiter '|' escape 'off';
 COPY copy_regression_text3 from stdin with delimiter '|';
--- This works in PostgreSQL, and these days in GPDB as well, but used to not
--- work until GPDB 6. This is just one line, because the newlines are
--- escaped. (Even on PostgreSQL, the COPY documentation recommends not to do
--- this, but let's test it.)
 COPY copy_regression_text3 from stdin with delimiter '|';
+ERROR:  missing data for column "b"
+CONTEXT:  COPY copy_regression_text3, line 2: "and another one\"
 COPY copy_regression_text3 from stdin with delimiter '|';
 SELECT * FROM copy_regression_text3 ORDER BY b,a;
                  a                  | b |      c      |      d      |      e       
@@ -241,13 +239,10 @@ SELECT * FROM copy_regression_text3 ORDER BY b,a;
  a single backslash \ in col a      | 4 | c text data | d text data | e text data
  c:\\file\data\neew\path            | 5 | c text data | d text data | e text data
  the at sign: @                     | 6 | c text data | d text data | e text data
- an embedded linefeed              +| 7 | c text data | d text data | e text data
- and another one                   +|   |             |             | 
-  in column a                       |   |             |             | 
  an embedded linefeed sequence     +| 7 | c text data | d text data | e text data
  in column a                        |   |             |             | 
  a single backslash \ in col a      | 8 | c text data | d text data | e text data
-(9 rows)
+(8 rows)
 
 DROP TABLE copy_regression_text1;
 DROP TABLE copy_regression_text2;

--- a/src/test/regress/sql/copy_eol.sql
+++ b/src/test/regress/sql/copy_eol.sql
@@ -1,0 +1,40 @@
+--
+-- copy data from file with different EOL and NEWLINE option.
+-- Using /usr/bin/printf in case of different behaviours on
+-- different OS, especially on ubuntu18.
+--
+CREATE TABLE copy_eol(id int, seq text);
+
+--- EOL: '\n'
+\!/usr/bin/printf '1\x1es1\x5c\n2\x1es2\x5c\n' > /tmp/copy_lf.file;
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'LF');
+COPY copy_eol FROM '/tmp/copy_lf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b'); 
+SELECT * FROM copy_eol ORDER BY id ASC;
+TRUNCATE copy_eol;
+
+--- EOL: '\r'
+--- produce '\r' step by step on linux
+\!/usr/bin/printf '1\x1es1\' > /tmp/copy_cr.file;
+\!/usr/bin/printf '\r' >> /tmp/copy_cr.file;
+\!/usr/bin/printf '2\x1es2\' >> /tmp/copy_cr.file;
+\!/usr/bin/printf '\r' >> /tmp/copy_cr.file;
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CR');
+COPY copy_eol FROM '/tmp/copy_cr.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+SELECT * FROM copy_eol ORDER BY id ASC;
+TRUNCATE copy_eol;
+
+--- EOL: '\r\n'
+\!/usr/bin/printf '1\x1es1\\\r\n2\x1es2\\\r\n' > /tmp/copy_crlf.file;
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+SELECT * FROM copy_eol ORDER BY id ASC;
+TRUNCATE copy_eol;
+
+--- EOL: '\r\n' with a '\r' in data
+\!/usr/bin/printf '1\x1es1\\\r\n2\x1es2\\\r\r\n3\x1es3\\\r\n' > /tmp/copy_crlf_1.file;
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b', NEWLINE 'CRLF');
+COPY copy_eol FROM '/tmp/copy_crlf_1.file' (FORMAT 'text', DELIMITER E'\x1e' , NULL E'\x1b\x4e',  ESCAPE E'\x1b');
+SELECT * FROM copy_eol ORDER BY id ASC;
+TRUNCATE copy_eol;
+
+DROP TABLE copy_eol;


### PR DESCRIPTION
The copy command read data from a file and process data once a character.
In non-CSV mode, anything after a backslash is skipped over, so that the EOL
character after a backslash can not be recognized.

An example file with content:
	1, message1
	2, message2`\`
	3, message3

The copy from the command will fail because line2 and line3 will be regarded as one line.
This pr also fixes other EOL: '\r', '\r\n', keep the same behaviour with 5x.
This commit cherry-pick from commit e07d84948f587ef9c250f6ce358b2c14b012e9a6 which has
been reverted because of different behaviour of echo on ubuntu18. Use printf with an absolute
path instead.

Co-authored-by: Mingli Zhang <avamingli@gmail.com>
Co-authored-by: zhaorui <zhaoru@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
