### PR TITLE
Autostats skip ownership check

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -311,6 +311,7 @@ char	   *gp_autostats_mode_string;
 int			gp_autostats_mode_in_functions;
 char	   *gp_autostats_mode_in_functions_string;
 int			gp_autostats_on_change_threshold = 100000;
+bool		gp_autostats_allow_nonowner = true;
 bool		log_autostats = true;
 
 /* --------------------------------------------------------------------------------------------------

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -281,19 +281,34 @@ analyze_rel_internal(Oid relid, RangeVar *relation,
 #endif
 
 	/*
-	 * Check if relation needs to be skipped based on ownership.  This check
-	 * happens also when building the relation list to analyze for a manual
-	 * operation, and needs to be done additionally here as ANALYZE could
+	 * analyze_rel can be called in 3 different contexts:  explicitly by the user
+	 * (eg. ANALYZE, VACUUM ANALYZE), implicitly by autovacuum, or implicitly by
+	 * autostats.
+	 *
+	 * In the first case, we always want to make sure the user is the owner of the
+	 * table.  In the autovacuum case, it will be called as superuser so we don't
+	 * really care, but the ownership check should always succeed.  For autostats,
+	 * we only do the check if gp_autostats_allow_nonowner=false, otherwise we can
+	 * proceed with the analyze.
+	 *
+	 * This check happens also when building the relation list to analyze for a
+	 * manual operation, and needs to be done additionally here as ANALYZE could
 	 * happen across multiple transactions where relation ownership could have
 	 * changed in-between.  Make sure to generate only logs for ANALYZE in
 	 * this case.
 	 */
-	if (!vacuum_is_relation_owner(RelationGetRelid(onerel),
-								  onerel->rd_rel,
-								  params->options & VACOPT_ANALYZE))
+
+	if (!(params->auto_stats && gp_autostats_allow_nonowner))
 	{
-		relation_close(onerel, ShareUpdateExclusiveLock);
-		return;
+		if (!vacuum_is_relation_owner(RelationGetRelid(onerel),
+			onerel->rd_rel,
+		  params->options & VACOPT_ANALYZE))
+		{
+			{
+				relation_close(onerel, ShareUpdateExclusiveLock);
+				return;
+			}
+		}
 	}
 
 	/*
@@ -1518,13 +1533,13 @@ acquire_sample_rows(Relation onerel, int elevel,
 	 * Emit some interesting relation info
 	 */
 	ereport(elevel,
-	        (errmsg("\"%s\": scanned %d of %u pages, "
-	                "containing %.0f live rows and %.0f dead rows; "
-	                "%d rows in sample, %.0f estimated total rows",
-	                RelationGetRelationName(onerel),
-	                bs.m, totalblocks,
-	                liverows, deadrows,
-	                numrows, *totalrows)));
+		(errmsg("\"%s\": scanned %d of %u pages, "
+				"containing %.0f live rows and %.0f dead rows; "
+				"%d rows in sample, %.0f estimated total rows",
+				RelationGetRelationName(onerel),
+				bs.m, totalblocks,
+				liverows, deadrows,
+				numrows, *totalrows)));
 
 	return numrows;
 }
@@ -2156,9 +2171,9 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	AttInMetadata *attinmeta;
 	StringInfoData str;
 	int			sampleTuples;	/* 32 bit - assume that number of tuples will not > 2B */
-	char 	  **funcRetValues;
-	bool 	   *funcRetNulls;
-	char 	  **values;
+	char	  **funcRetValues;
+	bool	   *funcRetNulls;
+	char	  **values;
 	int			numLiveColumns;
 	int			perseg_targrows;
 	int			ncolumns;

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -116,7 +116,7 @@ static void vac_update_relstats_from_list(List *updated_stats);
  * happen in vacuum().
  */
 void
-ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel)
+ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_stats)
 {
 	VacuumParams params;
 	bool		verbose = false;
@@ -243,6 +243,8 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel)
 
 	/* user-invoked vacuum never uses this parameter */
 	params.log_min_duration = -1;
+
+	params.auto_stats = auto_stats;
 
 	/* Now go through the common routine */
 	vacuum(vacstmt->rels, &params, NULL, isTopLevel);

--- a/src/backend/postmaster/autostats.c
+++ b/src/backend/postmaster/autostats.c
@@ -53,17 +53,21 @@ autostats_issue_analyze(Oid relationOid)
 	VacuumRelation *relation;
 	ParseState *pstate;
 
-	/*
-	 * If this user does not own the table, then auto-stats will not issue the
-	 * analyze.
-	 */
-	if (!(pg_class_ownercheck(relationOid, GetUserId()) ||
-		  (pg_database_ownercheck(MyDatabaseId, GetUserId()) && !IsSharedRelation(relationOid))))
+	if (!gp_autostats_allow_nonowner)
 	{
-		elog(DEBUG3, "Auto-stats did not issue ANALYZE on tableoid %d since the user does not have table-owner level permissions.",
-			 relationOid);
+		/*
+		 * If this user does not own the table, then auto-stats will not issue the
+		 * analyze.  This check will be skipped if gp_autostats_allow_nonowner=true
+		 */
+		if (!(pg_class_ownercheck(relationOid, GetUserId()) ||
+			 (pg_database_ownercheck(MyDatabaseId, GetUserId()) && !IsSharedRelation(relationOid))))
+		{
+			if (log_autostats)
+				elog(LOG, "Auto-stats did not issue ANALYZE on tableoid %d since the user does not have table-owner level permissions.",
+				relationOid);
 
-		return;
+				return;
+		}
 	}
 
 	/* Set up an ANALYZE command */
@@ -76,7 +80,7 @@ autostats_issue_analyze(Oid relationOid)
 	pstate = make_parsestate(NULL);
 	pstate->p_sourcetext = NULL;
 
-	ExecVacuum(pstate, analyzeStmt, false);
+	ExecVacuum(pstate, analyzeStmt, false, true);
 
 	free_parsestate(pstate);
 	pfree(analyzeStmt);

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2953,6 +2953,7 @@ table_recheck_autovac(Oid relid, HTAB *table_toast_map,
 		tab->at_params.multixact_freeze_table_age = multixact_freeze_table_age;
 		tab->at_params.is_wraparound = wraparound;
 		tab->at_params.log_min_duration = log_min_duration;
+		tab->at_params.auto_stats = false;
 		tab->at_vacuum_cost_limit = vac_cost_limit;
 		tab->at_vacuum_cost_delay = vac_cost_delay;
 		tab->at_relname = NULL;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -770,7 +770,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 				PreventCommandDuringRecovery(stmt->is_vacuumcmd ?
 											 "VACUUM" : "ANALYZE");
 				/* forbidden in parallel mode due to CommandIsReadOnly */
-				ExecVacuum(pstate, stmt, isTopLevel);
+				ExecVacuum(pstate, stmt, isTopLevel, false);
 			}
 			break;
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2805,7 +2805,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
-
+	{
+		{"gp_autostats_allow_nonowner", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Allow automatic stats collection on tables even for users who are not the owner of the relation."),
+			gettext_noop("If disabled, table statistics will be updated only when tables are modified by the owners of the relations.")
+		},
+		&gp_autostats_allow_nonowner,
+		false,
+		NULL, NULL, NULL
+	},
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL
@@ -4525,7 +4533,6 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		JOIN_ORDER_EXHAUSTIVE2_SEARCH, optimizer_join_order_options,
 		NULL, NULL, NULL
 	},
-
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0, NULL, NULL, NULL

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -663,6 +663,7 @@ typedef enum
 extern int	gp_autostats_mode;
 extern int	gp_autostats_mode_in_functions;
 extern int	gp_autostats_on_change_threshold;
+extern bool	gp_autostats_allow_nonowner;
 extern bool	log_autostats;
 
 

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -229,6 +229,7 @@ typedef struct VacuumParams
 										 * default value depends on reloptions */
 	VacOptTernaryValue truncate;	/* Truncate empty pages at the end,
 									 * default value depends on reloptions */
+	bool auto_stats;      /* invoked via automatic statistic collection */
 } VacuumParams;
 
 typedef struct
@@ -268,7 +269,7 @@ extern int	vacuum_multixact_freeze_table_age;
 
 
 /* in commands/vacuum.c */
-extern void ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel);
+extern void ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_stats);
 extern void vacuum(List *relations, VacuumParams *params,
 				   BufferAccessStrategy bstrategy, bool isTopLevel);
 extern void vac_open_indexes(Relation relation, LOCKMODE lockmode,

--- a/src/include/utils/guc_tables.h
+++ b/src/include/utils/guc_tables.h
@@ -96,8 +96,7 @@ enum config_group
 	LOGGING_WHAT,
 	PROCESS_TITLE,
 	STATS,
-
-    STATS_ANALYZE,                      /*CDB*/
+	STATS_ANALYZE,                      /*CDB*/
 	STATS_MONITORING,
 	STATS_COLLECTOR,
 	AUTOVACUUM,

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -157,6 +157,7 @@
 		"gp_autostats_mode",
 		"gp_autostats_mode_in_functions",
 		"gp_autostats_on_change_threshold",
+		"gp_autostats_allow_nonowner",
 		"gp_cached_segworkers_threshold",
 		"gp_command_count",
 		"gp_connection_send_timeout",

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -1,0 +1,160 @@
+-- start_matchsubs
+-- m/^LOG:  In mode on_change, command INSERT.* modifying 10 tuples caused Auto-ANALYZE./
+-- s/\(dboid,tableoid\)=\(\d+,\d+\)/\(dboid,tableoid\)=\(XXXXX,XXXXX\)/
+-- m/LOG:  Auto-stats did not issue ANALYZE on tableoid \d+ since the user does not have table-owner level permissions./
+-- s/tableoid \d+/tableoid XXXXX/
+-- end_matchsubs
+-- start_matchignore
+-- m/^LOG: .*Feature not supported: Non-default collation./
+-- m/^LOG:.*ERROR,"PG exception raised"/
+-- end_matchignore
+set gp_autostats_mode=on_change;
+set gp_autostats_on_change_threshold=9;
+set log_autostats=on;
+set client_min_messages=log;
+drop table if exists autostats_test;
+LOG:  statement: drop table if exists autostats_test;
+NOTICE:  table "autostats_test" does not exist, skipping
+create table autostats_test (a INTEGER);
+LOG:  statement: create table autostats_test (a INTEGER);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop user if exists autostats_nonowner;
+LOG:  statement: drop user if exists autostats_nonowner;
+NOTICE:  role "autostats_nonowner" does not exist, skipping
+create user autostats_nonowner;
+LOG:  statement: create user autostats_nonowner;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+-- Make sure rel_tuples starts at zero
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |         0
+(1 row)
+
+-- Try it with gp_autostats_allow_nonowner GUC enabled, but as a non-owner
+-- without INSERT permission.  Should fail with permission denied, without
+-- triggering autostats collection
+set gp_autostats_allow_nonowner=on;
+LOG:  statement: set gp_autostats_allow_nonowner=on;
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+insert into autostats_test select generate_series(1, 10);
+LOG:  statement: insert into autostats_test select generate_series(1, 10);
+LOG:  An exception was encountered during the execution of statement: insert into autostats_test select generate_series(1, 10);
+ERROR:  permission denied for table autostats_test
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |         0
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- Try it with GUC enabled, after granting INSERT, stats should update to 10
+grant insert on table autostats_test to autostats_nonowner;
+LOG:  statement: grant insert on table autostats_test to autostats_nonowner;
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+insert into autostats_test select generate_series(11, 20);
+LOG:  statement: insert into autostats_test select generate_series(11, 20);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        10
+(1 row)
+
+-- Try running analyze manually as nonowner, should fail
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+analyze autostats_test;
+LOG:  statement: analyze autostats_test;
+WARNING:  skipping "autostats_test" --- only table or database owner can analyze it
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        10
+(1 row)
+
+-- Try to disable allow_nonowner GUC as ordinary user, should fail
+set gp_autostats_allow_nonowner=off;
+LOG:  statement: set gp_autostats_allow_nonowner=off;
+LOG:  An exception was encountered during the execution of statement: set gp_autostats_allow_nonowner=off;
+ERROR:  permission denied to set parameter "gp_autostats_allow_nonowner"
+show gp_autostats_allow_nonowner;
+LOG:  statement: show gp_autostats_allow_nonowner;
+ gp_autostats_allow_nonowner 
+-----------------------------
+ on
+(1 row)
+
+-- GUC should still be enabled, stats should update to 20
+insert into autostats_test select generate_series(21, 30);
+LOG:  statement: insert into autostats_test select generate_series(21, 30);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        20
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- Change allow_nonowner GUC as admin, should work
+set gp_autostats_allow_nonowner=off;
+LOG:  statement: set gp_autostats_allow_nonowner=off;
+show gp_autostats_allow_nonowner;
+LOG:  statement: show gp_autostats_allow_nonowner;
+ gp_autostats_allow_nonowner 
+-----------------------------
+ off
+(1 row)
+
+-- GUC should be disabled, stats should not update
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+insert into autostats_test select generate_series(31, 40);
+LOG:  statement: insert into autostats_test select generate_series(31, 40);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+LOG:  Auto-stats did not issue ANALYZE on tableoid XXXXX since the user does not have table-owner level permissions.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        20
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- Try to enable allow_nonowner GUC as ordinary user, should fail
+-- GUC should still be disabled, stats should update from 20 to 40
+insert into autostats_test select generate_series(21, 30);
+LOG:  statement: insert into autostats_test select generate_series(21, 30);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        40
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- After 4 successful inserts, final row count should also be 40
+select COUNT(*) from autostats_test;
+LOG:  statement: select COUNT(*) from autostats_test;
+ count 
+-------
+    40
+(1 row)
+
+drop table if exists autostats_test;
+LOG:  statement: drop table if exists autostats_test;
+drop user autostats_nonowner;
+LOG:  statement: drop user autostats_nonowner;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -225,7 +225,7 @@ test: uao_ddl/alter_drop_allcol_row uao_ddl/alter_drop_allcol_column uao_ddl/alt
 test: uao_dml/uao_dml_cursor_row uao_dml/uao_dml_select_row uao_dml/uao_dml_cursor_column uao_dml/uao_dml_select_column
 
 
-# diable autovacuum for the test
+# disable autovacuum for the test
 test: disable_autovacuum
 # Run uao[cs]_catalog_tables separately. They run VACUUM FULL on
 # append-optimized tables and assume that no AWAITING_DROP segfiles exist at
@@ -249,6 +249,8 @@ test: vacuum_full_heap
 test: vacuum_full_heap_bitmapindex
 # Check for shmem leak for instrumentation slots
 test: instr_in_shmem_verify
+# check autostats
+test: autostats
 test: enable_autovacuum
 
 test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics

--- a/src/test/regress/sql/autostats.sql
+++ b/src/test/regress/sql/autostats.sql
@@ -1,0 +1,74 @@
+-- start_matchsubs
+-- m/^LOG:  In mode on_change, command INSERT.* modifying 10 tuples caused Auto-ANALYZE./
+-- s/\(dboid,tableoid\)=\(\d+,\d+\)/\(dboid,tableoid\)=\(XXXXX,XXXXX\)/
+-- m/LOG:  Auto-stats did not issue ANALYZE on tableoid \d+ since the user does not have table-owner level permissions./
+-- s/tableoid \d+/tableoid XXXXX/
+-- end_matchsubs
+-- start_matchignore
+-- m/^LOG: .*Feature not supported: Non-default collation./
+-- m/^LOG:.*ERROR,"PG exception raised"/
+-- end_matchignore
+set gp_autostats_mode=on_change;
+set gp_autostats_on_change_threshold=9;
+set log_autostats=on;
+set client_min_messages=log;
+
+drop table if exists autostats_test;
+create table autostats_test (a INTEGER);
+drop user if exists autostats_nonowner;
+create user autostats_nonowner;
+
+-- Make sure rel_tuples starts at zero
+select relname, reltuples from pg_class where relname='autostats_test';
+
+-- Try it with gp_autostats_allow_nonowner GUC enabled, but as a non-owner
+-- without INSERT permission.  Should fail with permission denied, without
+-- triggering autostats collection
+set gp_autostats_allow_nonowner=on;
+set role=autostats_nonowner;
+insert into autostats_test select generate_series(1, 10);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- Try it with GUC enabled, after granting INSERT, stats should update to 10
+grant insert on table autostats_test to autostats_nonowner;
+set role=autostats_nonowner;
+insert into autostats_test select generate_series(11, 20);
+select relname, reltuples from pg_class where relname='autostats_test';
+
+-- Try running analyze manually as nonowner, should fail
+set role=autostats_nonowner;
+analyze autostats_test;
+select relname, reltuples from pg_class where relname='autostats_test';
+
+-- Try to disable allow_nonowner GUC as ordinary user, should fail
+set gp_autostats_allow_nonowner=off;
+show gp_autostats_allow_nonowner;
+
+-- GUC should still be enabled, stats should update to 20
+insert into autostats_test select generate_series(21, 30);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- Change allow_nonowner GUC as admin, should work
+set gp_autostats_allow_nonowner=off;
+show gp_autostats_allow_nonowner;
+
+-- GUC should be disabled, stats should not update
+set role=autostats_nonowner;
+insert into autostats_test select generate_series(31, 40);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- Try to enable allow_nonowner GUC as ordinary user, should fail
+
+-- GUC should still be disabled, stats should update from 20 to 40
+insert into autostats_test select generate_series(21, 30);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- After 4 successful inserts, final row count should also be 40
+select COUNT(*) from autostats_test;
+
+drop table if exists autostats_test;
+drop user autostats_nonowner;


### PR DESCRIPTION
This PR adds the ability to allow autostats to be triggered whenever a table is modified by any user, rather than only when it's modified by the table's owner.

Note that autostats can only be triggered *after* a user has successfully modified the table, ie they must have some kind of write access to the table (INSERT, DELETE, or UPDATE)... so this change will not affect any abilities of users who have no access to the table or only read-only access.  Nevertheless, `gp_autostats_allow_nonowner` GUC is introduced as a way of disabling this behavior in case there is any existing SQL code whose performance depends on table statistics not being up to date after modification by a non-owner.

Only the superuser may modify this GUC.

Existing behavior is maintained when an ANALYZE command is issued explicitly by the user:  non-owners may trigger it by writing to the table, but still will not be allowed to explicitly run ANALYZE, regardless of the GUC setting.