### PR TITLE
FIX wrong variable name

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -488,7 +488,7 @@ smgrdounlink(SMgrRelation reln, bool isRedo)
 	 * xact.
 	 */
 	for (forknum = 0; forknum <= MAX_FORKNUM; forknum++)
-        smgrsw[which].smgr_unlink(rnode, InvalidForkNumber, isRedo);
+        smgrsw[which].smgr_unlink(rnode, forknum, isRedo);
 }
 
 /*


### PR DESCRIPTION
  FIX wrong variable name:
 `InvalidForkNumber` to `forknum`

