### PR TITLE
make gpload code same with 6x, add feature max_retries

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1850,15 +1850,12 @@ class gpload:
                 self.setup_connection(recurse)
             elif errorMessage.find("Connection timed out") != -1 and self.options.max_retries != 0:
                 recurse += 1
-                if self.options.max_retries > 0:
-                    if recurse > self.options.max_retries: # retry failed
-                        self.log(self.ERROR, "could not connect to database after retry %d times, " \
-                            "error message:\n %s" % (recurse-1, errorMessage))
-                    else:
-                        self.log(self.INFO, "retry to connect to database, %d of %d times" % (recurse,
-                            self.options.max_retries))
+                if self.options.max_retries > 0 and recurse > self.options.max_retries: # retry failed
+                    self.log(self.ERROR, "could not connect to database after retry %d times, " \
+                         "error message:\n %s" % (recurse-1, errorMessage))
                 else: # max_retries < 0, retry forever
-                    self.log(self.INFO, "retry to connect to database.")
+                    self.log(self.INFO, "retry to connect to database, %d of %d times" % (recurse,
+                        self.options.max_retries))
                 self.setup_connection(recurse)
             else:
                 self.log(self.ERROR, "could not connect to database: %s. Is " \

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -18,6 +18,7 @@ Options:
     -l logfile: log output to logfile
     --no_auto_trans: do not wrap gpload in transaction
     --gpfdist_timeout timeout: gpfdist timeout value
+    --max_retries retry_times: max retry times on gpdb connection timed out. 0 means disabled, -1 means forever
     --version: print version number and exit
     -?: help
 '''
@@ -1158,6 +1159,7 @@ class gpload:
         self.startTimestamp = time.time()
         self.error_table = False
         self.gpdb_version = ""
+        self.options.max_retries = 0
         self.support_cusfmt = 0
         seenv = False
         seenq = False
@@ -1180,7 +1182,7 @@ class gpload:
                     if argv[0]=='-h':
                         self.options.h = argv[1]
                         argv = argv[2:]
-                    if argv[0]=='--gpfdist_timeout':
+                    elif argv[0]=='--gpfdist_timeout':
                         self.options.gpfdist_timeout = argv[1]
                         argv = argv[2:]
                     elif argv[0]=='-p':
@@ -1218,6 +1220,9 @@ class gpload:
                         argv = argv[2:]
                     elif argv[0]=='-f':
                         configFilename = argv[1]
+                        argv = argv[2:]
+                    elif argv[0]=='--max_retries':
+                        self.options.max_retries = int(argv[1])
                         argv = argv[2:]
                     elif argv[0]=='--no_auto_trans':
                         self.options.no_auto_trans = True
@@ -1843,6 +1848,18 @@ class gpload:
                 if recurse > 10:
                     self.log(self.ERROR, "too many login attempt failures")
                 self.setup_connection(recurse)
+            elif errorMessage.find("Connection timed out") != -1 and self.options.max_retries != 0:
+                recurse += 1
+                if self.options.max_retries > 0:
+                    if recurse > self.options.max_retries: # retry failed
+                        self.log(self.ERROR, "could not connect to database after retry %d times, " \
+                            "error message:\n %s" % (recurse-1, errorMessage))
+                    else:
+                        self.log(self.INFO, "retry to connect to database, %d of %d times" % (recurse,
+                            self.options.max_retries))
+                else: # max_retries < 0, retry forever
+                    self.log(self.INFO, "retry to connect to database.")
+                self.setup_connection(recurse)
             else:
                 self.log(self.ERROR, "could not connect to database: %s. Is " \
                     "the Greenplum Database running on port %i?" % (errorMessage,
@@ -1866,7 +1883,7 @@ class gpload:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
                     for name, typ, mapto, hasseq in self.into_columns:
-                        if sqlIdentifierCompare(name, key):
+                        if sqlIdentifierCompare(name,key):
                             d[key] = typ
                             break
 
@@ -2518,7 +2535,19 @@ class gpload:
         try:
             self.db.query(sql.encode('utf-8'))
         except Exception, e:
-            self.log(self.ERROR, 'could not run SQL "%s": %s' % (sql, unicode(e)))
+            get_standard_conforming_strings = 'show standard_conforming_strings;'
+            try:
+                scs = self.db.query(get_standard_conforming_strings.encode('utf-8')).getresult()
+                if scs[0][0] == 'off':
+                    self.log(self.ERROR, 'could not run SQL "%s": %s ' % (sql, unicode(e)) +
+                    "standard_conforming_strings is set to 'off', please set it to 'on' and try again \n")
+                else:
+                    self.log(self.ERROR, 'could not run SQL "%s": %s' % (sql, unicode(e)))
+            except Exception, ee:
+                self.log(self.ERROR, 'could not run SQL "%s": %s ' % (sql, unicode(e)) +
+                "could not get standard_conforming_strings, %s " % unicode(ee) +
+                "if standard_conforming_strings is set to 'off', please set it to 'on' and try again \n"
+                )
 
         # set up to drop the external table at the end of operation, unless user
         # specified the 'reuse_tables' option, in which case we don't drop
@@ -2548,7 +2577,7 @@ class gpload:
         target_columns = []
         for column in self.into_columns:
             if column[2]:
-                target_columns.append([column[0], column[1]])
+                target_columns.append([quote_unident(column[0]), column[1]])
 
         if self.reuse_tables == True:
             is_temp_table = ''
@@ -2556,7 +2585,7 @@ class gpload:
 
             # create a string from all reuse conditions for staging tables and ancode it
             conditions_str = self.get_staging_conditions_string(target_table_name, target_columns, distcols)
-            encoding_conditions = hashlib.md5(conditions_str).hexdigest()
+            encoding_conditions = hashlib.md5(conditions_str.encode('utf-8')).hexdigest()
 					
             sql = self.get_reuse_staging_table_query(encoding_conditions)
             resultList = self.db.query(sql.encode('utf-8')).getresult()
@@ -2583,7 +2612,7 @@ class gpload:
         # MPP-14667 - self.reuse_tables should change one, and only one, aspect of how we build the following table,
         # and that is, whether it's a temp table or not. In other words, is_temp_table = '' iff self.reuse_tables == True.
         sql = 'CREATE %sTABLE %s ' % (is_temp_table, self.staging_table_name)
-        cols = map(lambda a:'%s %s' % (a[0], a[1]), target_columns)
+        cols = map(lambda a:'"%s" %s' % (a[0], a[1]), target_columns)
         sql += "(%s)" % ','.join(cols)
         sql += " DISTRIBUTED BY (%s)" % ', '.join(distcols)
         self.log(self.LOG, sql)
@@ -2821,7 +2850,7 @@ class gpload:
         match = self.map_stuff('gpload:output:match_columns',lambda x,y:'into_table.%s=from_table.%s'%(x,y),0)
         matchColumns = self.getconfig('gpload:output:match_columns',list)
 		
-        cols = filter(lambda a:a[2] != None, self.into_columns)				
+        cols = filter(lambda a:a[2] != None, self.into_columns)
         sql = 'INSERT INTO %s ' % self.get_qualified_tablename()
         sql += '(%s) ' % ','.join(map(lambda a:a[0], cols))
         sql += '(SELECT %s ' % ','.join(map(lambda a:'from_table.%s' % a[0], cols))

--- a/gpMgmt/bin/gpload_test/gpload2/query37.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query37.ans
@@ -1,22 +1,26 @@
-2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
-2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
-2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:52:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7
-2018-11-05 22:52:11|ERROR|could not run SQL "create external table ext_gpload_reusable_601e34fe_e10a_11e8_b2e8_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2021-09-15 08:14:08|INFO|gpload session started 2021-09-15 08:14:08
+2021-09-15 08:14:08|INFO|setting schema 'public' for table 'texttable'
+2021-09-15 08:14:08|INFO|started gpfdist -p 8081 -P 8082 -f "/tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-09-15 08:14:08|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-09-15 08:14:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_e691401a_15fc_11ec_aa58_c6df035ebc1f
+2021-09-15 08:14:08|ERROR|could not run SQL "create external table ext_gpload_reusable_e691401a_15fc_11ec_aa58_c6df035ebc1f("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.254.0.82:8081//tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
-2018-11-05 22:52:11|INFO|rows Inserted          = 0
-2018-11-05 22:52:11|INFO|rows Updated           = 0
-2018-11-05 22:52:11|INFO|data formatting errors = 0
-2018-11-05 22:52:11|INFO|gpload failed
-2018-11-05 22:52:11|INFO|gpload session started 2018-11-05 22:52:11
-2018-11-05 22:52:11|INFO|setting schema 'public' for table 'texttable'
-2018-11-05 22:52:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2018-11-05 22:52:11|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2018-11-05 22:52:12|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7
-2018-11-05 22:52:12|ERROR|could not run SQL "create external table ext_gpload_reusable_6067ad3c_e10a_11e8_b378_00505698a2d7("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2021-09-15 08:14:08|INFO|rows Inserted          = 0
+2021-09-15 08:14:08|INFO|rows Updated           = 0
+2021-09-15 08:14:08|INFO|data formatting errors = 0
+2021-09-15 08:14:08|INFO|gpload failed
+2021-09-15 08:14:08|INFO|gpload session started 2021-09-15 08:14:08
+2021-09-15 08:14:09|INFO|setting schema 'public' for table 'texttable'
+2021-09-15 08:14:09|INFO|started gpfdist -p 8081 -P 8082 -f "/tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-09-15 08:14:09|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-09-15 08:14:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_e6c1fade_15fc_11ec_82da_c6df035ebc1f
+2021-09-15 08:14:09|ERROR|could not run SQL "create external table ext_gpload_reusable_e6c1fade_15fc_11ec_82da_c6df035ebc1f("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.254.0.82:8081//tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter '|' null '\N' escape '\') encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
-2018-11-05 22:52:12|INFO|rows Inserted          = 0
-2018-11-05 22:52:12|INFO|rows Updated           = 0
-2018-11-05 22:52:12|INFO|data formatting errors = 0
-2018-11-05 22:52:12|INFO|gpload failed
+2021-09-15 08:14:09|INFO|rows Inserted          = 0
+2021-09-15 08:14:09|INFO|rows Updated           = 0
+2021-09-15 08:14:09|INFO|data formatting errors = 0
+2021-09-15 08:14:09|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query40.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query40.ans
@@ -1,51 +1,55 @@
-2021-08-18 10:35:48|INFO|gpload session started 2021-08-18 10:35:48
-2021-08-18 10:35:48|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-18 10:35:48|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-08-18 10:35:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ff737544_ffcc_11eb_a0d2_0050569e5d5e
-2021-08-18 10:35:48|ERROR|could not run SQL "create external table ext_gpload_reusable_ff737544_ffcc_11eb_a0d2_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
-LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+2021-09-15 08:14:13|INFO|gpload session started 2021-09-15 08:14:13
+2021-09-15 08:14:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-09-15 08:14:13|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-09-15 08:14:13|INFO|did not find an external table to reuse. creating ext_gpload_reusable_e98b1aa2_15fc_11ec_af50_c6df035ebc1f
+2021-09-15 08:14:13|ERROR|could not run SQL "create external table ext_gpload_reusable_e98b1aa2_15fc_11ec_af50_c6df035ebc1f("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8'
                                                                  ^
+ standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
-2021-08-18 10:35:48|INFO|rows Inserted          = 0
-2021-08-18 10:35:48|INFO|rows Updated           = 0
-2021-08-18 10:35:48|INFO|data formatting errors = 0
-2021-08-18 10:35:48|INFO|gpload failed
-2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
-2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-08-18 10:35:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ff88c8d6_ffcc_11eb_accb_0050569e5d5e
-2021-08-18 10:35:49|ERROR|could not run SQL "create external table ext_gpload_reusable_ff88c8d6_ffcc_11eb_accb_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
-LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+2021-09-15 08:14:13|INFO|rows Inserted          = 0
+2021-09-15 08:14:13|INFO|rows Updated           = 0
+2021-09-15 08:14:13|INFO|data formatting errors = 0
+2021-09-15 08:14:13|INFO|gpload failed
+2021-09-15 08:14:13|INFO|gpload session started 2021-09-15 08:14:13
+2021-09-15 08:14:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-09-15 08:14:14|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-09-15 08:14:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_e9b85990_15fc_11ec_bbbc_c6df035ebc1f
+2021-09-15 08:14:14|ERROR|could not run SQL "create external table ext_gpload_reusable_e9b85990_15fc_11ec_bbbc_c6df035ebc1f("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8'
                                                                  ^
+ standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
-2021-08-18 10:35:49|INFO|rows Inserted          = 0
-2021-08-18 10:35:49|INFO|rows Updated           = 0
-2021-08-18 10:35:49|INFO|data formatting errors = 0
-2021-08-18 10:35:49|INFO|gpload failed
-2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
-2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-18 10:35:49|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
-2021-08-18 10:35:49|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
-2021-08-18 10:35:49|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ff9d47fc_ffcc_11eb_b9ee_0050569e5d5e
-2021-08-18 10:35:49|ERROR|could not run SQL "create external table ext_gpload_reusable_ff9d47fc_ffcc_11eb_b9ee_0050569e5d5e("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
-LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+2021-09-15 08:14:14|INFO|rows Inserted          = 0
+2021-09-15 08:14:14|INFO|rows Updated           = 0
+2021-09-15 08:14:14|INFO|data formatting errors = 0
+2021-09-15 08:14:14|INFO|gpload failed
+2021-09-15 08:14:14|INFO|gpload session started 2021-09-15 08:14:14
+2021-09-15 08:14:14|INFO|setting schema 'public' for table 'testspecialchar'
+2021-09-15 08:14:14|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
+2021-09-15 08:14:14|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-09-15 08:14:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_e9e5fe40_15fc_11ec_aecc_c6df035ebc1f
+2021-09-15 08:14:14|ERROR|could not run SQL "create external table ext_gpload_reusable_e9e5fe40_15fc_11ec_aecc_c6df035ebc1f("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8'
                                                                  ^
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
-2021-08-18 10:35:49|INFO|rows Inserted          = 0
-2021-08-18 10:35:49|INFO|rows Updated           = 0
-2021-08-18 10:35:49|INFO|data formatting errors = 0
-2021-08-18 10:35:49|INFO|gpload failed
-2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
-2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-18 10:35:49|ERROR|no mapping for input column "'Field1'" to output table
-2021-08-18 10:35:49|INFO|rows Inserted          = 0
-2021-08-18 10:35:49|INFO|rows Updated           = 0
-2021-08-18 10:35:49|INFO|data formatting errors = 0
-2021-08-18 10:35:49|INFO|gpload failed
-2021-08-18 10:35:49|INFO|gpload session started 2021-08-18 10:35:49
-2021-08-18 10:35:49|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-18 10:35:49|ERROR|no mapping for input column "Field1" to output table
-2021-08-18 10:35:49|INFO|rows Inserted          = 0
-2021-08-18 10:35:49|INFO|rows Updated           = 0
-2021-08-18 10:35:49|INFO|data formatting errors = 0
-2021-08-18 10:35:49|INFO|gpload failed
+2021-09-15 08:14:14|INFO|rows Inserted          = 0
+2021-09-15 08:14:14|INFO|rows Updated           = 0
+2021-09-15 08:14:14|INFO|data formatting errors = 0
+2021-09-15 08:14:14|INFO|gpload failed
+2021-09-15 08:14:14|INFO|gpload session started 2021-09-15 08:14:14
+2021-09-15 08:14:14|INFO|setting schema 'public' for table 'testspecialchar'
+2021-09-15 08:14:14|ERROR|no mapping for input column "'Field1'" to output table
+2021-09-15 08:14:14|INFO|rows Inserted          = 0
+2021-09-15 08:14:14|INFO|rows Updated           = 0
+2021-09-15 08:14:14|INFO|data formatting errors = 0
+2021-09-15 08:14:14|INFO|gpload failed
+2021-09-15 08:14:14|INFO|gpload session started 2021-09-15 08:14:14
+2021-09-15 08:14:14|INFO|setting schema 'public' for table 'testspecialchar'
+2021-09-15 08:14:14|ERROR|no mapping for input column "Field1" to output table
+2021-09-15 08:14:14|INFO|rows Inserted          = 0
+2021-09-15 08:14:14|INFO|rows Updated           = 0
+2021-09-15 08:14:14|INFO|data formatting errors = 0
+2021-09-15 08:14:14|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query44.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query44.ans
@@ -1,0 +1,12 @@
+2021-09-23 22:58:25|INFO|gpload session started 2021-09-23 22:58:25
+2021-09-23 23:00:32|INFO|retry to connect to database, 1 of 2 times
+2021-09-23 23:02:39|INFO|retry to connect to database, 2 of 2 times
+2021-09-23 23:04:46|ERROR|could not connect to database after retry 2 times, error message:
+ could not connect to server: Connection timed out
+	Is the server running on host "1.2.3.4" and accepting
+	TCP/IP connections on port 15432?
+
+2021-09-23 23:04:46|INFO|rows Inserted          = 0
+2021-09-23 23:04:46|INFO|rows Updated           = 0
+2021-09-23 23:04:46|INFO|data formatting errors = 0
+2021-09-23 23:04:46|INFO|gpload failed


### PR DESCRIPTION
add max_retries feature
add more information of standard_conforming_strings when creating staging table sql failed
the logic of recognizing gpdb version still remains unchanged, which is different from 6X but right.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
