### PR TITLE
gprecoverseg: generate backout scripts to revert catalog changes

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -102,6 +102,8 @@ function install_python_requirements_on_single_host() {
 
     export PIP_CACHE_DIR=${PWD}/pip-cache-dir
     pip3 --retries 10 install -r ${requirements_txt}
+	# HACK; DELETE BEFORE MERGING
+	pip3 --retries 10 install coverage
 }
 
 function install_python_requirements_on_multi_host() {
@@ -117,6 +119,8 @@ function install_python_requirements_on_multi_host() {
     while read -r host; do
         scp ${requirements_txt} "$host":/tmp/requirements.txt
         ssh $host PIP_CACHE_DIR=${PIP_CACHE_DIR} pip3 --retries 10 install --user -r /tmp/requirements.txt
+        # HACK; DELETE BEFORE MERGING
+        ssh $host PIP_CACHE_DIR=${PIP_CACHE_DIR} pip3 --retries 10 install --user coverage
     done </tmp/hostfile_all
 }
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -55,6 +55,7 @@ class BuildMirrorsTestCase(GpTestCase):
         buildMirrorSegs_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
         buildMirrorSegs_obj._get_running_postgres_segments = Mock()
         configurationInterface.getConfigurationProvider = Mock()
+        configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.return_value = {} # mock backout_map
 
     def _common_asserts_with_stop_and_logger(self, buildMirrorSegs_obj, expected_logger_msg, expected_segs_to_stop,
                                              expected_segs_to_start, expected_segs_to_markdown, expected_segs_to_update,

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+
+from gppylib.gparray import GpArray, Segment
+from gppylib.mainUtils import ExceptionNoStackTraceNeeded
+from gppylib.system.configurationImplGpdb import GpConfigurationProviderUsingGpdbCatalog
+from mock import MagicMock, Mock, mock_open, patch
+
+class ConfigurationImplGpdbTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.configProvider = GpConfigurationProviderUsingGpdbCatalog()
+        self.conn = Mock()
+
+        self.coordinator = Segment.initFromString("1|-1|p|p|s|u|cdw|cdw|5432|/data/coordinator")
+        self.primary0 = Segment.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+        self.primary1 = Segment.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|/data/primary1")
+        self.mirror0 = Segment.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+        self.mirror1 = Segment.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
+        segments = [self.coordinator,self.primary0,self.primary1,self.mirror0,self.mirror1]
+        self.gpArray = GpArray(segments)
+        self.gpArray.setSegmentsAsLoadedFromDb(segments)
+
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemoveMirror(self, mockInsert, mockFetch):
+        addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.mirror0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'p', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: removed mirror segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[2])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemovePrimary(self, mockInsert, mockFetch):
+        addSQL = self.configProvider.updateSystemConfigRemovePrimary(self.conn, self.gpArray, self.primary0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(2::int2, 0::int2, 'm', 'm', 'n', 'd', 40000, 'sdw1', 'sdw1', '/data/primary0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment(2::int2)")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  2,\n  'foo: removed primary segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigAddMirror(self, mockInsert, mockFetch):
+        removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: inserted mirror segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', side_effect=[ [2], [0] ])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigAddPrimary(self, mockInsert, mockFetch):
+        removeSQL = self.configProvider.updateSystemConfigAddPrimary(self.conn, self.gpArray, self.primary0, "foo", {0: self.mirror0})
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment_mirror(0::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        mockFetch.assert_any_call(self.conn, "SELECT content FROM pg_catalog.gp_segment_configuration WHERE dbId = 2")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(2::int2, 0::int2, 'p', 'p', 'n', 'u', 40000, 'sdw1', 'sdw1', '/data/primary0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  2,\n  'foo: inserted primary segment configuration with contentid 0'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemoveAddMirror(self, mockInsert, mockFetch):
+        addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'p', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2)")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: inserted segment configuration for full recovery or original dbid 4'\n)", 1)
+

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -19,7 +19,7 @@
 from gppylib.mainUtils import *
 
 from optparse import OptionGroup
-import os, sys, signal, time
+import glob, os, sys, signal, shutil, time
 from contextlib import closing
 
 from gppylib import gparray, gplog, userinput, utils
@@ -351,6 +351,8 @@ class GpRecoverSegmentProgram:
                 sys.exit(1)
 
             self.trigger_fts_probe(port=gpEnv.getCoordinatorPort())
+
+            mirrorBuilder.remove_backout_directory()
 
             self.logger.info("********************************")
             self.logger.info("Segments successfully recovered.")

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -8,6 +8,7 @@ This file defines the interface that can be used to fetch and update system
 configuration information.
 """
 import os, copy
+from collections import defaultdict
 
 from gppylib.gplog import *
 from gppylib.utils import checkNotNone
@@ -108,25 +109,39 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         for seg in update.mirror_to_add:
             mirror_map[ seg.getSegmentContentId() ] = seg
 
+        # create a map by dbid in which to put backout SQL statements
+        backout_map = defaultdict(list)
+
         # remove mirror segments (e.g. for gpexpand rollback)
         for seg in update.mirror_to_remove:
-            self.__updateSystemConfigRemoveMirror(conn, seg, textForConfigTable)
+            addSQL = self.updateSystemConfigRemoveMirror(conn, gpArray, seg, textForConfigTable)
+            backout_map[seg.getSegmentDbId()].append(addSQL)
+            backout_map[seg.getSegmentDbId()].append(self.getPeerNotInSyncSQL(gpArray, seg))
 
         # remove primary segments (e.g for gpexpand rollback)
         for seg in update.primary_to_remove:
-            self.__updateSystemConfigRemovePrimary(conn, seg, textForConfigTable)
+            addSQL = self.updateSystemConfigRemovePrimary(gpArray, conn, seg, textForConfigTable)
+            backout_map[seg.getSegmentDbId()].append(addSQL)
+            backout_map[seg.getSegmentDbId()].append(self.getPeerNotInSyncSQL(gpArray, seg))
 
         # add new primary segments
         for seg in update.primary_to_add:
-            self.__updateSystemConfigAddPrimary(conn, gpArray, seg, textForConfigTable, mirror_map)
+            removeSQL = self.updateSystemConfigAddPrimary(conn, gpArray, seg, textForConfigTable, mirror_map)
+            backout_map[seg.getSegmentDbId()].append(removeSQL)
+            backout_map[seg.getSegmentDbId()].append(self.getPeerNotInSyncSQL(gpArray, seg))
 
         # add new mirror segments
         for seg in update.mirror_to_add:
-            self.__updateSystemConfigAddMirror(conn, gpArray, seg, textForConfigTable)
+            removeSQL = self.updateSystemConfigAddMirror(conn, gpArray, seg, textForConfigTable)
+            backout_map[seg.getSegmentDbId()].append(removeSQL)
+            backout_map[seg.getSegmentDbId()].append(self.getPeerNotInSyncSQL(gpArray, seg))
 
         # remove and add mirror segments necessitated by catalog attribute update
         for seg in update.mirror_to_remove_and_add:
-            self.__updateSystemConfigRemoveAddMirror(conn, gpArray, seg, textForConfigTable)
+            addSQL, removeSQL = self.updateSystemConfigRemoveAddMirror(conn, gpArray, seg, textForConfigTable)
+            backout_map[seg.getSegmentDbId()].append(removeSQL)
+            backout_map[seg.getSegmentDbId()].append(addSQL)
+            backout_map[seg.getSegmentDbId()].append(self.getPeerNotInSyncSQL(gpArray, seg))
 
         # apply updates to existing segments
         for seg in update.segment_to_update:
@@ -140,30 +155,34 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
 
         gpArray.setSegmentsAsLoadedFromDb([seg.copy() for seg in gpArray.getDbList()])
 
+        return backout_map
 
-    def __updateSystemConfigRemoveMirror(self, conn, seg, textForConfigTable):
+
+    def updateSystemConfigRemoveMirror(self, conn, gpArray, seg, textForConfigTable):
         """
         Remove a mirror segment currently in gp_segment_configuration
         but not present in the goal configuration and record our action
         in gp_configuration_history.
         """
         dbId   = seg.getSegmentDbId()
-        self.__callSegmentRemoveMirror(conn, seg)
+        addSQL = self.__callSegmentRemoveMirror(conn, gpArray, seg)
         self.__insertConfigHistory(conn, dbId, "%s: removed mirror segment configuration" % textForConfigTable)
+        return addSQL
 
 
-    def __updateSystemConfigRemovePrimary(self, conn, seg, textForConfigTable):
+    def updateSystemConfigRemovePrimary(self, conn, gpArray, seg, textForConfigTable):
         """
         Remove a primary segment currently in gp_segment_configuration
         but not present in the goal configuration and record our action
         in gp_configuration_history.
         """
         dbId = seg.getSegmentDbId()
-        self.__callSegmentRemove(conn, seg)
+        addSQL = self.__callSegmentRemove(conn, gpArray, seg)
         self.__insertConfigHistory(conn, dbId, "%s: removed primary segment configuration" % textForConfigTable)
+        return addSQL
 
 
-    def __updateSystemConfigAddPrimary(self, conn, gpArray, seg, textForConfigTable, mirror_map):
+    def updateSystemConfigAddPrimary(self, conn, gpArray, seg, textForConfigTable, mirror_map):
         """
         Add a primary segment specified in our goal configuration but
         which is missing from the current gp_segment_configuration table
@@ -173,14 +192,14 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         mirrorseg = mirror_map.get( seg.getSegmentContentId() )
 
         # add the new segment
-        dbId = self.__callSegmentAdd(conn, gpArray, seg)
+        dbId, removeSQL = self.__callSegmentAdd(conn, gpArray, seg)
 
         # gp_add_segment_primary() will update the mode and status.
 
         # get the newly added segment's content id
-        sql = "select content from pg_catalog.gp_segment_configuration where dbId = %s" % self.__toSqlIntValue(seg.getSegmentDbId())
+        sql = "SELECT content FROM pg_catalog.gp_segment_configuration WHERE dbId = %s" % self.__toSqlIntValue(seg.getSegmentDbId())
         logger.debug(sql)
-        sqlResult = self.__fetchSingleOutputRow(conn, sql)
+        sqlResult = self.fetchSingleOutputRow(conn, sql)
         contentId = int(sqlResult[0])
 
         # Set the new content id for the primary as well the mirror if present.
@@ -189,32 +208,35 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
             mirrorseg.setSegmentContentId(contentId)
 
         self.__insertConfigHistory(conn, dbId, "%s: inserted primary segment configuration with contentid %s" % (textForConfigTable, contentId))
+        return removeSQL
 
 
-    def __updateSystemConfigAddMirror(self, conn, gpArray, seg, textForConfigTable):
+    def updateSystemConfigAddMirror(self, conn, gpArray, seg, textForConfigTable):
         """
         Add a mirror segment specified in our goal configuration but
         which is missing from the current gp_segment_configuration table
         and record our action in gp_configuration_history.
         """
-        dbId = self.__callSegmentAddMirror(conn, gpArray, seg)
+        dbId, removeSQL = self.__callSegmentAddMirror(conn, gpArray, seg)
         self.__insertConfigHistory(conn, dbId, "%s: inserted mirror segment configuration" % textForConfigTable)
+        return removeSQL
 
 
-    def __updateSystemConfigRemoveAddMirror(self, conn, gpArray, seg, textForConfigTable):
+    def updateSystemConfigRemoveAddMirror(self, conn, gpArray, seg, textForConfigTable):
         """
         We've been asked to update the mirror in a manner that require
         it to be removed and then re-added.   Perform the tasks
         and record our action in gp_configuration_history.
         """
         origDbId = seg.getSegmentDbId()
-        self.__callSegmentRemoveMirror(conn, seg)
+        addSQL = self.__callSegmentRemoveMirror(conn, gpArray, seg)
 
-        dbId = self.__callSegmentAddMirror(conn, gpArray, seg)
+        dbId, removeSQL = self.__callSegmentAddMirror(conn, gpArray, seg, removeAndAdd=True)
 
         self.__insertConfigHistory(conn, seg.getSegmentDbId(),
                                    "%s: inserted segment configuration for full recovery or original dbid %s" \
                                    % (textForConfigTable, origDbId))
+        return addSQL, removeSQL
 
 
     def __updateSystemConfigUpdateSegment(self, conn, gpArray, seg, originalSeg, textForConfigTable):
@@ -226,25 +248,63 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
 
         self.__insertConfigHistory(conn, seg.getSegmentDbId(), what % textForConfigTable)
 
-    def __callSegmentRemoveMirror(self, conn, seg):
+    # This is a helper function for creating backout scripts, since we need to use the original segment information,
+    # not the segment information after it has been updated to facilitate recovery.  Not all code paths result in the
+    # segments-as-loaded array being populated, hence the None checks.
+    def __getSegmentAsLoaded(self, gpArray, seg):
+        segments = gpArray.getSegmentsAsLoadedFromDb()
+        if segments is not None:
+            matching_segment = [s for s in segments if s.getSegmentDbId() == seg.getSegmentDbId()]
+            if matching_segment:
+                return matching_segment[0]
+        return seg
+
+    def __getConfigurationHistorySQL(self, dbid):
+        sql = ";\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t%s,\n\t%s\n)" \
+            % (
+                self.__toSqlIntValue(dbid),
+                "'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid %d'" % dbid,
+              )
+        return sql
+
+    #
+    # The below __callSegment[Action][Target] functions return the SQL statements to reverse the changes they make
+    # (not the SQL statements they actually call), to be used to generate backout scripts to reverse the changes later.
+    #
+
+    def __callSegmentRemoveMirror(self, conn, gpArray, seg):
         """
         Call gp_remove_segment_mirror() to remove the mirror.
         """
-        sql = "SELECT gp_remove_segment_mirror(%s::int2)" % (self.__toSqlIntValue(seg.getSegmentContentId()))
+        sql = self.__getSegmentRemoveMirrorSQL(seg)
         logger.debug(sql)
-        result = self.__fetchSingleOutputRow(conn, sql)
+        result = self.fetchSingleOutputRow(conn, sql)
         assert result[0] # must return True
+        return self.__getSegmentAddSQL(self.__getSegmentAsLoaded(gpArray, seg), backout=True)
 
+    def __getSegmentRemoveMirrorSQL(self, seg, backout=False):
+        sql = "SELECT gp_remove_segment_mirror(%s::int2)" % (self.__toSqlIntValue(seg.getSegmentContentId()))
+        if backout:
+            sql += self.__getConfigurationHistorySQL(seg.getSegmentDbId())
+        return sql
 
-    def __callSegmentRemove(self, conn, seg):
+    def __callSegmentRemove(self, conn, gpArray, seg):
         """
         Call gp_remove_segment() to remove the primary.
         """
-        sql = "SELECT gp_remove_segment(%s::int2)" % (self.__toSqlIntValue(seg.getSegmentDbId()))
+        sql = self.__getSegmentRemoveSQL(seg)
         logger.debug(sql)
-        result = self.__fetchSingleOutputRow(conn, sql)
+        result = self.fetchSingleOutputRow(conn, sql)
         assert result[0]
+        return self.__getSegmentAddMirrorSQL(self.__getSegmentAsLoaded(gpArray, seg), backout=True)
 
+    def __getSegmentRemoveSQL(self, seg, backout=False, removeAndAdd=False):
+        sql = "SELECT gp_remove_segment(%s::int2)" % (self.__toSqlIntValue(seg.getSegmentDbId()))
+        # Don't generate a configuration history line in the updateSystemConfigRemoveAddMirror case,
+        # to avoid duplication; the later call to __getSegmentAddSQL will take care of that.
+        if backout and not removeAndAdd:
+            sql += self.__getConfigurationHistorySQL(seg.getSegmentDbId())
+        return sql
 
     def __callSegmentAdd(self, conn, gpArray, seg):
         """
@@ -257,23 +317,32 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         """
         logger.debug('callSegmentAdd %s' % repr(seg))
 
-        sql = "SELECT gp_add_segment(%s::int2, %s::int2, 'p', 'p', 'n', 'u', %s, %s, %s, %s)" \
+        sql = self.__getSegmentAddSQL(seg)
+        logger.debug(sql)
+        sqlResult = self.fetchSingleOutputRow(conn, sql)
+        dbId = int(sqlResult[0])
+        removeSQL = self.__getSegmentRemoveMirrorSQL(self.__getSegmentAsLoaded(gpArray, seg), backout=True)
+        seg.setSegmentDbId(dbId)
+        return dbId, removeSQL
+
+    def __getSegmentAddSQL(self, seg, backout=False):
+        sql = "SELECT gp_add_segment(%s::int2, %s::int2, '%s', '%s', 'n', '%s', %s, %s, %s, %s)" \
             % (
                 self.__toSqlIntValue(seg.getSegmentDbId()),
                 self.__toSqlIntValue(seg.getSegmentContentId()),
+                'm' if backout else 'p',
+                seg.getSegmentPreferredRole(),
+                'd' if backout else 'u',
                 self.__toSqlIntValue(seg.getSegmentPort()),
                 self.__toSqlTextValue(seg.getSegmentHostName()),
                 self.__toSqlTextValue(seg.getSegmentAddress()),
                 self.__toSqlTextValue(seg.getSegmentDataDirectory()),
               )
-        logger.debug(sql)
-        sqlResult = self.__fetchSingleOutputRow(conn, sql)
-        dbId = int(sqlResult[0])
-        seg.setSegmentDbId(dbId)
-        return dbId
+        if backout:
+            sql += self.__getConfigurationHistorySQL(seg.getSegmentDbId())
+        return sql
 
-
-    def __callSegmentAddMirror(self, conn, gpArray, seg):
+    def __callSegmentAddMirror(self, conn, gpArray, seg, removeAndAdd=False):
         """
         Similar to __callSegmentAdd, ideally we should call gp_add_segment_mirror() to add the mirror.
         But chicken-egg problem also exists in mirror case. If we use gp_add_segment_mirror(),
@@ -282,6 +351,16 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         """
         logger.debug('callSegmentAddMirror %s' % repr(seg))
 
+        sql = self.__getSegmentAddMirrorSQL(seg)
+
+        logger.debug(sql)
+        sqlResult = self.fetchSingleOutputRow(conn, sql)
+        dbId = int(sqlResult[0])
+        removeSQL = self.__getSegmentRemoveSQL(self.__getSegmentAsLoaded(gpArray, seg), backout=True, removeAndAdd=removeAndAdd)
+        seg.setSegmentDbId(dbId)
+        return dbId, removeSQL
+
+    def __getSegmentAddMirrorSQL(self, seg, backout=False):
         sql = "SELECT gp_add_segment(%s::int2, %s::int2, 'm', 'm', 'n', 'd', %s, %s, %s, %s)" \
             % (
                 self.__toSqlIntValue(seg.getSegmentDbId()),
@@ -291,13 +370,23 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
                 self.__toSqlTextValue(seg.getSegmentAddress()),
                 self.__toSqlTextValue(seg.getSegmentDataDirectory()),
               )
+        if backout:
+            sql += self.__getConfigurationHistorySQL(seg.getSegmentDbId())
+        return sql
 
-        logger.debug(sql)
-        sqlResult = self.__fetchSingleOutputRow(conn, sql)
-        dbId = int(sqlResult[0])
-        seg.setSegmentDbId(dbId)
-        return dbId
-
+    # This function generates a statement to update the mode of a given segment's peer to
+    # "not in sync", something that is necessary to do for every segment that is added in a
+    # backout script.  The gp_add_segment function sets the added segment's mode to 'n', and
+    # if its peer's mode doesn't match (is still set to 's') when the next query is executed,
+    # this will almost certainly crash the cluster.
+    def getPeerNotInSyncSQL(self, gpArray, seg):
+        peerMap = gpArray.getDbIdToPeerMap()
+        dbid = seg.getSegmentDbId()
+        if dbid in peerMap: # The dbid may not be in the peer map, if e.g. we're getting here from gpexpand, in which case no action is necessary
+            peerSegment = peerMap[dbid]
+            updateStmt = "SET allow_system_table_mods=true;\nUPDATE gp_segment_configuration SET mode = 'n' WHERE dbid = %d;"
+            return updateStmt % peerSegment.getSegmentDbId()
+        return ""
 
     def __updateSegmentModeStatus(self, conn, seg):
         # run an update
@@ -305,12 +394,12 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
             "  SET\n" + \
             "  mode = " + self.__toSqlCharValue(seg.getSegmentMode()) + ",\n" \
             "  status = " + self.__toSqlCharValue(seg.getSegmentStatus()) + "\n" \
-            "WHERE dbid = " + self.__toSqlIntValue(seg.getSegmentDbId())
+            "WHERE dbid = " + self.__toSqlIntValue(seg.getSegmentDbId()) + ";"
         logger.debug(sql)
         dbconn.executeUpdateOrInsert(conn, sql, 1)
 
 
-    def __fetchSingleOutputRow(self, conn, sql, retry=False):
+    def fetchSingleOutputRow(self, conn, sql, retry=False):
         """
         Execute specified SQL command and return what we expect to be a single row.
         Raise an exception when more or fewer than one row is seen and when more

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -84,6 +84,8 @@ class GpRecoversegTestCase(GpTestCase):
             patch('gppylib.commands.base.WorkerPool', return_value=self.pool),
             patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value={}),
             patch('gppylib.gplog.get_default_logger'),
+            patch('gppylib.operations.buildMirrorSegments.GpMirrorListToBuild.initialize_backout_directory'),
+            patch('gppylib.operations.buildMirrorSegments.GpMirrorListToBuild.remove_backout_directory'),
             patch.object(GpMirrorListToBuild, "__init__", return_value=None),
             patch.object(GpMirrorListToBuild, "buildMirrors"),
             patch.object(GpMirrorListToBuild, "getAdditionalWarnings"),

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -536,6 +536,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the information of a "primary" segment on a remote host is saved
           And the gprecoverseg input file "newDirectoryFile" and all backout files are cleaned up
+          And coverage is installed
          When user kills a "primary" process with the saved information
           And user can start transactions
          Then the saved "primary" segment is marked down in config

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -504,3 +504,86 @@ Feature: gprecoverseg tests
         And the tablespace is valid
         And the row count from table "public.before_host_is_down" in "gptest" is verified against the saved data
         And the row count from table "public.after_host_is_down" in "gptest" is verified against the saved data
+
+    @concourse_cluster
+    Scenario: gprecoverseg does not create backout scripts if a segment recovery fails before the catalog is changed
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+         When user kills a "primary" process with the saved information
+          And user can start transactions
+         Then the saved "primary" segment is marked down in config
+
+         When all files in gpAdminLogs directory are deleted
+          And the user asynchronously sets up to end gprecoverseg process when "Recovery type" is printed in the logs
+          And the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of -15
+          And verify there are no gprecoverseg backout files
+          And the gprecoverseg lock directory is removed
+
+         When the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of 0
+         When the user runs "gprecoverseg -r -a"
+         Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg can revert catalog changes after a failed segment recovery
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "newDirectoryFile" and all backout files are cleaned up
+         When user kills a "primary" process with the saved information
+          And user can start transactions
+         Then the saved "primary" segment is marked down in config
+
+         When a gprecoverseg input file "newDirectoryFile" is created with a different data directory for content 0
+          And the user runs "chmod 000 /tmp/newDirectoryFile"
+          And all files in gpAdminLogs directory are deleted
+          #And the user asynchronously sets up to end gprecoverseg process when "Generating configuration backout scripts" is printed in the logs
+          And the user runs "gprecoverseg -i /tmp/newDirectoryFile -a -v"
+          #Then gprecoverseg should return a return code of -15
+          Then gprecoverseg should return a return code of 1
+          And gprecoverseg should print "Recovery Target instance directory   = /tmp/newdir" to stdout
+
+        Given a gprecoverseg backout file exists for content 0
+         When the gprecoverseg backout script is run
+         Then the primary for content 0 should have its original data directory in the system configuration
+          # The backout script should revert the catalog, but still leave the segment down.
+          And verify that mirror on content 0 is down
+          And the gp_configuration_history table should contain a backout entry for the primary segment for content 0
+          And the gprecoverseg lock directory is removed
+          And user can start transactions
+
+         When the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of 0
+         When the user runs "gprecoverseg -r -a"
+         Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg cleans up backout scripts upon successful segment recovery
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "newDirectoryFile" and all backout files are cleaned up
+         When user kills a "primary" process with the saved information
+          And user can start transactions
+         Then the saved "primary" segment is marked down in config
+
+         When a gprecoverseg input file "newDirectoryFile" is created with a different data directory for content 0
+          And the user runs "gprecoverseg -i /tmp/newDirectoryFile -a -v"
+         Then gprecoverseg should return a return code of 0
+         Then gprecoverseg should print "Recovery Target instance directory   = /tmp/newdir" to stdout
+          And gprecoverseg should print "Removing backout directory, as backout scripts are not required after a successful recovery." to stdout
+          And the user runs "gprecoverseg -r -a"
+         Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+          And verify there are no gprecoverseg backout files
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -366,3 +366,12 @@ def impl(context, seg, content):
         num_tuples = dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE dbid = %d AND gp_configuration_history.desc LIKE 'gprecoverseg: segment config for backout%%';" % dbid)
         if num_tuples != 1:
             raise Exception("Expected configuration history table to contain 1 entry for dbid %d, found %d" % (dbid, num_tuples))
+
+# HACK; DELETE BEFORE MERGING
+@given('coverage is installed')
+def impl(context):
+    with dbconn.connect(dbconn.DbURL(), unsetSearchPath=False) as conn:
+        result = dbconn.query(conn, "SELECT distinct(hostname) FROM gp_segment_configuration")
+        hosts = [r[0] for r in result]
+        cmd = Command(name='Install coverage', cmdStr = "gpssh -h %s PIP_CACHE_DIR=${PIP_CACHE_DIR} pip3 --retries 10 install --user coverage" % (" -h ".join(hosts)))
+        cmd.run(validateAfter=True)

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -6,7 +6,7 @@ from gppylib.db import dbconn
 from gppylib.commands import gp
 from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
 from test.behave_utils.utils import *
-import platform
+import glob, os, os.path, platform, shutil
 from behave import given, when, then
 
 
@@ -15,14 +15,23 @@ from behave import given, when, then
 @when('the information of a "{seg}" segment on a remote host is saved')
 @then('the information of a "{seg}" segment on a remote host is saved')
 def impl(context, seg):
-    if seg == "mirror":
-        gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    if seg == "primary":
+        primary_segs = [seg for seg in gparray.getDbList()
+                       if seg.isSegmentPrimary() and seg.getSegmentHostName() != platform.node()]
+        context.remote_pair_primary_segdbId = primary_segs[0].getSegmentDbId()
+        context.remote_pair_primary_segcid = primary_segs[0].getSegmentContentId()
+        context.remote_pair_primary_host = primary_segs[0].getSegmentHostName()
+        context.remote_pair_primary_datadir = primary_segs[0].getSegmentDataDirectory()
+    elif seg == "mirror":
         mirror_segs = [seg for seg in gparray.getDbList()
                        if seg.isSegmentMirror() and seg.getSegmentHostName() != platform.node()]
         context.remote_mirror_segdbId = mirror_segs[0].getSegmentDbId()
         context.remote_mirror_segcid = mirror_segs[0].getSegmentContentId()
         context.remote_mirror_seghost = mirror_segs[0].getSegmentHostName()
         context.remote_mirror_datadir = mirror_segs[0].getSegmentDataDirectory()
+    else:
+        raise Exception('Valid segment types are "primary" and "mirror"')
 
 @given('the information of the corresponding primary segment on a remote host is saved')
 @when('the information of the corresponding primary segment on a remote host is saved')
@@ -54,6 +63,27 @@ def impl(context, seg):
     row_count = getRows('postgres', qry)[0][0]
     if row_count != 1:
         raise Exception('Expected %s segment %s on host %s to be down, but it is running.' % (seg, datadir, seghost))
+
+@then('the saved "{seg}" segment is eventually marked down in config')
+def impl(context, seg):
+    if seg == "mirror":
+        dbid = context.remote_mirror_segdbId
+        seghost = context.remote_mirror_seghost
+        datadir = context.remote_mirror_datadir
+    else:
+        dbid = context.remote_pair_primary_segdbId
+        seghost = context.remote_pair_primary_host
+        datadir = context.remote_pair_primary_datadir
+
+    timeout = 300
+    for i in range(timeout):
+        qry = """select count(*) from gp_segment_configuration where status='d' and hostname='%s' and dbid=%s""" % (seghost, dbid)
+        row_count = getRows('postgres', qry)[0][0]
+        if row_count == 1:
+            return
+        sleep(1)
+
+    raise Exception('Expected %s segment %s on host %s to be down, but it is still running after %d seconds.' % (seg, datadir, seghost, timeout))
 
 @when('user kills a "{seg}" process with the saved information')
 def impl(context, seg):
@@ -248,3 +278,91 @@ def compare_gparray_with_recovered_host(before_gparray, after_gparray, expected_
         msg = "MISMATCH\n\nactual_before:\n{}\n\nexpected_before:\n{}\n\nactual_after:\n{}\n\nexpected_after:\n{}\n".format(
             before_segs, expected_before_segs, after_segs, expected_after_segs)
         raise Exception(msg)
+
+@when('a gprecoverseg input file "{filename}" is created with a different data directory for content {content}')
+def impl(context, filename, content):
+    line = ""
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+        result = dbconn.query(conn, "SELECT port, hostname, datadir FROM gp_segment_configuration WHERE preferred_role='p' AND content = %s;" % content).fetchall()
+        port, hostname, datadir = result[0][0], result[0][1], result[0][2]
+        line = "%s|%s|%s %s|%s|/tmp/newdir" % (hostname, port, datadir, hostname, port)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+def find_backout_dirs():
+    return glob.glob("%s/gpAdminLogs/gprecoverseg_*_backout" % os.path.expanduser("~"))
+
+def get_current_backout_directory():
+    dirs = find_backout_dirs()
+    if len(dirs) == 0:
+        raise Exception("No backout directory found in %s." % cdd)
+    elif len(dirs) > 1:
+        raise Exception("Multiple backout directories found in %s." % cdd)
+    return dirs[0]
+
+@given('a gprecoverseg backout file exists for content {content}')
+def impl(context, content):
+    backout_dir = get_current_backout_directory()
+    if not os.path.exists("%s/revert_gprecoverseg_catalog_changes.sh" % backout_dir):
+        raise Exception("The main coordinator backout script does not exist.")
+
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+        dbid = dbconn.querySingleton(conn, "SELECT dbid FROM gp_segment_configuration WHERE preferred_role='p' AND content = %s;" % content)
+        if not os.path.exists("%s/backout_%s.sql" % (backout_dir, dbid)):
+            raise Exception("The segment backout file for content %s does not exist." % content)
+
+@when('the gprecoverseg backout script is run')
+def impl(context):
+    backout_dir = get_current_backout_directory()
+    context.execute_steps(u'''
+        Then the user runs command "chmod +x {backout_dir}/revert_gprecoverseg_catalog_changes.sh"
+         And the user runs command "bash -c {backout_dir}/revert_gprecoverseg_catalog_changes.sh"
+         And bash should return a return code of 0
+         And user can start transactions
+         '''.format(backout_dir=backout_dir))
+
+@then('the primary for content {content} should have its original data directory in the system configuration')
+def impl(context, content):
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+        datadir = dbconn.querySingleton(conn, "SELECT datadir FROM gp_segment_configuration WHERE preferred_role='p' AND content = %s;" % content)
+        if not datadir == context.remote_pair_primary_datadir:
+            raise Exception("Expected datadir %s, got %s" % (context.remote_pair_primary_datadir, datadir))
+
+@given('the gprecoverseg input file "{filename}" and all backout files are cleaned up')
+@then('the gprecoverseg input file "{filename}" and all backout files are cleaned up')
+def impl(context, filename):
+    if os.path.exists(filename):
+        os.remove(filename)
+    dirs = find_backout_dirs()
+    for backout_dir in dirs:
+        if os.path.exists(backout_dir):
+            shutil.rmtree(backout_dir)
+
+@then('verify there are no gprecoverseg backout files')
+def impl(context):
+    dirs = find_backout_dirs()
+    if len(dirs) > 0:
+        raise Exception("One or more backout directories exist: %s" % dirs)
+
+@then('the gprecoverseg lock directory is removed')
+def impl(context):
+    lock_dir = "%s/gprecoverseg.lock" % os.environ["COORDINATOR_DATA_DIRECTORY"]
+    if os.path.exists(lock_dir):
+        shutil.rmtree(lock_dir)
+
+@then('the gp_configuration_history table should contain a backout entry for the {seg} segment for content {content}')
+def impl(context, seg, content):
+    role = ""
+    if seg == "primary":
+        role = 'p'
+    elif seg == "mirror":
+        role = 'm'
+    else:
+        raise Exception('Valid segment types are "primary" and "mirror"')
+
+    with dbconn.connect(dbconn.DbURL(), unsetSearchPath=False) as conn:
+        dbid = dbconn.querySingleton(conn, "SELECT dbid FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, role))
+        num_tuples = dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE dbid = %d AND gp_configuration_history.desc LIKE 'gprecoverseg: segment config for backout%%';" % dbid)
+        if num_tuples != 1:
+            raise Exception("Expected configuration history table to contain 1 entry for dbid %d, found %d" % (dbid, num_tuples))

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -656,6 +656,16 @@ def are_segments_running():
     return result
 
 
+def is_segment_running(role, contentid):
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    segments = gparray.getDbList()
+    for seg in segments:
+        if seg.getSegmentRole() == role and seg.content == contentid and seg.status != 'u':
+            print("segment is not up - %s" % seg)
+            return False
+    return True
+
+
 def modify_sql_file(file, hostport):
     if os.path.isfile(file):
         for line in fileinput.FileInput(file, inplace=1):


### PR DESCRIPTION
If gprecoverseg fails while recovering a segment to a different host or location, it can leave the catalog in a bad state for any subsequent recovery attempts.  This commit modifies gprecoverseg to create backout scripts whenever the -i option is used, which can be run to revert the configuration information for any segments that fail to recover to its pre-recovery state and which will be deleted upon successful recovery.
