### PR TITLE
docs - address some compression-related inconsistencies

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -185,7 +185,7 @@
             <row>
               <entry colname="col1">Column</entry>
               <entry colname="col2">Column and Table</entry>
-              <entry colname="col3"><codeph>RLE_TYPE</codeph>, <codeph>ZLIB</codeph>, <codeph>ZSTD</codeph>, and
+              <entry colname="col3"><codeph>RLE_TYPE</codeph><sup>2</sup>, <codeph>ZLIB</codeph>, <codeph>ZSTD</codeph>, and
                   <codeph>QUICKLZ</codeph><sup>1</sup></entry>
             </row>
           </tbody>
@@ -194,6 +194,9 @@
       <p>
         <note type="note"><sup>1</sup>QuickLZ compression is not available in the open source
           version of Greenplum Database.</note>
+        <note type="note"><sup>2</sup><codeph>RLE_TYPE</codeph> compression is available only
+          for those Greenplum Database tables that you create
+          <codeph>WITH (orientation=column)</codeph>.</note>
       </p>
       <p>When choosing a compression type and level for append-optimized tables, consider these
         factors:</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -496,7 +496,8 @@ CREATE [ [GLOBAL | LOCAL] {TEMPORARY | TEMP} | UNLOGGED ] TABLE [IF NOT EXISTS]
             created as a regular heap-storage table.</pd>
           <pd><b>blocksize</b> — Set to the size, in bytes, for each block in a table. The
               <codeph>blocksize</codeph> must be between 8192 and 2097152 bytes, and be a multiple
-            of 8192. The default is 32768.</pd>
+            of 8192. The default is 32768. The <codeph>blocksize</codeph>
+            option is valid only if <codeph>appendoptimized=TRUE</codeph>.</pd>
           <pd><b>orientation</b> — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
             if <codeph>appendoptimized=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
@@ -529,8 +530,10 @@ CREATE [ [GLOBAL | LOCAL] {TEMPORARY | TEMP} | UNLOGGED ] TABLE [IF NOT EXISTS]
               compression. The delta compression algorithm is based on the delta between column
               values in consecutive rows and is designed to improve compression when data is loaded
               in sorted order or the compression is applied to column data that is in sorted
-              order.</p><p>For information about using table compression, see "Choosing the Table
-              Storage Model" in the <cite>Greenplum Database Administrator Guide</cite>.</p></pd>
+              order.</p><p>For information about using table compression, see
+              <xref href="../../admin_guide/ddl/ddl-storage.xml#topic1" type="topic"
+                format="dita">Choosing the Table Storage Model</xref>
+              in the <cite>Greenplum Database Administrator Guide</cite>.</p></pd>
               <pd><b>compresslevel</b> — For Zstd compression of append-optimized tables, set to an
             integer value from 1 (fastest compression) to 19 (highest compression ratio). For zlib
             compression, the valid range is from 1 to 9. QuickLZ compression level can only be set

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
@@ -20,7 +20,7 @@
       <codeblock>   appendoptimized={TRUE|FALSE}
    blocksize={8192-2097152}
    orientation={COLUMN|ROW}
-   compresstype={ZLIB|ZSTD|QUICKLZ}
+   compresstype={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
    compresslevel={1-19 | 1}
    fillfactor={10-100}
    [oids=FALSE]</codeblock>
@@ -87,19 +87,36 @@
             heap-storage table.</pd>
           <pd><b>blocksize</b> — Set to the size, in bytes for each block in a table. The <codeph>blocksize
             </codeph> must be between 8192 and 2097152 bytes, and be a multiple of 8192. The default
-            is 32768.</pd>
+            is 32768.  The <codeph>blocksize</codeph>
+            option is valid only if <codeph>appendoptimized=TRUE</codeph>.</pd>
           <pd><b>orientation</b> — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
             if <codeph>appendoptimized=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
-          <pd><b>compresstype</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>, or
-              <codeph>QUICKLZ</codeph><sup>1</sup> to specify the type of compression used. The
+          <pd><b>compresstype</b> — Set to <codeph>ZLIB</codeph> (the default), <codeph>ZSTD</codeph>, 
+              <codeph>RLE_TYPE</codeph>, or <codeph>QUICKLZ</codeph><sup>1</sup> to specify
+            the type of compression used. The 
             value <codeph>NONE</codeph> disables compression. Zstd provides for both speed or a
             good compression ratio, tunable with the <codeph>compresslevel</codeph> option.
             QuickLZ and zlib are provided for backwards-compatibility. Zstd outperforms these
             compression types on usual workloads. The <codeph>compresstype</codeph> option is
             valid only if <codeph>appendoptimized=TRUE</codeph>.<note
               type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
-              release of Tanzu Greenplum.</note></pd>
+              release of Tanzu Greenplum.</note>
+            <p>The value <codeph>RLE_TYPE</codeph>, which is supported only if
+                <codeph>orientation</codeph>=<codeph>column</codeph> is specified, enables the
+              run-length encoding (RLE) compression algorithm. RLE compresses data better than the
+              Zstd, zlib, or QuickLZ compression algorithms when the same data value occurs in many
+              consecutive rows.</p><p>For columns of type <codeph>BIGINT</codeph>,
+                <codeph>INTEGER</codeph>, <codeph>DATE</codeph>, <codeph>TIME</codeph>, or
+                <codeph>TIMESTAMP</codeph>, delta compression is also applied if the
+                <codeph>compresstype</codeph> option is set to <codeph>RLE_TYPE</codeph>
+              compression. The delta compression algorithm is based on the delta between column
+              values in consecutive rows and is designed to improve compression when data is loaded
+              in sorted order or the compression is applied to column data that is in sorted
+              order.</p><p>For information about using table compression, see
+              <xref href="../../admin_guide/ddl/ddl-storage.xml#topic1" type="topic"
+                format="dita">Choosing the Table Storage Model</xref>
+              in the <cite>Greenplum Database Administrator Guide</cite>.</p></pd>
           <pd><b>compresslevel</b> — For Zstd compression of append-optimized tables, set to an
             integer value from 1 (fastest compression) to 19 (highest compression ratio). For
             zlib compression, the valid range is from 1 to 9. QuickLZ compression level can only

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_appendonly.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_appendonly.xml
@@ -94,6 +94,8 @@
             <entry colname="col3"/>
             <entry colname="col4">Type of compression used to compress append-optimized tables.
               Valid values are:<ul id="ul_mrr_hwj_f1b">
+                <li><codeph>none</codeph> (no compression)</li>
+                <li><codeph>rle_type</codeph> (run-length encoding compression)</li>
                 <li><codeph>zlib</codeph> (gzip compression)</li>
                 <li><codeph>zstd</codeph> (Zstandard compression)</li>
                 <li otherprops="pivotal"><codeph>quicklz</codeph><sup>1</sup></li>


### PR DESCRIPTION
some inconsistencies in the compression-related docs were identified in https://github.com/greenplum-db/gpdb/issues/10476.  addressing those in this PR.  if my understanding is correct:
- RLE_TYPE and NONE compression types are supported for ao tables and columns.
- RLE_TYPE supported on table or column only when table ORIENTATION=column.
- blocksize supported only when appendoptimized=true.
- add text about RLE_TYPE from CREATE TABLE page to CREATE TABLE AS page.
- update pg_appendonly compresstype description to include rle_type and none.
- add real xrefs to admin guide topics.

(not clear to me why the compression type values are sometimes all caps in the docs, and other times lowercase.  i just went along with what the current paged used.
