### PR TITLE
docs - add content for new gp_legacy_string_agg gpcontrib module

### DIFF
--- a/gpdb-doc/dita/install_guide/install_modules.xml
+++ b/gpdb-doc/dita/install_guide/install_modules.xml
@@ -34,6 +34,8 @@
                   format="dita">fuzzystrmatch</xref></li>
               <li><xref href="../ref_guide/modules/gp_sparse_vector.xml" type="topic" scope="peer"
                   format="dita">gp_sparse_vector</xref></li>
+              <li><xref href="../ref_guide/modules/gp_legacy_string_agg.xml" type="topic" scope="peer"
+                  format="dita">gp_legacy_string_agg</xref></li>
             </ul>
           </stentry>
           <stentry>

--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -173,10 +173,15 @@
             <codeph>int4_avg_accum()</codeph> function, you will need to revise your aggregate for
           the new signature. </li>
         <li>The <codeph>string_agg(expression)</codeph> function has been removed from Greenplum 6.
-          The function concatenates text values into a string. You can replace the single argument
+          The function concatenates text values into a string. You can replace the single-argument
           function with the function <codeph>string_agg(expression, delimiter)</codeph> and specify
           an empty string as the <codeph>delimiter</codeph>, for example
-            <codeph>string_agg(txt_col1, '').</codeph></li>
+            <codeph>string_agg(txt_col1, '').</codeph> If updating each <codeph>string_agg()</codeph>
+          function invocation is not immediately feasible in your environment, you may choose
+          to use <xref href="../ref_guide/modules/gp_legacy_string_agg.xml" format="dita"
+            scope="peer">gp_legacy_string_agg</xref>, a Greenplum Database contrib module that
+          implements the legacy single-argument <codeph>string_agg()</codeph> function that
+          was available in Greenplum Database 5.</li>
         <li>The <codeph>offset</codeph> argument of the <codeph>lag(expr, offset[,
             default])</codeph> window function has changed from <codeph>int8</codeph> in Greenplum
           4.3 to <codeph>int4</codeph> in Greenplum 5 and 6.</li>

--- a/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
@@ -16,7 +16,7 @@
         <p>The <codeph>gp_legacy_string_agg</codeph> module is installed when you install
           Greenplum Database. Before you can use the function defined in the module, you
           must register the <codeph>gp_legacy_string_agg</codeph> extension in each database
-          where you want to use the functions.
+          where you want to use the function.
           <ph otherprops="pivotal">Refer to <xref href="../../install_guide/install_modules.xml"
             format="dita" scope="peer">Installing Additional Supplied Modules</xref>
           for more information about registering the module.</ph></p>

--- a/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
@@ -7,6 +7,8 @@
       <p>The <codeph>gp_legacy_string_agg</codeph> module re-introduces the single-argument
         <codeph>string_agg()</codeph> function that was present in Greenplum Database 5.</p>
       <p>The <codeph>gp_legacy_string_agg</codeph> module is a Greenplum Database extension.</p>
+      <note>Use this module to aid migration from Greenplum Database 5 to the native,
+        two-argument <codeph>string_agg()</codeph> function included in Greenplum 6.</note>
     </body>
     <topic id="topic_reg">
       <title>Installing and Registering the Module</title>

--- a/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
@@ -20,7 +20,7 @@
           for more information about registering the module.</ph></p>
       </body>
     </topic>
-    <topic id="topic_doc">
+    <topic id="topic_use">
       <title>Using the Module</title>
       <body>
         <p>The single-argument <codeph>string_agg()</codeph> function has the following
@@ -48,6 +48,18 @@ WARNING:  Deprecated call to string_agg(text), use string_agg(text, text) instea
 --------------
  ccccbbbb
 (1 row)</codeblock>
+      </body>
+    </topic>
+    <topic id="topic_migrate">
+      <title>Migrating to the Two-Argument string_agg() Function</title>
+      <body>
+        <p>Greenplum Database 6 includes a native, two-argument, text input
+          <codeph>string_agg()</codeph> function:</p>
+        <codeblock>string_agg( text, text )</codeblock>
+        <p>The following function invocation is equivalent to the single-argument
+          <codeph>string_agg()</codeph> function that is provided in this module:</p>
+        <codeblock>string_agg( text, '' )</codeblock>
+        <p>You can use this conversion when you are ready to migrate from this contrib module.</p>
       </body>
     </topic>
   </topic>

--- a/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_legacy_string_agg.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<dita>
+  <topic id="topic_gpsv">
+    <title>gp_legacy_string_agg</title>
+    <body>
+      <p>The <codeph>gp_legacy_string_agg</codeph> module re-introduces the single-argument
+        <codeph>string_agg()</codeph> function that was present in Greenplum Database 5.</p>
+      <p>The <codeph>gp_legacy_string_agg</codeph> module is a Greenplum Database extension.</p>
+    </body>
+    <topic id="topic_reg">
+      <title>Installing and Registering the Module</title>
+      <body>
+        <p>The <codeph>gp_legacy_string_agg</codeph> module is installed when you install
+          Greenplum Database. Before you can use the function defined in the module, you
+          must register the <codeph>gp_legacy_string_agg</codeph> extension in each database
+          where you want to use the functions.
+          <ph otherprops="pivotal">Refer to <xref href="../../install_guide/install_modules.xml"
+            format="dita" scope="peer">Installing Additional Supplied Modules</xref>
+          for more information about registering the module.</ph></p>
+      </body>
+    </topic>
+    <topic id="topic_doc">
+      <title>Using the Module</title>
+      <body>
+        <p>The single-argument <codeph>string_agg()</codeph> function has the following
+          signature:</p>
+        <codeblock>string_agg( text )</codeblock>
+        <p>You can use the function to concatenate non-null input values into a string. For
+          example:</p>
+        <codeblock>SELECT string_agg(a) FROM (VALUES('aaaa'),('bbbb'),('cccc'),(NULL)) g(a);
+WARNING:  Deprecated call to string_agg(text), use string_agg(text, text) instead
+  string_agg  
+--------------
+ aaaabbbbcccc
+(1 row)</codeblock>
+        <p>The function concatenates each string value until it encounters a null value,
+          and then returns the string. The function returns a null value when no rows are
+          selected in the query.</p>
+        <p><codeph>string_agg()</codeph> produces results that depend on the ordering of the
+          input rows. The ordering is unspecified by default; you can control the ordering by
+          specifying an <codeph>ORDER BY</codeph> clause within the aggregate. For example:</p>
+        <codeblock>CREATE TABLE table1(a int, b text);
+INSERT INTO table1 VALUES(4, 'aaaa'),(2, 'bbbb'),(1, 'cccc'), (3, NULL);
+SELECT string_agg(b ORDER BY a) FROM table1;
+WARNING:  Deprecated call to string_agg(text), use string_agg(text, text) instead
+  string_agg  
+--------------
+ ccccbbbb
+(1 row)</codeblock>
+      </body>
+    </topic>
+  </topic>
+</dita>

--- a/gpdb-doc/dita/ref_guide/modules/intro.xml
+++ b/gpdb-doc/dita/ref_guide/modules/intro.xml
@@ -27,6 +27,10 @@
        <li><codeph><xref href="fuzzystrmatch.xml"
              format="dita">fuzzystrmatch</xref></codeph> - Determines similarities and differences
          between strings.</li>
+       <li><codeph><xref href="gp_legacy_string_agg.xml" scope="peer"
+             format="dita">gp_legacy_string_agg</xref></codeph> - Implements a
+         legacy, single-argument <codeph>string_agg()</codeph> aggregate function that was
+         present in Greenplum Database 5.</li>
        <li><codeph><xref href="gp_sparse_vector.xml" scope="peer"
              format="dita">gp_sparse_vector</xref></codeph> - Implements
          a Greenplum Database data type that uses compressed storage of zeros to make

--- a/gpdb-doc/dita/ref_guide/modules/modules.ditamap
+++ b/gpdb-doc/dita/ref_guide/modules/modules.ditamap
@@ -8,6 +8,7 @@
     <topicref href="dblink.xml"/>
     <topicref href="diskquota.xml"/>
     <topicref href="fuzzystrmatch.xml"/>
+    <topicref href="gp_legacy_string_agg.xml"/>
     <topicref href="gp_sparse_vector.xml"/>
     <topicref href="hstore.xml"/>
     <topicref href="orafce_ref.xml"/>


### PR DESCRIPTION
document the new gpcontrib single-argument string_agg() function.  note that this function was not previously documented in greenplum 5.  in this PR:
- include gp_legacy_string_agg in the list of additional supplied modules.
- update the migrate topic mention to reference the new module.
- add a separate topic for the module which identifies how to install/register/use it.

doc review site link for new topic:  https://docs-lisa-legacy-stringagg.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/modules/gp_legacy_string_agg.html (behind vpn)