### PR TITLE
Add CHECK_FOR_INTERRUPTS call when processing sequence nextval().

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -1148,6 +1148,9 @@ processResults(CdbDispatchResult *dispatchResult)
 			 * (ex: releasing all the locks, etc.), shouldn't attempt to call
 			 * nextval_qd() again.
 			 */
+
+			CHECK_FOR_INTERRUPTS();
+
 			int64 last;
 			int64 cached;
 			int64 increment;


### PR DESCRIPTION
After the sequence refactor in eae1ee3fbead8baad3803c64de8cbee07d076d9e,
an INSERT query on a table with a sequence column is not cancellable in
some cases. Specifically, if the QE makes a nextval request, the QD
should process any interrupts, or the QD could continuously receive
requests and never check for interrupts while it's in
checkDispatchResult(). There was no measurable overhead difference with
adding this check.