### PR TITLE
Fix an accidental bitmap metapage overwrite case

### DIFF
--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -112,10 +112,12 @@ _bitmap_xlog_insert_lovitem(XLogRecPtr lsn, XLogRecord *record)
 		Buffer		metabuf;
 
 		metabuf = XLogReadBufferExtended(xlrec->bm_node, xlrec->bm_fork,
-												BM_METAPAGE, RBM_ZERO_AND_LOCK);
+										 BM_METAPAGE, RBM_NORMAL);
 		if (!BufferIsValid(metabuf))
  			return;
-		
+
+		LockBuffer(metabuf, BUFFER_LOCK_EXCLUSIVE);
+
 		metapage = (BMMetaPage) PageGetContents(BufferGetPage(metabuf));
 		if (PageGetLSN(BufferGetPage(metabuf)) < lsn)
 		{


### PR DESCRIPTION
In commit 7a4dd51, which introduced bitmap index support for unlogged
tables, we incorrectly supplied RBM_ZERO to XLogReadBufferExtended(),
where we try to update the metapage's pd_lsn while replaying an LOV item
insert.  (Later during merge commit f2e0802692d, it was changed to
RBM_ZERO_AND_LOCK, since it is unsafe to use RBM_ZERO. See: 8fc23a9ed0a)
Prior to this change, we were using XLogReadBuffer() with init=false
(effectively RBM_NORMAL).

The consequence of this change is that if the metapage is not present in
shared buffers, it will not be fetched from disk. Instead, a zeroed out
page will be returned. A subsequent flush of the metapage will lead to
an inadvertent overwrite.

The fix here is to simply revert to using RBM_NORMAL. We also need to
grab the buffer lock (as we used to before 7a4dd51 with the use of
XLogReadBuffer()) - see header comment in XLogReadBuffer() to see why
the lock is necessary.

This was originally identified in PR: #7466 

This does not need a backport to 5X, as the issue was introduced much
later. It does not need to go into master, as we call XLogReadBufferForRedo(),
which supplies RBM_NORMAL (See f8f4227976a)