### PR TITLE
Fix autostats test

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -311,7 +311,7 @@ char	   *gp_autostats_mode_string;
 int			gp_autostats_mode_in_functions;
 char	   *gp_autostats_mode_in_functions_string;
 int			gp_autostats_on_change_threshold = 100000;
-bool		gp_autostats_allow_nonowner = true;
+bool		gp_autostats_allow_nonowner = false;
 bool		log_autostats = true;
 
 /* --------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -137,24 +137,25 @@ LOG:  statement: reset role;
 insert into autostats_test select generate_series(21, 30);
 LOG:  statement: insert into autostats_test select generate_series(21, 30);
 LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+reset client_min_messages;
+LOG:  statement: reset client_min_messages;
 select relname, reltuples from pg_class where relname='autostats_test';
-LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
     relname     | reltuples 
 ----------------+-----------
  autostats_test |        40
 (1 row)
 
 reset role;
-LOG:  statement: reset role;
 -- After 4 successful inserts, final row count should also be 40
 select COUNT(*) from autostats_test;
-LOG:  statement: select COUNT(*) from autostats_test;
  count 
 -------
     40
 (1 row)
 
 drop table if exists autostats_test;
-LOG:  statement: drop table if exists autostats_test;
 drop user autostats_nonowner;
-LOG:  statement: drop user autostats_nonowner;
+reset gp_autostats_mode;
+reset gp_autostats_on_change_threshold;
+reset log_autostats;
+reset gp_autostats_allow_nonowner;

--- a/src/test/regress/sql/autostats.sql
+++ b/src/test/regress/sql/autostats.sql
@@ -64,6 +64,7 @@ reset role;
 
 -- GUC should still be disabled, stats should update from 20 to 40
 insert into autostats_test select generate_series(21, 30);
+reset client_min_messages;
 select relname, reltuples from pg_class where relname='autostats_test';
 reset role;
 
@@ -72,3 +73,8 @@ select COUNT(*) from autostats_test;
 
 drop table if exists autostats_test;
 drop user autostats_nonowner;
+
+reset gp_autostats_mode;
+reset gp_autostats_on_change_threshold;
+reset log_autostats;
+reset gp_autostats_allow_nonowner;


### PR DESCRIPTION
Also update initial value of gp_autostats_allow_nonowner in cbdvars.c;
This shouldn't matter, but keeping it consistent for readability.

Co-authored-by: Alexandra Wang <walexandra@vmware.com>