### PR TITLE
Trying to make write_log() thread safe.

### DIFF
--- a/src/backend/cdb/cdbthreadlog.c
+++ b/src/backend/cdb/cdbthreadlog.c
@@ -79,6 +79,7 @@ static void
 get_timestamp(char *strfbuf, int length)
 {
 	pg_time_t	stamp_time;
+	struct pg_tm	tm;
 	char		msbuf[8];
 	struct timeval tv;
 
@@ -93,7 +94,7 @@ get_timestamp(char *strfbuf, int length)
 #else
 				"%Y-%m-%d %H:%M:%S        ",
 #endif
-				pg_localtime(&stamp_time, log_timezone));
+				pg_localtime_thread_safe(&stamp_time, log_timezone, &tm));
 
 	/* 'paste' milliseconds into place... */
 	sprintf(msbuf, ".%06d", (int) (tv.tv_usec));

--- a/src/include/pgtime.h
+++ b/src/include/pgtime.h
@@ -46,6 +46,9 @@ typedef struct pg_tzenum pg_tzenum;
 /* these functions are in localtime.c */
 
 extern struct pg_tm *pg_localtime(const pg_time_t *timep, const pg_tz *tz);
+extern struct pg_tm *pg_localtime_thread_safe(const pg_time_t *timep,
+											  const pg_tz *tz,
+											  struct pg_tm *const tmp);
 extern struct pg_tm *pg_gmtime(const pg_time_t *timep);
 extern int	pg_next_dst_boundary(const pg_time_t *timep,
 								 long int *before_gmtoff,

--- a/src/timezone/localtime.c
+++ b/src/timezone/localtime.c
@@ -1377,6 +1377,17 @@ pg_localtime(const pg_time_t *timep, const pg_tz *tz)
 	return localsub(&tz->state, timep, &tm);
 }
 
+/*
+ * pg_localtime_thread_safe is similar to pg_localtime.
+ *
+ * Except we don't use the global variable 'tm' to make it thread-safe.
+ */
+struct pg_tm *
+pg_localtime_thread_safe(const pg_time_t *timep, const pg_tz *tz,
+						 struct pg_tm *const tmp)
+{
+	return localsub(&tz->state, timep, tmp);
+}
 
 /*
  * gmtsub is to gmtime as localsub is to localtime.


### PR DESCRIPTION
Currently, `write_log()` is not thread safe, though it should be. The calling trace is:

```
write_log() -> get_timestamp() -> pg_localtime()
```

pg_locatime() is modifying the global variable `struct pg_tm *tm` and when multiple threads calling `pg_localtime()` there's a possibility that makes gpdb crash (See: #11300 ). This PR is trying to make `write_log()` thread safe by introducing a new thread safe function `pg_localtime_thread_safe()` without modifying the interface or function body of the original `pg_locatime()`.

I haven't crafted a test since I have no idea how to test this change. It would be great if somebody can help me :-)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
