### PR TITLE
Fix cursor CURRENT OF operation reported wrong error message

### DIFF
--- a/src/test/regress/expected/portals_updatable.out
+++ b/src/test/regress/expected/portals_updatable.out
@@ -806,6 +806,20 @@ DECLARE c CURSOR FOR SELECT * FROM aocotest;
 DELETE FROM aocotest WHERE CURRENT OF c;
 ERROR:  "aocotest" is not simply updatable
 ROLLBACK;
+-- Negative: cursor with limit/offset against ordinary table
+-- The issue: https://github.com/greenplum-db/gpdb/issues/9838
+CREATE TABLE tidscan_9838(id integer);
+INSERT INTO tidscan_9838 (id) VALUES (1), (2), (3);
+BEGIN;
+DECLARE c CURSOR FOR SELECT ctid, * FROM tidscan_9838 LIMIT 1;
+UPDATE tidscan_9838 SET id = -id WHERE CURRENT OF c;
+ERROR:  cursor "c" is not a simply updatable scan of table "tidscan_9838"
+ROLLBACK;
+BEGIN;
+DECLARE c CURSOR FOR SELECT ctid, * FROM tidscan_9838 OFFSET 1;
+UPDATE tidscan_9838 SET id = -id WHERE CURRENT OF c;
+ERROR:  cursor "c" is not a simply updatable scan of table "tidscan_9838"
+ROLLBACK;
 --
 -- PL/pgSQL cursors
 --

--- a/src/test/regress/expected/portals_updatable_optimizer.out
+++ b/src/test/regress/expected/portals_updatable_optimizer.out
@@ -806,6 +806,20 @@ DECLARE c CURSOR FOR SELECT * FROM aocotest;
 DELETE FROM aocotest WHERE CURRENT OF c;
 ERROR:  "aocotest" is not simply updatable
 ROLLBACK;
+-- Negative: cursor with limit/offset against ordinary table
+-- The issue: https://github.com/greenplum-db/gpdb/issues/9838
+CREATE TABLE tidscan_9838(id integer);
+INSERT INTO tidscan_9838 (id) VALUES (1), (2), (3);
+BEGIN;
+DECLARE c CURSOR FOR SELECT ctid, * FROM tidscan_9838 LIMIT 1;
+UPDATE tidscan_9838 SET id = -id WHERE CURRENT OF c;
+ERROR:  cursor "c" is not a simply updatable scan of table "tidscan_9838"
+ROLLBACK;
+BEGIN;
+DECLARE c CURSOR FOR SELECT ctid, * FROM tidscan_9838 OFFSET 1;
+UPDATE tidscan_9838 SET id = -id WHERE CURRENT OF c;
+ERROR:  cursor "c" is not a simply updatable scan of table "tidscan_9838"
+ROLLBACK;
 --
 -- PL/pgSQL cursors
 --

--- a/src/test/regress/sql/portals_updatable.sql
+++ b/src/test/regress/sql/portals_updatable.sql
@@ -448,6 +448,18 @@ DECLARE c CURSOR FOR SELECT * FROM aocotest;
 DELETE FROM aocotest WHERE CURRENT OF c;
 ROLLBACK;
 
+-- Negative: cursor with limit/offset against ordinary table
+-- The issue: https://github.com/greenplum-db/gpdb/issues/9838
+CREATE TABLE tidscan_9838(id integer);
+INSERT INTO tidscan_9838 (id) VALUES (1), (2), (3);
+BEGIN;
+DECLARE c CURSOR FOR SELECT ctid, * FROM tidscan_9838 LIMIT 1;
+UPDATE tidscan_9838 SET id = -id WHERE CURRENT OF c;
+ROLLBACK;
+BEGIN;
+DECLARE c CURSOR FOR SELECT ctid, * FROM tidscan_9838 OFFSET 1;
+UPDATE tidscan_9838 SET id = -id WHERE CURRENT OF c;
+ROLLBACK;
 
 --
 -- PL/pgSQL cursors


### PR DESCRIPTION
Based on 6X_STABLE behavior, the desirable error message is
'cursor "c" is not a simply updatable scan of table "tidscan"'.
The reason of reporting "Unexpected internal error" on master
branch is because the commit "updatable evaluation for partition
table" 20ae004 limited the simply updatable check to partitioned
table and temporary table, the ordinary table skipped the check
and proceeded then failed at the empty tuple slot check.

Also, PG12 removed tuple slot allocation from LIMIT plan node,
intended to save some cost and separate the determination of the
result type from the slot creation(refer to postgres/postgres@1ef6bd2).
This causes the empty tuple slot check failed in above scenario.

To be consistent with the design, a straightforward fix should
be applying "simply-updatable" check to ordinary tables as well.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
