### PR TITLE
Bump Orca version to 3.120.0 and add GUC to limit bindings

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.119.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.120.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.119.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.120.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12487,7 +12487,7 @@ int
 main ()
 {
 
-return strncmp("3.119.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.120.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12497,7 +12497,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.119.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.120.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.119.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.120.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -707,6 +707,7 @@ COptTasks::CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model)
 		(ULONG) optimizer_array_expansion_threshold;
 	ULONG join_order_threshold = (ULONG) optimizer_join_order_threshold;
 	ULONG broadcast_threshold = (ULONG) optimizer_penalize_broadcast_threshold;
+	ULONG xform_bind_threshold = (ULONG) optimizer_xform_bind_threshold;
 
 	return GPOS_NEW(mp) COptimizerConfig(
 		GPOS_NEW(mp)
@@ -722,7 +723,7 @@ COptTasks::CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model)
 				  broadcast_threshold,
 				  false, /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
-				  PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD),
+				  PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD, xform_bind_threshold),
 		GPOS_NEW(mp) CWindowOids(OID(F_WINDOW_DUMMY), OID(F_WINDOW_RANK_OID)));
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -561,6 +561,7 @@ int			optimizer_array_expansion_threshold;
 int			optimizer_join_order_threshold;
 int			optimizer_join_order;
 int			optimizer_cte_inlining_bound;
+int			optimizer_xform_bind_threshold;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
 bool		optimizer_force_expanded_distinct_aggs;
@@ -4729,6 +4730,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&optimizer_array_expansion_threshold,
 		100, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"optimizer_xform_bind_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Maximum number bindings per xform per group expression"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_xform_bind_threshold,
+		0, 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -483,6 +483,7 @@ extern int optimizer_join_order_threshold;
 extern int optimizer_join_order;
 extern int optimizer_join_arity_for_associativity_commutativity;
 extern int optimizer_cte_inlining_bound;
+extern int optimizer_xform_bind_threshold;
 extern bool optimizer_force_multistage_agg;
 extern bool optimizer_force_three_stage_scalar_dqa;
 extern bool optimizer_force_expanded_distinct_aggs;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11922,4 +11922,29 @@ select max(a) over(order by a) + min(a) over(order by a) from tcorr1;
         2
 (1 row)
 
+--- optimizer_xform_bind_threshold should limit the search space and quickly
+--- generate a plan (<100ms, but if this GUC is not set it will take minutes to
+--- optimize)
+create table binding (a int) distributed by (a);
+set optimizer_xform_bind_threshold=100;
+set statement_timeout = '15s';
+select a in (
+       select a from binding as t1 where a in (
+           select a from binding as t2 where a in (
+               select a from binding as t3 where a in (
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+               )
+           )
+       )
+   ) from binding;
+ ?column? 
+----------
+(0 rows)
+
+reset optimizer_xform_bind_threshold;
+reset statement_timeout;
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11982,4 +11982,29 @@ select max(a) over(order by a) + min(a) over(order by a) from tcorr1;
         2
 (1 row)
 
+--- optimizer_xform_bind_threshold should limit the search space and quickly
+--- generate a plan (<100ms, but if this GUC is not set it will take minutes to
+--- optimize)
+create table binding (a int) distributed by (a);
+set optimizer_xform_bind_threshold=100;
+set statement_timeout = '15s';
+select a in (
+       select a from binding as t1 where a in (
+           select a from binding as t2 where a in (
+               select a from binding as t3 where a in (
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+               )
+           )
+       )
+   ) from binding;
+ ?column? 
+----------
+(0 rows)
+
+reset optimizer_xform_bind_threshold;
+reset statement_timeout;
 reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2079,6 +2079,30 @@ select * from tcorr1 where a > (select 1+max(count(*) over (order by a)) over (p
 -- this one should work, no nesting
 select max(a) over(order by a) + min(a) over(order by a) from tcorr1;
 
+--- optimizer_xform_bind_threshold should limit the search space and quickly
+--- generate a plan (<100ms, but if this GUC is not set it will take minutes to
+--- optimize)
+create table binding (a int) distributed by (a);
+set optimizer_xform_bind_threshold=100;
+
+set statement_timeout = '15s';
+select a in (
+       select a from binding as t1 where a in (
+           select a from binding as t2 where a in (
+               select a from binding as t3 where a in (
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+                   union
+                   select a from binding as t4 join binding as t5 using(a) group by t4.a
+               )
+           )
+       )
+   ) from binding;
+reset optimizer_xform_bind_threshold;
+reset statement_timeout;
+
+
 reset optimizer_trace_fallback;
 
 -- start_ignore


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/12574

Corresponding Orca commit "Limit number of bindings per group expression
in Orca"

This commit adds a guc, optimizer_xform_bind_threshold, to limit the
number of bindings for each group expression to a certain value. By
default, this is set to 0 (unlimited). A reasonable value for this would
be 1000 or 10000, but it is query dependent.

Example query affected by this change:

```
create table t (a int) distributed by (a);

explain select a in (
    select a from t as t1 where a in (
        select a from t as t2 where a in (
            select a from t as t3 where a in (
                select a from t as t4 join t as t5 using(a) group by t4.a
                union
                select a from t as t4 join t as t5 using(a) group by t4.a
                union
                select a from t as t4 join t as t5 using(a) group by t4.a
            )
        )
    )
) from t;

```

Previously this was binded hundreds of thousands of times with an
optimization time of 40s+:
```
CXformLeftOuterApply2LeftOuterJoin: 5 calls, 433071 total bindings, 136085 alternatives generated, 34598ms
CXformLeftSemiApplyIn2LeftSemiJoin: 3 calls, 23345 total bindings, 9075 alternatives generated, 2073ms
```
