### PR TITLE
docs - clarify the desc of gp_resqueue_priority_cpucores_per_segment

### DIFF
--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -393,23 +393,29 @@
                 interval at which CPU usage is recalculated for all active statements. The default
                 value for this parameter should be sufficient for typical database operations. </li>
               <li id="iz174445"><codeph>gp_resqueue_priority_cpucores_per_segment</codeph> -
-                Specifies the number of CPU cores allocated per segment instance. The default value
-                is 4 for the master and segments. <p>Each host checks its
+                Specifies the number of CPU cores allocated per primary segment instance on a
+                segment host. The default value
+                is 4 for the master and segment hosts. <p>Each Greenplum host checks its
                   own <codeph>postgresql.conf</codeph> file for the value of this parameter. This
-                  parameter also affects the master node, where it should be set to a value
+                  parameter also affects the master host, where it should be set to a value
                   reflecting the higher ratio of CPU cores. For example, on a cluster that has 10
-                  CPU cores per host and 4 segments per host, you would specify these values for
-                    <codeph>gp_resqueue_priority_cpucores_per_segment</codeph>:</p><p>10 for the
-                  master and standby master. Typically, only the master instance is on the master
-                  host.</p><p>2.5 for segment instances on the segment hosts. </p><p>If the
+                  CPU cores per segment host and 4 primary segments per host, you would specify
+                   the following values for
+                    <codeph>gp_resqueue_priority_cpucores_per_segment</codeph>:</p>
+                  <ul>
+                    <li>10 on the master and standby master hosts. Typically, only a single
+                      master segment instance runs on the master host.</li>
+                    <li>2.5 on each segment host (10 cores divided by 4 primary segments).</li>
+                  </ul>
+                <p>If the
                   parameter value is not set correctly, either the CPU might not be fully utilized,
                   or query prioritization might not work as expected. For example, if the Greenplum
                   Database cluster has fewer than one segment instance per CPU core on your segment
-                  hosts, make sure you adjust this value accordingly. </p><p>Actual CPU core
+                  hosts, make sure that you adjust this value accordingly. </p><p>Actual CPU core
                   utilization is based on the ability of Greenplum Database to parallelize a query
-                  and the resources required to run the query. </p><p>Note: Any CPU core that is
-                  available to the operating system is included in the number of CPU cores. For
-                  example, virtual CPU cores are included in the number of CPU cores.</p></li>
+                  and the resources required to run the query. </p><p>Note: Include any CPU core that is
+                  available to the operating system in the number of CPU cores, including
+                  virtual CPU cores.</p></li>
             </ul></li>
           <li id="iz171977">If you wish to view or change any of the resource management parameter
             values, you can use the <codeph>gpconfig</codeph> utility. </li>

--- a/gpdb-doc/dita/admin_guide/workload_mgmt.xml
+++ b/gpdb-doc/dita/admin_guide/workload_mgmt.xml
@@ -393,8 +393,10 @@
                 interval at which CPU usage is recalculated for all active statements. The default
                 value for this parameter should be sufficient for typical database operations. </li>
               <li id="iz174445"><codeph>gp_resqueue_priority_cpucores_per_segment</codeph> -
-                Specifies the number of CPU cores allocated per primary segment instance on a
-                segment host. The default value
+                Specifies the number of CPU cores allocated per segment instance on a
+                segment host. If the segment is configured with primary-mirror segment
+                instance pairs, use the
+                number of primary segment instances on the host in the calculation. The default value
                 is 4 for the master and segment hosts. <p>Each Greenplum host checks its
                   own <codeph>postgresql.conf</codeph> file for the value of this parameter. This
                   parameter also affects the master host, where it should be set to a value

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4516,7 +4516,7 @@
         cores, in the total number of available cores.</p> 
       <p> For example, if a Greenplum Database cluster has 10-core segment hosts that are
         configured with four primary segments, set the value to 2.5 on each segment host
-        (10 divided by 4 ).
+        (10 divided by 4).
         A master host typically has only a single running master instance, so set the
         value on the master and standby maaster hosts to reflect the usage of all available
         CPU cores, in this case 10. </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4509,8 +4509,9 @@
     <body>
       <note>The <codeph>gp_resqueue_priority_cpucores_per_segment</codeph> server configuration
         parameter is enforced only when resource queue-based resource management is active.</note>
-      <p>Specifies the number of CPU units allocated to each primary segment instance on a
-        segment host.
+      <p>Specifies the number of CPU units allocated to each segment instance on a
+        segment host. If the segment is configured with primary-mirror segment instance pairs,
+        use the number of primary segment instances on the host in the calculation.
         Include any CPU core that is available to the operating system, including virtual CPU
         cores, in the total number of available cores.</p> 
       <p> For example, if a Greenplum Database cluster has 10-core segment hosts that are

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4509,11 +4509,16 @@
     <body>
       <note>The <codeph>gp_resqueue_priority_cpucores_per_segment</codeph> server configuration
         parameter is enforced only when resource queue-based resource management is active.</note>
-      <p>Specifies the number of CPU units allocated per segment instance. For example, if a
-        Greenplum Database cluster has 10-core segment hosts that are configured with four segments,
-        set the value for the segment instances to 2.5. For the master instance, the value would be
-        10. A master host typically has only the master instance running on it, so the value for the
-        master should reflect the usage of all available CPU cores. </p>
+      <p>Specifies the number of CPU units allocated to each primary segment instance on a
+        segment host.
+        Include any CPU core that is available to the operating system, including virtual CPU
+        cores, in the total number of available cores.</p> 
+      <p> For example, if a Greenplum Database cluster has 10-core segment hosts that are
+        configured with four primary segments, set the value to 2.5 on each segment host
+        (10 divided by 4 ).
+        A master host typically has only a single running master instance, so set the
+        value on the master and standby maaster hosts to reflect the usage of all available
+        CPU cores, in this case 10. </p>
       <p>Incorrect settings can result in CPU under-utilization or query prioritization not working
         as designed. </p>
       <table id="gp_resqueue_priority_cpucores_per_segment_table">


### PR DESCRIPTION
clarify use of virtual CPU cores and primary segments in the calculation of this server configuration parameter.
