### PR TITLE
docs - for new GPORCA guc optimizer_xform_bind_threshold

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -481,6 +481,9 @@
               <xref href="#optimizer_use_gpdb_allocators" format="dita"
                 >optimizer_use_gpdb_allocators</xref></li>
             <li>
+              <xref href="#optimizer_xform_bind_threshold" format="dita"
+                >optimizer_xform_bind_threshold</xref></li>
+            <li>
               <p>
                 <xref href="#plan_cache_mode"/></p>
             </li>
@@ -7788,6 +7791,38 @@
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">true</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_xform_bind_threshold">
+    <title>optimizer_xform_bind_threshold</title>
+    <body>
+      <p>When GPORCA is enabled (the default), this parameter controls the maximum number of
+        bindings per transform that GPORCA produces per group expression. Setting this
+        parameter limits the number of alternatives that GPORCA creates, in many cases
+        reducing the optimization time and overall memory usage of queries that include
+        deeply nested expressions.</p>
+      <p>The default value is <codeph>0</codeph>, GPORCA produces an unlimited set of bindings.</p>
+      <table id="table_oxbt">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 - INT_MAX</entry>
+              <entry colname="col2">0</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -338,11 +338,11 @@
               >optimizer_enable_multiple_distinct_aggs</xref></p>
             <p><xref href="guc-list.xml#optimizer_force_agg_skew_avoidance" type="section"
                 >optimizer_force_agg_skew_avoidance</xref></p>
+          </stentry>
+          <stentry>
             <p><xref href="guc-list.xml#optimizer_force_multistage_agg" type="section"
                 >optimizer_force_multistage_agg</xref>
             </p>
-          </stentry>
-          <stentry>
             <p><xref href="guc-list.xml#optimizer_force_three_stage_scalar_dqa" type="section"
                 >optimizer_force_three_stage_scalar_dqa</xref></p>
             <p><xref href="guc-list.xml#optimizer_join_arity_for_associativity_commutativity"
@@ -371,6 +371,8 @@
                 >optimizer_sort_factor</xref></p>
             <p><xref href="guc-list.xml#optimizer_use_gpdb_allocators" format="dita"
                 >optimizer_use_gpdb_allocators</xref></p>
+            <p><xref href="guc-list.xml#optimizer_xform_bind_threshold" format="dita"
+                >optimizer_xform_bind_threshold</xref></p>
           </stentry>
         </strow>
       </simpletable>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -243,6 +243,7 @@
             <topicref href="guc-list.xml#optimizer_print_optimization_stats"/>
             <topicref href="guc-list.xml#optimizer_sort_factor"/>
             <topicref href="guc-list.xml#optimizer_use_gpdb_allocators"/>
+            <topicref href="guc-list.xml#optimizer_xform_bind_threshold"/>
             <topicref href="guc-list.xml#password_encryption"/>
             <topicref href="guc-list.xml#plan_cache_mode"/>
             <topicref href="guc-list.xml#pljava_classpath"/>


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/12574, https://github.com/greenplum-db/gpdb/pull/12619,  https://github.com/greenplum-db/gpdb/pull/12620

add the server configuration parameter to the reference guide.

this will be backported to 6X_STABLE, 5X_STABLE.