### PR TITLE
Fix wrong results with nested SRF in Orca

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CScalarFunc.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarFunc.cpp
@@ -207,10 +207,9 @@ CScalarFunc::TypeModifier() const
 //
 //---------------------------------------------------------------------------
 BOOL
-CScalarFunc::FHasNonScalarFunction(CExpressionHandle &	//exprhdl
-)
+CScalarFunc::FHasNonScalarFunction(CExpressionHandle &exprhdl)
 {
-	return m_returns_set;
+	return m_returns_set || CScalar::FHasNonScalarFunction(exprhdl);
 }
 
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13986,6 +13986,11 @@ ERROR:  set-returning functions are not allowed in COALESCE
 LINE 1: select count(*) from (select trim(coalesce(regexp_split_to_t...
                                                    ^
 HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
+select count(regexp_split_to_table((a)::text, ','::text)) from nested_srf;
+ERROR:  aggregate function calls cannot contain set-returning function calls
+LINE 1: select count(regexp_split_to_table((a)::text, ','::text)) fr...
+                     ^
+HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
 truncate nested_srf;
 insert into nested_srf values (NULL);
 select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13941,3 +13941,62 @@ select a in (
 
 reset optimizer_xform_bind_threshold;
 reset statement_timeout;
+-- an agg of a non-SRF with a nested SRF should be treated as a SRF, the
+-- optimizer must not eliminate the SRF or it can produce incorrect results
+set optimizer_trace_fallback = on;
+create table nested_srf(a text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into nested_srf values ('abc,def,ghi');
+select * from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ regexp_split_to_table 
+-----------------------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ btrim 
+-------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
+ERROR:  set-returning functions are not allowed in CASE
+LINE 1: ...t(*) from (select trim( case when a!='abc' then  (regexp_spl...
+                                                             ^
+HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
+select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+ERROR:  set-returning functions are not allowed in COALESCE
+LINE 1: select count(*) from (select trim(coalesce(regexp_split_to_t...
+                                                   ^
+HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
+truncate nested_srf;
+insert into nested_srf values (NULL);
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ btrim 
+-------
+(0 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ count 
+-------
+     0
+(1 row)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14355,6 +14355,11 @@ ERROR:  set-returning functions are not allowed in COALESCE
 LINE 1: select count(*) from (select trim(coalesce(regexp_split_to_t...
                                                    ^
 HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
+select count(regexp_split_to_table((a)::text, ','::text)) from nested_srf;
+ERROR:  aggregate function calls cannot contain set-returning function calls
+LINE 1: select count(regexp_split_to_table((a)::text, ','::text)) fr...
+                     ^
+HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
 truncate nested_srf;
 insert into nested_srf values (NULL);
 select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14306,3 +14306,70 @@ select a in (
 
 reset optimizer_xform_bind_threshold;
 reset statement_timeout;
+-- an agg of a non-SRF with a nested SRF should be treated as a SRF, the
+-- optimizer must not eliminate the SRF or it can produce incorrect results
+set optimizer_trace_fallback = on;
+create table nested_srf(a text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into nested_srf values ('abc,def,ghi');
+select * from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ regexp_split_to_table 
+-----------------------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
+ btrim 
+-------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
+ERROR:  set-returning functions are not allowed in CASE
+LINE 1: ...t(*) from (select trim( case when a!='abc' then  (regexp_spl...
+                                                             ^
+HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
+select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+ERROR:  set-returning functions are not allowed in COALESCE
+LINE 1: select count(*) from (select trim(coalesce(regexp_split_to_t...
+                                                   ^
+HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
+truncate nested_srf;
+insert into nested_srf values (NULL);
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
+ btrim 
+-------
+(0 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
+ count 
+-------
+     0
+(1 row)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3380,6 +3380,7 @@ select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) f
 
 select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
 select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+select count(regexp_split_to_table((a)::text, ','::text)) from nested_srf;
 
 truncate nested_srf;
 insert into nested_srf values (NULL);

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3366,6 +3366,28 @@ select a in (
 reset optimizer_xform_bind_threshold;
 reset statement_timeout;
 
+-- an agg of a non-SRF with a nested SRF should be treated as a SRF, the
+-- optimizer must not eliminate the SRF or it can produce incorrect results
+set optimizer_trace_fallback = on;
+create table nested_srf(a text);
+insert into nested_srf values ('abc,def,ghi');
+
+select * from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+select count(*) from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+
+select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
+select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+
+truncate nested_srf;
+insert into nested_srf values (NULL);
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+
+reset optimizer_trace_fallback;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Previously, if we had a query such as
`select count(*)  from (select trim(regexp_split_to_table((a)::text, ','::text)) from bar)a;`

Orca would consider the `trim()` function as a non-set returning function (SRF) and optimize away
the function call, leading to incorrect results. Because
`regexp_split_to_table` is a SRF, we must also consider `trim` to be a
SRF and evaluate the nested function.

Orca will now check the nested functions too. If any of these DXL
children are a SRF, the outer function is also marked as set-returning.
