### PR TITLE
[Backport] Add GUC for allowing autostats to be triggered by non-owners

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -323,6 +323,7 @@ char	   *gp_autostats_mode_string;
 int			gp_autostats_mode_in_functions;
 char	   *gp_autostats_mode_in_functions_string;
 int			gp_autostats_on_change_threshold = 100000;
+bool		gp_autostats_allow_nonowner = false;
 bool		log_autostats = true;
 
 /* --------------------------------------------------------------------------------------------------

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2972,6 +2972,7 @@ autovacuum_do_vac_analyze(autovac_table *tab,
 	/* we pass the OID, but might need this anyway for an error message */
 	vacstmt.relation = &rangevar;
 	vacstmt.va_cols = NIL;
+	vacstmt.auto_stats = false;
 
 	/* Let pgstat know what we're doing */
 	autovac_report_activity(tab);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -783,6 +783,11 @@ standard_ProcessUtility(Node *parsetree,
 		case T_VacuumStmt:
 			{
 				VacuumStmt *stmt = (VacuumStmt *) parsetree;
+				/*
+				 * GPDB: this is vacuum/analyze manually, not auto stats. Could
+				 * also have done this in the parser.
+				 */
+				stmt->auto_stats = false;
 
 				/* we choose to allow this during "read only" transactions */
 				PreventCommandDuringRecovery((stmt->options & VACOPT_VACUUM) ?

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3089,6 +3089,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
+	{
+		{"gp_autostats_allow_nonowner", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Allow automatic stats collection on tables even for users who are not the owner of the relation."),
+			gettext_noop("If disabled, table statistics will be updated only when tables are modified by the owners of the relations.")
+		},
+		&gp_autostats_allow_nonowner,
+		false,
+		NULL, NULL, NULL
+	},
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL
@@ -4924,7 +4933,6 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		JOIN_ORDER_EXHAUSTIVE_SEARCH, optimizer_join_order_options,
 		NULL, NULL, NULL
 	},
-
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0, NULL, NULL, NULL

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -822,6 +822,7 @@ typedef enum
 extern int	gp_autostats_mode;
 extern int	gp_autostats_mode_in_functions;
 extern int	gp_autostats_on_change_threshold;
+extern bool	gp_autostats_allow_nonowner;
 extern bool	log_autostats;
 
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3151,6 +3151,9 @@ typedef struct VacuumStmt
 	bool appendonly_relation_empty;
 
 	AOVacuumPhase appendonly_phase;
+
+	/* invoked via automatic statistic collection */
+	bool auto_stats;
 } VacuumStmt;
 
 /* ----------------------

--- a/src/include/utils/guc_tables.h
+++ b/src/include/utils/guc_tables.h
@@ -91,8 +91,7 @@ enum config_group
 	LOGGING_WHEN,
 	LOGGING_WHAT,
 	STATS,
-
-    STATS_ANALYZE,                      /*CDB*/
+	STATS_ANALYZE,                      /*CDB*/
 	STATS_MONITORING,
 	STATS_COLLECTOR,
 	AUTOVACUUM,

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -145,6 +145,7 @@
 		"gp_autostats_mode",
 		"gp_autostats_mode_in_functions",
 		"gp_autostats_on_change_threshold",
+		"gp_autostats_allow_nonowner",
 		"gp_cached_segworkers_threshold",
 		"gp_command_count",
 		"gp_connection_send_timeout",

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -1,0 +1,161 @@
+-- start_matchsubs
+-- m/^LOG:  In mode on_change, command INSERT.* modifying 10 tuples caused Auto-ANALYZE./
+-- s/\(dboid,tableoid\)=\(\d+,\d+\)/\(dboid,tableoid\)=\(XXXXX,XXXXX\)/
+-- m/LOG:  Auto-stats did not issue ANALYZE on tableoid \d+ since the user does not have table-owner level permissions./
+-- s/tableoid \d+/tableoid XXXXX/
+-- end_matchsubs
+-- start_matchignore
+-- m/^LOG: .*Feature not supported: Non-default collation./
+-- m/^LOG:.*ERROR,"PG exception raised"/
+-- end_matchignore
+set gp_autostats_mode=on_change;
+set gp_autostats_on_change_threshold=9;
+set log_autostats=on;
+set client_min_messages=log;
+drop table if exists autostats_test;
+LOG:  statement: drop table if exists autostats_test;
+NOTICE:  table "autostats_test" does not exist, skipping
+create table autostats_test (a INTEGER);
+LOG:  statement: create table autostats_test (a INTEGER);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop user if exists autostats_nonowner;
+LOG:  statement: drop user if exists autostats_nonowner;
+NOTICE:  role "autostats_nonowner" does not exist, skipping
+create user autostats_nonowner;
+LOG:  statement: create user autostats_nonowner;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+-- Make sure rel_tuples starts at zero
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |         0
+(1 row)
+
+-- Try it with gp_autostats_allow_nonowner GUC enabled, but as a non-owner
+-- without INSERT permission.  Should fail with permission denied, without
+-- triggering autostats collection
+set gp_autostats_allow_nonowner=on;
+LOG:  statement: set gp_autostats_allow_nonowner=on;
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+insert into autostats_test select generate_series(1, 10);
+LOG:  statement: insert into autostats_test select generate_series(1, 10);
+LOG:  An exception was encountered during the execution of statement: insert into autostats_test select generate_series(1, 10);
+ERROR:  permission denied for relation autostats_test
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |         0
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- Try it with GUC enabled, after granting INSERT, stats should update to 10
+grant insert on table autostats_test to autostats_nonowner;
+LOG:  statement: grant insert on table autostats_test to autostats_nonowner;
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+insert into autostats_test select generate_series(11, 20);
+LOG:  statement: insert into autostats_test select generate_series(11, 20);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        10
+(1 row)
+
+-- Try running analyze manually as nonowner, should fail
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+analyze autostats_test;
+LOG:  statement: analyze autostats_test;
+WARNING:  skipping "autostats_test" --- only table or database owner can analyze it
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        10
+(1 row)
+
+-- Try to disable allow_nonowner GUC as ordinary user, should fail
+set gp_autostats_allow_nonowner=off;
+LOG:  statement: set gp_autostats_allow_nonowner=off;
+LOG:  An exception was encountered during the execution of statement: set gp_autostats_allow_nonowner=off;
+ERROR:  permission denied to set parameter "gp_autostats_allow_nonowner"
+show gp_autostats_allow_nonowner;
+LOG:  statement: show gp_autostats_allow_nonowner;
+ gp_autostats_allow_nonowner 
+-----------------------------
+ on
+(1 row)
+
+-- GUC should still be enabled, stats should update to 20
+insert into autostats_test select generate_series(21, 30);
+LOG:  statement: insert into autostats_test select generate_series(21, 30);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        20
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- Change allow_nonowner GUC as admin, should work
+set gp_autostats_allow_nonowner=off;
+LOG:  statement: set gp_autostats_allow_nonowner=off;
+show gp_autostats_allow_nonowner;
+LOG:  statement: show gp_autostats_allow_nonowner;
+ gp_autostats_allow_nonowner 
+-----------------------------
+ off
+(1 row)
+
+-- GUC should be disabled, stats should not update
+set role=autostats_nonowner;
+LOG:  statement: set role=autostats_nonowner;
+insert into autostats_test select generate_series(31, 40);
+LOG:  statement: insert into autostats_test select generate_series(31, 40);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+LOG:  Auto-stats did not issue ANALYZE on tableoid XXXXX since the user does not have table-owner level permissions.
+select relname, reltuples from pg_class where relname='autostats_test';
+LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        20
+(1 row)
+
+reset role;
+LOG:  statement: reset role;
+-- Try to enable allow_nonowner GUC as ordinary user, should fail
+-- GUC should still be disabled, stats should update from 20 to 40
+insert into autostats_test select generate_series(21, 30);
+LOG:  statement: insert into autostats_test select generate_series(21, 30);
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+reset client_min_messages;
+LOG:  statement: reset client_min_messages;
+select relname, reltuples from pg_class where relname='autostats_test';
+    relname     | reltuples 
+----------------+-----------
+ autostats_test |        40
+(1 row)
+
+reset role;
+-- After 4 successful inserts, final row count should also be 40
+select COUNT(*) from autostats_test;
+ count 
+-------
+    40
+(1 row)
+
+drop table if exists autostats_test;
+drop user autostats_nonowner;
+reset gp_autostats_mode;
+reset gp_autostats_on_change_threshold;
+reset log_autostats;
+reset gp_autostats_allow_nonowner;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -244,6 +244,9 @@ test: vacuum_full_freeze_heap
 test: vacuum_full_heap
 test: vacuum_full_heap_bitmapindex
 
+# check autostats
+test: autostats
+
 test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics
 test: metadata_track
 test: session_reset

--- a/src/test/regress/sql/autostats.sql
+++ b/src/test/regress/sql/autostats.sql
@@ -1,0 +1,80 @@
+-- start_matchsubs
+-- m/^LOG:  In mode on_change, command INSERT.* modifying 10 tuples caused Auto-ANALYZE./
+-- s/\(dboid,tableoid\)=\(\d+,\d+\)/\(dboid,tableoid\)=\(XXXXX,XXXXX\)/
+-- m/LOG:  Auto-stats did not issue ANALYZE on tableoid \d+ since the user does not have table-owner level permissions./
+-- s/tableoid \d+/tableoid XXXXX/
+-- end_matchsubs
+-- start_matchignore
+-- m/^LOG: .*Feature not supported: Non-default collation./
+-- m/^LOG:.*ERROR,"PG exception raised"/
+-- end_matchignore
+set gp_autostats_mode=on_change;
+set gp_autostats_on_change_threshold=9;
+set log_autostats=on;
+set client_min_messages=log;
+
+drop table if exists autostats_test;
+create table autostats_test (a INTEGER);
+drop user if exists autostats_nonowner;
+create user autostats_nonowner;
+
+-- Make sure rel_tuples starts at zero
+select relname, reltuples from pg_class where relname='autostats_test';
+
+-- Try it with gp_autostats_allow_nonowner GUC enabled, but as a non-owner
+-- without INSERT permission.  Should fail with permission denied, without
+-- triggering autostats collection
+set gp_autostats_allow_nonowner=on;
+set role=autostats_nonowner;
+insert into autostats_test select generate_series(1, 10);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- Try it with GUC enabled, after granting INSERT, stats should update to 10
+grant insert on table autostats_test to autostats_nonowner;
+set role=autostats_nonowner;
+insert into autostats_test select generate_series(11, 20);
+select relname, reltuples from pg_class where relname='autostats_test';
+
+-- Try running analyze manually as nonowner, should fail
+set role=autostats_nonowner;
+analyze autostats_test;
+select relname, reltuples from pg_class where relname='autostats_test';
+
+-- Try to disable allow_nonowner GUC as ordinary user, should fail
+set gp_autostats_allow_nonowner=off;
+show gp_autostats_allow_nonowner;
+
+-- GUC should still be enabled, stats should update to 20
+insert into autostats_test select generate_series(21, 30);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- Change allow_nonowner GUC as admin, should work
+set gp_autostats_allow_nonowner=off;
+show gp_autostats_allow_nonowner;
+
+-- GUC should be disabled, stats should not update
+set role=autostats_nonowner;
+insert into autostats_test select generate_series(31, 40);
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- Try to enable allow_nonowner GUC as ordinary user, should fail
+
+-- GUC should still be disabled, stats should update from 20 to 40
+insert into autostats_test select generate_series(21, 30);
+reset client_min_messages;
+select relname, reltuples from pg_class where relname='autostats_test';
+reset role;
+
+-- After 4 successful inserts, final row count should also be 40
+select COUNT(*) from autostats_test;
+
+drop table if exists autostats_test;
+drop user autostats_nonowner;
+
+reset gp_autostats_mode;
+reset gp_autostats_on_change_threshold;
+reset log_autostats;
+reset gp_autostats_allow_nonowner;


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/12591

6X_STABLE VACUUM code has been refactored in 7X, so it was not a simple cherry-pick, but the gist of this fix remains the same and so does the tests.