### PR TITLE
Don't collect execution stats if the query failed

### DIFF
--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1085,7 +1085,7 @@ ExecSetParamPlan(SubPlanState *node, ExprContext *econtext, QueryDesc *queryDesc
 	SubLinkType subLinkType = subplan->subLinkType;
 	EState	   *estate = planstate->state;
 	ScanDirection dir = estate->es_direction;
-	MemoryContext oldcontext;
+	MemoryContext oldcontext = NULL;
 	TupleTableSlot *slot;
 	ListCell   *pvar;
 	ListCell   *l;
@@ -1414,6 +1414,12 @@ PG_CATCH();
 {
 	/* Restore memory high-water mark for root slice of main query. */
 	MemoryContextSetPeakSpace(planstate->state->es_query_cxt, savepeakspace);
+
+	if (oldcontext)
+		MemoryContextSwitchTo(oldcontext);
+
+	/* restore scan direction */
+	estate->es_direction = dir;
 
 	/*
 	 * Clean up the interconnect.

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1412,25 +1412,6 @@ PG_TRY();
 }
 PG_CATCH();
 {
-	/* If EXPLAIN ANALYZE, collect local and distributed execution stats. */
-	if (planstate->instrument && planstate->instrument->need_cdb)
-	{
-		if(Gp_role == GP_ROLE_DISPATCH)
-			cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
-		if (!explainRecvStats &&
-			shouldDispatch &&
-			queryDesc->estate->dispatcherState)
-		{
-			/* Wait for all gangs to finish.  Cancel slowpokes. */
-			cdbdisp_cancelDispatch(queryDesc->estate->dispatcherState);
-
-			cdbexplain_recvExecStats(planstate,
-									 queryDesc->estate->dispatcherState->primaryResults,
-									 LocallyExecutingSliceIndex(queryDesc->estate),
-									 econtext->ecxt_estate->showstatctx);
-		}
-	}
-
 	/* Restore memory high-water mark for root slice of main query. */
 	MemoryContextSetPeakSpace(planstate->state->es_query_cxt, savepeakspace);
 


### PR DESCRIPTION
Currently, if one segment (like seg1) panics due to some reason, other
segments (like seg0) will report "InstrEndLoop called on running node".

This is because QE on seg1 reports ERROR to QD when execution fails,
and the QD dispatches cancel command to all the QEs, but another QE on
seg0 is not finished yet, its `instr` structure is not cleaned up.

This commit is to remove the logic of sending stats when execution
failed, which is not needed.

Fixes greenplum-db#9904