### PR TITLE
Docs: Added GUC quote_all_identifiers

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -506,6 +506,9 @@
               <xref href="#port"/>
             </li>
             <li>
+              <xref href="#quote_all_identifiers"/>
+            </li>
+            <li>
               <xref href="#random_page_cost"/>
             </li>
             <li>
@@ -8055,6 +8058,36 @@
               <entry colname="col1">any valid port number</entry>
               <entry colname="col2">5432</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="quote_all_identifiers">
+    <title>quote_all_identifiers</title>
+    <body>
+      <p>Ensures that all identifiers are quoted, even if they are not keywords, when the database
+        generates SQL. See also the <codeph>--quote-all-identifiers</codeph> option of <codeph><xref
+            href="../../utility_guide/ref/pg_dump.xml"/></codeph> and <codeph><xref
+            href="../../utility_guide/ref/pg_dumpall.xml"/></codeph>.</p>
+      <table id="table_umd_ds4_brb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">false</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8087,7 +8087,7 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">false</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+              <entry colname="col3">local<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1310,6 +1310,10 @@
                 <xref href="guc-list.xml#escape_string_warning" type="section"
                   >escape_string_warning</xref>
               </p>
+              <p>
+                <xref href="guc-list.xml#quote_all_identifiers" type="section"
+                  >quote_all_identifiers</xref>
+              </p>
             </stentry>
             <stentry>
               <p><xref href="guc-list.xml#regex_flavor" type="section">regex_flavor</xref>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -251,6 +251,7 @@
             <topicref href="guc-list.xml#pljava_release_lingering_savepoints"/>
             <topicref href="guc-list.xml#pljava_vmoptions"/>
             <topicref href="guc-list.xml#port"/>
+            <topicref href="guc-list.xml#quote_all_identifiers"/>
             <topicref href="guc-list.xml#random_page_cost"/>
             <topicref href="guc-list.xml#readable_external_table_timeout"/>
             <topicref href="guc-list.xml#repl_catchup_within_range"/>


### PR DESCRIPTION
Adding documentation for GUC quote_all_identifiers. 
Needs to be merged to master and 6x.
Re: parameter categories, I have not added it under any of the existing categories. Would any of them fit?
I thought about [Past Version Compatibility Parameters](https://gpdb.docs.pivotal.io/6-17/ref_guide/config_params/guc_category-list.html#topic48) since it is used when upgrading from 5.x to 6.x but not sure if it fits.
Preview site: https://mireia-quote-all-identifiers.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/config_params/guc-list.html#quote_all_identifiers