### PR TITLE
docs - for new guc gp_autostats_allow_nonowner

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -472,9 +472,13 @@
           that could disrupt the system, so it is not recommended to set it globally. It could be
           useful in a session, for example to automatically analyze a table following a load.</p>
         <p>Setting the <codeph>gp_autostats_allow_nonowner</codeph> server configuration
-          parameter to <codeph>true</codeph> follows the rules above, and instructs Greenplum
-          Database to also trigger statistics collection when a table is updated by a
-          non-owner.</p>
+          parameter to <codeph>true</codeph> also instructs Greenplum Database to trigger
+          automatic statistics collection on a table when:</p>
+        <ul>
+          <li><codeph>gp_autostats_mode=on_change</codeph> and the table is modified by a non-owner.</li>
+          <li><codeph>gp_autostats_mode=on_no_stats</codeph> and the first user to
+            <codeph>INSERT</codeph> or <codeph>COPY</codeph> into the table is a non-owner.</li>
+        </ul>
         <p>To disable automatic statistics collection outside of functions, set the
             <codeph>gp_autostats_mode</codeph> parameter to
           <codeph>none</codeph>:<codeblock>gpconfigure -c gp_autostats_mode -v none</codeblock></p>

--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -439,7 +439,7 @@
           performed on the table. For partitioned tables, automatic statistics collection is only
           triggered when the operation is run directly on a leaf table, and then only the leaf table
           is analyzed.</p>
-        <p>Automatic statistics collection is governed a server configuration parameter,
+        <p>Automatic statistics collection is governed by a server configuration parameter,
           and has three modes:<ul id="ul_epn_pcb_mt">
             <li><codeph>none</codeph> disables automatic statistics collection.</li>
             <li><codeph>on_no_stats</codeph> triggers an analyze operation for a table with no

--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -439,15 +439,18 @@
           performed on the table. For partitioned tables, automatic statistics collection is only
           triggered when the operation is run directly on a leaf table, and then only the leaf table
           is analyzed.</p>
-        <p>Automatic statistics collection has three modes:<ul id="ul_epn_pcb_mt">
+        <p>Automatic statistics collection is governed a server configuration parameter,
+          and has three modes:<ul id="ul_epn_pcb_mt">
             <li><codeph>none</codeph> disables automatic statistics collection.</li>
             <li><codeph>on_no_stats</codeph> triggers an analyze operation for a table with no
               existing statistics when any of the commands <codeph>CREATE TABLE AS SELECT</codeph>,
-                <codeph>INSERT</codeph>, or <codeph>COPY</codeph> are run on the table. </li>
+                <codeph>INSERT</codeph>, or <codeph>COPY</codeph> are run on the table by the
+                table owner. </li>
             <li><codeph>on_change</codeph> triggers an analyze operation when any of the commands
                 <codeph>CREATE TABLE AS SELECT</codeph>, <codeph>UPDATE</codeph>,
                 <codeph>DELETE</codeph>, <codeph>INSERT</codeph>, or <codeph>COPY</codeph> are
-              run on the table and the number of rows affected exceeds the threshold defined by
+              run on the table by the table owner, and the number of rows affected exceeds the
+              threshold defined by
               the <codeph>gp_autostats_on_change_threshold</codeph> configuration parameter.</li>
           </ul></p>
         <p>The automatic statistics collection mode is set separately for commands that occur within
@@ -468,6 +471,10 @@
           it. The <codeph>on_change</codeph> mode could trigger large, unexpected analyze operations
           that could disrupt the system, so it is not recommended to set it globally. It could be
           useful in a session, for example to automatically analyze a table following a load.</p>
+        <p>Setting the <codeph>gp_autostats_allow_nonowner</codeph> server configuration
+          parameter to <codeph>true</codeph> follows the rules above, and instructs Greenplum
+          Database to also trigger statistics collection when a table is updated by a
+          non-owner.</p>
         <p>To disable automatic statistics collection outside of functions, set the
             <codeph>gp_autostats_mode</codeph> parameter to
           <codeph>none</codeph>:<codeblock>gpconfigure -c gp_autostats_mode -v none</codeblock></p>

--- a/gpdb-doc/dita/best_practices/analyze.xml
+++ b/gpdb-doc/dita/best_practices/analyze.xml
@@ -75,9 +75,14 @@
           <codeph>on_change</codeph>: <codeph>CREATE TABLE AS SELECT</codeph>,
           <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, <codeph>INSERT</codeph>, and
           <codeph>COPY</codeph>.</p>
-      <p>Setting <codeph>gp_autostats_allow_nonowner</codeph> to <codeph>true</codeph>
-        follows the rules above, and also instructs Greenplum Database to trigger statistics
-        collection when a table is updated by a non-owner.</p>
+      <p>Setting the <codeph>gp_autostats_allow_nonowner</codeph> server configuration
+        parameter to <codeph>true</codeph> also instructs Greenplum Database to trigger
+        automatic statistics collection on a table when:</p>
+      <ul>
+        <li><codeph>gp_autostats_mode=on_change</codeph> and the table is modified by a non-owner.</li>
+        <li><codeph>gp_autostats_mode=on_no_stats</codeph> and the first user to
+          <codeph>INSERT</codeph> or <codeph>COPY</codeph> into the table is a non-owner.</li>
+      </ul>
       <p>Setting <codeph>gp_autostats_mode</codeph> to <codeph>none</codeph> disables automatics
         statistics collection. </p>
       <p> For partitioned tables, automatic statistics collection is not triggered if data is

--- a/gpdb-doc/dita/best_practices/analyze.xml
+++ b/gpdb-doc/dita/best_practices/analyze.xml
@@ -65,15 +65,19 @@
         planner adds an <codeph>ANALYZE</codeph> step to the query. </p>
       <p>By default, <codeph>gp_autostats_mode</codeph> is <codeph>on_no_stats</codeph>, which
         triggers statistics collection for <codeph>CREATE TABLE AS SELECT</codeph>,
-          <codeph>INSERT</codeph>, or <codeph>COPY</codeph> operations on any table that has no
-        existing statistics. </p>
+          <codeph>INSERT</codeph>, or <codeph>COPY</codeph> operations invoked by the table
+        owner on any table that has no existing statistics. </p>
       <p>Setting <codeph>gp_autostats_mode</codeph> to <codeph>on_change</codeph> triggers
         statistics collection only when the number of rows affected exceeds the threshold defined by
           <codeph>gp_autostats_on_change_threshold</codeph>, which has a default value of
-        2147483647. Operations that can trigger automatic statistics collection with
-          <codeph>on_change</codeph> are: <codeph>CREATE TABLE AS SELECT</codeph>,
+        2147483647. The following operations invoked on a table by its owner can trigger
+        automatic statistics collection with
+          <codeph>on_change</codeph>: <codeph>CREATE TABLE AS SELECT</codeph>,
           <codeph>UPDATE</codeph>, <codeph>DELETE</codeph>, <codeph>INSERT</codeph>, and
           <codeph>COPY</codeph>.</p>
+      <p>Setting <codeph>gp_autostats_allow_nonowner</codeph> to <codeph>true</codeph>
+        follows the rules above, and also instructs Greenplum Database to trigger statistics
+        collection when a table is updated by a non-owner.</p>
       <p>Setting <codeph>gp_autostats_mode</codeph> to <codeph>none</codeph> disables automatics
         statistics collection. </p>
       <p> For partitioned tables, automatic statistics collection is not triggered if data is

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -156,6 +156,9 @@
               <xref href="#gp_appendonly_compaction_threshold"/>
             </li>
             <li>
+              <xref href="#gp_autostats_allow_nonowner"/>
+            </li>
+            <li>
               <xref href="#gp_autostats_mode"/>
             </li>
             <li>
@@ -2125,6 +2128,41 @@
               <entry colname="col1">integer (%)</entry>
               <entry colname="col2">10</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_autostats_allow_nonowner">
+    <title>gp_autostats_allow_nonowner</title>
+    <body>
+      <p>When <codeph>gp_autostats_mode=on_change</codeph>, Greenplum Database automatically
+        triggers statistics collection on a table after it is modified by its owner.</p>
+      <p>The <codeph>gp_autostats_allow_nonowner</codeph> server configuration parameter
+        determines whether or not to allow Greenplum Database to trigger automatic statistics
+        collection when a table is modified by a non-owner.</p>
+      <p>The default value is <codeph>false</codeph>; Greenplum Database does not trigger
+        automatic statistics collection on a table that is updated by a non-owner.</p>
+      <p>The <codeph>gp_autostats_allow_nonowner</codeph> configuration parameter can be
+        changed only by a superuser.</p>
+      <table id="gp_auto_stats_allow_nonowner_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">false</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p><p>superuser</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2137,13 +2137,18 @@
   <topic id="gp_autostats_allow_nonowner">
     <title>gp_autostats_allow_nonowner</title>
     <body>
-      <p>When <codeph>gp_autostats_mode=on_change</codeph>, Greenplum Database automatically
-        triggers statistics collection on a table after it is modified by its owner.</p>
       <p>The <codeph>gp_autostats_allow_nonowner</codeph> server configuration parameter
         determines whether or not to allow Greenplum Database to trigger automatic statistics
         collection when a table is modified by a non-owner.</p>
       <p>The default value is <codeph>false</codeph>; Greenplum Database does not trigger
         automatic statistics collection on a table that is updated by a non-owner.</p>
+      <p>When set to <codeph>true</codeph>, Greenplum Database will also trigger automatic
+         statistics collection on a table when:</p>
+      <ul>
+        <li><codeph>gp_autostats_mode=on_change</codeph> and the table is modified by a non-owner.</li>
+        <li><codeph>gp_autostats_mode=on_no_stats</codeph> and the first user to
+          <codeph>INSERT</codeph> or <codeph>COPY</codeph> into the table is a non-owner.</li>
+      </ul>
       <p>The <codeph>gp_autostats_allow_nonowner</codeph> configuration parameter can be
         changed only by a superuser.</p>
       <table id="gp_auto_stats_allow_nonowner_table">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -899,12 +899,17 @@
         <strow>
           <stentry>
             <p>
+              <xref href="guc-list.xml#gp_autostats_allow_nonowner" type="section">gp_autostats_allow_nonowner</xref>
+            </p>
+            <p>
               <xref href="guc-list.xml#gp_autostats_mode" type="section">gp_autostats_mode</xref>
             </p>
             <p>
               <xref href="guc-list.xml#gp_autostats_mode_in_functions" type="section"
                 >gp_autostats_mode_in_functions</xref>
             </p>
+          </stentry>
+          <stentry>
             <p>
               <xref href="guc-list.xml#gp_autostats_on_change_threshold" type="section"
                 >gp_autostats_on_change_threshold</xref>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -75,6 +75,7 @@
             <topicref href="guc-list.xml#gp_adjust_selectivity_for_outerjoins"/>
             <topicref href="guc-list.xml#gp_appendonly_compaction"/>
             <topicref href="guc-list.xml#gp_appendonly_compaction_threshold"/>
+            <topicref href="guc-list.xml#gp_autostats_allow_nonowner"/>
             <topicref href="guc-list.xml#gp_autostats_mode"/>
             <topicref href="guc-list.xml#gp_autostats_mode_in_functions"/>
             <topicref href="guc-list.xml#gp_autostats_on_change_threshold"/>


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/12591, https://github.com/greenplum-db/gpdb/pull/12624.

add guc reference for new gp_autostats_allow_nonowner guc.  misc updates to existing topics about automatic stats collection.

question:  what is greenplum's behaviour when this guc is set to true and gp_autostats_mode=on_no_stats?

this will be backported to 6X_STABLE.