### PR TITLE
[6X backport] Fix ORCA runaway cleaner exception handler  (#12612)

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -953,6 +953,9 @@ gpdb::GetComparisonOperator(Oid left_oid, Oid right_oid, unsigned int cmpt)
 {
 	GP_WRAP_START;
 	{
+#ifdef FAULT_INJECTOR
+		SIMPLE_FAULT_INJECTOR("gpdbwrappers_get_comparison_operator");
+#endif
 		/* catalog tables: pg_amop */
 		return get_comparison_operator(left_oid, right_oid, (CmpType) cmpt);
 	}

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
@@ -94,11 +94,12 @@ CMDAccessorUtils::FCmpExists(CMDAccessor *md_accessor, IMDId *left_mdid,
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		GPOS_ASSERT(
-			GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound));
-		GPOS_RESET_EX;
-
-		return false;
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound))
+		{
+			GPOS_RESET_EX;
+			return false;
+		}
+		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 }
@@ -167,11 +168,12 @@ CMDAccessorUtils::FCmpOrCastedCmpExists(IMDId *left_mdid, IMDId *right_mdid,
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		GPOS_ASSERT(
-			GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound));
-		GPOS_RESET_EX;
-
-		return false;
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound))
+		{
+			GPOS_RESET_EX;
+			return false;
+		}
+		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 }
@@ -358,11 +360,12 @@ CMDAccessorUtils::FCastExists(CMDAccessor *md_accessor, IMDId *mdid_src,
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		GPOS_ASSERT(
-			GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound));
-		GPOS_RESET_EX;
-
-		return false;
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound))
+		{
+			GPOS_RESET_EX;
+			return false;
+		}
+		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 }
@@ -401,9 +404,12 @@ CMDAccessorUtils::FScalarOpReturnsNullOnNullInput(CMDAccessor *md_accessor,
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		GPOS_ASSERT(
-			GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound));
-		GPOS_RESET_EX;
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound))
+		{
+			GPOS_RESET_EX;
+			return false;
+		}
+		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
 

--- a/src/test/isolation2/expected/runaway_query.out
+++ b/src/test/isolation2/expected/runaway_query.out
@@ -1,0 +1,30 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+CREATE OR REPLACE LANGUAGE plpgsql;
+CREATE
+
+CREATE TABLE runaway_query_test_table(a bigint NOT NULL) DISTRIBUTED BY (a);
+CREATE
+
+-- Use error fault to simulate vmem protect error and force cancel query.
+SELECT gp_inject_fault_infinite('gpdbwrappers_get_comparison_operator', 'error', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Following query will trip the fault during ORCA optimization
+EXPLAIN (COSTS OFF) SELECT a FROM runaway_query_test_table WHERE (a = ANY ((ARRAY[42])));
+ QUERY PLAN                                    
+-----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)      
+   ->  Seq Scan on runaway_query_test_table    
+         Filter: (a = ANY ('{42}'::integer[])) 
+ Optimizer: Postgres query optimizer           
+(4 rows)
+
+SELECT gp_inject_fault('all', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/expected/runaway_query_optimizer.out
+++ b/src/test/isolation2/expected/runaway_query_optimizer.out
@@ -1,0 +1,24 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+CREATE OR REPLACE LANGUAGE plpgsql;
+CREATE
+
+CREATE TABLE runaway_query_test_table(a bigint NOT NULL) DISTRIBUTED BY (a);
+CREATE
+
+-- Use error fault to simulate vmem protect error and force cancel query.
+SELECT gp_inject_fault_infinite('gpdbwrappers_get_comparison_operator', 'error', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Following query will trip the fault during ORCA optimization
+EXPLAIN (COSTS OFF) SELECT a FROM runaway_query_test_table WHERE (a = ANY ((ARRAY[42])));
+ERROR:  fault triggered, fault name:'gpdbwrappers_get_comparison_operator' fault type:'error'
+
+SELECT gp_inject_fault('all', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -264,6 +264,7 @@ ignore: restore_memory_accounting_default
 test: setup_startup_memory_accounting
 test: oom_startup_memory
 test: restore_memory_accounting_default
+test: runaway_query
 
 # Too many exec accounts test start
 test: setup_too_many_exec_accounts

--- a/src/test/isolation2/sql/runaway_query.sql
+++ b/src/test/isolation2/sql/runaway_query.sql
@@ -1,0 +1,12 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE OR REPLACE LANGUAGE plpgsql;
+
+CREATE TABLE runaway_query_test_table(a bigint NOT NULL) DISTRIBUTED BY (a);
+
+-- Use error fault to simulate vmem protect error and force cancel query.
+SELECT gp_inject_fault_infinite('gpdbwrappers_get_comparison_operator', 'error', 1);
+
+-- Following query will trip the fault during ORCA optimization
+EXPLAIN (COSTS OFF) SELECT a FROM runaway_query_test_table WHERE (a = ANY ((ARRAY[42])));
+
+SELECT gp_inject_fault('all', 'reset', 1);


### PR DESCRIPTION
Runaway query detector uses the built-in exception handling framework to
cancel queries by propagating a "Cancelling query" ERROR. Issue is that
ORCA could sometimes swallow the exception and prevent the query from
canceling.  Ultimately this could nullify the runaway cleaner and lead
to an out of memory exception in ORCA.

(cherry picked from commit 07ed32bc7f389c262ab748a3b2fb65e5d36f9447)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
