### PR TITLE
Fix backup block logic for Bitmap index bitmap pages

### DIFF
--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -1110,7 +1110,7 @@ _bitmap_log_updateword(Relation rel, Buffer bitmapBuffer, int word_no)
 
 	XLogBeginInsert();
 	XLogRegisterData((char*)&xlBitmapWord, sizeof(xl_bm_updateword));
-	XLogRegisterBuffer(0, bitmapBuffer, REGBUF_STANDARD);
+	XLogRegisterBuffer(0, bitmapBuffer, 0);
 
 	recptr = XLogInsert(RM_BITMAP_ID, XLOG_BITMAP_UPDATEWORD);
 
@@ -1185,10 +1185,10 @@ _bitmap_log_updatewords(Relation rel,
 
 	XLogBeginInsert();
 	XLogRegisterData((char*)&xlBitmapWords, sizeof(xl_bm_updatewords));
-	XLogRegisterBuffer(0, firstBuffer, REGBUF_STANDARD);
+	XLogRegisterBuffer(0, firstBuffer, 0);
 
 	if (BufferIsValid(secondBuffer))
-		XLogRegisterBuffer(1, secondBuffer, REGBUF_STANDARD);
+		XLogRegisterBuffer(1, secondBuffer, 0);
 
 	if (new_lastpage)
 	{

--- a/src/test/isolation2/expected/bitmap_update_words_backup_block.out
+++ b/src/test/isolation2/expected/bitmap_update_words_backup_block.out
@@ -1,0 +1,71 @@
+-- Setup fault injectors.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- Skip FTS probes for this test to avoid segment being marked down on restart.
+1:SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1:SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+1:SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+CREATE TABLE bm_update_words_backup_block (id int) WITH (appendonly = true);
+CREATE
+
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO bm_update_words_backup_block SELECT i%100 FROM generate_series(1, 200) AS i;
+INSERT 200
+2: INSERT INTO bm_update_words_backup_block SELECT i%100 FROM generate_series(1, 200) AS i;
+INSERT 200
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+
+CREATE INDEX bm_update_words_backup_block_idx ON bm_update_words_backup_block USING bitmap (id);
+CREATE
+
+-- INSERTs will attempt to add a bitmap page but will cause a word
+-- expansion and a bitmap page split due to overflow. See bitmap
+-- function updatesetbit_inpage().
+2: INSERT INTO bm_update_words_backup_block VALUES (97);
+INSERT 1
+2: INSERT INTO bm_update_words_backup_block VALUES (97), (99);
+INSERT 2
+
+-- Run a CHECKPOINT to force this next INSERT to add backup blocks of
+-- the two bitmap pages to its XLOG_BITMAP_UPDATEWORDS record.
+2: CHECKPOINT;
+CHECKPOINT
+2: INSERT INTO bm_update_words_backup_block VALUES (97);
+INSERT 1
+
+-- Do an immediate restart to force crash recovery. The above INSERT
+-- should be replayed with the backup blocks.
+1: SELECT pg_ctl(datadir, 'restart') FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+3: INSERT INTO bm_update_words_backup_block VALUES (97);
+INSERT 1
+
+-- Turn FTS back on.
+3:SELECT gp_inject_fault('fts_probe', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -83,6 +83,7 @@ test: gp_collation
 test: ao_upgrade
 test: bitmap_index_concurrent
 test: bitmap_index_crash
+test: bitmap_update_words_backup_block
 
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table

--- a/src/test/isolation2/sql/bitmap_update_words_backup_block.sql
+++ b/src/test/isolation2/sql/bitmap_update_words_backup_block.sql
@@ -1,0 +1,39 @@
+-- Setup fault injectors.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Skip FTS probes for this test to avoid segment being marked down on restart.
+1:SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+1:SELECT gp_request_fts_probe_scan();
+1:SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+
+CREATE TABLE bm_update_words_backup_block (id int) WITH (appendonly = true);
+
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO bm_update_words_backup_block SELECT i%100 FROM generate_series(1, 200) AS i;
+2: INSERT INTO bm_update_words_backup_block SELECT i%100 FROM generate_series(1, 200) AS i;
+1: COMMIT;
+2: COMMIT;
+
+CREATE INDEX bm_update_words_backup_block_idx ON bm_update_words_backup_block USING bitmap (id);
+
+-- INSERTs will attempt to add a bitmap page but will cause a word
+-- expansion and a bitmap page split due to overflow. See bitmap
+-- function updatesetbit_inpage().
+2: INSERT INTO bm_update_words_backup_block VALUES (97);
+2: INSERT INTO bm_update_words_backup_block VALUES (97), (99);
+
+-- Run a CHECKPOINT to force this next INSERT to add backup blocks of
+-- the two bitmap pages to its XLOG_BITMAP_UPDATEWORDS record.
+2: CHECKPOINT;
+2: INSERT INTO bm_update_words_backup_block VALUES (97);
+
+-- Do an immediate restart to force crash recovery. The above INSERT
+-- should be replayed with the backup blocks.
+1: SELECT pg_ctl(datadir, 'restart') FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+3: INSERT INTO bm_update_words_backup_block VALUES (97);
+
+-- Turn FTS back on.
+3:SELECT gp_inject_fault('fts_probe', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;


### PR DESCRIPTION
Bitmap indexes bitmap pages don't use standard buffer page
structure. These store the hwords and cwords as part of page content,
which forms the full page content of the
page. `XLOG_BITMAP_UPDATEWORD` and `XLOG_BITMAP_UPDATEWORDS` WAL
records incorrectly set `buffer_std to true` when writing WAL. This
caused backup block created to be empty for these pages as it conveys
hole start as 24 and length as 32728 (which essentially maps to entire
page to skipped from backed up). We should be copying full 32K page as
backup block for bitmap pages.

Co-authored-by: Jimmy Yih <jyih@vmware.com>

This is a forward-port of 6X_STABLE commit:
https://github.com/greenplum-db/gpdb/commit/c810e139940aa6a470419d5993d62289a86bb0cf

Conflicts fixed:
1. There are XLogRegisterBuffer flags now. We just need to remove the
   REGBUF_STANDARD flag when registering the bitmap buffers.
2. The isolation2 test wasn't working as expected because the INSERT
   after CHECKPOINT was showing up as a BITMAP_INSERT_BITMAP_LASTWORDS
   record instead of an XLOG_BITMAP_UPDATEWORDS record. Needed to add
   one more INSERT to take up the BITMAP_INSERT_BITMAP_LASTWORDS
   record which allowed the next INSERT to be the expected
   XLOG_BITMAP_UPDATEWORDS record that the test needs.