### PR TITLE
Bump catalog version for the parallel retrieve cursor feature.

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302104151
+#define CATALOG_VERSION_NO	302109291
 
 #endif


### PR DESCRIPTION
Forget to do this in the parallel retrieve cursor code.