### PR TITLE
Expand partition table in parallel

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1628,14 +1628,17 @@ WHERE
 
     def _populate_partitioned_tables(self, dbname):
         """
-        population of status_detail for partitioned tables, leaf partition cannot
-        has different numsegments with root partition, we need to expand root
-        partition in one shot, so just populate root partition for now.
+        The policy of leaves can be different of the policy of root, But it must
+        follow below rules:
+        If a partitioned table is Hash distributed, then all its leaf partitions
+        must also be Hash partitioned on the same distribution key, with the
+        same 'numsegments', or randomly distributed with the same 'numsegments'.
+        If a partitioned table is Randomly distributed, then all the leaves must
+        be randomly distributed as well.
 
-        TODO:
-        We used to use a tricky but effective way to expand leaf partition in
-        in parallel, that way is still under discussion. Keep the old method
-        here in case we need bring it back someday.
+        population of status_detail for partitioned tables, leaf partition can
+        has different policy with root partition, we need to expand leaf
+        partitions separately in parallel.
 
         Step1:
            BEGIN;
@@ -1644,44 +1647,59 @@ WHERE
            Change all leaf partition to random distributed;
            COMMIT;
         Step2:
-           Change all leaf partition's policy back to old policy with a mandatory
-           data movement.
+           Change all leaf partition's policy back to parent's policy with set distributed
+           with(REORGANIZE=true)
         """
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
-        sql = """
-SELECT
-    current_database(),
-    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-    c.oid as tableoid,
-    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name,
-    2 as rank,
-    false as external_writable,
-    '%s' as undone_status,
-    NULL as expansion_started,
-    NULL as expansion_finished,
-    %s as source_bytes
-FROM
-    pg_class c,
-    pg_namespace n,
-    pg_partitioned_table p,
-    gp_distribution_policy d
-WHERE
-    c.relnamespace = n.oid
-    AND p.partrelid = c.oid
-    AND NOT c.relispartition
-    AND d.localoid = c.oid
-ORDER BY fq_name, tableoid desc
-                  """ % (undone_status, src_bytes_str)
-        self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
+
+        cursor = dbconn.query(table_conn, """
+            SELECT partrelid::regclass AS relname
+            FROM pg_partitioned_table, pg_class
+            WHERE partrelid = pg_class.oid AND relispartition = FALSE;
+        """)
+        for row in cursor:
+            prepare_cmd = """
+                ALTER TABLE %s EXPAND PARTITION PREPARE;
+            """ % (row.relname)
+            self.logger.debug(prepare_cmd)
+            dbconn.execSQL(table_conn, prepare_cmd, autocommit=False)
+
+        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(relid)"
+        get_status_detail_cmd = """
+             SELECT
+                current_database(),
+                quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
+                c.oid as tableoid,
+                quote_ident(n.nspname) || '.' || quote_ident(d.relname) as root_partition_name,
+                2 as rank,
+                false as external_writable,
+                '%s' as undone_status,
+                NULL as expansion_started,
+                NULL as expansion_finished
+                %s as source_bytes
+            FROM
+                pg_inherits a,
+                pg_partitioned_table b,
+                pg_class c, 
+                pg_class d,
+                pg_namespace n
+            WHERE
+                a.inhparent=b.partrelid and
+                a.inhrelid = c.oid and
+                a.inhparent = d.oid and
+                c.relnamespace = n.oid and
+                c.relkind != 'p';
+        """ % (undone_status, src_bytes_str)
+        self.logger.debug(get_status_detail_cmd)
 
         try:
             data_file = os.path.abspath('./status_detail.dat')
             self.logger.debug('status_detail data file: %s' % data_file)
-            copySQL = """COPY (%s) TO '%s'""" % (sql, data_file)
+            copySQL = """COPY (%s) TO '%s'""" % (get_status_detail_cmd, data_file)
 
             self.logger.debug(copySQL)
             dbconn.execSQL(table_conn, copySQL)
+            table_conn.commit()
             table_conn.close()
         except Exception as e:
             raise ExpansionError(e)
@@ -1960,11 +1978,18 @@ class ExpandTable():
         dbconn.execSQL(status_conn, sql)
 
     def expand(self, table_conn, cancel_flag):
-        # for root partition, we want to expand whose partition in one shot
-        # TODO: expand leaf partitions separately in parallel
-        only_str = "" if self.is_root_partition else "ONLY"
-        external_str = "EXTERNAL" if self.external_writable else ""
-        sql = 'ALTER %s TABLE %s %s EXPAND TABLE' % (external_str, only_str, self.fq_name)
+        # expand leaf partitions separately in parallel
+        if self.root_partition_name is not None:
+            get_dist_cmd = """
+                SELECT pg_get_table_distributedby('%s'::regclass) AS distribution_policy;
+            """ % (self.root_partition_name)
+            res = dbconn.queryRow(table_conn, get_dist_cmd)
+            # FIXME: handle EXTERNAL writable tables
+            sql = "ALTER TABLE %s SET WITH (REORGANIZE=true) %s" % (self.fq_name, res.distribution_policy)
+        else:
+            # FIXME: Can "ONLY" be allowed in "EXPAND TABLE"?
+            external_str = "EXTERNAL" if self.external_writable else ""
+            sql = 'ALTER TABLE %s %s EXPAND TABLE' % (external_str, self.fq_name)
 
         logger.info('Expanding %s.%s' % (self.dbname, self.fq_name))
         logger.debug("Expand SQL: %s" % sql)

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -440,3 +440,22 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "public.test_matview" is 4
         And distribution information from table "public.test_matview" and "public.test_matview_base" in "gptest" are the same
+
+    @gpexpand_verify_partition_table
+    Scenario: Verify should succeed when expand partition table
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "1" primaries only
+        And database "gptest" exists
+        And the user create a partition table with name "partition_test"
+        And distribution information from table "partition_test" with data in "gptest" is saved
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 3 new segments
+        When the user runs gpexpand to redistribute
+        Then the numsegments of table "partition_test" is 4
+        Then distribution information from table "partition_test" with data in "gptest" is verified against saved data

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -191,6 +191,16 @@ def impl(conetxt, tabname):
         dbconn.execSQL(conn, sql)
         conn.commit()
 
+@given('the user create a partition table with name "{tabname}"')
+def impl(conetxt, tabname):
+    dbname = 'gptest'
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
+        sql = "create table {tabname}(i int) partition by range(i) (start(0) end(10001) every(1000)) distributed by (i)".format(tabname=tabname)
+        dbconn.execSQL(conn, sql)
+        sql = "INSERT INTO {tabname} SELECT generate_series(1, 10000)".format(tabname=tabname)
+        dbconn.execSQL(conn, sql)
+        conn.commit()
+
 
 @given('the user executes "{sql}" with named connection "{cname}"')
 def impl(context, cname, sql):
@@ -2872,11 +2882,14 @@ def impl(context, table_name, dbname):
 @given('distribution information from table "{table}" with data in "{dbname}" is saved')
 def impl(context, table, dbname):
     context.pre_redistribution_row_count = _get_row_count_per_segment(table, dbname)
+    context.pre_redistribution_dist_policy = _get_dist_policy_per_partition(table, dbname)
 
 @then('distribution information from table "{table}" with data in "{dbname}" is verified against saved data')
 def impl(context, table, dbname):
     pre_distribution_row_count = context.pre_redistribution_row_count
+    pre_redistribution_dist_policy = context.pre_redistribution_dist_policy
     post_distribution_row_count = _get_row_count_per_segment(table, dbname)
+    post_distribution_dist_policy = _get_dist_policy_per_partition(table, dbname)
 
     if len(pre_distribution_row_count) >= len(post_distribution_row_count):
         raise Exception("Failed to redistribute table. Expected to have more than %d segments, got %d segments" % (len(pre_distribution_row_count), len(post_distribution_row_count)))
@@ -2903,6 +2916,14 @@ def impl(context, table, dbname):
         raise Exception("Unexpected variance for redistributed data in table %s. Relative standard error %f exceeded tolerance factor of %f." %
                 (table, relative_std_error, tolerance))
 
+    for i in range(len(post_distribution_dist_policy)):
+        if(post_distribution_dist_policy[i][0] == pre_redistribution_dist_policy[i][0] or \
+           post_distribution_dist_policy[i][1] != pre_redistribution_dist_policy[i][1] or \
+           post_distribution_dist_policy[i][2] != pre_redistribution_dist_policy[i][2]):
+            raise Exception("""Redistributed policy does not match pre-redistribution policy.
+            before expanded: %s, after expanded: %s""" % (",".join(map(str, pre_redistribution_dist_policy[i])), \
+            ",".join(map(str, post_distribution_dist_policy[i]))))
+
 
 @then('the row count from table "{table_name}" in "{dbname}" is verified against the saved data')
 def impl(context, table_name, dbname):
@@ -2926,6 +2947,13 @@ def _get_row_count_per_segment(table, dbname):
         cursor = dbconn.query(conn, query)
         rows = cursor.fetchall()
     return [row[1] for row in rows] # indices are the gp segment id's, so no need to store them explicitly
+
+def _get_dist_policy_per_partition(table, dbname):
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
+        query = "select * from gp_distribution_policy where localoid::regclass::text like '%s%%' order by localoid;" % table
+        cursor = dbconn.query(conn, query)
+        rows = cursor.fetchall()
+    return [row[2:5] for row in rows] # we only need numsegments、distkey、distclass
 
 @given('run rollback')
 @then('run rollback')

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3260,6 +3260,13 @@ alter_table_cmd:
 					n->subtype = AT_ExpandTable;
 					$$ = (Node *)n;
 				}
+			/* ALTER TABLE <name> EXPAND PARTITION PREPARE*/
+			| EXPAND PARTITION PREPARE
+				{
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+					n->subtype = AT_ExpandPartitionTablePrepare;
+					$$ = (Node *)n;
+				}
 			/* ALTER TABLE <name> OF <type_name> */
 			| OF any_name
 				{

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1993,6 +1993,7 @@ typedef enum AlterTableType
 
 	AT_SetDistributedBy,		/* SET DISTRIBUTED BY */
 	AT_ExpandTable,          /* EXPAND DISTRIBUTED */
+	AT_ExpandPartitionTablePrepare,	/* EXPAND PARTITION PREPARE */
 
 	/* GPDB: Legacy commands to manipulate partitions */
 	AT_PartAdd,					/* Add */

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1401,14 +1401,16 @@ select *, gp_segment_id from reorg_leaf_1_prt_p0;
 -- fail: cannot change the distribution key of one partition
 alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
 ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy can not be set for an interior branch.
 -- distribution key is already 'c', so this is allowed
 alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can not be set for an interior branch.
 alter table reorg_leaf_1_prt_p0 set with (reorganize=true);
 -- same with a leaf partition
 alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(b);
 ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0_2_prt_1"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(c);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
  a | b | c | gp_segment_id 

--- a/src/test/regress/expected/gpdist.out
+++ b/src/test/regress/expected/gpdist.out
@@ -290,13 +290,13 @@ create table pt (i int, j int, k int) distributed by (i) partition by range(k)
 (start(1) end(10) every(2));
 alter table pt_1_prt_1 set distributed by (j);
 ERROR:  can't set the distribution policy of "pt_1_prt_1"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 alter table pt_1_prt_2 set distributed randomly;
 ERROR:  can't set the distribution policy of "pt_1_prt_2"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 alter table pt_1_prt_2 set distributed by (k);
 ERROR:  can't set the distribution policy of "pt_1_prt_2"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 insert into pt values(1, 1, 1);
 insert into pt values(2, 2, 2);
 insert into pt values(3, 3, 3);
@@ -351,8 +351,8 @@ create table pt(i int, j int, k int, l char(2)) distributed by (i)
 partition by range(k) subpartition by list(l) subpartition template(values('A'),
 values('B')) (start(30) end(50) every(10));
 alter table only pt set distributed randomly;
-ERROR:  can't set the distribution policy of ONLY "pt"
-HINT:  Distribution policy may be set for an entire partitioned table or one of its leaf parts.
+ERROR:  can't set the distribution policy of "pt" ONLY
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
 insert into pt values(35, 35, 35, 'A');
 insert into pt values(36, 35, 35, 'A');
 insert into pt values(37, 35, 35, 'A');
@@ -370,7 +370,7 @@ select gp_segment_id, * from pt_1;
 
 alter table only pt_1_prt_2 set distributed by (j);
 ERROR:  can't set the distribution policy of "pt_1_prt_2"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy can not be set for an interior branch.
 insert into pt values(45, 45, 45, 'B');
 insert into pt values(45, 46, 46, 'B');
 insert into pt values(45, 47, 47, 'B');
@@ -386,7 +386,7 @@ select gp_segment_id, * from pt_2;
 
 alter table pt_1_prt_2_2_prt_1 set distributed by (j);
 ERROR:  can't set the distribution policy of "pt_1_prt_2_2_prt_1"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 insert into pt values(45, 45, 45, 'A');
 insert into pt values(45, 46, 46, 'A');
 insert into pt values(45, 47, 47, 'A');

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -290,13 +290,13 @@ create table pt (i int, j int, k int) distributed by (i) partition by range(k)
 (start(1) end(10) every(2));
 alter table pt_1_prt_1 set distributed by (j);
 ERROR:  can't set the distribution policy of "pt_1_prt_1"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 alter table pt_1_prt_2 set distributed randomly;
 ERROR:  can't set the distribution policy of "pt_1_prt_2"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 alter table pt_1_prt_2 set distributed by (k);
 ERROR:  can't set the distribution policy of "pt_1_prt_2"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 insert into pt values(1, 1, 1);
 insert into pt values(2, 2, 2);
 insert into pt values(3, 3, 3);
@@ -351,8 +351,8 @@ create table pt(i int, j int, k int, l char(2)) distributed by (i)
 partition by range(k) subpartition by list(l) subpartition template(values('A'),
 values('B')) (start(30) end(50) every(10));
 alter table only pt set distributed randomly;
-ERROR:  can't set the distribution policy of ONLY "pt"
-HINT:  Distribution policy may be set for an entire partitioned table or one of its leaf parts.
+ERROR:  can't set the distribution policy of "pt" ONLY
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
 insert into pt values(35, 35, 35, 'A');
 insert into pt values(36, 35, 35, 'A');
 insert into pt values(37, 35, 35, 'A');
@@ -370,7 +370,7 @@ select gp_segment_id, * from pt_1;
 
 alter table only pt_1_prt_2 set distributed by (j);
 ERROR:  can't set the distribution policy of "pt_1_prt_2"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy can not be set for an interior branch.
 insert into pt values(45, 45, 45, 'B');
 insert into pt values(45, 46, 46, 'B');
 insert into pt values(45, 47, 47, 'B');
@@ -386,7 +386,7 @@ select gp_segment_id, * from pt_2;
 
 alter table pt_1_prt_2_2_prt_1 set distributed by (j);
 ERROR:  can't set the distribution policy of "pt_1_prt_2_2_prt_1"
-HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+HINT:  Distribution policy of a partition can only be the same as its parent's.
 insert into pt values(45, 45, 45, 'A');
 insert into pt values(45, 46, 46, 'A');
 insert into pt values(45, 47, 47, 'A');

--- a/src/test/regress/expected/partition_expand.out
+++ b/src/test/regress/expected/partition_expand.out
@@ -1,0 +1,683 @@
+create extension if not exists gp_debug_numsegments;
+select gp_debug_set_create_table_default_numsegments(1);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 1
+(1 row)
+
+--only partition table can be expanded partition prepare
+drop table if exists t_hash_expand_prepare;
+NOTICE:  table "t_hash_expand_prepare" does not exist, skipping
+create table t_hash_expand_prepare (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+alter table t_hash_expand_prepare expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_hash_expand_prepare"
+DETAIL:  only root partition can be expanded partition prepare
+drop table t_hash_expand_prepare;
+--partition table distributed by hash
+drop table if exists t_hash_partition;
+NOTICE:  table "t_hash_partition" does not exist, skipping
+create table t_hash_partition(a int,b int,c int)
+ partition by range (a)
+ ( start (1) end (20) every(10),
+   default partition extra
+ );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ 
+insert into t_hash_partition select i,i,i from generate_series(1,30) i;
+--only parent of partition table can be expanded partition prepare
+alter table t_hash_partition_1_prt_2 expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_hash_partition_1_prt_2"
+DETAIL:  only root partition can be expanded partition prepare
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+           localoid           | policytype | numsegments | distkey | distclass 
+------------------------------+------------+-------------+---------+-----------
+ t_hash_partition             | p          |           1 | 1       | 10054
+ t_hash_partition_1_prt_extra | p          |           1 | 1       | 10054
+ t_hash_partition_1_prt_2     | p          |           1 | 1       | 10054
+ t_hash_partition_1_prt_3     | p          |           1 | 1       | 10054
+(4 rows)
+
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+ gp_segment_id |           localoid           | policytype | numsegments | distkey | distclass 
+---------------+------------------------------+------------+-------------+---------+-----------
+             1 | t_hash_partition             | p          |           1 | 1       | 10054
+             1 | t_hash_partition_1_prt_extra | p          |           1 | 1       | 10054
+             1 | t_hash_partition_1_prt_2     | p          |           1 | 1       | 10054
+             1 | t_hash_partition_1_prt_3     | p          |           1 | 1       | 10054
+             0 | t_hash_partition             | p          |           1 | 1       | 10054
+             0 | t_hash_partition_1_prt_extra | p          |           1 | 1       | 10054
+             0 | t_hash_partition_1_prt_2     | p          |           1 | 1       | 10054
+             0 | t_hash_partition_1_prt_3     | p          |           1 | 1       | 10054
+             2 | t_hash_partition             | p          |           1 | 1       | 10054
+             2 | t_hash_partition_1_prt_extra | p          |           1 | 1       | 10054
+             2 | t_hash_partition_1_prt_2     | p          |           1 | 1       | 10054
+             2 | t_hash_partition_1_prt_3     | p          |           1 | 1       | 10054
+(12 rows)
+
+alter table t_hash_partition expand partition prepare;
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+           localoid           | policytype | numsegments | distkey | distclass 
+------------------------------+------------+-------------+---------+-----------
+ t_hash_partition             | p          |           3 | 1       | 10054
+ t_hash_partition_1_prt_extra | p          |           3 |         | 
+ t_hash_partition_1_prt_2     | p          |           3 |         | 
+ t_hash_partition_1_prt_3     | p          |           3 |         | 
+(4 rows)
+
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+ gp_segment_id |           localoid           | policytype | numsegments | distkey | distclass 
+---------------+------------------------------+------------+-------------+---------+-----------
+             1 | t_hash_partition             | p          |           3 | 1       | 10054
+             1 | t_hash_partition_1_prt_extra | p          |           3 |         | 
+             1 | t_hash_partition_1_prt_2     | p          |           3 |         | 
+             1 | t_hash_partition_1_prt_3     | p          |           3 |         | 
+             0 | t_hash_partition             | p          |           3 | 1       | 10054
+             0 | t_hash_partition_1_prt_extra | p          |           3 |         | 
+             0 | t_hash_partition_1_prt_2     | p          |           3 |         | 
+             0 | t_hash_partition_1_prt_3     | p          |           3 |         | 
+             2 | t_hash_partition             | p          |           3 | 1       | 10054
+             2 | t_hash_partition_1_prt_extra | p          |           3 |         | 
+             2 | t_hash_partition_1_prt_2     | p          |           3 |         | 
+             2 | t_hash_partition_1_prt_3     | p          |           3 |         | 
+(12 rows)
+
+alter table t_hash_partition expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_hash_partition"
+DETAIL:  table has already been expanded partiton prepare
+--dml of parent table
+select count(*) from t_hash_partition;
+ count 
+-------
+    30
+(1 row)
+
+select count(*) from t_hash_partition where a=1;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from t_hash_partition where a=5;
+ count 
+-------
+     1
+(1 row)
+
+insert into t_hash_partition select i,i,i from generate_series(1,30) i;
+select count(*) from t_hash_partition;
+ count 
+-------
+    60
+(1 row)
+
+select count(*) from t_hash_partition where a=1;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_hash_partition where a=3;
+ count 
+-------
+     2
+(1 row)
+
+delete from t_hash_partition where a=1;
+select count(*) from t_hash_partition where a=1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from t_hash_partition;
+ count 
+-------
+    58
+(1 row)
+
+update t_hash_partition set a = a+1;
+select count(*) from t_hash_partition where a=3;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_hash_partition; 
+ count 
+-------
+    58
+(1 row)
+
+--dml of child table
+select count(*) from t_hash_partition_1_prt_2;
+ count 
+-------
+    16
+(1 row)
+
+select count(*) from t_hash_partition_1_prt_2 where a=2;
+ count 
+-------
+     0
+(1 row)
+
+insert into t_hash_partition_1_prt_2 values(8,1,1);
+select count(*) from t_hash_partition_1_prt_2;
+ count 
+-------
+    17
+(1 row)
+
+select count(*) from t_hash_partition;
+ count 
+-------
+    59
+(1 row)
+
+drop table t_hash_partition;
+--partition table distributed randomly 
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+drop table if exists t_randomly_partition;
+NOTICE:  table "t_randomly_partition" does not exist, skipping
+create table t_randomly_partition(a int,b int,c int) distributed randomly
+ partition by range (a)
+ ( start (1) end (20) every(10),
+   default partition extra
+ );
+ 
+insert into t_randomly_partition select i,i,i from generate_series(1,30) i;
+--only parent of partition table can be expanded partition prepare
+alter table t_randomly_partition_1_prt_2 expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_randomly_partition_1_prt_2"
+DETAIL:  only root partition can be expanded partition prepare
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+             localoid             | policytype | numsegments | distkey | distclass 
+----------------------------------+------------+-------------+---------+-----------
+ t_randomly_partition             | p          |           2 |         | 
+ t_randomly_partition_1_prt_extra | p          |           2 |         | 
+ t_randomly_partition_1_prt_2     | p          |           2 |         | 
+ t_randomly_partition_1_prt_3     | p          |           2 |         | 
+(4 rows)
+
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+ gp_segment_id |             localoid             | policytype | numsegments | distkey | distclass 
+---------------+----------------------------------+------------+-------------+---------+-----------
+             1 | t_randomly_partition             | p          |           2 |         | 
+             1 | t_randomly_partition_1_prt_extra | p          |           2 |         | 
+             1 | t_randomly_partition_1_prt_2     | p          |           2 |         | 
+             1 | t_randomly_partition_1_prt_3     | p          |           2 |         | 
+             2 | t_randomly_partition             | p          |           2 |         | 
+             2 | t_randomly_partition_1_prt_extra | p          |           2 |         | 
+             2 | t_randomly_partition_1_prt_2     | p          |           2 |         | 
+             2 | t_randomly_partition_1_prt_3     | p          |           2 |         | 
+             0 | t_randomly_partition             | p          |           2 |         | 
+             0 | t_randomly_partition_1_prt_extra | p          |           2 |         | 
+             0 | t_randomly_partition_1_prt_2     | p          |           2 |         | 
+             0 | t_randomly_partition_1_prt_3     | p          |           2 |         | 
+(12 rows)
+
+alter table t_randomly_partition expand partition prepare;
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+             localoid             | policytype | numsegments | distkey | distclass 
+----------------------------------+------------+-------------+---------+-----------
+ t_randomly_partition             | p          |           3 |         | 
+ t_randomly_partition_1_prt_extra | p          |           3 |         | 
+ t_randomly_partition_1_prt_2     | p          |           3 |         | 
+ t_randomly_partition_1_prt_3     | p          |           3 |         | 
+(4 rows)
+
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+ gp_segment_id |             localoid             | policytype | numsegments | distkey | distclass 
+---------------+----------------------------------+------------+-------------+---------+-----------
+             0 | t_randomly_partition             | p          |           3 |         | 
+             0 | t_randomly_partition_1_prt_extra | p          |           3 |         | 
+             0 | t_randomly_partition_1_prt_2     | p          |           3 |         | 
+             0 | t_randomly_partition_1_prt_3     | p          |           3 |         | 
+             1 | t_randomly_partition             | p          |           3 |         | 
+             1 | t_randomly_partition_1_prt_extra | p          |           3 |         | 
+             1 | t_randomly_partition_1_prt_2     | p          |           3 |         | 
+             1 | t_randomly_partition_1_prt_3     | p          |           3 |         | 
+             2 | t_randomly_partition             | p          |           3 |         | 
+             2 | t_randomly_partition_1_prt_extra | p          |           3 |         | 
+             2 | t_randomly_partition_1_prt_2     | p          |           3 |         | 
+             2 | t_randomly_partition_1_prt_3     | p          |           3 |         | 
+(12 rows)
+
+		
+alter table t_randomly_partition expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_randomly_partition"
+DETAIL:  table has already been expanded partiton prepare
+--dml of parent table
+select count(*) from t_randomly_partition;
+ count 
+-------
+    30
+(1 row)
+
+select count(*) from t_randomly_partition where a=1;
+ count 
+-------
+     1
+(1 row)
+
+insert into t_randomly_partition select i,i,i from generate_series(1,30) i;
+select count(*) from t_randomly_partition;
+ count 
+-------
+    60
+(1 row)
+
+select count(*) from t_randomly_partition where a=1;
+ count 
+-------
+     2
+(1 row)
+
+delete from t_randomly_partition where a=1;
+select count(*) from t_randomly_partition where a=1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from t_randomly_partition;
+ count 
+-------
+    58
+(1 row)
+
+update t_randomly_partition set a = a+1;
+select count(*) from t_randomly_partition where a=3;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_randomly_partition; 
+ count 
+-------
+    58
+(1 row)
+
+--dml of child table
+select count(*) from t_randomly_partition_1_prt_2;
+ count 
+-------
+    16
+(1 row)
+
+select count(*) from t_randomly_partition_1_prt_2 where a=2;
+ count 
+-------
+     0
+(1 row)
+
+insert into t_randomly_partition_1_prt_2 values(8,1,1);
+select count(*) from t_randomly_partition_1_prt_2;
+ count 
+-------
+    17
+(1 row)
+
+select count(*) from t_randomly_partition;
+ count 
+-------
+    59
+(1 row)
+
+drop table t_randomly_partition;
+--subpartition table distributed hash
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+drop table if exists t_hash_subpartition;
+NOTICE:  table "t_hash_subpartition" does not exist, skipping
+create table t_hash_subpartition
+(
+	r_regionkey integer not null,
+	r_name char(25)
+)
+partition by range (r_regionkey)
+subpartition by list (r_name) subpartition template
+(
+	subpartition CHINA values ('CHINA'),
+	subpartition america values ('AMERICA')
+)
+(
+	partition region1 start (0),
+	partition region2 start (3),
+	partition region3 start (5) end (8)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r_regionkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ 
+insert into t_hash_subpartition values(2,'CHINA');
+insert into t_hash_subpartition values(4,'CHINA');
+insert into t_hash_subpartition values(6,'CHINA');
+insert into t_hash_subpartition values(1,'AMERICA');
+insert into t_hash_subpartition values(3,'AMERICA');
+insert into t_hash_subpartition values(5,'AMERICA');
+--only parent of partition table can be expanded partition prepare
+alter table t_hash_subpartition_1_prt_region1 expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_hash_subpartition_1_prt_region1"
+DETAIL:  only root partition can be expanded partition prepare
+alter table t_hash_subpartition_1_prt_region1_2_prt_china expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_hash_subpartition_1_prt_region1_2_prt_china"
+DETAIL:  only root partition can be expanded partition prepare
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+(10 rows)
+
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+ gp_segment_id |                    localoid                     | policytype | numsegments | distkey | distclass 
+---------------+-------------------------------------------------+------------+-------------+---------+-----------
+             0 | t_hash_subpartition                             | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition                             | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition                             | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+(30 rows)
+
+alter table t_hash_subpartition expand partition prepare;
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+(10 rows)
+
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+ gp_segment_id |                    localoid                     | policytype | numsegments | distkey | distclass 
+---------------+-------------------------------------------------+------------+-------------+---------+-----------
+             0 | t_hash_subpartition                             | p          |           3 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+             0 | t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 |         | 
+             0 | t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+             0 | t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+             0 | t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+             0 | t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+             0 | t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+             2 | t_hash_subpartition                             | p          |           3 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+             2 | t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 |         | 
+             2 | t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+             2 | t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+             2 | t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+             2 | t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+             2 | t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+             1 | t_hash_subpartition                             | p          |           3 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+             1 | t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 |         | 
+             1 | t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+             1 | t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+             1 | t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+             1 | t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+             1 | t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+(30 rows)
+
+alter table t_hash_subpartition expand partition prepare;
+ERROR:  cannot expand partition table prepare "t_hash_subpartition"
+DETAIL:  table has already been expanded partiton prepare
+--dml of parent table
+select count(*) from t_hash_subpartition;
+ count 
+-------
+     6
+(1 row)
+
+select count(*) from t_hash_subpartition where r_regionkey=1;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from t_hash_subpartition where r_regionkey=5;
+ count 
+-------
+     1
+(1 row)
+
+insert into t_hash_subpartition values(1,'CHINA');
+insert into t_hash_subpartition values(2,'CHINA');
+insert into t_hash_subpartition values(3,'CHINA');
+insert into t_hash_subpartition values(4,'AMERICA');
+insert into t_hash_subpartition values(5,'AMERICA');
+insert into t_hash_subpartition values(6,'AMERICA');
+select count(*) from t_hash_subpartition;
+ count 
+-------
+    12
+(1 row)
+
+select count(*) from t_hash_subpartition where r_regionkey=1;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_hash_subpartition where r_regionkey=5;
+ count 
+-------
+     2
+(1 row)
+
+delete from t_hash_subpartition where r_regionkey=1;
+select count(*) from t_hash_subpartition where r_regionkey=1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from t_hash_subpartition;
+ count 
+-------
+    10
+(1 row)
+
+update t_hash_subpartition set r_regionkey = r_regionkey+1;
+select count(*) from t_hash_subpartition where r_regionkey=3;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_hash_subpartition; 
+ count 
+-------
+    10
+(1 row)
+
+--dml of child table
+select count(*) from t_hash_subpartition_1_prt_region1;
+ count 
+-------
+     0
+(1 row)
+
+insert into t_hash_subpartition_1_prt_region1 values(1,'CHINA');
+select count(*) from t_hash_subpartition_1_prt_region1;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from t_hash_subpartition;
+ count 
+-------
+    11
+(1 row)
+
+--dml of subchild table
+select * from t_hash_subpartition_1_prt_region1_2_prt_china;
+ r_regionkey |          r_name           
+-------------+---------------------------
+           1 | CHINA                    
+(1 row)
+
+insert into t_hash_subpartition_1_prt_region1_2_prt_china values(1,'CHINA');
+select count(*) from t_hash_subpartition_1_prt_region1_2_prt_china;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_hash_subpartition_1_prt_region1;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from t_hash_subpartition;
+ count 
+-------
+    12
+(1 row)
+
+drop table t_hash_subpartition;
+--cleanup
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+drop extension gp_debug_numsegments;

--- a/src/test/regress/expected/partition_expand.out
+++ b/src/test/regress/expected/partition_expand.out
@@ -860,7 +860,6 @@ WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region1_2_p
 HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region1_2_prt_china" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution.
 --the policy of leaf is the same as parent's
 alter table t_hash_subpartition_1_prt_region1_2_prt_china set distributed by (r_regionkey);
-WARNING:  relcache reference leak: relation "t_hash_subpartition_1_prt_region1" not closed
 select localoid::regclass, policytype, numsegments, distkey, distclass
 	from gp_distribution_policy where localoid in (
 		't_hash_subpartition'::regclass,
@@ -1132,6 +1131,24 @@ select localoid::regclass, policytype, numsegments, distkey, distclass
 (10 rows)
 
 drop table t_random_subpartition;
+create table t_root_partition_expand (a int, b int) partition by range (b) distributed by (a);
+create table t1_partition_expand (a int, b int) distributed by (a); -- same column order as parent
+create table t2_partition_expand (x int, b int, a int) distributed by (a); -- different column order from parent
+alter table t2_partition_expand drop column x;
+alter table t_root_partition_expand attach partition t1_partition_expand for values from (1) to (5);
+alter table t_root_partition_expand attach partition t2_partition_expand for values from (5) to (10);
+alter table t_root_partition_expand expand partition prepare;
+select localoid::regclass, policytype, numsegments, distkey, distclass
+from gp_distribution_policy where localoid in ('t_root_partition_expand'::regclass, 't1_partition_expand'::regclass, 't2_partition_expand'::regclass);
+        localoid         | policytype | numsegments | distkey | distclass 
+-------------------------+------------+-------------+---------+-----------
+ t_root_partition_expand | p          |           3 | 1       | 10054
+ t1_partition_expand     | p          |           3 |         | 
+ t2_partition_expand     | p          |           3 |         | 
+(3 rows)
+
+alter table t1_partition_expand set distributed by (a);
+alter table t2_partition_expand set distributed by (a);
 --cleanup
 select gp_debug_reset_create_table_default_numsegments();
  gp_debug_reset_create_table_default_numsegments 

--- a/src/test/regress/expected/partition_expand.out
+++ b/src/test/regress/expected/partition_expand.out
@@ -192,7 +192,7 @@ select count(*) from t_hash_partition;
 (1 row)
 
 drop table t_hash_partition;
---partition table distributed randomly 
+--partition table distributed randomly
 select gp_debug_set_create_table_default_numsegments(2);
  gp_debug_set_create_table_default_numsegments 
 -----------------------------------------------
@@ -673,6 +673,465 @@ select count(*) from t_hash_subpartition;
 (1 row)
 
 drop table t_hash_subpartition;
+--------------------------------------------------------
+--test for set distributed of partition table
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+--subpartition distributed by hash
+drop table if exists t_hash_subpartition;
+NOTICE:  table "t_hash_subpartition" does not exist, skipping
+create table t_hash_subpartition
+(
+	r_regionkey integer not null,
+	r_name char(25),
+	r_comment varchar(152)
+)
+partition by range (r_regionkey)
+subpartition by list (r_name) subpartition template
+(
+	subpartition china values ('CHINA'),
+	subpartition america values ('AMERICA')
+)
+(
+	partition region1 start (0),
+	partition region2 start (3),
+	partition region3 start (5) end (8)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r_regionkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+(10 rows)
+
+--can not set distributed for interior parts of partition table
+alter table t_hash_subpartition_1_prt_region1 set distributed randomly;
+ERROR:  can't set the distribution policy of "t_hash_subpartition_1_prt_region1"
+HINT:  Distribution policy can not be set for an interior branch.
+--can not set distributed for interior parts of partition table
+alter table t_hash_subpartition_1_prt_region1 set distributed by(r_regionkey);
+ERROR:  can't set the distribution policy of "t_hash_subpartition_1_prt_region1"
+HINT:  Distribution policy can not be set for an interior branch.
+--error when the policy of leaf is different of parent's
+alter table t_hash_subpartition_1_prt_region1_2_prt_china set distributed randomly;
+ERROR:  can't set the distribution policy of "t_hash_subpartition_1_prt_region1_2_prt_china"
+HINT:  Distribution policy of a partition can only be the same as its parent's.
+--the policy of leaf is the same as parent's
+alter table t_hash_subpartition_1_prt_region1_2_prt_china set distributed by(r_regionkey);
+WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region1_2_prt_china" already set to (r_regionkey)
+HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region1_2_prt_china" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (r_regionkey) to force redistribution
+--ok
+alter table t_hash_subpartition set distributed randomly;
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region1               | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region2               | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region3               | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 |         | 
+(10 rows)
+
+--expand partition prepare
+drop table t_hash_subpartition;
+create table t_hash_subpartition
+(
+	r_regionkey integer not null,
+	r_name char(25),
+	r_comment varchar(152)
+)
+partition by range (r_regionkey)
+subpartition by list (r_name) subpartition template
+(
+	subpartition china values ('CHINA'),
+	subpartition america values ('AMERICA')
+)
+(
+	partition region1 start (0),
+	partition region2 start (3),
+	partition region3 start (5) end (8)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r_regionkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+(10 rows)
+
+alter table t_hash_subpartition expand partition prepare;
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+(10 rows)
+
+--can not set distributed for interior parts of partition table
+alter table t_hash_subpartition_1_prt_region2 set  distributed randomly;
+ERROR:  can't set the distribution policy of "t_hash_subpartition_1_prt_region2"
+HINT:  Distribution policy can not be set for an interior branch.
+alter table t_hash_subpartition_1_prt_region2 set  distributed by (r_regionkey);
+ERROR:  can't set the distribution policy of "t_hash_subpartition_1_prt_region2"
+HINT:  Distribution policy can not be set for an interior branch.
+--the policy of leaf is the same as original
+alter table t_hash_subpartition_1_prt_region1_2_prt_china set distributed randomly;
+WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region1_2_prt_china" already set to DISTRIBUTED RANDOMLY
+HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region1_2_prt_china" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution.
+--the policy of leaf is the same as parent's
+alter table t_hash_subpartition_1_prt_region1_2_prt_china set distributed by (r_regionkey);
+WARNING:  relcache reference leak: relation "t_hash_subpartition_1_prt_region1" not closed
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 | 1       | 10054
+(10 rows)
+
+--alter root of partition table
+alter table t_hash_subpartition set distributed by (r_regionkey);
+WARNING:  distribution policy of relation "t_hash_subpartition" already set to (r_regionkey)
+HINT:  Use ALTER TABLE "t_hash_subpartition" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (r_regionkey) to force redistribution
+WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region1" already set to (r_regionkey)
+HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region1" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (r_regionkey) to force redistribution
+WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region2" already set to (r_regionkey)
+HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region2" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (r_regionkey) to force redistribution
+WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region3" already set to (r_regionkey)
+HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region3" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (r_regionkey) to force redistribution
+WARNING:  distribution policy of relation "t_hash_subpartition_1_prt_region1_2_prt_china" already set to (r_regionkey)
+HINT:  Use ALTER TABLE "t_hash_subpartition_1_prt_region1_2_prt_china" SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (r_regionkey) to force redistribution
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+                    localoid                     | policytype | numsegments | distkey | distclass 
+-------------------------------------------------+------------+-------------+---------+-----------
+ t_hash_subpartition                             | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_china   | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region1_2_prt_america | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_china   | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region2_2_prt_america | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_china   | p          |           3 | 1       | 10054
+ t_hash_subpartition_1_prt_region3_2_prt_america | p          |           3 | 1       | 10054
+(10 rows)
+
+drop table t_hash_subpartition;
+--subpartition distributed randomly
+drop table if exists t_random_subpartition;
+NOTICE:  table "t_random_subpartition" does not exist, skipping
+create table t_random_subpartition
+(
+	r_regionkey integer not null,
+	r_name char(25),
+	r_comment varchar(152)
+) distributed randomly
+partition by range (r_regionkey)
+subpartition by list (r_name) subpartition template
+(
+	subpartition china values ('CHINA'),
+	subpartition america values ('AMERICA')
+)
+(
+	partition region1 start (0),
+	partition region2 start (3),
+	partition region3 start (5) end (8)
+);
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_random_subpartition'::regclass,
+		't_random_subpartition_1_prt_region1'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region2'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region3'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_america'::regclass);
+                     localoid                      | policytype | numsegments | distkey | distclass 
+---------------------------------------------------+------------+-------------+---------+-----------
+ t_random_subpartition                             | p          |           2 |         | 
+ t_random_subpartition_1_prt_region1               | p          |           2 |         | 
+ t_random_subpartition_1_prt_region2               | p          |           2 |         | 
+ t_random_subpartition_1_prt_region3               | p          |           2 |         | 
+ t_random_subpartition_1_prt_region1_2_prt_china   | p          |           2 |         | 
+ t_random_subpartition_1_prt_region1_2_prt_america | p          |           2 |         | 
+ t_random_subpartition_1_prt_region2_2_prt_china   | p          |           2 |         | 
+ t_random_subpartition_1_prt_region2_2_prt_america | p          |           2 |         | 
+ t_random_subpartition_1_prt_region3_2_prt_china   | p          |           2 |         | 
+ t_random_subpartition_1_prt_region3_2_prt_america | p          |           2 |         | 
+(10 rows)
+
+--can not set distributed for interior parts of partition table
+alter table t_random_subpartition_1_prt_region1 set distributed randomly;
+ERROR:  can't set the distribution policy of "t_random_subpartition_1_prt_region1"
+HINT:  Distribution policy can not be set for an interior branch.
+alter table t_random_subpartition_1_prt_region1 set distributed by(r_regionkey);
+ERROR:  can't set the distribution policy of "t_random_subpartition_1_prt_region1"
+HINT:  Distribution policy can not be set for an interior branch.
+--the policy of leaf is the same as original
+alter table t_random_subpartition_1_prt_region1_2_prt_china set distributed randomly;
+WARNING:  distribution policy of relation "t_random_subpartition_1_prt_region1_2_prt_china" already set to DISTRIBUTED RANDOMLY
+HINT:  Use ALTER TABLE "t_random_subpartition_1_prt_region1_2_prt_china" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution.
+--error, the policy of leaf is different from parent's
+alter table t_random_subpartition_1_prt_region1_2_prt_china set distributed by(r_regionkey);
+ERROR:  can't set the distribution policy of "t_random_subpartition_1_prt_region1_2_prt_china"
+HINT:  Distribution policy of a partition can only be the same as its parent's.
+--alter root of partition table
+alter table t_random_subpartition set distributed  by(r_regionkey);
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_random_subpartition'::regclass,
+		't_random_subpartition_1_prt_region1'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region2'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region3'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_america'::regclass);
+                     localoid                      | policytype | numsegments | distkey | distclass 
+---------------------------------------------------+------------+-------------+---------+-----------
+ t_random_subpartition                             | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region1               | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region2               | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region3               | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region1_2_prt_china   | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region1_2_prt_america | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region2_2_prt_china   | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region2_2_prt_america | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region3_2_prt_china   | p          |           2 | 1       | 10054
+ t_random_subpartition_1_prt_region3_2_prt_america | p          |           2 | 1       | 10054
+(10 rows)
+
+--expand partition prepare
+drop table t_random_subpartition;
+create table t_random_subpartition
+(
+	r_regionkey integer not null,
+	r_name char(25),
+	r_comment varchar(152)
+)
+distributed randomly
+partition by range (r_regionkey)
+subpartition by list (r_name) subpartition template
+(
+	subpartition china values ('CHINA'),
+	subpartition america values ('AMERICA')
+)
+(
+	partition region1 start (0),
+	partition region2 start (3),
+	partition region3 start (5) end (8)
+);
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_random_subpartition'::regclass,
+		't_random_subpartition_1_prt_region1'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region2'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region3'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_america'::regclass);
+                     localoid                      | policytype | numsegments | distkey | distclass 
+---------------------------------------------------+------------+-------------+---------+-----------
+ t_random_subpartition                             | p          |           2 |         | 
+ t_random_subpartition_1_prt_region1               | p          |           2 |         | 
+ t_random_subpartition_1_prt_region2               | p          |           2 |         | 
+ t_random_subpartition_1_prt_region3               | p          |           2 |         | 
+ t_random_subpartition_1_prt_region1_2_prt_china   | p          |           2 |         | 
+ t_random_subpartition_1_prt_region1_2_prt_america | p          |           2 |         | 
+ t_random_subpartition_1_prt_region2_2_prt_china   | p          |           2 |         | 
+ t_random_subpartition_1_prt_region2_2_prt_america | p          |           2 |         | 
+ t_random_subpartition_1_prt_region3_2_prt_china   | p          |           2 |         | 
+ t_random_subpartition_1_prt_region3_2_prt_america | p          |           2 |         | 
+(10 rows)
+
+alter table t_random_subpartition expand partition prepare;
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_random_subpartition'::regclass,
+		't_random_subpartition_1_prt_region1'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region2'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region3'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_america'::regclass);
+                     localoid                      | policytype | numsegments | distkey | distclass 
+---------------------------------------------------+------------+-------------+---------+-----------
+ t_random_subpartition                             | p          |           3 |         | 
+ t_random_subpartition_1_prt_region1               | p          |           3 |         | 
+ t_random_subpartition_1_prt_region2               | p          |           3 |         | 
+ t_random_subpartition_1_prt_region3               | p          |           3 |         | 
+ t_random_subpartition_1_prt_region1_2_prt_china   | p          |           3 |         | 
+ t_random_subpartition_1_prt_region1_2_prt_america | p          |           3 |         | 
+ t_random_subpartition_1_prt_region2_2_prt_china   | p          |           3 |         | 
+ t_random_subpartition_1_prt_region2_2_prt_america | p          |           3 |         | 
+ t_random_subpartition_1_prt_region3_2_prt_china   | p          |           3 |         | 
+ t_random_subpartition_1_prt_region3_2_prt_america | p          |           3 |         | 
+(10 rows)
+
+--can not set distributed for interior parts of partition table
+alter table t_random_subpartition_1_prt_region3 set  distributed randomly;
+ERROR:  can't set the distribution policy of "t_random_subpartition_1_prt_region3"
+HINT:  Distribution policy can not be set for an interior branch.
+alter table t_random_subpartition_1_prt_region3 set  distributed by (r_regionkey);
+ERROR:  can't set the distribution policy of "t_random_subpartition_1_prt_region3"
+HINT:  Distribution policy can not be set for an interior branch.
+--the policy of leaf is the same as parent's
+alter table t_random_subpartition_1_prt_region1_2_prt_china set distributed randomly;
+WARNING:  distribution policy of relation "t_random_subpartition_1_prt_region1_2_prt_china" already set to DISTRIBUTED RANDOMLY
+HINT:  Use ALTER TABLE "t_random_subpartition_1_prt_region1_2_prt_china" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution.
+--error, the policy of leaf is different from parent's
+alter table t_random_subpartition_1_prt_region1_2_prt_china set distributed by (r_regionkey);
+ERROR:  can't set the distribution policy of "t_random_subpartition_1_prt_region1_2_prt_china"
+HINT:  Distribution policy of a partition can only be the same as its parent's.
+--alter root of partition table
+alter table t_random_subpartition set distributed by (r_regionkey);
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_random_subpartition'::regclass,
+		't_random_subpartition_1_prt_region1'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region2'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_random_subpartition_1_prt_region3'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_random_subpartition_1_prt_region3_2_prt_america'::regclass);
+                     localoid                      | policytype | numsegments | distkey | distclass 
+---------------------------------------------------+------------+-------------+---------+-----------
+ t_random_subpartition                             | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region1               | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region2               | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region3               | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region1_2_prt_china   | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region1_2_prt_america | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region2_2_prt_china   | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region2_2_prt_america | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region3_2_prt_china   | p          |           3 | 1       | 10054
+ t_random_subpartition_1_prt_region3_2_prt_america | p          |           3 | 1       | 10054
+(10 rows)
+
+drop table t_random_subpartition;
 --cleanup
 select gp_debug_reset_create_table_default_numsegments();
  gp_debug_reset_create_table_default_numsegments 

--- a/src/test/regress/sql/partition_expand.sql
+++ b/src/test/regress/sql/partition_expand.sql
@@ -534,8 +534,21 @@ select localoid::regclass, policytype, numsegments, distkey, distclass
 		't_random_subpartition_1_prt_region3_2_prt_america'::regclass);
 drop table t_random_subpartition;
 
+create table t_root_partition_expand (a int, b int) partition by range (b) distributed by (a);
+create table t1_partition_expand (a int, b int) distributed by (a); -- same column order as parent
+create table t2_partition_expand (x int, b int, a int) distributed by (a); -- different column order from parent
+alter table t2_partition_expand drop column x;
+
+alter table t_root_partition_expand attach partition t1_partition_expand for values from (1) to (5);
+alter table t_root_partition_expand attach partition t2_partition_expand for values from (5) to (10);
+
+alter table t_root_partition_expand expand partition prepare;
+select localoid::regclass, policytype, numsegments, distkey, distclass
+from gp_distribution_policy where localoid in ('t_root_partition_expand'::regclass, 't1_partition_expand'::regclass, 't2_partition_expand'::regclass);
+alter table t1_partition_expand set distributed by (a);
+alter table t2_partition_expand set distributed by (a);
+
+
 --cleanup
 select gp_debug_reset_create_table_default_numsegments();
 drop extension gp_debug_numsegments;
-
-

--- a/src/test/regress/sql/partition_expand.sql
+++ b/src/test/regress/sql/partition_expand.sql
@@ -1,0 +1,273 @@
+create extension if not exists gp_debug_numsegments;
+select gp_debug_set_create_table_default_numsegments(1);
+
+--only partition table can be expanded partition prepare
+drop table if exists t_hash_expand_prepare;
+create table t_hash_expand_prepare (c1 int, c2 int, c3 int, c4 int) distributed by (c1, c2);
+alter table t_hash_expand_prepare expand partition prepare;
+drop table t_hash_expand_prepare;
+
+--partition table distributed by hash
+drop table if exists t_hash_partition;
+create table t_hash_partition(a int,b int,c int)
+ partition by range (a)
+ ( start (1) end (20) every(10),
+   default partition extra
+ );
+ 
+insert into t_hash_partition select i,i,i from generate_series(1,30) i;
+
+--only parent of partition table can be expanded partition prepare
+alter table t_hash_partition_1_prt_2 expand partition prepare;
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+
+alter table t_hash_partition expand partition prepare;
+
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_partition_1_prt_2'::regclass, 't_hash_partition_1_prt_3'::regclass,
+		't_hash_partition_1_prt_extra'::regclass, 't_hash_partition'::regclass);
+
+
+alter table t_hash_partition expand partition prepare;
+
+--dml of parent table
+select count(*) from t_hash_partition;
+select count(*) from t_hash_partition where a=1;
+select count(*) from t_hash_partition where a=5;
+
+insert into t_hash_partition select i,i,i from generate_series(1,30) i;
+
+select count(*) from t_hash_partition;
+select count(*) from t_hash_partition where a=1;
+select count(*) from t_hash_partition where a=3;
+
+delete from t_hash_partition where a=1;
+select count(*) from t_hash_partition where a=1;
+select count(*) from t_hash_partition;
+
+update t_hash_partition set a = a+1;
+select count(*) from t_hash_partition where a=3;
+select count(*) from t_hash_partition; 
+
+--dml of child table
+select count(*) from t_hash_partition_1_prt_2;
+select count(*) from t_hash_partition_1_prt_2 where a=2;
+insert into t_hash_partition_1_prt_2 values(8,1,1);
+select count(*) from t_hash_partition_1_prt_2;
+select count(*) from t_hash_partition;
+
+drop table t_hash_partition;
+
+--partition table distributed randomly 
+
+select gp_debug_set_create_table_default_numsegments(2);
+drop table if exists t_randomly_partition;
+create table t_randomly_partition(a int,b int,c int) distributed randomly
+ partition by range (a)
+ ( start (1) end (20) every(10),
+   default partition extra
+ );
+ 
+insert into t_randomly_partition select i,i,i from generate_series(1,30) i;
+
+--only parent of partition table can be expanded partition prepare
+alter table t_randomly_partition_1_prt_2 expand partition prepare;
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+
+alter table t_randomly_partition expand partition prepare;
+
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_randomly_partition_1_prt_2'::regclass, 't_randomly_partition_1_prt_3'::regclass,
+		't_randomly_partition_1_prt_extra'::regclass, 't_randomly_partition'::regclass);
+		
+alter table t_randomly_partition expand partition prepare;
+
+--dml of parent table
+select count(*) from t_randomly_partition;
+select count(*) from t_randomly_partition where a=1;
+
+insert into t_randomly_partition select i,i,i from generate_series(1,30) i;
+
+select count(*) from t_randomly_partition;
+select count(*) from t_randomly_partition where a=1;
+
+delete from t_randomly_partition where a=1;
+select count(*) from t_randomly_partition where a=1;
+select count(*) from t_randomly_partition;
+
+update t_randomly_partition set a = a+1;
+select count(*) from t_randomly_partition where a=3;
+select count(*) from t_randomly_partition; 
+
+--dml of child table
+select count(*) from t_randomly_partition_1_prt_2;
+select count(*) from t_randomly_partition_1_prt_2 where a=2;
+insert into t_randomly_partition_1_prt_2 values(8,1,1);
+select count(*) from t_randomly_partition_1_prt_2;
+select count(*) from t_randomly_partition;
+
+drop table t_randomly_partition;
+
+--subpartition table distributed hash
+select gp_debug_set_create_table_default_numsegments(2);
+drop table if exists t_hash_subpartition;
+create table t_hash_subpartition
+(
+	r_regionkey integer not null,
+	r_name char(25)
+)
+partition by range (r_regionkey)
+subpartition by list (r_name) subpartition template
+(
+	subpartition CHINA values ('CHINA'),
+	subpartition america values ('AMERICA')
+)
+(
+	partition region1 start (0),
+	partition region2 start (3),
+	partition region3 start (5) end (8)
+);
+ 
+insert into t_hash_subpartition values(2,'CHINA');
+insert into t_hash_subpartition values(4,'CHINA');
+insert into t_hash_subpartition values(6,'CHINA');
+insert into t_hash_subpartition values(1,'AMERICA');
+insert into t_hash_subpartition values(3,'AMERICA');
+insert into t_hash_subpartition values(5,'AMERICA');
+
+--only parent of partition table can be expanded partition prepare
+alter table t_hash_subpartition_1_prt_region1 expand partition prepare;
+alter table t_hash_subpartition_1_prt_region1_2_prt_china expand partition prepare;
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+alter table t_hash_subpartition expand partition prepare;
+
+--master policy info
+select localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_distribution_policy where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+--segment policy info
+select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, distclass
+	from gp_dist_random('gp_distribution_policy') where localoid in (
+		't_hash_subpartition'::regclass,
+		't_hash_subpartition_1_prt_region1'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region1_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region2'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region2_2_prt_america'::regclass,
+		't_hash_subpartition_1_prt_region3'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_china'::regclass,
+		't_hash_subpartition_1_prt_region3_2_prt_america'::regclass);
+
+alter table t_hash_subpartition expand partition prepare;
+
+--dml of parent table
+select count(*) from t_hash_subpartition;
+select count(*) from t_hash_subpartition where r_regionkey=1;
+select count(*) from t_hash_subpartition where r_regionkey=5;
+
+insert into t_hash_subpartition values(1,'CHINA');
+insert into t_hash_subpartition values(2,'CHINA');
+insert into t_hash_subpartition values(3,'CHINA');
+insert into t_hash_subpartition values(4,'AMERICA');
+insert into t_hash_subpartition values(5,'AMERICA');
+insert into t_hash_subpartition values(6,'AMERICA');
+
+select count(*) from t_hash_subpartition;
+select count(*) from t_hash_subpartition where r_regionkey=1;
+select count(*) from t_hash_subpartition where r_regionkey=5;
+
+delete from t_hash_subpartition where r_regionkey=1;
+select count(*) from t_hash_subpartition where r_regionkey=1;
+select count(*) from t_hash_subpartition;
+
+update t_hash_subpartition set r_regionkey = r_regionkey+1;
+select count(*) from t_hash_subpartition where r_regionkey=3;
+select count(*) from t_hash_subpartition; 
+
+--dml of child table
+select count(*) from t_hash_subpartition_1_prt_region1;
+insert into t_hash_subpartition_1_prt_region1 values(1,'CHINA');
+select count(*) from t_hash_subpartition_1_prt_region1;
+select count(*) from t_hash_subpartition;
+
+--dml of subchild table
+select * from t_hash_subpartition_1_prt_region1_2_prt_china;
+insert into t_hash_subpartition_1_prt_region1_2_prt_china values(1,'CHINA');
+select count(*) from t_hash_subpartition_1_prt_region1_2_prt_china;
+select count(*) from t_hash_subpartition_1_prt_region1;
+select count(*) from t_hash_subpartition;
+
+drop table t_hash_subpartition;
+
+--cleanup
+select gp_debug_reset_create_table_default_numsegments();
+drop extension gp_debug_numsegments;
+
+


### PR DESCRIPTION
    The policy of leaves can be different from the policy of root, But it must follow below rules:
    1、If a partitioned table is Hash distributed, then all its leaf partitions must also be Hash partitioned on the
    same distribution key, with the same 'numsegments', or randomly distributed with the same 'numsegments'.
    2、If a partitioned table is Randomly distributed, then all the leaves must be randomly distributed as well.

    we expand leaf partitions separately in parallel rather than expand root partition in one shot through two steps:
    Step1:
           BEGIN;
           Lock all root/interior/leaf partitions
           Change all numsegments of root/interior/leaf partitions to size of cluster;
           Change all leaf partition to random distributed;
           COMMIT;
    Step2:
           Change all leaf partition's policy back to parent's policy with set distributed with(REORGANIZE=true) in parallel.

---------

**We divide this PR into several commits, it is easy to review one by one. **

---------

**NOTE 1:**  this work is based on several work before (Thank all of them):

* The discussion here https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/rSacd_vI-fM/m/pkAW-Z-lCgAJ
* The PR from @uglthinx  https://github.com/greenplum-db/gpdb/pull/10613
* The work by @xuebinsu and @yinil-hello

--------

**NOTE2**

~~This PR is to master branch. Previous version gpdb (6), ORCA will treat a partition table as randomly distributed if policy is inconsistent among root and leafs. But master branch misses this logic. We need to do more work on ORCA. This is why WIP in the PR title.~~

It is ready for review now.

~~Open a new pr for ORCA related issue: https://github.com/greenplum-db/gpdb/pull/12671~~

The pr 12671 is merged.

