### PR TITLE
Beforehand generation of transaction ID when inserting into AO tables.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -22,6 +22,7 @@
 #include "access/appendonlywriter.h"
 #include "access/heapam.h"
 #include "access/hio.h"
+#include "access/xact.h"
 #include "catalog/catalog.h"
 #include "catalog/gp_fastsequence.h"
 #include "catalog/namespace.h"
@@ -909,6 +910,12 @@ aocs_insert_values(AOCSInsertDesc idesc, Datum *d, bool *null, AOTupleId *aoTupl
 								   "",	/* databaseName */
 								   RelationGetRelationName(idesc->aoi_rel));	/* tableName */
 #endif
+
+	/*
+	 * Generate new transaction id if necessary, so dependent entities, such as
+	 * spgist indexes, can use it outside aocs_insert_values.
+	 */
+	(void) GetCurrentTransactionId();
 
 	/* As usual, at this moment, we assume one col per vp */
 	for (i = 0; i < RelationGetNumberOfAttributes(rel); ++i)

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2849,6 +2849,12 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 
 	Assert(RelationIsAoRows(relation));
 
+	/*
+	 * Generate new transaction id if necessary, so dependent entities, such as
+	 * spgist indexes, can use it outside appendonly_insert.
+	 */
+	(void) GetCurrentTransactionId();
+
 	if (aoInsertDesc->useNoToast)
 		need_toast = false;
 	else

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -3129,3 +3129,70 @@ explain (costs off)
  Optimizer: Postgres query optimizer
 (4 rows)
 
+--
+-- Check spgist index work with AO tables
+--
+-- insert to AO table with spgist index
+create table spgist_ao_test(idx_col int4range)
+with (appendonly=true);
+create index spgist_ao_test_idx on spgist_ao_test
+using spgist(idx_col);
+--insert should not fall with spgutils.c:724 assertion
+insert into spgist_ao_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+-- insert to AOCS table with spgist index
+create table spgist_aocs_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+create index spgist_aocs_test_idx on spgist_aocs_test
+using spgist(idx_col);
+insert into spgist_aocs_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+--second insert call not triggers aocsam.c:770 condition
+--insert should not fall with spgutils.c:724 assertion
+insert into spgist_aocs_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+-- update to AO table with spgist index
+create table spgist_ao_upd_test(idx_col int4range)
+with (appendonly=true);
+insert into spgist_ao_upd_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+create index spgist_ao_upd_test_idx on spgist_ao_upd_test
+using spgist(idx_col);
+--update should not fall with spgutils.c:724 assertion
+update spgist_ao_upd_test set idx_col = int4range(1, 2, '[]');
+-- update to AOCS table with spgist index
+create table spgist_aocs_upd_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+create index spgist_aocs_upd_test_idx on spgist_aocs_upd_test
+using spgist(idx_col);
+insert into spgist_aocs_upd_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+--second update should not fall with spgutils.c:724 assertion
+update spgist_ao_upd_test set idx_col = int4range(1, 2, '[]');
+-- copy to AO table with spgist index
+create table spgist_ao_copy_test(idx_col int4range)
+with (appendonly=true);
+insert into spgist_ao_copy_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+create index spgist_ao_copy_test_idx on spgist_ao_copy_test
+using spgist(idx_col);
+copy spgist_ao_copy_test to '/tmp/spgist_test';
+--copy should not fall with spgutils.c:724 assertion or any segment failures
+copy spgist_ao_copy_test from '/tmp/spgist_test';
+-- copy to AOCS table with spgist index
+create table spgist_aocs_copy_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+insert into spgist_aocs_copy_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+create index spgist_aocs_copy_test_idx on spgist_aocs_copy_test
+using spgist(idx_col);
+copy spgist_aocs_copy_test to '/tmp/spgist_test';
+--copy should not fall with spgutils.c:724 assertion or any segment failures
+copy spgist_aocs_copy_test from '/tmp/spgist_test';

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3160,3 +3160,70 @@ explain (costs off)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (4 rows)
 
+--
+-- Check spgist index work with AO tables
+--
+-- insert to AO table with spgist index
+create table spgist_ao_test(idx_col int4range)
+with (appendonly=true);
+create index spgist_ao_test_idx on spgist_ao_test
+using spgist(idx_col);
+--insert should not fall with spgutils.c:724 assertion
+insert into spgist_ao_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+-- insert to AOCS table with spgist index
+create table spgist_aocs_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+create index spgist_aocs_test_idx on spgist_aocs_test
+using spgist(idx_col);
+insert into spgist_aocs_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+--second insert call not triggers aocsam.c:770 condition
+--insert should not fall with spgutils.c:724 assertion
+insert into spgist_aocs_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+-- update to AO table with spgist index
+create table spgist_ao_upd_test(idx_col int4range)
+with (appendonly=true);
+insert into spgist_ao_upd_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+create index spgist_ao_upd_test_idx on spgist_ao_upd_test
+using spgist(idx_col);
+--update should not fall with spgutils.c:724 assertion
+update spgist_ao_upd_test set idx_col = int4range(1, 2, '[]');
+-- update to AOCS table with spgist index
+create table spgist_aocs_upd_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+create index spgist_aocs_upd_test_idx on spgist_aocs_upd_test
+using spgist(idx_col);
+insert into spgist_aocs_upd_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+--second update should not fall with spgutils.c:724 assertion
+update spgist_ao_upd_test set idx_col = int4range(1, 2, '[]');
+-- copy to AO table with spgist index
+create table spgist_ao_copy_test(idx_col int4range)
+with (appendonly=true);
+insert into spgist_ao_copy_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+create index spgist_ao_copy_test_idx on spgist_ao_copy_test
+using spgist(idx_col);
+copy spgist_ao_copy_test to '/tmp/spgist_test';
+--copy should not fall with spgutils.c:724 assertion or any segment failures
+copy spgist_ao_copy_test from '/tmp/spgist_test';
+-- copy to AOCS table with spgist index
+create table spgist_aocs_copy_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+insert into spgist_aocs_copy_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+create index spgist_aocs_copy_test_idx on spgist_aocs_copy_test
+using spgist(idx_col);
+copy spgist_aocs_copy_test to '/tmp/spgist_test';
+--copy should not fall with spgutils.c:724 assertion or any segment failures
+copy spgist_aocs_copy_test from '/tmp/spgist_test';

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -975,3 +975,89 @@ RESET enable_indexonlyscan;
 
 explain (costs off)
   select * from tenk1 where (thousand, tenthous) in ((1,1001), (null,null));
+
+--
+-- Check spgist index work with AO tables
+--
+-- insert to AO table with spgist index
+create table spgist_ao_test(idx_col int4range)
+with (appendonly=true);
+
+create index spgist_ao_test_idx on spgist_ao_test
+using spgist(idx_col);
+--insert should not fall with spgutils.c:724 assertion
+insert into spgist_ao_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+
+-- insert to AOCS table with spgist index
+create table spgist_aocs_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+
+create index spgist_aocs_test_idx on spgist_aocs_test
+using spgist(idx_col);
+
+insert into spgist_aocs_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+--second insert call not triggers aocsam.c:770 condition
+--insert should not fall with spgutils.c:724 assertion
+insert into spgist_aocs_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+
+-- update to AO table with spgist index
+create table spgist_ao_upd_test(idx_col int4range)
+with (appendonly=true);
+
+insert into spgist_ao_upd_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+
+create index spgist_ao_upd_test_idx on spgist_ao_upd_test
+using spgist(idx_col);
+--update should not fall with spgutils.c:724 assertion
+update spgist_ao_upd_test set idx_col = int4range(1, 2, '[]');
+
+-- update to AOCS table with spgist index
+create table spgist_aocs_upd_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+
+create index spgist_aocs_upd_test_idx on spgist_aocs_upd_test
+using spgist(idx_col);
+
+insert into spgist_aocs_upd_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+--second update should not fall with spgutils.c:724 assertion
+update spgist_ao_upd_test set idx_col = int4range(1, 2, '[]');
+
+-- copy to AO table with spgist index
+create table spgist_ao_copy_test(idx_col int4range)
+with (appendonly=true);
+
+insert into spgist_ao_copy_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+
+create index spgist_ao_copy_test_idx on spgist_ao_copy_test
+using spgist(idx_col);
+
+copy spgist_ao_copy_test to '/tmp/spgist_test';
+--copy should not fall with spgutils.c:724 assertion or any segment failures
+copy spgist_ao_copy_test from '/tmp/spgist_test';
+
+-- copy to AOCS table with spgist index
+create table spgist_aocs_copy_test(idx_col int4range)
+with (appendonly=true, orientation=column);
+
+insert into spgist_aocs_copy_test
+select int4range(i, i, '[]')
+from generate_series(0,10000) i;
+
+create index spgist_aocs_copy_test_idx on spgist_aocs_copy_test
+using spgist(idx_col);
+
+copy spgist_aocs_copy_test to '/tmp/spgist_test';
+--copy should not fall with spgutils.c:724 assertion or any segment failures
+copy spgist_aocs_copy_test from '/tmp/spgist_test';


### PR DESCRIPTION
Empty transaction ID can cause errors on dependent entities, such as spgist indexes.
The fix adding a call to 'GetCurrentTransactionId' like it's done in vanilla Postgres version of 'heap_insert' function. Additional regression tests shows how to reproduce an error using spgist index before fix.
