### PR TITLE
Correct the real firstTid in _bitmap_union

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -893,6 +893,17 @@ restart:
 		result->nextTid = words->firstTid;
 
 	/*
+	 * Current words may not contain the expected nextTid, since the
+	 * blockno may skiped several blocks if BitmapAdd choose to skip
+	 * the blockno that can not be matched.
+	 */
+	if (words->firstTid < result->nextTid)
+	{
+		Assert(words->nwords < 1);
+		return false;
+	}
+
+	/*
 	 * If the catch up processd all unmatch words that exceed current block's
 	 * end. Then restart for a new block.
 	 */

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -372,7 +372,7 @@ _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result)
 	/*
 	 * Iterate each word until catch up to the next tid to search.
 	 */
-	for(; result->lastScanWordNo < words->nwords && words->firstTid < result->nextTid;
+	for(; words->nwords > 0 && words->firstTid < result->nextTid;
 		result->lastScanWordNo++)
 	{
 		if (IS_FILL_WORD(words->hwords, result->lastScanWordNo))
@@ -387,7 +387,7 @@ _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result)
 			{
 				fillLength = 1;
 				/* Skip all empty bits, this may cause words->firstTid > result->nextTid */
-				words->firstTid = fillLength * BM_HRL_WORD_SIZE;
+				words->firstTid += fillLength * BM_HRL_WORD_SIZE;
 				words->nwords--;
 
 				/* reset next tid to skip all empty words */
@@ -664,6 +664,15 @@ _bitmap_union(BMBatchWords **batches, uint32 numBatches, BMBatchWords *result)
 
 	/* save batch->startNo for each input bitmap vector */
 	prevstarts = (uint32 *)palloc0(numBatches * sizeof(uint32));
+
+	/*
+	 * Update the real firstTid for the bachwords with unioned batches.
+	 * This is required because we may result->firstTid is set to nextTid
+	 * to fetch in _bitmap_nextbatchwords for bitmap index scan, but the
+	 * read words may not reach this position yet, the below calculation
+	 * will set it back to the real first tid of current result batch.
+	 */
+	result->firstTid = ((batches[0]->nextread - 1) * BM_HRL_WORD_SIZE) + 1;
 
 	/* 
 	 * Compute the next read offset. We fast forward compressed


### PR DESCRIPTION
In previous refactor which try to resolve issue:
https://github.com/greenplum-db/gpdb/issues/11308.
We change the way to calculate the firstTid holding in the
current position batch words, since concurrent insert will cause
the wrong tid matching in words_get_match().

To fix that issue in PR https://github.com/greenplum-db/gpdb/pull/11377,
we always get the correct firstTid from the bitmap index page.
But _bitmap_union is not touched. It was responsible to union bitmap
batch words for multivalues index scan like `where x in (x1, x2)` or `x > v`.

And also the logic for the catch up loop is not correct in
_bitmap_catchup_to_next_tid, it should check remain words number.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
