### PR TITLE
Updating postgres_setup.bash to skip certificate check

### DIFF
--- a/contrib/postgres_fdw/postgres_setup.bash
+++ b/contrib/postgres_fdw/postgres_setup.bash
@@ -19,7 +19,7 @@ pgbin="pgsql"
 if [ ! -d "${pgbin}" ] ; then
 	mkdir ${pgbin}
 	if [ ! -d postgresql-10.4 ]; then
-		wget https://ftp.postgresql.org/pub/source/v10.4/postgresql-10.4.tar.gz
+		wget --no-check-certificate https://ftp.postgresql.org/pub/source/v10.4/postgresql-10.4.tar.gz
 		tar -xvf postgresql-10.4.tar.gz
 	fi
 	pushd postgresql-10.4


### PR DESCRIPTION
The script fails on the pipeline when downloading postgres source from
the URL for testing postgres_fdw tests. This is because there are new
updated certificates.
This commit adds a temporary workaround to skip the certificate check
for now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
