### PR TITLE
Make postgres_for_fdw input optional

### DIFF
--- a/concourse/tasks/ic_gpdb.yml
+++ b/concourse/tasks/ic_gpdb.yml
@@ -5,6 +5,7 @@ inputs:
   - name: gpdb_src
   - name: bin_gpdb
   - name: postgres_for_fdw
+    optional: true
 outputs:
   - name: sqldump
 params:


### PR DESCRIPTION
It shouldn't be required for the interconnect test which uses the same
task.yml file

Authored-by: Karen Huddleston <khuddleston@vmware.com>

