### PR TITLE
Fix wrong results with nested SRF in Orca

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CScalarFunc.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarFunc.cpp
@@ -206,10 +206,9 @@ CScalarFunc::TypeModifier() const
 //
 //---------------------------------------------------------------------------
 BOOL
-CScalarFunc::FHasNonScalarFunction(CExpressionHandle &	//exprhdl
-)
+CScalarFunc::FHasNonScalarFunction(CExpressionHandle &exprhdl)
 {
-	return m_returns_set;
+	return m_returns_set || CScalar::FHasNonScalarFunction(exprhdl);
 }
 
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13793,3 +13793,67 @@ select a in (
 
 reset optimizer_xform_bind_threshold;
 reset statement_timeout;
+-- an agg of a non-SRF with a nested SRF should be treated as a SRF, the
+-- optimizer must not eliminate the SRF or it can produce incorrect results
+set optimizer_trace_fallback = on;
+create table nested_srf(a text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into nested_srf values ('abc,def,ghi');
+select * from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ regexp_split_to_table 
+-----------------------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ btrim 
+-------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select count(regexp_split_to_table((a)::text, ','::text)) from nested_srf;
+ERROR:  set-valued function called in context that cannot accept a set  (seg2 slice1 127.0.0.1:6004 pid=82558)
+-- This produces wrong results on planner
+select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+ count 
+-------
+     1
+(1 row)
+
+truncate nested_srf;
+insert into nested_srf values (NULL);
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ btrim 
+-------
+(0 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ count 
+-------
+     0
+(1 row)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14052,3 +14052,65 @@ select a in (
 
 reset optimizer_xform_bind_threshold;
 reset statement_timeout;
+-- an agg of a non-SRF with a nested SRF should be treated as a SRF, the
+-- optimizer must not eliminate the SRF or it can produce incorrect results
+set optimizer_trace_fallback = on;
+create table nested_srf(a text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into nested_srf values ('abc,def,ghi');
+select * from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ regexp_split_to_table 
+-----------------------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ btrim 
+-------
+ abc
+ def
+ ghi
+(3 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
+ count 
+-------
+     3
+(1 row)
+
+select count(regexp_split_to_table((a)::text, ','::text)) from nested_srf;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Operator Aggregate function with set returning attributes not supported
+ERROR:  set-valued function called in context that cannot accept a set  (seg2 slice1 127.0.0.1:6004 pid=82293)
+-- This produces wrong results on planner
+select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+ERROR:  set-valued function called in context that cannot accept a set  (seg2 slice1 127.0.0.1:6004 pid=82021)
+truncate nested_srf;
+insert into nested_srf values (NULL);
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ btrim 
+-------
+(0 rows)
+
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+ count 
+-------
+     0
+(1 row)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3077,6 +3077,30 @@ select a in (
 reset optimizer_xform_bind_threshold;
 reset statement_timeout;
 
+-- an agg of a non-SRF with a nested SRF should be treated as a SRF, the
+-- optimizer must not eliminate the SRF or it can produce incorrect results
+set optimizer_trace_fallback = on;
+create table nested_srf(a text);
+insert into nested_srf values ('abc,def,ghi');
+
+select * from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+select count(*) from (select regexp_split_to_table((a)::text, ','::text) from nested_srf)a;
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+
+select count(*) from (select trim( case when a!='abc' then  (regexp_split_to_table((a)::text, ','::text)) else ' ' end) from nested_srf)a;
+select count(regexp_split_to_table((a)::text, ','::text)) from nested_srf;
+-- This produces wrong results on planner
+select count(*) from (select trim(coalesce(regexp_split_to_table((a)::text, ','::text),'')) from nested_srf)a;
+
+truncate nested_srf;
+insert into nested_srf values (NULL);
+
+select * from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) from nested_srf)a;
+
+reset optimizer_trace_fallback;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Previously, if we had a query such as
`select count(*)  from (select trim(regexp_split_to_table((a)::text, ','::text)) from bar)a;`

Orca would consider the `trim()` function as a non-SRF and optimize away
the function call, leading to incorrect results. Because
`regexp_split_to_table` is a SRF, we must also consider `trim` to be a
SRF and evaluate the nested function.

Orca will now recurse into the function's children when determining
whether it is a SRF. If any of its children are SRF, the outer function
will also be treated as a SRF and evaluated.

Backport of https://github.com/greenplum-db/gpdb/pull/12623