### PR TITLE
[clang-tidy] Enable modernize-use-bool-literals and modernize-use-using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: |
   modernize-use-nullptr,
   modernize-use-default-member-init,
   modernize-use-bool-literals,
+  modernize-use-using
   readability-make-member-function-const,
   readability-non-const-parameter,
   readability-static-accessed-through-instance,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: |
   modernize-use-equals-delete,
   modernize-use-nullptr,
   modernize-use-default-member-init,
+  modernize-use-bool-literals,
   readability-make-member-function-const,
   readability-non-const-parameter,
   readability-static-accessed-through-instance,

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2124,7 +2124,7 @@ CTranslatorUtils::CreateDXLProjElemConstNULL(CMemoryPool *mp,
 	else if (mdid->Equals(&CMDIdGPDB::m_mdid_bool))
 	{
 		datum_dxl = GPOS_NEW(mp)
-			CDXLDatumBool(mp, mdid, true /*fConstNull*/, 0 /*value*/);
+			CDXLDatumBool(mp, mdid, true /*fConstNull*/, false /*value*/);
 	}
 	else if (mdid->Equals(&CMDIdGPDB::m_mdid_oid))
 	{

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEInfo.h
@@ -87,22 +87,22 @@ private:
 	};
 
 	// hash map mapping ULONG -> SConsumerCounter
-	typedef CHashMap<ULONG, SConsumerCounter, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupDelete<SConsumerCounter> >
-		UlongToConsumerCounterMap;
+	using UlongToConsumerCounterMap =
+		CHashMap<ULONG, SConsumerCounter, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupDelete<SConsumerCounter>>;
 
 	// map iterator
-	typedef CHashMapIter<ULONG, SConsumerCounter, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupDelete<SConsumerCounter> >
-		UlongToConsumerCounterMapIter;
+	using UlongToConsumerCounterMapIter =
+		CHashMapIter<ULONG, SConsumerCounter, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupDelete<SConsumerCounter>>;
 
 	// hash map mapping ULONG -> UlongToConsumerCounterMap: maps from CTE producer ID to all consumers inside this CTE
-	typedef CHashMap<ULONG, UlongToConsumerCounterMap, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<UlongToConsumerCounterMap> >
-		UlongToProducerConsumerMap;
+	using UlongToProducerConsumerMap =
+		CHashMap<ULONG, UlongToConsumerCounterMap, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<UlongToConsumerCounterMap>>;
 
 	//-------------------------------------------------------------------
 	//	@struct:
@@ -169,16 +169,16 @@ private:
 	};	//class CCTEInfoEntry
 
 	// hash maps mapping ULONG -> CCTEInfoEntry
-	typedef CHashMap<ULONG, CCTEInfoEntry, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CCTEInfoEntry> >
-		UlongToCTEInfoEntryMap;
+	using UlongToCTEInfoEntryMap =
+		CHashMap<ULONG, CCTEInfoEntry, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CCTEInfoEntry>>;
 
 	// map iterator
-	typedef CHashMapIter<ULONG, CCTEInfoEntry, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupRelease<CCTEInfoEntry> >
-		UlongToCTEInfoEntryMapIter;
+	using UlongToCTEInfoEntryMapIter =
+		CHashMapIter<ULONG, CCTEInfoEntry, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupRelease<CCTEInfoEntry>>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
@@ -29,16 +29,15 @@ namespace gpopt
 using namespace gpos;
 
 // hash map from CTE id to corresponding producer plan properties
-typedef CHashMap<ULONG, CDrvdPropPlan, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupRelease<CDrvdPropPlan> >
-	UlongToDrvdPropPlanMap;
+using UlongToDrvdPropPlanMap =
+	CHashMap<ULONG, CDrvdPropPlan, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<CDrvdPropPlan>>;
 
 // iterator for plan properties map
-typedef CHashMapIter<ULONG, CDrvdPropPlan, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CDrvdPropPlan> >
-	UlongToDrvdPropPlanMapIter;
+using UlongToDrvdPropPlanMapIter =
+	CHashMapIter<ULONG, CDrvdPropPlan, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CDrvdPropPlan>>;
 
 // forward declaration
 class CCTEReq;
@@ -148,16 +147,16 @@ private:
 	};	// class CCTEMapEntry
 
 	// map CTE id to CTE map entry
-	typedef CHashMap<ULONG, CCTEMapEntry, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CCTEMapEntry> >
-		UlongToCTEMapEntryMap;
+	using UlongToCTEMapEntryMap =
+		CHashMap<ULONG, CCTEMapEntry, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CCTEMapEntry>>;
 
 	// map iterator
-	typedef CHashMapIter<ULONG, CCTEMapEntry, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupRelease<CCTEMapEntry> >
-		UlongToCTEMapEntryMapIter;
+	using UlongToCTEMapEntryMapIter =
+		CHashMapIter<ULONG, CCTEMapEntry, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupRelease<CCTEMapEntry>>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
@@ -111,16 +111,16 @@ private:
 	};	// class CCTEReqEntry
 
 	// map CTE id to CTE Req entry
-	typedef CHashMap<ULONG, CCTEReqEntry, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CCTEReqEntry> >
-		UlongToCTEReqEntryMap;
+	using UlongToCTEReqEntryMap =
+		CHashMap<ULONG, CCTEReqEntry, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CCTEReqEntry>>;
 
 	// map iterator
-	typedef CHashMapIter<ULONG, CCTEReqEntry, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupRelease<CCTEReqEntry> >
-		UlongToCTEReqEntryMapIter;
+	using UlongToCTEReqEntryMapIter =
+		CHashMapIter<ULONG, CCTEReqEntry, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupRelease<CCTEReqEntry>>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -29,18 +29,17 @@ using namespace gpmd;
 class CColRef;
 
 // colref array
-typedef CDynamicPtrArray<CColRef, CleanupNULL> CColRefArray;
-typedef CDynamicPtrArray<CColRefArray, CleanupRelease> CColRef2dArray;
+using CColRefArray = CDynamicPtrArray<CColRef, CleanupNULL>;
+using CColRef2dArray = CDynamicPtrArray<CColRefArray, CleanupRelease>;
 
 // hash map mapping ULONG -> CColRef
-typedef CHashMap<ULONG, CColRef, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupNULL<CColRef> >
-	UlongToColRefMap;
+using UlongToColRefMap =
+	CHashMap<ULONG, CColRef, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupNULL<CColRef>>;
 // iterator
-typedef CHashMapIter<ULONG, CColRef, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupNULL<CColRef> >
-	UlongToColRefMapIter;
+using UlongToColRefMapIter =
+	CHashMapIter<ULONG, CColRef, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupNULL<CColRef>>;
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -238,12 +237,12 @@ operator<<(IOstream &os, CColRef &cr)
 }
 
 // hash map: CColRef -> ULONG
-typedef CHashMap<CColRef, ULONG, CColRef::HashValue, gpos::Equals<CColRef>,
-				 CleanupNULL<CColRef>, CleanupDelete<ULONG> >
-	ColRefToUlongMap;
+using ColRefToUlongMap =
+	CHashMap<CColRef, ULONG, CColRef::HashValue, gpos::Equals<CColRef>,
+			 CleanupNULL<CColRef>, CleanupDelete<ULONG>>;
 
-typedef CDynamicPtrArray<ColRefToUlongMap, CleanupRelease>
-	ColRefToUlongMapArray;
+using ColRefToUlongMapArray =
+	CDynamicPtrArray<ColRefToUlongMap, CleanupRelease>;
 
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
@@ -25,17 +25,17 @@ namespace gpopt
 class CColRefSet;
 
 // short hand for colref set array
-typedef CDynamicPtrArray<CColRefSet, CleanupRelease> CColRefSetArray;
+using CColRefSetArray = CDynamicPtrArray<CColRefSet, CleanupRelease>;
 
 // hash map mapping CColRef -> CColRefSet
-typedef CHashMap<CColRef, CColRefSet, CColRef::HashValue, CColRef::Equals,
-				 CleanupNULL<CColRef>, CleanupRelease<CColRefSet> >
-	ColRefToColRefSetMap;
+using ColRefToColRefSetMap =
+	CHashMap<CColRef, CColRefSet, CColRef::HashValue, CColRef::Equals,
+			 CleanupNULL<CColRef>, CleanupRelease<CColRefSet>>;
 
 // hash map mapping INT -> CColRef
-typedef CHashMap<INT, CColRef, gpos::HashValue<INT>, gpos::Equals<INT>,
-				 CleanupDelete<INT>, CleanupNULL<CColRef> >
-	IntToColRefMap;
+using IntToColRefMap =
+	CHashMap<INT, CColRef, gpos::HashValue<INT>, gpos::Equals<INT>,
+			 CleanupDelete<INT>, CleanupNULL<CColRef>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -29,26 +29,25 @@ class CExpression;
 class CConstraint;
 
 // constraint array
-typedef CDynamicPtrArray<CConstraint, CleanupRelease> CConstraintArray;
+using CConstraintArray = CDynamicPtrArray<CConstraint, CleanupRelease>;
 
 // hash map mapping CColRef -> CConstraintArray
-typedef CHashMap<CColRef, CConstraintArray, CColRef::HashValue, CColRef::Equals,
-				 CleanupNULL<CColRef>, CleanupRelease<CConstraintArray> >
-	ColRefToConstraintArrayMap;
+using ColRefToConstraintArrayMap =
+	CHashMap<CColRef, CConstraintArray, CColRef::HashValue, CColRef::Equals,
+			 CleanupNULL<CColRef>, CleanupRelease<CConstraintArray>>;
 
 // mapping CConstraint -> BOOL to cache previous containment queries,
 // we use pointer equality here for fast map lookup -- since we do shallow comparison, we do not take ownership
 // of pointer values
-typedef CHashMap<CConstraint, BOOL, gpos::HashPtr<CConstraint>,
-				 gpos::EqualPtr<CConstraint>, CleanupNULL<CConstraint>,
-				 CleanupNULL<BOOL> >
-	ConstraintContainmentMap;
+using ConstraintContainmentMap =
+	CHashMap<CConstraint, BOOL, gpos::HashPtr<CConstraint>,
+			 gpos::EqualPtr<CConstraint>, CleanupNULL<CConstraint>,
+			 CleanupNULL<BOOL>>;
 
 // hash map mapping ULONG -> CConstraint
-typedef CHashMap<ULONG, CConstraint, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupRelease<CConstraint> >
-	UlongToConstraintMap;
+using UlongToConstraintMap =
+	CHashMap<ULONG, CConstraint, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<CConstraint>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -27,7 +27,7 @@
 namespace gpopt
 {
 // range array
-typedef CDynamicPtrArray<CRange, CleanupRelease> CRangeArray;
+using CRangeArray = CDynamicPtrArray<CRange, CleanupRelease>;
 
 using namespace gpos;
 using namespace gpmd;
@@ -269,8 +269,8 @@ operator<<(IOstream &os, const CConstraintInterval *interval)
 	return interval->OsPrint(os);
 }
 
-typedef CDynamicPtrArray<CConstraintInterval, CleanupRelease>
-	CConstraintIntervalArray;
+using CConstraintIntervalArray =
+	CDynamicPtrArray<CConstraintInterval, CleanupRelease>;
 }  // namespace gpopt
 
 #endif	// !GPOPT_CConstraintInterval_H

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
@@ -35,13 +35,13 @@ class CDrvdPropPlan;
 class CCostContext;
 
 // array of cost contexts
-typedef CDynamicPtrArray<CCostContext, CleanupRelease> CCostContextArray;
+using CCostContextArray = CDynamicPtrArray<CCostContext, CleanupRelease>;
 
 // cost context pointer definition
-typedef CCostContext *COSTCTXT_PTR;
+using COSTCTXT_PTR = CCostContext *;
 
 // cost context pointer definition
-typedef const CCostContext *CONST_COSTCTXT_PTR;
+using CONST_COSTCTXT_PTR = const CCostContext *;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
@@ -169,8 +169,8 @@ public:
 };	// class CDistributionSpec
 
 // arrays of distribution spec
-typedef CDynamicPtrArray<CDistributionSpec, CleanupRelease>
-	CDistributionSpecArray;
+using CDistributionSpecArray =
+	CDynamicPtrArray<CDistributionSpec, CleanupRelease>;
 }  // namespace gpopt
 
 #endif	// !GPOPT_IDistributionSpec_H

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
@@ -29,7 +29,7 @@ class CDrvdPropCtxt;
 class CReqdPropPlan;
 
 // dynamic array for properties
-typedef CDynamicPtrArray<CDrvdProp, CleanupRelease> CDrvdPropArray;
+using CDrvdPropArray = CDynamicPtrArray<CDrvdProp, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxt.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxt.h
@@ -26,7 +26,7 @@ class CDrvdPropCtxt;
 class CDrvdProp;
 
 // dynamic array for properties
-typedef CDynamicPtrArray<CDrvdPropCtxt, CleanupRelease> CDrvdPropCtxtArray;
+using CDrvdPropCtxtArray = CDynamicPtrArray<CDrvdPropCtxt, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
@@ -24,8 +24,8 @@ namespace gpopt
 class CFunctionalDependency;
 
 // definition of array of functional dependencies
-typedef CDynamicPtrArray<CFunctionalDependency, CleanupRelease>
-	CFunctionalDependencyArray;
+using CFunctionalDependencyArray =
+	CDynamicPtrArray<CFunctionalDependency, CleanupRelease>;
 
 using namespace gpos;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptCtxt.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptCtxt.h
@@ -26,9 +26,9 @@ namespace gpopt
 using namespace gpos;
 
 // hash maps ULONG -> array of ULONGs
-typedef CHashMap<ULONG, CBitSet, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupRelease<CBitSet> >
-	UlongToBitSetMap;
+using UlongToBitSetMap =
+	CHashMap<ULONG, CBitSet, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<CBitSet>>;
 
 // forward declarations
 class CColRefSet;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
@@ -35,11 +35,11 @@ class COptimizationContext;
 class CDrvdPropPlan;
 
 // optimization context pointer definition
-typedef COptimizationContext *OPTCTXT_PTR;
+using OPTCTXT_PTR = COptimizationContext *;
 
 // array of optimization contexts
-typedef CDynamicPtrArray<COptimizationContext, CleanupRelease>
-	COptimizationContextArray;
+using COptimizationContextArray =
+	CDynamicPtrArray<COptimizationContext, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COrderSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COrderSpec.h
@@ -23,7 +23,7 @@ namespace gpopt
 {
 // type definition of corresponding dynamic pointer array
 class COrderSpec;
-typedef CDynamicPtrArray<COrderSpec, CleanupRelease> COrderSpecArray;
+using COrderSpecArray = CDynamicPtrArray<COrderSpec, CleanupRelease>;
 
 using namespace gpos;
 
@@ -116,8 +116,8 @@ private:
 	};	// class COrderExpression
 
 	// array of order expressions
-	typedef CDynamicPtrArray<COrderExpression, CleanupDelete>
-		COrderExpressionArray;
+	using COrderExpressionArray =
+		CDynamicPtrArray<COrderExpression, CleanupDelete>;
 
 
 	// memory pool

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
@@ -107,8 +107,8 @@ private:
 
 	};	// CPartInfoEntry
 
-	typedef CDynamicPtrArray<CPartInfoEntry, CleanupRelease>
-		CPartInfoEntryArray;
+	using CPartInfoEntryArray =
+		CDynamicPtrArray<CPartInfoEntry, CleanupRelease>;
 
 	// partition table consumers
 	CPartInfoEntryArray *m_pdrgppartentries;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
@@ -24,7 +24,7 @@ class CColRefSet;
 class CPartKeys;
 
 // array of part keys
-typedef CDynamicPtrArray<CPartKeys, CleanupRelease> CPartKeysArray;
+using CPartKeysArray = CDynamicPtrArray<CPartKeys, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartitionPropagationSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartitionPropagationSpec.h
@@ -86,8 +86,8 @@ private:
 		static INT CmpFunc(const void *val1, const void *val2);
 	};
 
-	typedef CDynamicPtrArray<SPartPropSpecInfo, CleanupRelease>
-		SPartPropSpecInfoArray;
+	using SPartPropSpecInfoArray =
+		CDynamicPtrArray<SPartPropSpecInfo, CleanupRelease>;
 
 	// partition required/derived info, sorted by scanid
 	SPartPropSpecInfoArray *m_part_prop_spec_infos = nullptr;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
@@ -28,7 +28,7 @@ class COperator;
 class CReqdProp;
 
 // dynamic array for required properties
-typedef CDynamicPtrArray<CReqdProp, CleanupRelease> CReqdPropArray;
+using CReqdPropArray = CDynamicPtrArray<CReqdProp, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CStateMachine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CStateMachine.h
@@ -53,11 +53,11 @@ class CStateMachine
 private:
 #ifdef GPOS_DEBUG
 	// shorthand for sets and iterators
-	typedef CEnumSet<TEnumState, tenumstateSentinel> EsetStates;
-	typedef CEnumSet<TEnumEvent, tenumeventSentinel> EsetEvents;
+	using EsetStates = CEnumSet<TEnumState, tenumstateSentinel>;
+	using EsetEvents = CEnumSet<TEnumEvent, tenumeventSentinel>;
 
-	typedef CEnumSetIter<TEnumState, tenumstateSentinel> EsetStatesIter;
-	typedef CEnumSetIter<TEnumEvent, tenumeventSentinel> EsetEventsIter;
+	using EsetStatesIter = CEnumSetIter<TEnumState, tenumstateSentinel>;
+	using EsetEventsIter = CEnumSetIter<TEnumEvent, tenumeventSentinel>;
 #endif	// GPOS_DEBUG
 
 	// current state
@@ -149,9 +149,8 @@ private:
 	}
 
 	// shorthand for walker function type
-	typedef void (*PfWalker)(const CStateMachine *psm, TEnumState tenumstateOld,
-							 TEnumState tenumstateNew, TEnumEvent tenumevent,
-							 void *pvContext);
+	using PfWalker = void (*)(const CStateMachine *, TEnumState, TEnumState,
+							  TEnumEvent, void *);
 
 	// generic walker function, called for every edge in the graph
 	void

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -976,9 +976,8 @@ public:
 };	// class CUtils
 
 // hash set from expressions
-typedef CHashSet<CExpression, CExpression::UlHashDedup, CUtils::Equals,
-				 CleanupRelease<CExpression> >
-	ExprHashSet;
+using ExprHashSet = CHashSet<CExpression, CExpression::UlHashDedup,
+							 CUtils::Equals, CleanupRelease<CExpression>>;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
@@ -22,7 +22,7 @@ namespace gpopt
 {
 // type definition of corresponding dynamic pointer array
 class CWindowFrame;
-typedef CDynamicPtrArray<CWindowFrame, CleanupRelease> CWindowFrameArray;
+using CWindowFrameArray = CDynamicPtrArray<CWindowFrame, CleanupRelease>;
 
 using namespace gpos;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/SPartSelectorInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/SPartSelectorInfo.h
@@ -37,10 +37,10 @@ struct SPartSelectorInfoEntry
 	}
 };
 
-typedef CHashMap<ULONG, SPartSelectorInfoEntry, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupDelete<SPartSelectorInfoEntry> >
-	SPartSelectorInfo;
+using SPartSelectorInfo =
+	CHashMap<ULONG, SPartSelectorInfoEntry, gpos::HashValue<ULONG>,
+			 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+			 CleanupDelete<SPartSelectorInfoEntry>>;
 
 }  // namespace gpopt
 #endif	// !GPOPT_CPartSelectorInfo_H

--- a/src/backend/gporca/libgpopt/include/gpopt/cost/CCost.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/cost/CCost.h
@@ -20,7 +20,7 @@ namespace gpopt
 using namespace gpos;
 
 class CCost;
-typedef CDynamicPtrArray<CCost, CleanupDelete> CCostArray;
+using CCostArray = CDynamicPtrArray<CCost, CleanupDelete>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
@@ -36,8 +36,8 @@ using namespace gpmd;
 using namespace gpnaucrates;
 
 // dynamic array of cost model params
-typedef CDynamicPtrArray<ICostModelParams::SCostParam, CleanupDelete>
-	ICostModelParamsArray;
+using ICostModelParamsArray =
+	CDynamicPtrArray<ICostModelParams::SCostParam, CleanupDelete>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CEnumeratorConfig.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CEnumeratorConfig.h
@@ -33,7 +33,7 @@ using namespace gpos;
 class CExpression;
 
 // type definition of plan checker
-typedef BOOL(FnPlanChecker)(CExpression *);
+using FnPlanChecker = BOOL(CExpression *);
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -90,7 +90,7 @@ private:
 	};	// struct SSamplePlan
 
 	// array og unsigned long long int
-	typedef CDynamicPtrArray<SSamplePlan, CleanupDelete> SSamplePlanArray;
+	using SSamplePlanArray = CDynamicPtrArray<SSamplePlan, CleanupDelete>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/mdcache/CMDAccessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/mdcache/CMDAccessor.h
@@ -65,7 +65,7 @@ using namespace gpos;
 using namespace gpmd;
 
 
-typedef IMDId *MdidPtr;
+using MdidPtr = IMDId *;
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -90,7 +90,7 @@ class CMDAccessor
 {
 public:
 	// ccache template for mdcache
-	typedef CCache<IMDCacheObject *, CMDKey *> MDCache;
+	using MDCache = CCache<IMDCacheObject *, CMDKey *>;
 
 private:
 	// element in the hashtable of cache accessors maintained by the MD accessor
@@ -99,28 +99,28 @@ private:
 
 
 	// cache accessor for objects in a MD cache
-	typedef CCacheAccessor<IMDCacheObject *, CMDKey *> CacheAccessorMD;
+	using CacheAccessorMD = CCacheAccessor<IMDCacheObject *, CMDKey *>;
 
 	// hashtable for cache accessors indexed by the md id of the accessed object
-	typedef CSyncHashtable<SMDAccessorElem, MdidPtr> MDHT;
+	using MDHT = CSyncHashtable<SMDAccessorElem, MdidPtr>;
 
-	typedef CSyncHashtableAccessByKey<SMDAccessorElem, MdidPtr> MDHTAccessor;
+	using MDHTAccessor = CSyncHashtableAccessByKey<SMDAccessorElem, MdidPtr>;
 
 	// iterator for the cache accessors hashtable
-	typedef CSyncHashtableIter<SMDAccessorElem, MdidPtr> MDHTIter;
-	typedef CSyncHashtableAccessByIter<SMDAccessorElem, MdidPtr>
-		MDHTIterAccessor;
+	using MDHTIter = CSyncHashtableIter<SMDAccessorElem, MdidPtr>;
+	using MDHTIterAccessor =
+		CSyncHashtableAccessByIter<SMDAccessorElem, MdidPtr>;
 
 	// hashtable for MD providers indexed by the source system id
-	typedef CSyncHashtable<SMDProviderElem, SMDProviderElem> MDPHT;
+	using MDPHT = CSyncHashtable<SMDProviderElem, SMDProviderElem>;
 
-	typedef CSyncHashtableAccessByKey<SMDProviderElem, SMDProviderElem>
-		MDPHTAccessor;
+	using MDPHTAccessor =
+		CSyncHashtableAccessByKey<SMDProviderElem, SMDProviderElem>;
 
 	// iterator for the providers hashtable
-	typedef CSyncHashtableIter<SMDProviderElem, SMDProviderElem> MDPHTIter;
-	typedef CSyncHashtableAccessByIter<SMDProviderElem, SMDProviderElem>
-		MDPHTIterAccessor;
+	using MDPHTIter = CSyncHashtableIter<SMDProviderElem, SMDProviderElem>;
+	using MDPHTIterAccessor =
+		CSyncHashtableAccessByIter<SMDProviderElem, SMDProviderElem>;
 
 	// element in the cache accessor hashtable maintained by the MD Accessor
 	struct SMDAccessorElem

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
@@ -27,16 +27,16 @@ class CColRef;
 class CPartConstraint;
 
 // hash maps of part constraints indexed by part index id
-typedef CHashMap<ULONG, CPartConstraint, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupRelease<CPartConstraint> >
-	UlongToPartConstraintMap;
+using UlongToPartConstraintMap =
+	CHashMap<ULONG, CPartConstraint, gpos::HashValue<ULONG>,
+			 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+			 CleanupRelease<CPartConstraint>>;
 
 // map iterator
-typedef CHashMapIter<ULONG, CPartConstraint, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CPartConstraint> >
-	UlongToPartConstraintMapIter;
+using UlongToPartConstraintMapIter =
+	CHashMapIter<ULONG, CPartConstraint, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CPartConstraint>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -27,11 +27,11 @@ using namespace gpos;
 using namespace gpmd;
 
 // dynamic array of columns -- array owns columns
-typedef CDynamicPtrArray<CColumnDescriptor, CleanupRelease>
-	CColumnDescriptorArray;
+using CColumnDescriptorArray =
+	CDynamicPtrArray<CColumnDescriptor, CleanupRelease>;
 
 // dynamic array of bitsets
-typedef CDynamicPtrArray<CBitSet, CleanupRelease> CBitSetArray;
+using CBitSetArray = CDynamicPtrArray<CBitSet, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -32,10 +32,10 @@ namespace gpopt
 {
 // cleanup function for arrays
 class CExpression;
-typedef CDynamicPtrArray<CExpression, CleanupRelease> CExpressionArray;
+using CExpressionArray = CDynamicPtrArray<CExpression, CleanupRelease>;
 
 // array of arrays of expression pointers
-typedef CDynamicPtrArray<CExpressionArray, CleanupRelease> CExpressionArrays;
+using CExpressionArrays = CDynamicPtrArray<CExpressionArray, CleanupRelease>;
 
 class CGroupExpression;
 class CDrvdPropPlan;
@@ -322,16 +322,15 @@ operator<<(IOstream &os, CExpression &expr)
 }
 
 // hash map from ULONG to expression
-typedef CHashMap<ULONG, CExpression, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupRelease<CExpression> >
-	UlongToExprMap;
+using UlongToExprMap =
+	CHashMap<ULONG, CExpression, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<CExpression>>;
 
 // map iterator
-typedef CHashMapIter<ULONG, CExpression, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CExpression> >
-	UlongToExprMapIter;
+using UlongToExprMapIter =
+	CHashMapIter<ULONG, CExpression, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CExpression>>;
 
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionFactorizer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionFactorizer.h
@@ -43,39 +43,38 @@ class CExpressionFactorizer
 {
 private:
 	// map expression to a count, used in factorization
-	typedef CHashMap<CExpression, ULONG, CExpression::HashValue, CUtils::Equals,
-					 CleanupRelease<CExpression>, CleanupDelete<ULONG> >
-		ExprMap;
+	using ExprMap =
+		CHashMap<CExpression, ULONG, CExpression::HashValue, CUtils::Equals,
+				 CleanupRelease<CExpression>, CleanupDelete<ULONG>>;
 
 	// map operators to an array of expression arrays, corresponding to
 	// a disjunction of expressions on columns created by that operator
-	typedef CHashMap<ULONG, CExpressionArrays, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CExpressionArrays> >
-		SourceToArrayPosMap;
+	using SourceToArrayPosMap =
+		CHashMap<ULONG, CExpressionArrays, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CExpressionArrays>>;
 
 	// iterator for map of operator to disjunctive form representation
-	typedef CHashMapIter<ULONG, CExpressionArrays, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupRelease<CExpressionArrays> >
-		SourceToArrayPosMapIter;
+	using SourceToArrayPosMapIter =
+		CHashMapIter<ULONG, CExpressionArrays, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupRelease<CExpressionArrays>>;
 
 	// map columns to an array of expression arrays, corresponding to
 	// a disjunction of expressions using that column
-	typedef CHashMap<CColRef, CExpressionArrays, gpos::HashPtr<CColRef>,
-					 gpos::EqualPtr<CColRef>, CleanupNULL<CColRef>,
-					 CleanupRelease<CExpressionArrays> >
-		ColumnToArrayPosMap;
+	using ColumnToArrayPosMap =
+		CHashMap<CColRef, CExpressionArrays, gpos::HashPtr<CColRef>,
+				 gpos::EqualPtr<CColRef>, CleanupNULL<CColRef>,
+				 CleanupRelease<CExpressionArrays>>;
 
 	// iterator for map of column to disjunctive form representation
-	typedef CHashMapIter<CColRef, CExpressionArrays, gpos::HashPtr<CColRef>,
-						 gpos::EqualPtr<CColRef>, CleanupNULL<CColRef>,
-						 CleanupRelease<CExpressionArrays> >
-		ColumnToArrayPosMapIter;
+	using ColumnToArrayPosMapIter =
+		CHashMapIter<CColRef, CExpressionArrays, gpos::HashPtr<CColRef>,
+					 gpos::EqualPtr<CColRef>, CleanupNULL<CColRef>,
+					 CleanupRelease<CExpressionArrays>>;
 
-	typedef CExpression *(*PexprProcessDisj)(
-		CMemoryPool *mp, CExpression *pexpr,
-		CExpression *pexprLowestLogicalAncestor);
+	using PexprProcessDisj = CExpression *(*) (CMemoryPool *, CExpression *,
+											   CExpression *);
 
 	// helper for determining if given expression factor should be added to factors array
 	static void AddFactor(CMemoryPool *mp, CExpression *pexpr,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -36,16 +36,16 @@ class CExpressionPreprocessor
 {
 private:
 	// map CTE id to collected predicates
-	typedef CHashMap<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CExpressionArray> >
-		CTEPredsMap;
+	using CTEPredsMap =
+		CHashMap<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CExpressionArray>>;
 
 	// iterator for map of CTE id to collected predicates
-	typedef CHashMapIter<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupRelease<CExpressionArray> >
-		CTEPredsMapIter;
+	using CTEPredsMapIter =
+		CHashMapIter<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupRelease<CExpressionArray>>;
 
 	// generate a conjunction of equality predicates between the columns in the given set
 	static CExpression *PexprConjEqualityPredicates(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalConstTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalConstTableGet.h
@@ -18,7 +18,7 @@
 namespace gpopt
 {
 // dynamic array of datum arrays -- array owns elements
-typedef CDynamicPtrArray<IDatumArray, CleanupRelease> IDatum2dArray;
+using IDatum2dArray = CDynamicPtrArray<IDatumArray, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -18,10 +18,9 @@
 
 namespace gpopt
 {
-typedef CHashMap<CExpression, CExpression, CExpression::HashValue,
-				 CUtils::Equals, CleanupRelease<CExpression>,
-				 CleanupRelease<CExpression> >
-	ExprPredToExprPredPartMap;
+using ExprPredToExprPredPartMap =
+	CHashMap<CExpression, CExpression, CExpression::HashValue, CUtils::Equals,
+			 CleanupRelease<CExpression>, CleanupRelease<CExpression>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -31,12 +31,12 @@ class CReqdPropPlan;
 class CReqdPropRelational;
 
 // dynamic array for operators
-typedef CDynamicPtrArray<COperator, CleanupRelease> COperatorArray;
+using COperatorArray = CDynamicPtrArray<COperator, CleanupRelease>;
 
 // hash map mapping CColRef -> CColRef
-typedef CHashMap<CColRef, CColRef, CColRef::HashValue, CColRef::Equals,
-				 CleanupNULL<CColRef>, CleanupNULL<CColRef> >
-	ColRefToColRefMap;
+using ColRefToColRefMap =
+	CHashMap<CColRef, CColRef, CColRef::HashValue, CColRef::Equals,
+			 CleanupNULL<CColRef>, CleanupNULL<CColRef>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
@@ -34,7 +34,7 @@ namespace gpopt
 using namespace gpos;
 
 // arrays of unsigned integer arrays
-typedef CDynamicPtrArray<ULONG_PTR, CleanupDeleteArray> UlongPtrArray;
+using UlongPtrArray = CDynamicPtrArray<ULONG_PTR, CleanupDeleteArray>;
 
 class CTableDescriptor;
 class CCTEMap;
@@ -138,10 +138,10 @@ private:
 	};	// class CReqdColsRequest
 
 	// map of incoming required columns request to computed column sets
-	typedef CHashMap<CReqdColsRequest, CColRefSet, CReqdColsRequest::HashValue,
-					 CReqdColsRequest::Equals, CleanupRelease<CReqdColsRequest>,
-					 CleanupRelease<CColRefSet> >
-		ReqdColsReqToColRefSetMap;
+	using ReqdColsReqToColRefSetMap =
+		CHashMap<CReqdColsRequest, CColRefSet, CReqdColsRequest::HashValue,
+				 CReqdColsRequest::Equals, CleanupRelease<CReqdColsRequest>,
+				 CleanupRelease<CColRefSet>>;
 
 	// hash map of child columns requests
 	ReqdColsReqToColRefSetMap *m_phmrcr;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArray.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArray.h
@@ -22,7 +22,7 @@ namespace gpopt
 using namespace gpos;
 using namespace gpmd;
 
-typedef CDynamicPtrArray<CScalarConst, CleanupRelease> CScalarConstArray;
+using CScalarConstArray = CDynamicPtrArray<CScalarConst, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -41,13 +41,13 @@ class CExpression;
 
 // type definitions
 // array of groups
-typedef CDynamicPtrArray<CGroup, CleanupNULL> CGroupArray;
+using CGroupArray = CDynamicPtrArray<CGroup, CleanupNULL>;
 
 // map required plan props to cost lower bound of corresponding plan
-typedef CHashMap<CReqdPropPlan, CCost, CReqdPropPlan::UlHashForCostBounding,
-				 CReqdPropPlan::FEqualForCostBounding,
-				 CleanupRelease<CReqdPropPlan>, CleanupDelete<CCost> >
-	ReqdPropPlanToCostMap;
+using ReqdPropPlanToCostMap =
+	CHashMap<CReqdPropPlan, CCost, CReqdPropPlan::UlHashForCostBounding,
+			 CReqdPropPlan::FEqualForCostBounding,
+			 CleanupRelease<CReqdPropPlan>, CleanupDelete<CCost>>;
 
 // optimization levels in ascending order,
 // under a given optimization context, group expressions in higher levels
@@ -75,9 +75,7 @@ class CGroup : public CRefCount, public DbgPrintMixin<CGroup>
 
 public:
 	// type definition of optimization context hash table
-	typedef CSyncHashtable<COptimizationContext,  // entry
-						   COptimizationContext /* search key */>
-		ShtOC;
+	using ShtOC = CSyncHashtable<COptimizationContext, COptimizationContext>;
 
 	// states of a group
 	enum EState
@@ -99,19 +97,16 @@ public:
 
 private:
 	// definition of hash table iter
-	typedef CSyncHashtableIter<COptimizationContext,  // entry
-							   COptimizationContext>
-		ShtIter;
+	using ShtIter =
+		CSyncHashtableIter<COptimizationContext, COptimizationContext>;
 
 	// definition of hash table iter accessor
-	typedef CSyncHashtableAccessByIter<COptimizationContext,  // entry
-									   COptimizationContext>
-		ShtAccIter;
+	using ShtAccIter =
+		CSyncHashtableAccessByIter<COptimizationContext, COptimizationContext>;
 
 	// definition of hash table accessor
-	typedef CSyncHashtableAccessByKey<COptimizationContext,	 // entry
-									  COptimizationContext>
-		ShtAcc;
+	using ShtAcc =
+		CSyncHashtableAccessByKey<COptimizationContext, COptimizationContext>;
 
 	//---------------------------------------------------------------------------
 	//	@class:
@@ -152,17 +147,15 @@ private:
 	};	// struct SContextLink
 
 	// map of processed links in TreeMap structure
-	typedef CHashMap<SContextLink, BOOL, SContextLink::HashValue,
-					 SContextLink::Equals, CleanupDelete<SContextLink>,
-					 CleanupDelete<BOOL> >
-		LinkMap;
+	using LinkMap = CHashMap<SContextLink, BOOL, SContextLink::HashValue,
+							 SContextLink::Equals, CleanupDelete<SContextLink>,
+							 CleanupDelete<BOOL>>;
 
 	// map of computed stats objects during costing
-	typedef CHashMap<
+	using OptCtxtToIStatisticsMap = CHashMap<
 		COptimizationContext, IStatistics, COptimizationContext::UlHashForStats,
 		COptimizationContext::FEqualForStats,
-		CleanupRelease<COptimizationContext>, CleanupRelease<IStatistics> >
-		OptCtxtToIStatisticsMap;
+		CleanupRelease<COptimizationContext>, CleanupRelease<IStatistics>>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -67,31 +67,23 @@ public:
 	};
 
 	// type definition of cost context hash table
-	typedef CSyncHashtable<CCostContext,  // entry
-						   OPTCTXT_PTR /* search key */>
-		ShtCC;
+	using ShtCC = CSyncHashtable<CCostContext, OPTCTXT_PTR>;
 
 private:
 	// definition of context hash table accessor
-	typedef CSyncHashtableAccessByKey<CCostContext,	 // entry
-									  OPTCTXT_PTR>
-		ShtAcc;
+	using ShtAcc = CSyncHashtableAccessByKey<CCostContext, OPTCTXT_PTR>;
 
 	// definition of context hash table iter
-	typedef CSyncHashtableIter<CCostContext,  // entry
-							   OPTCTXT_PTR>
-		ShtIter;
+	using ShtIter = CSyncHashtableIter<CCostContext, OPTCTXT_PTR>;
 
 	// definition of context hash table iter accessor
-	typedef CSyncHashtableAccessByIter<CCostContext,  // entry
-									   OPTCTXT_PTR>
-		ShtAccIter;
+	using ShtAccIter = CSyncHashtableAccessByIter<CCostContext, OPTCTXT_PTR>;
 
 	// map of partial plans to their costs
-	typedef CHashMap<CPartialPlan, CCost, CPartialPlan::HashValue,
-					 CPartialPlan::Equals, CleanupRelease<CPartialPlan>,
-					 CleanupDelete<CCost> >
-		PartialPlanToCostMap;
+	using PartialPlanToCostMap =
+		CHashMap<CPartialPlan, CCost, CPartialPlan::HashValue,
+				 CPartialPlan::Equals, CleanupRelease<CPartialPlan>,
+				 CleanupDelete<CCost>>;
 
 
 	// expression id

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExploration.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExploration.h
@@ -59,7 +59,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// job state machine
 	JSM m_jsm;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionExploration.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionExploration.h
@@ -60,7 +60,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// job state machine
 	JSM m_jsm;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionImplementation.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionImplementation.h
@@ -62,7 +62,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// job state machine
 	JSM m_jsm;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionOptimization.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpressionOptimization.h
@@ -70,7 +70,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// job state machine
 	JSM m_jsm;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupImplementation.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupImplementation.h
@@ -61,7 +61,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// job state machine
 	JSM m_jsm;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupOptimization.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupOptimization.h
@@ -65,7 +65,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// job state machine
 	JSM m_jsm;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobStateMachine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobStateMachine.h
@@ -80,10 +80,10 @@ class CJobStateMachine
 {
 private:
 	// pointer to job action function
-	typedef TEnumEvent (*PFuncAction)(CSchedulerContext *psc, CJob *pjOwner);
+	using PFuncAction = TEnumEvent (*)(CSchedulerContext *, CJob *);
 
 	// shorthand for state machine
-	typedef CStateMachine<TEnumState, estSentinel, TEnumEvent, eevSentinel> SM;
+	using SM = CStateMachine<TEnumState, estSentinel, TEnumEvent, eevSentinel>;
 
 	// array of actions corresponding to states
 	PFuncAction m_rgPfuncAction[estSentinel];

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobTransformation.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobTransformation.h
@@ -54,7 +54,7 @@ public:
 
 private:
 	// shorthand for job state machine
-	typedef CJobStateMachine<EState, estSentinel, EEvent, eevSentinel> JSM;
+	using JSM = CJobStateMachine<EState, estSentinel, EEvent, eevSentinel>;
 
 	// target group expression
 	CGroupExpression *m_pgexpr;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
@@ -28,9 +28,8 @@ class CMemoProxy;
 class COptimizationContext;
 
 // memo tree map definition
-typedef CTreeMap<CCostContext, CExpression, CDrvdPropCtxtPlan,
-				 CCostContext::HashValue, CCostContext::Equals>
-	MemoTreeMap;
+using MemoTreeMap = CTreeMap<CCostContext, CExpression, CDrvdPropCtxtPlan,
+							 CCostContext::HashValue, CCostContext::Equals>;
 
 using namespace gpos;
 
@@ -46,19 +45,15 @@ class CMemo : public gpos::DbgPrintMixin<CMemo>
 {
 private:
 	// definition of hash table key accessor
-	typedef CSyncHashtableAccessByKey<CGroupExpression,	 // entry
-									  CGroupExpression>
-		ShtAcc;
+	using ShtAcc =
+		CSyncHashtableAccessByKey<CGroupExpression, CGroupExpression>;
 
 	// definition of hash table iterator
-	typedef CSyncHashtableIter<CGroupExpression,  // entry
-							   CGroupExpression>
-		ShtIter;
+	using ShtIter = CSyncHashtableIter<CGroupExpression, CGroupExpression>;
 
 	// definition of hash table iterator accessor
-	typedef CSyncHashtableAccessByIter<CGroupExpression,  // entry
-									   CGroupExpression>
-		ShtAccIter;
+	using ShtAccIter =
+		CSyncHashtableAccessByIter<CGroupExpression, CGroupExpression>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
@@ -27,7 +27,7 @@ class CSearchStage;
 class CExpression;
 
 // definition of array of search stages
-typedef CDynamicPtrArray<CSearchStage, CleanupDelete> CSearchStageArray;
+using CSearchStageArray = CDynamicPtrArray<CSearchStage, CleanupDelete>;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CTreeMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CTreeMap.h
@@ -47,21 +47,21 @@ template <class T, class R, class U, ULONG (*HashFn)(const T *),
 class CTreeMap
 {
 	// array of source pointers (sources owned by 3rd party)
-	typedef CDynamicPtrArray<T, CleanupNULL> DrgPt;
+	using DrgPt = CDynamicPtrArray<T, CleanupNULL>;
 
 	// array of result pointers (results owned by the tree we unrank)
-	typedef CDynamicPtrArray<R, CleanupRelease<R> > DrgPr;
+	using DrgPr = CDynamicPtrArray<R, CleanupRelease<R>>;
 
 	// generic rehydrate function
-	typedef R *(*PrFn)(CMemoryPool *, T *, DrgPr *, U *);
+	using PrFn = R *(*) (CMemoryPool *, T *, DrgPr *, U *);
 
 private:
 	// fwd declaration
 	class CTreeNode;
 
 	// arrays of internal nodes
-	typedef CDynamicPtrArray<CTreeNode, CleanupNULL> CTreeNodeArray;
-	typedef CDynamicPtrArray<CTreeNodeArray, CleanupRelease> CTreeNode2dArray;
+	using CTreeNodeArray = CDynamicPtrArray<CTreeNode, CleanupNULL>;
+	using CTreeNode2dArray = CDynamicPtrArray<CTreeNodeArray, CleanupRelease>;
 
 	//---------------------------------------------------------------------------
 	//	@class:
@@ -402,17 +402,15 @@ private:
 	CTreeNode *m_ptnRoot;
 
 	// map of all nodes
-	typedef gpos::CHashMap<T, CTreeNode, HashFn, EqFn, CleanupNULL,
-						   CleanupDelete<CTreeNode> >
-		TMap;
-	typedef gpos::CHashMapIter<T, CTreeNode, HashFn, EqFn, CleanupNULL,
-							   CleanupDelete<CTreeNode> >
-		TMapIter;
+	using TMap = gpos::CHashMap<T, CTreeNode, HashFn, EqFn, CleanupNULL,
+								CleanupDelete<CTreeNode>>;
+	using TMapIter = gpos::CHashMapIter<T, CTreeNode, HashFn, EqFn, CleanupNULL,
+										CleanupDelete<CTreeNode>>;
 
 	// map of created links
-	typedef CHashMap<STreeLink, BOOL, STreeLink::HashValue, STreeLink::Equals,
-					 CleanupDelete<STreeLink>, CleanupDelete<BOOL> >
-		LinkMap;
+	using LinkMap =
+		CHashMap<STreeLink, BOOL, STreeLink::HashValue, STreeLink::Equals,
+				 CleanupDelete<STreeLink>, CleanupDelete<BOOL>>;
 
 	TMap *m_ptmap;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -50,14 +50,14 @@ using namespace gpmd;
 using namespace gpdxl;
 
 // hash maps
-typedef CHashMap<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupNULL>
-	UlongToExprArrayMap;
+using UlongToExprArrayMap =
+	CHashMap<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
+			 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupNULL>;
 
 // iterator
-typedef CHashMapIter<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupNULL>
-	UlongToExprArrayMapIter;
+using UlongToExprArrayMapIter =
+	CHashMapIter<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupNULL>;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -57,9 +57,9 @@ using namespace gpdxl;
 using namespace gpnaucrates;
 
 // hash map mapping CColRef -> CDXLNode
-typedef CHashMap<CColRef, CDXLNode, CColRef::HashValue, CColRef::Equals,
-				 CleanupNULL<CColRef>, CleanupRelease<CDXLNode> >
-	ColRefToDXLNodeMap;
+using ColRefToDXLNodeMap =
+	CHashMap<CColRef, CDXLNode, CColRef::HashValue, CColRef::Equals,
+			 CleanupNULL<CColRef>, CleanupRelease<CDXLNode>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CDecorrelator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CDecorrelator.h
@@ -31,8 +31,8 @@ class CDecorrelator
 {
 private:
 	// definition of operator processor
-	typedef BOOL(FnProcessor)(CMemoryPool *, CExpression *, BOOL,
-							  CExpression **, CExpressionArray *, CColRefSet *);
+	using FnProcessor = BOOL(CMemoryPool *, CExpression *, BOOL, CExpression **,
+							 CExpressionArray *, CColRefSet *);
 
 	//---------------------------------------------------------------------------
 	//	@struct:

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
@@ -87,21 +87,20 @@ private:
 	}
 
 	// hash map from component to best join order
-	typedef CHashMap<CBitSet, CExpression, UlHashBitSet, FEqualBitSet,
-					 CleanupRelease<CBitSet>, CleanupRelease<CExpression> >
-		BitSetToExpressionMap;
+	using BitSetToExpressionMap =
+		CHashMap<CBitSet, CExpression, UlHashBitSet, FEqualBitSet,
+				 CleanupRelease<CBitSet>, CleanupRelease<CExpression>>;
 
 	// hash map from component pair to connecting edges
-	typedef CHashMap<SComponentPair, CExpression, SComponentPair::HashValue,
-					 SComponentPair::Equals, CleanupRelease<SComponentPair>,
-					 CleanupRelease<CExpression> >
-		ComponentPairToExpressionMap;
+	using ComponentPairToExpressionMap =
+		CHashMap<SComponentPair, CExpression, SComponentPair::HashValue,
+				 SComponentPair::Equals, CleanupRelease<SComponentPair>,
+				 CleanupRelease<CExpression>>;
 
 	// hash map from expression to cost of best join order
-	typedef CHashMap<CExpression, CDouble, CExpression::HashValue,
-					 CUtils::Equals, CleanupRelease<CExpression>,
-					 CleanupDelete<CDouble> >
-		ExpressionToCostMap;
+	using ExpressionToCostMap =
+		CHashMap<CExpression, CDouble, CExpression::HashValue, CUtils::Equals,
+				 CleanupRelease<CExpression>, CleanupDelete<CDouble>>;
 
 	// lookup table for links
 	ComponentPairToExpressionMap *m_phmcomplink;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -303,8 +303,8 @@ private:
 		}
 	};
 
-	typedef CDynamicPtrArray<SExpressionInfo, CleanupRelease<SExpressionInfo> >
-		SExpressionInfoArray;
+	using SExpressionInfoArray =
+		CDynamicPtrArray<SExpressionInfo, CleanupRelease<SExpressionInfo>>;
 
 	//---------------------------------------------------------------------------
 	//	@struct:
@@ -349,8 +349,8 @@ private:
 	};
 
 	// dynamic array of SGroupInfo, where each index represents an alternative group of a given level k
-	typedef CDynamicPtrArray<SGroupInfo, CleanupRelease<SGroupInfo> >
-		SGroupInfoArray;
+	using SGroupInfoArray =
+		CDynamicPtrArray<SGroupInfo, CleanupRelease<SGroupInfo>>;
 
 	// info for a join level, the set of all groups representing <m_level>-way joins
 	struct SLevelInfo : public CRefCount
@@ -390,23 +390,22 @@ private:
 		return pbsFst->Equals(pbsSnd);
 	}
 
-	typedef CHashMap<CExpression, SEdge, CExpression::HashValue, CUtils::Equals,
-					 CleanupRelease<CExpression>, CleanupRelease<SEdge> >
-		ExpressionToEdgeMap;
+	using ExpressionToEdgeMap =
+		CHashMap<CExpression, SEdge, CExpression::HashValue, CUtils::Equals,
+				 CleanupRelease<CExpression>, CleanupRelease<SEdge>>;
 
 	// dynamic array of SGroupInfos
-	typedef CHashMap<CBitSet, SGroupInfo, UlHashBitSet, FEqualBitSet,
-					 CleanupRelease<CBitSet>, CleanupRelease<SGroupInfo> >
-		BitSetToGroupInfoMap;
+	using BitSetToGroupInfoMap =
+		CHashMap<CBitSet, SGroupInfo, UlHashBitSet, FEqualBitSet,
+				 CleanupRelease<CBitSet>, CleanupRelease<SGroupInfo>>;
 
 	// iterator over group infos in a level
-	typedef CHashMapIter<CBitSet, SGroupInfo, UlHashBitSet, FEqualBitSet,
-						 CleanupRelease<CBitSet>, CleanupRelease<SGroupInfo> >
-		BitSetToGroupInfoMapIter;
+	using BitSetToGroupInfoMapIter =
+		CHashMapIter<CBitSet, SGroupInfo, UlHashBitSet, FEqualBitSet,
+					 CleanupRelease<CBitSet>, CleanupRelease<SGroupInfo>>;
 
 	// dynamic array of SLevelInfos, where each index represents the level
-	typedef CDynamicPtrArray<SLevelInfo, CleanupRelease<SLevelInfo> >
-		DPv2Levels;
+	using DPv2Levels = CDynamicPtrArray<SLevelInfo, CleanupRelease<SLevelInfo>>;
 
 	// an array of an array of groups, organized by level at the first array dimension,
 	// main data structure for dynamic programming

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -352,8 +352,8 @@ operator<<(IOstream &os, CXform &xform)
 }
 
 // shorthands for enum sets and iterators of xform ids
-typedef CEnumSet<CXform::EXformId, CXform::ExfSentinel> CXformSet;
-typedef CEnumSetIter<CXform::EXformId, CXform::ExfSentinel> CXformSetIter;
+using CXformSet = CEnumSet<CXform::EXformId, CXform::ExfSentinel>;
+using CXformSetIter = CEnumSetIter<CXform::EXformId, CXform::ExfSentinel>;
 }  // namespace gpopt
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
@@ -31,9 +31,9 @@ class CXformFactory
 {
 private:
 	// definition of hash map to maintain mappings
-	typedef CHashMap<CHAR, CXform, gpos::HashValue<CHAR>, CXform::FEqualIds,
-					 CleanupDeleteArray<CHAR>, CleanupNULL<CXform> >
-		XformNameToXformMap;
+	using XformNameToXformMap =
+		CHashMap<CHAR, CXform, gpos::HashValue<CHAR>, CXform::FEqualIds,
+				 CleanupDeleteArray<CHAR>, CleanupNULL<CXform>>;
 
 	// memory pool
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSimplifySubquery.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSimplifySubquery.h
@@ -33,10 +33,10 @@ class CXformSimplifySubquery : public CXformExploration
 {
 private:
 	// definition of simplification function
-	typedef BOOL(FnSimplify)(CMemoryPool *mp, CExpression *, CExpression **);
+	using FnSimplify = BOOL(CMemoryPool *, CExpression *, CExpression **);
 
 	// definition of matching function
-	typedef BOOL(FnMatch)(COperator *);
+	using FnMatch = BOOL(COperator *);
 
 	// transform existential subqueries to count(*) subqueries
 	static BOOL FSimplifyExistential(CMemoryPool *mp, CExpression *pexprScalar,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSplitDQA.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSplitDQA.h
@@ -33,10 +33,9 @@ class CXformSplitDQA : public CXformExploration
 {
 private:
 	// hash map between expression and a column reference
-	typedef CHashMap<CExpression, CColRef, CExpression::HashValue,
-					 CUtils::Equals, CleanupRelease<CExpression>,
-					 CleanupNULL<CColRef> >
-		ExprToColRefMap;
+	using ExprToColRefMap =
+		CHashMap<CExpression, CColRef, CExpression::HashValue, CUtils::Equals,
+				 CleanupRelease<CExpression>, CleanupNULL<CColRef>>;
 
 	// generate an expression with multi-level aggregation
 	static CExpression *PexprMultiLevelAggregation(

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSubqJoin2Apply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSubqJoin2Apply.h
@@ -31,10 +31,10 @@ class CXformSubqJoin2Apply : public CXformSubqueryUnnest
 {
 private:
 	// hash map between expression and a column reference
-	typedef CHashMap<CExpression, CColRef, HashPtr<CExpression>,
-					 EqualPtr<CExpression>, CleanupRelease<CExpression>,
-					 CleanupNULL<CColRef> >
-		ExprToColRefMap;
+	using ExprToColRefMap =
+		CHashMap<CExpression, CColRef, HashPtr<CExpression>,
+				 EqualPtr<CExpression>, CleanupRelease<CExpression>,
+				 CleanupNULL<CColRef>>;
 
 	// helper to transform function
 	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -41,19 +41,19 @@ class CPartConstraint;
 class CTableDescriptor;
 
 // map of expression to array of expressions
-typedef CHashMap<CExpression, CExpressionArray, CExpression::HashValue,
-				 CUtils::Equals, CleanupRelease<CExpression>,
-				 CleanupRelease<CExpressionArray> >
-	ExprToExprArrayMap;
+using ExprToExprArrayMap =
+	CHashMap<CExpression, CExpressionArray, CExpression::HashValue,
+			 CUtils::Equals, CleanupRelease<CExpression>,
+			 CleanupRelease<CExpressionArray>>;
 
 // iterator of map of expression to array of expressions
-typedef CHashMapIter<CExpression, CExpressionArray, CExpression::HashValue,
-					 CUtils::Equals, CleanupRelease<CExpression>,
-					 CleanupRelease<CExpressionArray> >
-	ExprToExprArrayMapIter;
+using ExprToExprArrayMapIter =
+	CHashMapIter<CExpression, CExpressionArray, CExpression::HashValue,
+				 CUtils::Equals, CleanupRelease<CExpression>,
+				 CleanupRelease<CExpressionArray>>;
 
 // array of array of expressions
-typedef CDynamicPtrArray<CExpressionArray, CleanupRelease> CExpressionArrays;
+using CExpressionArrays = CDynamicPtrArray<CExpressionArray, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -4456,7 +4456,7 @@ CUtils::IsExprNDVPreserving(CExpression *pexpr,
 	// go down the expression tree, visiting the child containing a scalar ident until
 	// we found the ident or until we found a non-NDV-preserving function (at which point there
 	// is no more need to check)
-	while (1)
+	while (true)
 	{
 		COperator *pop = curr_expr->Pop();
 		ULONG child_with_scalar_ident = 0;

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
@@ -172,8 +172,8 @@ CJoinOrder::CJoinOrder(CMemoryPool *mp, CExpressionArray *all_components,
 	  m_ulComps(0),
 	  m_include_loj_childs(include_loj_childs)
 {
-	typedef SComponent *Pcomp;
-	typedef SEdge *Pedge;
+	using Pcomp = SComponent *;
+	using Pedge = SEdge *;
 
 	const ULONG num_of_nary_children = all_components->Size();
 	INT num_of_lojs = 0;
@@ -293,8 +293,8 @@ CJoinOrder::CJoinOrder(CMemoryPool *mp, CExpressionArray *all_components,
 	  m_ulComps(0),
 	  m_include_loj_childs(false)  // not used by CXformExpandNAryJoinDPv2
 {
-	typedef SComponent *Pcomp;
-	typedef SEdge *Pedge;
+	using Pcomp = SComponent *;
+	using Pedge = SEdge *;
 
 	const ULONG num_of_nary_children = all_components->Size();
 

--- a/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
@@ -22,7 +22,7 @@ template <class T, void (*CleanupFn)(T *)>
 class CDynamicPtrArray;
 
 // comparison function signature
-typedef INT (*CompareFn)(const void *, const void *);
+using CompareFn = INT (*)(const void *, const void *);
 
 // frequently used destroy functions
 
@@ -60,18 +60,18 @@ CleanupRelease(T *elem)
 // commonly used array types
 
 // arrays of unsigned integers
-typedef CDynamicPtrArray<ULONG, CleanupDelete> ULongPtrArray;
+using ULongPtrArray = CDynamicPtrArray<ULONG, CleanupDelete>;
 // array of unsigned integer arrays
-typedef CDynamicPtrArray<ULongPtrArray, CleanupRelease> ULongPtr2dArray;
+using ULongPtr2dArray = CDynamicPtrArray<ULongPtrArray, CleanupRelease>;
 
 // arrays of integers
-typedef CDynamicPtrArray<INT, CleanupDelete> IntPtrArray;
+using IntPtrArray = CDynamicPtrArray<INT, CleanupDelete>;
 
 // array of strings
-typedef CDynamicPtrArray<CWStringBase, CleanupDelete> StringPtrArray;
+using StringPtrArray = CDynamicPtrArray<CWStringBase, CleanupDelete>;
 
 // arrays of chars
-typedef CDynamicPtrArray<CHAR, CleanupDelete> CharPtrArray;
+using CharPtrArray = CDynamicPtrArray<CHAR, CleanupDelete>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpos/include/gpos/common/CHashMap.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CHashMap.h
@@ -128,12 +128,12 @@ private:
 	ULONG m_size;
 
 	// each hash chain is an array of hashmap elements
-	typedef CDynamicPtrArray<CHashMapElem, CleanupDelete> CHashSetElemArray;
+	using CHashSetElemArray = CDynamicPtrArray<CHashMapElem, CleanupDelete>;
 	CHashSetElemArray **const m_chains;
 
 	// array for keys
 	// We use CleanupNULL because the keys are owned by the hash table
-	typedef CDynamicPtrArray<K, CleanupNULL> Keys;
+	using Keys = CDynamicPtrArray<K, CleanupNULL>;
 	Keys *const m_keys;
 
 	IntPtrArray *const m_filled_chains;
@@ -295,9 +295,9 @@ public:
 
 };	// class CHashMap
 
-typedef CHashMap<ULONG, ULONG, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupDelete<ULONG> >
-	UlongToUlongMap;
+using UlongToUlongMap =
+	CHashMap<ULONG, ULONG, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupDelete<ULONG>>;
 }  // namespace gpos
 
 #endif	// !GPOS_CHashMap_H

--- a/src/backend/gporca/libgpos/include/gpos/common/CHashMapIter.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CHashMapIter.h
@@ -32,7 +32,7 @@ template <class K, class T, ULONG (*HashFn)(const K *),
 class CHashMapIter : public CStackObject
 {
 	// short hand for hashmap type
-	typedef CHashMap<K, T, HashFn, EqFn, DestroyKFn, DestroyTFn> TMap;
+	using TMap = CHashMap<K, T, HashFn, EqFn, DestroyKFn, DestroyTFn>;
 
 private:
 	// map to iterate

--- a/src/backend/gporca/libgpos/include/gpos/common/CHashSet.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CHashSet.h
@@ -111,12 +111,12 @@ private:
 	ULONG m_size;
 
 	// each hash chain is an array of hashset elements
-	typedef CDynamicPtrArray<CHashSetElem, CleanupDelete> HashSetElemArray;
+	using HashSetElemArray = CDynamicPtrArray<CHashSetElem, CleanupDelete>;
 	HashSetElemArray **m_chains;
 
 	// array for elements
 	// We use CleanupNULL because the elements are owned by the hash table
-	typedef CDynamicPtrArray<T, CleanupNULL> Elements;
+	using Elements = CDynamicPtrArray<T, CleanupNULL>;
 	Elements *const m_elements;
 
 	IntPtrArray *const m_filled_chains;

--- a/src/backend/gporca/libgpos/include/gpos/common/CHashSetIter.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CHashSetIter.h
@@ -19,7 +19,7 @@ template <class T, ULONG (*HashFn)(const T *),
 class CHashSetIter : public CStackObject
 {
 	// short hand for hashset type
-	typedef CHashSet<T, HashFn, EqFn, CleanupFn> TSet;
+	using TSet = CHashSet<T, HashFn, EqFn, CleanupFn>;
 
 private:
 	// set to iterate

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtable.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtable.h
@@ -141,7 +141,7 @@ private:
 
 public:
 	// type definition of function used to cleanup element
-	typedef void (*DestroyEntryFuncPtr)(T *);
+	using DestroyEntryFuncPtr = void (*)(T *);
 
 	// ctor
 	CSyncHashtable<T, K>()

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtableAccessByIter.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtableAccessByIter.h
@@ -36,7 +36,7 @@ class CSyncHashtableAccessByIter : public CSyncHashtableAccessorBase<T, K>
 
 private:
 	// shorthand for base class
-	typedef class CSyncHashtableAccessorBase<T, K> Base;
+	using Base = class CSyncHashtableAccessorBase<T, K>;
 
 	// target iterator
 	CSyncHashtableIter<T, K> &m_iter;

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtableAccessByKey.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtableAccessByKey.h
@@ -34,7 +34,7 @@ class CSyncHashtableAccessByKey : public CSyncHashtableAccessorBase<T, K>
 {
 private:
 	// shorthand for accessor's base class
-	typedef class CSyncHashtableAccessorBase<T, K> Base;
+	using Base = class CSyncHashtableAccessorBase<T, K>;
 
 	// target key
 	const K &m_key;

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtableAccessorBase.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtableAccessorBase.h
@@ -36,7 +36,7 @@ class CSyncHashtableAccessorBase : public CStackObject
 {
 private:
 	// shorthand for buckets
-	typedef struct CSyncHashtable<T, K>::SBucket SBucket;
+	using SBucket = typename gpos::CSyncHashtable<T, K>::SBucket;
 
 	// target hashtable
 	CSyncHashtable<T, K> &m_ht;

--- a/src/backend/gporca/libgpos/include/gpos/common/clibtypes.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/clibtypes.h
@@ -21,25 +21,25 @@
 namespace gpos
 {
 // container for user and system time
-typedef struct rusage RUSAGE;
+using RUSAGE = struct rusage;
 
 // represent an elapsed time
-typedef struct timeval TIMEVAL;
+using TIMEVAL = struct timeval;
 
 // hold minimal information about the local time zone
-typedef struct timezone TIMEZONE;
+using TIMEZONE = struct timezone;
 
 // represents an elapsed time
-typedef struct timespec TIMESPEC;
+using TIMESPEC = struct timespec;
 
 // store system time values
-typedef time_t TIME_T;
+using TIME_T = time_t;
 
 // containing a calendar date and time broken down into its components.
-typedef struct tm TIME;
+using TIME = struct tm;
 
 // store information of a calling process
-typedef Dl_info DL_INFO;
+using DL_INFO = Dl_info;
 }  // namespace gpos
 
 #endif	// !GPOS_clibtypes_H

--- a/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
@@ -27,7 +27,7 @@ namespace gpos
 {
 namespace clib
 {
-typedef INT (*Comparator)(const void *, const void *);
+using Comparator = INT (*)(const void *, const void *);
 
 // compare a specified number of bytes of two regions of memory
 INT Memcmp(const void *left, const void *right, SIZE_T num_bytes);

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -33,10 +33,10 @@ private:
 	CMemoryPool *m_mp;
 
 	// short hand for Table of Message Tables (TMT)
-	typedef CSyncHashtable<CMessageTable, ELocale> TMT;
+	using TMT = CSyncHashtable<CMessageTable, ELocale>;
 
 	// short hand for TMT accessor
-	typedef CSyncHashtableAccessByKey<CMessageTable, ELocale> TMTAccessor;
+	using TMTAccessor = CSyncHashtableAccessByKey<CMessageTable, ELocale>;
 
 	// basic hash table
 	TMT m_hash_table;

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageTable.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageTable.h
@@ -28,10 +28,10 @@ namespace gpos
 class CMessageTable
 {
 	// short hand for message tables
-	typedef CSyncHashtable<CMessage, CException> MessageTable;
+	using MessageTable = CSyncHashtable<CMessage, CException>;
 
 	// short hand for message table accessor
-	typedef CSyncHashtableAccessByKey<CMessage, CException> MTAccessor;
+	using MTAccessor = CSyncHashtableAccessByKey<CMessage, CException>;
 
 	// message hashtable
 	MessageTable m_hash_table;

--- a/src/backend/gporca/libgpos/include/gpos/io/IOstream.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/IOstream.h
@@ -16,7 +16,7 @@
 namespace gpos
 {
 // wide char ostream
-typedef std::basic_ostream<WCHAR, std::char_traits<WCHAR> > WOSTREAM;
+using WOSTREAM = std::basic_ostream<WCHAR, std::char_traits<WCHAR>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libgpos/include/gpos/io/iotypes.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/iotypes.h
@@ -18,7 +18,7 @@
 namespace gpos
 {
 // file state structure
-typedef struct stat SFileStat;
+using SFileStat = struct stat;
 }  // namespace gpos
 
 #endif	// !GPOS_iotypes_H

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
@@ -74,19 +74,19 @@ class CCache
 
 public:
 	// type definition of key hashing and equality functions
-	typedef ULONG (*HashFuncPtr)(const K &);
-	typedef BOOL (*EqualFuncPtr)(const K &, const K &);
+	using HashFuncPtr = ULONG (*)(const K &);
+	using EqualFuncPtr = BOOL (*)(const K &, const K &);
 
 private:
-	typedef CCacheEntry<T, K> CCacheHashTableEntry;
+	using CCacheHashTableEntry = CCacheEntry<T, K>;
 
 	// type definition of hashtable, accessor and iterator
-	typedef CSyncHashtable<CCacheHashTableEntry, K> CCacheHashtable;
-	typedef CSyncHashtableAccessByKey<CCacheHashTableEntry, K>
-		CCacheHashtableAccessor;
-	typedef CSyncHashtableIter<CCacheHashTableEntry, K> CCacheHashtableIter;
-	typedef CSyncHashtableAccessByIter<CCacheHashTableEntry, K>
-		CCacheHashtableIterAccessor;
+	using CCacheHashtable = CSyncHashtable<CCacheHashTableEntry, K>;
+	using CCacheHashtableAccessor =
+		CSyncHashtableAccessByKey<CCacheHashTableEntry, K>;
+	using CCacheHashtableIter = CSyncHashtableIter<CCacheHashTableEntry, K>;
+	using CCacheHashtableIterAccessor =
+		CSyncHashtableAccessByIter<CCacheHashTableEntry, K>;
 
 	// memory pool for allocating hashtable and cache entries
 	CMemoryPool *m_mp;

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -37,13 +37,13 @@ namespace gpos
 class CMemoryPoolManager
 {
 private:
-	typedef CSyncHashtableAccessByKey<CMemoryPool, ULONG_PTR>
-		MemoryPoolKeyAccessor;
+	using MemoryPoolKeyAccessor =
+		CSyncHashtableAccessByKey<CMemoryPool, ULONG_PTR>;
 
-	typedef CSyncHashtableIter<CMemoryPool, ULONG_PTR> MemoryPoolIter;
+	using MemoryPoolIter = CSyncHashtableIter<CMemoryPool, ULONG_PTR>;
 
-	typedef CSyncHashtableAccessByIter<CMemoryPool, ULONG_PTR>
-		MemoryPoolIterAccessor;
+	using MemoryPoolIterAccessor =
+		CSyncHashtableAccessByIter<CMemoryPool, ULONG_PTR>;
 
 	// memory pool in which all objects created by the manager itself
 	// are allocated - must be thread-safe

--- a/src/backend/gporca/libgpos/include/gpos/types.h
+++ b/src/backend/gporca/libgpos/include/gpos/types.h
@@ -39,47 +39,47 @@ namespace gpos
 // Basic types to be used instead of built-ins
 // Add types as needed;
 
-typedef unsigned char BYTE;
-typedef char CHAR;
+using BYTE = unsigned char;
+using CHAR = char;
 // ignore signed char for the moment
 
 // wide character type
-typedef wchar_t WCHAR;
+using WCHAR = wchar_t;
 
-typedef bool BOOL;
+using BOOL = bool;
 
 // numeric types
 
-typedef size_t SIZE_T;
-typedef ssize_t SSIZE_T;
-typedef mode_t MODE_T;
+using SIZE_T = size_t;
+using SSIZE_T = ssize_t;
+using MODE_T = mode_t;
 
 // define ULONG,ULLONG as types which implement standard's
 // requirements for ULONG_MAX and ULLONG_MAX; eliminate standard's slack
 // by fixed sizes rather than min requirements
 
-typedef uint32_t ULONG;
+using ULONG = uint32_t;
 GPOS_CPL_ASSERT(4 == sizeof(ULONG));
 enum
 {
 	ulong_max = ((::gpos::ULONG) -1)
 };
 
-typedef uint64_t ULLONG;
+using ULLONG = uint64_t;
 GPOS_CPL_ASSERT(8 == sizeof(ULLONG));
 enum
 {
 	ullong_max = ((::gpos::ULLONG) -1)
 };
 
-typedef uintptr_t ULONG_PTR;
+using ULONG_PTR = uintptr_t;
 #define ULONG_PTR_MAX (gpos::ullong_max)
 
-typedef uint16_t USINT;
-typedef int16_t SINT;
-typedef int32_t INT;
-typedef int64_t LINT;
-typedef intptr_t INT_PTR;
+using USINT = uint16_t;
+using SINT = int16_t;
+using INT = int32_t;
+using LINT = int64_t;
+using INT_PTR = intptr_t;
 
 GPOS_CPL_ASSERT(2 == sizeof(USINT));
 GPOS_CPL_ASSERT(2 == sizeof(SINT));
@@ -109,13 +109,13 @@ enum
 	sint_min = (-gpos::sint_max - 1)
 };
 
-typedef double DOUBLE;
+using DOUBLE = double;
 
 // holds for all platforms
 GPOS_CPL_ASSERT(sizeof(ULONG_PTR) == sizeof(void *));
 
 // variadic parameter list type
-typedef va_list VA_LIST;
+using VA_LIST = va_list;
 
 // enum for results on OS level (instead of using a global error variable)
 enum GPOS_RESULT

--- a/src/backend/gporca/libgpos/src/common/CBitSet.cpp
+++ b/src/backend/gporca/libgpos/src/common/CBitSet.cpp
@@ -102,7 +102,7 @@ CBitSet::FindLinkByOffset(ULONG offset, CBitSetLink *bsl) const
 	GPOS_ASSERT_IMP(nullptr != cursor,
 					GPOS_OK == m_bsllist.Find(cursor) && "cursor not in list");
 
-	while (1)
+	while (true)
 	{
 		// no more links or we've overshot the target
 		if (nullptr == cursor || cursor->GetOffset() > offset)

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
@@ -28,9 +28,9 @@ using namespace gpmd;
 class IDatum;
 
 // hash map mapping ULONG -> Datum
-typedef CHashMap<ULONG, IDatum, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupRelease<IDatum> >
-	UlongToIDatumMap;
+using UlongToIDatumMap =
+	CHashMap<ULONG, IDatum, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<IDatum>>;
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -145,7 +145,7 @@ public:
 };	// class IDatum
 
 // array of idatums
-typedef CDynamicPtrArray<IDatum, CleanupRelease> IDatumArray;
+using IDatumArray = CDynamicPtrArray<IDatum, CleanupRelease>;
 }  // namespace gpnaucrates
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/CDXLUtils.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/CDXLUtils.h
@@ -51,7 +51,7 @@ class CParseHandlerDXL;
 class CDXLMemoryManager;
 class CQueryToDXLResult;
 
-typedef CDynamicPtrArray<CStatistics, CleanupRelease> CStatisticsArray;
+using CStatisticsArray = CDynamicPtrArray<CStatistics, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/gpdb_types.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/gpdb_types.h
@@ -15,7 +15,7 @@
 
 using namespace gpos;
 
-typedef ULONG OID;
+using OID = ULONG;
 
 #define GPDB_INT2 OID(21)
 #define GPDB_INT4 OID(23)

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColDescr.h
@@ -28,7 +28,7 @@ using namespace gpmd;
 class CXMLSerializer;
 class CDXLColDescr;
 
-typedef CDynamicPtrArray<CDXLColDescr, CleanupRelease> CDXLColDescrArray;
+using CDXLColDescrArray = CDynamicPtrArray<CDXLColDescr, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColRef.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColRef.h
@@ -31,7 +31,7 @@ class CXMLSerializer;
 class CDXLColRef;
 
 // arrays of column references
-typedef CDynamicPtrArray<CDXLColRef, CleanupRelease> CDXLColRefArray;
+using CDXLColRefArray = CDynamicPtrArray<CDXLColRef, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLCtasStorageOptions.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLCtasStorageOptions.h
@@ -72,7 +72,7 @@ public:
 		}
 	};
 
-	typedef CDynamicPtrArray<CDXLCtasOption, CleanupDelete> CDXLCtasOptionArray;
+	using CDXLCtasOptionArray = CDynamicPtrArray<CDXLCtasOption, CleanupDelete>;
 
 	//-------------------------------------------------------------------
 	//	@enum:

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLDatum.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLDatum.h
@@ -105,10 +105,10 @@ public:
 };
 
 // array of datums
-typedef CDynamicPtrArray<CDXLDatum, CleanupRelease> CDXLDatumArray;
+using CDXLDatumArray = CDynamicPtrArray<CDXLDatum, CleanupRelease>;
 
 // dynamic array of datum arrays -- array owns elements
-typedef CDynamicPtrArray<CDXLDatumArray, CleanupRelease> CDXLDatum2dArray;
+using CDXLDatum2dArray = CDynamicPtrArray<CDXLDatumArray, CleanupRelease>;
 }  // namespace gpdxl
 
 #endif	// !GPDXL_CDXLDatum_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h
@@ -28,14 +28,14 @@ class CDXLOperator;
 class CXMLSerializer;
 class CDXLDirectDispatchInfo;
 
-typedef CDynamicPtrArray<CDXLNode, CleanupRelease> CDXLNodeArray;
+using CDXLNodeArray = CDynamicPtrArray<CDXLNode, CleanupRelease>;
 
 // arrays of OID
-typedef CDynamicPtrArray<OID, CleanupDelete> OidArray;
+using OidArray = CDynamicPtrArray<OID, CleanupDelete>;
 
-typedef CHashMap<ULONG, CDXLNode, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupRelease<CDXLNode> >
-	IdToCDXLNodeMap;
+using IdToCDXLNodeMap =
+	CHashMap<ULONG, CDXLNode, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<CDXLNode>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
@@ -41,7 +41,7 @@
 #include "naucrates/md/IMDIndex.h"
 
 // dynamic array of XML strings
-typedef CDynamicPtrArray<XMLCh, CleanupNULL> XMLChArray;
+using XMLChArray = CDynamicPtrArray<XMLCh, CleanupNULL>;
 
 // fwd decl
 namespace gpmd

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowKey.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowKey.h
@@ -70,7 +70,7 @@ public:
 	}
 };
 
-typedef CDynamicPtrArray<CDXLWindowKey, CleanupRelease> CDXLWindowKeyArray;
+using CDXLWindowKeyArray = CDynamicPtrArray<CDXLWindowKey, CleanupRelease>;
 }  // namespace gpdxl
 #endif	// !GPDXL_CDXLWindowKey_H
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowSpec.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowSpec.h
@@ -98,7 +98,7 @@ public:
 	}
 };
 
-typedef CDynamicPtrArray<CDXLWindowSpec, CleanupRelease> CDXLWindowSpecArray;
+using CDXLWindowSpecArray = CDynamicPtrArray<CDXLWindowSpec, CleanupRelease>;
 }  // namespace gpdxl
 #endif	// !GPDXL_CDXLWindowSpec_H
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerBase.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerBase.h
@@ -29,8 +29,8 @@ class CParseHandlerManager;
 class CParseHandlerBase;
 
 // dynamic arrays of parse handlers
-typedef CDynamicPtrArray<CParseHandlerBase, CleanupDelete>
-	CParseHandlerBaseArray;
+using CParseHandlerBaseArray =
+	CDynamicPtrArray<CParseHandlerBase, CleanupDelete>;
 
 XERCES_CPP_NAMESPACE_USE
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
@@ -27,9 +27,9 @@ using namespace gpos;
 XERCES_CPP_NAMESPACE_USE
 
 // shorthand for functions creating operator parse handlers
-typedef CParseHandlerBase *(ParseHandlerOpCreatorFunc)(CMemoryPool *mp,
-													   CParseHandlerManager *,
-													   CParseHandlerBase *);
+using ParseHandlerOpCreatorFunc = CParseHandlerBase *(CMemoryPool *,
+													  CParseHandlerManager *,
+													  CParseHandlerBase *);
 
 // fwd decl
 class CDXLTokens;
@@ -61,9 +61,9 @@ IsXMLStrEqual(const XMLCh *xml_str1, const XMLCh *xml_str2)
 //---------------------------------------------------------------------------
 class CParseHandlerFactory
 {
-	typedef CHashMap<const XMLCh, ParseHandlerOpCreatorFunc, GetHashXMLStr,
-					 IsXMLStrEqual, CleanupNULL, CleanupNULL>
-		TokenParseHandlerFuncMap;
+	using TokenParseHandlerFuncMap =
+		CHashMap<const XMLCh, ParseHandlerOpCreatorFunc, GetHashXMLStr,
+				 IsXMLStrEqual, CleanupNULL, CleanupNULL>;
 
 	// pair of DXL token type and the corresponding parse handler
 	struct SParseHandlerMapping

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerManager.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerManager.h
@@ -30,7 +30,7 @@ class CParseHandlerPhysicalOp;
 class CDXLMemoryManager;
 
 // stack of parse handlers
-typedef CStack<CParseHandlerBase> ParseHandlerStack;
+using ParseHandlerStack = CStack<CParseHandlerBase>;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/CXMLSerializer.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/CXMLSerializer.h
@@ -35,7 +35,7 @@ using namespace gpos;
 class CXMLSerializer
 {
 	// stack of strings
-	typedef CStack<const CWStringBase> StrStack;
+	using StrStack = CStack<const CWStringBase>;
 
 private:
 	// memory pool

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLBucket.h
@@ -112,7 +112,7 @@ public:
 };
 
 // array of dxl buckets
-typedef CDynamicPtrArray<CDXLBucket, CleanupRelease> CDXLBucketArray;
+using CDXLBucketArray = CDynamicPtrArray<CDXLBucket, CleanupRelease>;
 }  // namespace gpmd
 
 #endif	// !GPMD_CDXLBucket_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLColStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLColStats.h
@@ -149,7 +149,7 @@ public:
 };
 
 // array of dxl column stats
-typedef CDynamicPtrArray<CDXLColStats, CleanupRelease> CDXLColStatsArray;
+using CDXLColStatsArray = CDynamicPtrArray<CDXLColStats, CleanupRelease>;
 }  // namespace gpmd
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedColumn.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedColumn.h
@@ -114,8 +114,8 @@ public:
 };
 
 // array of dxl buckets
-typedef CDynamicPtrArray<CDXLStatsDerivedColumn, CleanupRelease>
-	CDXLStatsDerivedColumnArray;
+using CDXLStatsDerivedColumnArray =
+	CDynamicPtrArray<CDXLStatsDerivedColumn, CleanupRelease>;
 }  // namespace gpmd
 
 #endif	// !GPMD_CDXLStatsDerivedColumn_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedRelation.h
@@ -86,8 +86,8 @@ public:
 };
 
 // array of dxl buckets
-typedef CDynamicPtrArray<CDXLStatsDerivedRelation, CleanupRelease>
-	CDXLStatsDerivedRelationArray;
+using CDXLStatsDerivedRelationArray =
+	CDynamicPtrArray<CDXLStatsDerivedRelation, CleanupRelease>;
 }  // namespace gpmd
 
 #endif	// !GPMD_CDXLStatsDerivedRelation_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDColumn.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDColumn.h
@@ -116,7 +116,7 @@ public:
 };
 
 // array of metadata column descriptor
-typedef CDynamicPtrArray<CMDColumn, CleanupRelease> CMDColumnArray;
+using CMDColumnArray = CDynamicPtrArray<CMDColumn, CleanupRelease>;
 
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDName.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDName.h
@@ -56,7 +56,7 @@ public:
 };
 
 // array of names
-typedef CDynamicPtrArray<CMDName, CleanupDelete> CMDNameArray;
+using CMDNameArray = CDynamicPtrArray<CMDName, CleanupDelete>;
 }  // namespace gpmd
 
 #endif	// !GPMD_CMDName_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDProviderMemory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDProviderMemory.h
@@ -38,9 +38,9 @@ class CMDProviderMemory : public IMDProvider
 {
 protected:
 	// hash map of serialized MD objects indexed by their MD id
-	typedef CHashMap<IMDId, CWStringDynamic, IMDId::MDIdHash,
-					 IMDId::MDIdCompare, CleanupRelease, CleanupDelete>
-		MDIdToSerializedMDIdMap;
+	using MDIdToSerializedMDIdMap =
+		CHashMap<IMDId, CWStringDynamic, IMDId::MDIdHash, IMDId::MDIdCompare,
+				 CleanupRelease, CleanupDelete>;
 
 	// metadata objects indexed by their metadata id
 	MDIdToSerializedMDIdMap *m_mdmap;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRequest.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRequest.h
@@ -43,7 +43,7 @@ public:
 	struct SMDFuncRequest;
 
 	// array of type requests
-	typedef CDynamicPtrArray<SMDTypeRequest, CleanupDelete> SMDTypeRequestArray;
+	using SMDTypeRequestArray = CDynamicPtrArray<SMDTypeRequest, CleanupDelete>;
 
 	//---------------------------------------------------------------------------
 	//	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CSystemId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CSystemId.h
@@ -72,7 +72,7 @@ public:
 };
 
 // dynamic arrays over md system id elements
-typedef CDynamicPtrArray<CSystemId, CleanupDelete> CSystemIdArray;
+using CSystemIdArray = CDynamicPtrArray<CSystemId, CleanupDelete>;
 }  // namespace gpmd
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDCacheObject.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDCacheObject.h
@@ -102,7 +102,7 @@ public:
 #endif
 };
 
-typedef CDynamicPtrArray<IMDCacheObject, CleanupRelease> IMDCacheObjectArray;
+using IMDCacheObjectArray = CDynamicPtrArray<IMDCacheObject, CleanupRelease>;
 
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -169,17 +169,15 @@ public:
 };
 
 // common structures over metadata id elements
-typedef CDynamicPtrArray<IMDId, CleanupRelease> IMdIdArray;
+using IMdIdArray = CDynamicPtrArray<IMDId, CleanupRelease>;
 
 // hash set for mdid
-typedef CHashSet<IMDId, IMDId::MDIdHash, IMDId::MDIdCompare,
-				 CleanupRelease<IMDId> >
-	MdidHashSet;
+using MdidHashSet =
+	CHashSet<IMDId, IMDId::MDIdHash, IMDId::MDIdCompare, CleanupRelease<IMDId>>;
 
 // iterator over the hash set for column id information for missing statistics
-typedef CHashSetIter<IMDId, IMDId::MDIdHash, IMDId::MDIdCompare,
-					 CleanupRelease<IMDId> >
-	MdidHashSetIter;
+using MdidHashSetIter = CHashSetIter<IMDId, IMDId::MDIdHash, IMDId::MDIdCompare,
+									 CleanupRelease<IMDId>>;
 
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDProvider.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDProvider.h
@@ -60,7 +60,7 @@ public:
 };
 
 // arrays of MD providers
-typedef CDynamicPtrArray<IMDProvider, CleanupRelease> CMDProviderArray;
+using CMDProviderArray = CDynamicPtrArray<IMDProvider, CleanupRelease>;
 
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -208,7 +208,7 @@ public:
 };
 
 // common structure over relation and external relation metadata for index info
-typedef CDynamicPtrArray<CMDIndexInfo, CleanupRelease> CMDIndexInfoArray;
+using CMDIndexInfoArray = CDynamicPtrArray<CMDIndexInfo, CleanupRelease>;
 
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
@@ -32,7 +32,7 @@ using namespace gpmd;
 class CBucket;
 
 // dynamic array of buckets
-typedef CDynamicPtrArray<CBucket, CleanupDelete> CBucketArray;
+using CBucketArray = CDynamicPtrArray<CBucket, CleanupDelete>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -29,7 +29,7 @@ namespace gpnaucrates
 {
 // type definitions
 // array of doubles
-typedef CDynamicPtrArray<CDouble, CleanupDelete> CDoubleArray;
+using CDoubleArray = CDynamicPtrArray<CDouble, CleanupDelete>;
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -41,28 +41,26 @@ typedef CDynamicPtrArray<CDouble, CleanupDelete> CDoubleArray;
 class CHistogram : public gpos::DbgPrintMixin<CHistogram>
 {
 	// hash map from column id to a histogram
-	typedef CHashMap<ULONG, CHistogram, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupDelete<CHistogram> >
-		UlongToHistogramMap;
+	using UlongToHistogramMap =
+		CHashMap<ULONG, CHistogram, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<CHistogram>>;
 
 	// iterator
-	typedef CHashMapIter<ULONG, CHistogram, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupDelete<CHistogram> >
-		UlongToHistogramMapIter;
+	using UlongToHistogramMapIter =
+		CHashMapIter<ULONG, CHistogram, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupDelete<CHistogram>>;
 
 	// hash map from column ULONG to CDouble
-	typedef CHashMap<ULONG, CDouble, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupDelete<CDouble> >
-		UlongToDoubleMap;
+	using UlongToDoubleMap =
+		CHashMap<ULONG, CDouble, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<CDouble>>;
 
 	// iterator
-	typedef CHashMapIter<ULONG, CDouble, gpos::HashValue<ULONG>,
-						 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-						 CleanupDelete<CDouble> >
-		UlongToDoubleMapIter;
+	using UlongToDoubleMapIter =
+		CHashMapIter<ULONG, CDouble, gpos::HashValue<ULONG>,
+					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					 CleanupDelete<CDouble>>;
 
 private:
 	// shared memory pool
@@ -213,9 +211,8 @@ private:
 			return DCost();
 		}
 	};
-	typedef CDynamicPtrArray<SAdjBucketBoundary,
-							 CleanupDelete<SAdjBucketBoundary> >
-		SAdjBucketBoundaryArray;
+	using SAdjBucketBoundaryArray =
+		CDynamicPtrArray<SAdjBucketBoundary, CleanupDelete<SAdjBucketBoundary>>;
 
 public:
 	CHistogram &operator=(const CHistogram &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
@@ -99,7 +99,7 @@ public:
 };	// class CPoint
 
 // array of CPoints
-typedef CDynamicPtrArray<CPoint, CleanupRelease> CPointArray;
+using CPointArray = CDynamicPtrArray<CPoint, CleanupRelease>;
 }  // namespace gpnaucrates
 
 #endif	// !GPNAUCRATES_CPoint_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CScaleFactorUtils.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CScaleFactorUtils.h
@@ -75,17 +75,17 @@ public:
 		}
 	};
 
-	typedef CDynamicPtrArray<SJoinCondition, CleanupDelete> SJoinConditionArray;
+	using SJoinConditionArray = CDynamicPtrArray<SJoinCondition, CleanupDelete>;
 
-	typedef CHashMap<IMdIdArray, CDoubleArray, SJoinCondition::HashValue,
+	using OIDPairToScaleFactorArrayMap =
+		CHashMap<IMdIdArray, CDoubleArray, SJoinCondition::HashValue,
+				 SJoinCondition::Equals, CleanupRelease<IMdIdArray>,
+				 CleanupRelease<CDoubleArray>>;
+
+	using OIDPairToScaleFactorArrayMapIter =
+		CHashMapIter<IMdIdArray, CDoubleArray, SJoinCondition::HashValue,
 					 SJoinCondition::Equals, CleanupRelease<IMdIdArray>,
-					 CleanupRelease<CDoubleArray> >
-		OIDPairToScaleFactorArrayMap;
-
-	typedef CHashMapIter<IMdIdArray, CDoubleArray, SJoinCondition::HashValue,
-						 SJoinCondition::Equals, CleanupRelease<IMdIdArray>,
-						 CleanupRelease<CDoubleArray> >
-		OIDPairToScaleFactorArrayMapIter;
+					 CleanupRelease<CDoubleArray>>;
 
 	// generate the hashmap of scale factors grouped by pred tables, also produces array of complex join preds
 	static OIDPairToScaleFactorArrayMap *GenerateScaleFactorMap(

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -38,16 +38,15 @@ using namespace gpmd;
 using namespace gpopt;
 
 // hash maps ULONG -> array of ULONGs
-typedef CHashMap<ULONG, ULongPtrArray, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupRelease<ULongPtrArray> >
-	UlongToUlongPtrArrayMap;
+using UlongToUlongPtrArrayMap =
+	CHashMap<ULONG, ULongPtrArray, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease<ULongPtrArray>>;
 
 // iterator
-typedef CHashMapIter<ULONG, ULongPtrArray, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<ULongPtrArray> >
-	UlongToUlongPtrArrayMapIter;
+using UlongToUlongPtrArrayMapIter =
+	CHashMapIter<ULONG, ULongPtrArray, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<ULongPtrArray>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatisticsUtils.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatisticsUtils.h
@@ -69,7 +69,7 @@ private:
 	};
 
 	// array of SMcvVPairs
-	typedef CDynamicPtrArray<SMcvPair, CleanupDelete> SMcvPairPtrArray;
+	using SMcvPairPtrArray = CDynamicPtrArray<SMcvPair, CleanupDelete>;
 
 	// given MCVs and histogram buckets, merge them into buckets of a single histogram
 	static CBucketArray *MergeMcvHistBucket(

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPred.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPred.h
@@ -92,7 +92,7 @@ public:
 };	// class CStatsPred
 
 // array of filters
-typedef CDynamicPtrArray<CStatsPred, CleanupRelease> CStatsPredPtrArry;
+using CStatsPredPtrArry = CDynamicPtrArray<CStatsPred, CleanupRelease>;
 
 // comparison function for sorting predicates
 INT

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredJoin.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredJoin.h
@@ -94,7 +94,7 @@ public:
 };	// class CStatsPredJoin
 
 // array of filters
-typedef CDynamicPtrArray<CStatsPredJoin, CleanupRelease> CStatsPredJoinArray;
+using CStatsPredJoinArray = CDynamicPtrArray<CStatsPredJoin, CleanupRelease>;
 }  // namespace gpnaucrates
 
 #endif	// !GPNAUCRATES_CStatsPredJoin_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CUpperBoundNDVs.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CUpperBoundNDVs.h
@@ -25,7 +25,7 @@ using namespace gpmd;
 class CUpperBoundNDVs;
 
 // dynamic array of upper bound ndvs
-typedef CDynamicPtrArray<CUpperBoundNDVs, CleanupDelete> CUpperBoundNDVPtrArray;
+using CUpperBoundNDVPtrArray = CDynamicPtrArray<CUpperBoundNDVs, CleanupDelete>;
 
 //---------------------------------------------------------------------------
 //      @class:

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -39,35 +39,33 @@ using namespace gpopt;
 class IStatistics;
 
 // hash map from column id to a histogram
-typedef CHashMap<ULONG, CHistogram, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupDelete<CHistogram> >
-	UlongToHistogramMap;
+using UlongToHistogramMap =
+	CHashMap<ULONG, CHistogram, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupDelete<CHistogram>>;
 
 // iterator
-typedef CHashMapIter<ULONG, CHistogram, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupDelete<CHistogram> >
-	UlongToHistogramMapIter;
+using UlongToHistogramMapIter =
+	CHashMapIter<ULONG, CHistogram, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<CHistogram>>;
 
 // hash map from column ULONG to CDouble
-typedef CHashMap<ULONG, CDouble, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupDelete<CDouble> >
-	UlongToDoubleMap;
+using UlongToDoubleMap =
+	CHashMap<ULONG, CDouble, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupDelete<CDouble>>;
 
 // iterator
-typedef CHashMapIter<ULONG, CDouble, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupDelete<CDouble> >
-	UlongToDoubleMapIter;
+using UlongToDoubleMapIter =
+	CHashMapIter<ULONG, CDouble, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<CDouble>>;
 
-typedef CHashMap<ULONG, ULONG, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupDelete<ULONG> >
-	UlongToUlongMap;
+using UlongToUlongMap =
+	CHashMap<ULONG, ULONG, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupDelete<ULONG>>;
 
 // hash maps mapping INT -> ULONG
-typedef CHashMap<INT, ULONG, gpos::HashValue<INT>, gpos::Equals<INT>,
-				 CleanupDelete<INT>, CleanupDelete<ULONG> >
-	IntToUlongMap;
+using IntToUlongMap =
+	CHashMap<INT, ULONG, gpos::HashValue<INT>, gpos::Equals<INT>,
+			 CleanupDelete<INT>, CleanupDelete<ULONG>>;
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -208,7 +206,7 @@ operator<<(IOstream &os, IStatistics &stats)
 }
 
 // dynamic array for derived stats
-typedef CDynamicPtrArray<IStatistics, CleanupRelease> IStatisticsArray;
+using IStatisticsArray = CDynamicPtrArray<IStatistics, CleanupRelease>;
 }  // namespace gpnaucrates
 
 #endif	// !GPNAUCRATES_IStatistics_H

--- a/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
@@ -86,9 +86,9 @@ using gpmd::CMDIdGPDB;
 class CConstraintInterval;
 class IConstExprEvaluator;
 
-typedef CDynamicPtrArray<CExpression, CleanupNULL> CExpressionJoinsArray;
+using CExpressionJoinsArray = CDynamicPtrArray<CExpression, CleanupNULL>;
 
-typedef BOOL(FnDXLPlanChecker)(CDXLNode *);
+using FnDXLPlanChecker = BOOL(CDXLNode *);
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/server/include/unittest/gpopt/base/CRangeTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/base/CRangeTest.h
@@ -31,7 +31,7 @@ using namespace gpos;
 //---------------------------------------------------------------------------
 class CRangeTest
 {
-	typedef IDatum *(*PfPdatum)(CMemoryPool *mp, INT i);
+	using PfPdatum = IDatum *(*) (CMemoryPool *, INT);
 
 private:
 	static GPOS_RESULT EresInitAndCheckRanges(CMemoryPool *mp, IMDId *mdid,

--- a/src/backend/gporca/server/include/unittest/gpopt/base/CStateMachineTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/base/CStateMachineTest.h
@@ -64,7 +64,7 @@ public:
 	{
 	private:
 		// shorthand for state machine
-		typedef CStateMachine<EStates, esSentinel, EEvents, eeSentinel> SM;
+		using SM = CStateMachine<EStates, esSentinel, EEvents, eeSentinel>;
 
 		// state machine
 		SM m_sm;

--- a/src/backend/gporca/server/include/unittest/gpopt/csq/CCorrelatedExecutionTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/csq/CCorrelatedExecutionTest.h
@@ -25,7 +25,7 @@
 // forward declarations
 namespace gpdxl
 {
-typedef CDynamicPtrArray<INT, CleanupDelete> IntPtrArray;
+using IntPtrArray = CDynamicPtrArray<INT, CleanupDelete>;
 }
 
 namespace gpopt

--- a/src/backend/gporca/server/include/unittest/gpopt/engine/CEngineTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/engine/CEngineTest.h
@@ -35,7 +35,7 @@ private:
 #ifdef GPOS_DEBUG
 
 	// type definition for of expression generator
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 
 	// helper for testing engine using an array of expression generators
 	static GPOS_RESULT EresTestEngine(Pfpexpr rgpf[], ULONG size);
@@ -50,7 +50,7 @@ private:
 
 public:
 	// type definition of optimizer test function
-	typedef void(FnOptimize)(CMemoryPool *, CExpression *, CSearchStageArray *);
+	using FnOptimize = void(CMemoryPool *, CExpression *, CSearchStageArray *);
 
 	// main driver
 	static GPOS_RESULT EresUnittest();

--- a/src/backend/gporca/server/include/unittest/gpopt/mdcache/CMDAccessorTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/mdcache/CMDAccessorTest.h
@@ -45,7 +45,7 @@ private:
 	static void *PvInitMDAAndLookup(void *pv);
 
 	// cache task function pointer
-	typedef void *(*TaskFuncPtr)(void *);
+	using TaskFuncPtr = void *(*) (void *);
 
 	// structure for passing parameters to task functions
 	struct SMDCacheTaskParams

--- a/src/backend/gporca/server/include/unittest/gpopt/minidump/CICGTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/minidump/CICGTest.h
@@ -32,7 +32,7 @@ class CICGTest
 {
 private:
 	// function pointer type for checking predicates over DXL fragments
-	typedef BOOL(FnDXLOpPredicate)(CDXLOperator *);
+	using FnDXLOpPredicate = BOOL(CDXLOperator *);
 
 	// counter used to mark last successful test
 	static ULONG m_ulTestCounter;

--- a/src/backend/gporca/server/include/unittest/gpopt/operators/CExpressionPreprocessorTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/operators/CExpressionPreprocessorTest.h
@@ -32,8 +32,7 @@ class CExpressionPreprocessorTest
 {
 private:
 	// shorthand for functions for generating the expression for unnest test
-	typedef CExpression *(FnPexprUnnestTestCase)(CMemoryPool *mp,
-												 CExpression *pexpr);
+	using FnPexprUnnestTestCase = CExpression *(CMemoryPool *, CExpression *);
 
 	// unnest scalar subqueries test cases
 	struct SUnnestSubqueriesTestCase

--- a/src/backend/gporca/server/include/unittest/gpopt/search/CSearchStrategyTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/search/CSearchStrategyTest.h
@@ -30,11 +30,11 @@ class CSearchStrategyTest
 {
 private:
 	// type definition for of expression generator
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 
 	// type definition for of optimize function
-	typedef void (*PfnOptimize)(CMemoryPool *, CExpression *,
-								CSearchStageArray *);
+	using PfnOptimize = void (*)(CMemoryPool *, CExpression *,
+								 CSearchStageArray *);
 
 	// generate random search strategy
 	static CSearchStageArray *PdrgpssRandom(CMemoryPool *mp);

--- a/src/backend/gporca/server/include/unittest/gpopt/search/CTreeMapTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/search/CTreeMapTest.h
@@ -29,7 +29,7 @@ class CTreeMapTest
 {
 	// fwd declaration
 	class CNode;
-	typedef CDynamicPtrArray<CNode, CleanupRelease<CNode> > CNodeArray;
+	using CNodeArray = CDynamicPtrArray<CNode, CleanupRelease<CNode>>;
 
 	// struct for resulting trees
 	class CNode : public CRefCount
@@ -64,8 +64,8 @@ private:
 					  BOOL *fTestTrue);
 
 	// shorthand for tests
-	typedef CTreeMap<ULONG, CNode, BOOL, HashValue<ULONG>, Equals<ULONG> >
-		TestMap;
+	using TestMap =
+		CTreeMap<ULONG, CNode, BOOL, HashValue<ULONG>, Equals<ULONG>>;
 
 	// helper to generate loaded the tree map
 	static TestMap *PtmapLoad(CMemoryPool *mp);

--- a/src/backend/gporca/server/src/unittest/dxl/base/CDatumTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/base/CDatumTest.cpp
@@ -78,7 +78,7 @@ CDatumTest::EresUnittest_Basics()
 	CAutoOptCtxt aoc(mp, &mda, nullptr, /* pceeval */
 					 CTestUtils::GetCostModel(mp));
 
-	typedef IDatum *(*Pfpdatum)(CMemoryPool *, BOOL);
+	using Pfpdatum = IDatum *(*) (CMemoryPool *, BOOL);
 
 	Pfpdatum rgpf[] = {
 		CreateInt2Datum, CreateInt4Datum, CreateInt8Datum,

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -234,9 +234,10 @@ CJoinCardinalityTest::EresUnittest_Join()
 			// for this test the col name doesn't matter
 			CWStringConst str(GPOS_WSZ_LIT("col"));
 			// create column references for grouping columns
-			(void) col_factory->PcrCreate(
-				pmdtypeint4, default_type_modifier, nullptr, ul /* attno */,
-				false /*IsNullable*/, id, CName(&str), false /*IsDistCol*/, 0);
+			(void) col_factory->PcrCreate(pmdtypeint4, default_type_modifier,
+										  nullptr, ul /* attno */,
+										  false /*IsNullable*/, id, CName(&str),
+										  false /*IsDistCol*/, false);
 		}
 	}
 	cols->Release();

--- a/src/backend/gporca/server/src/unittest/gpopt/engine/CEngineTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/engine/CEngineTest.cpp
@@ -466,7 +466,7 @@ CEngineTest::EresTestEngine(Pfpexpr rgpf[], ULONG size)
 GPOS_RESULT
 CEngineTest::EresUnittest_BuildMemoWithSubqueries()
 {
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *, BOOL);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *, BOOL);
 	Pfpexpr rgpf[] = {
 		CSubqueryTestUtils::PexprSelectWithAllAggSubquery,
 		CSubqueryTestUtils::PexprSelectWithAggSubquery,

--- a/src/backend/gporca/server/src/unittest/gpopt/operators/CContradictionTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/operators/CContradictionTest.cpp
@@ -67,7 +67,7 @@ CContradictionTest::EresUnittest_Constraint()
 	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
 
 
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 
 	Pfpexpr rgpf[] = {
 		CTestUtils::PexprLogicalApplyWithOuterRef<CLogicalInnerApply>,

--- a/src/backend/gporca/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
@@ -263,7 +263,7 @@ CExpressionPreprocessorTest::EresUnittest_PreProcess()
 	pmdp->AddRef();
 	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
 
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 	Pfpexpr rgpf[] = {
 		CTestUtils::PexprLogicalSelectWithConstAnySubquery,
 		CTestUtils::PexprLogicalSelectWithConstAllSubquery,

--- a/src/backend/gporca/server/src/unittest/gpopt/operators/CExpressionTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/operators/CExpressionTest.cpp
@@ -153,7 +153,7 @@ CExpressionTest::EresUnittest_SimpleOps()
 	pmdp->AddRef();
 	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
 
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 
 	Pfpexpr rgpf[] = {
 		CTestUtils::PexprLogicalGet,

--- a/src/backend/gporca/server/src/unittest/gpopt/xforms/CDecorrelatorTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/xforms/CDecorrelatorTest.cpp
@@ -62,7 +62,7 @@ CDecorrelatorTest::EresUnittest_Decorrelate()
 	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
 
 	// test cases
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 	Pfpexpr rgpf[] = {CTestUtils::PexprLogicalGbAggCorrelated,
 					  CTestUtils::PexprLogicalSelectCorrelated,
 					  CTestUtils::PexprLogicalJoinCorrelated,

--- a/src/backend/gporca/server/src/unittest/gpopt/xforms/CSubqueryHandlerTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/xforms/CSubqueryHandlerTest.cpp
@@ -93,7 +93,7 @@ CSubqueryHandlerTest::EresUnittest_Subquery2Apply()
 	pmdp->AddRef();
 	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
 
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *, BOOL);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *, BOOL);
 	Pfpexpr rgpf[] = {
 		CSubqueryTestUtils::PexprSelectWithAggSubquery,
 		CSubqueryTestUtils::PexprSelectWithAggSubqueryConstComparison,

--- a/src/backend/gporca/server/src/unittest/gpopt/xforms/CXformTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/xforms/CXformTest.cpp
@@ -65,7 +65,7 @@ CXformTest::EresUnittest_ApplyXforms()
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();
 
-	typedef CExpression *(*Pfpexpr)(CMemoryPool *);
+	using Pfpexpr = CExpression *(*) (CMemoryPool *);
 	Pfpexpr rgpf[] = {
 		CTestUtils::PexprLogicalApplyWithOuterRef<CLogicalInnerApply>,
 		CTestUtils::PexprLogicalApply<CLogicalLeftSemiApply>,


### PR DESCRIPTION
Enable a couple clang-tidy checks that I think are both non-controversial.
Also, seems worthwhile to turn on more clang-tidy checks that might help
prevent future subtle bugs

All the diffs were auto generated by clang-tidy and eyeballed by me, except for 
CSyncHashtableAccessorBase.h which I had to fixup myself.