### PR TITLE
Correct the real firstTid in _bitmap_union

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -930,6 +930,17 @@ restart:
 		result->nextTid = words->firstTid;
 
 	/*
+	 * Current words may not contain the expected nextTid, since the
+	 * blockno may skiped several blocks if BitmapAdd choose to skip
+	 * the blockno that can not be matched.
+	 */
+	if (words->firstTid < result->nextTid)
+	{
+		Assert(words->nwords < 1);
+		return false;
+	}
+
+	/*
 	 * If the catch up processd all unmatch words that exceed current block's
 	 * end. Then restart for a new block.
 	 */

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -376,7 +376,7 @@ _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result)
 	/*
 	 * Iterate each word until catch up to the next tid to search.
 	 */
-	for(; result->lastScanWordNo < words->nwords && words->firstTid < result->nextTid;
+	for(; words->nwords > 0 && words->firstTid < result->nextTid;
 		result->lastScanWordNo++)
 	{
 		if (IS_FILL_WORD(words->hwords, result->lastScanWordNo))
@@ -391,7 +391,7 @@ _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result)
 			{
 				fillLength = 1;
 				/* Skip all empty bits, this may cause words->firstTid > result->nextTid */
-				words->firstTid = fillLength * BM_HRL_WORD_SIZE;
+				words->firstTid += fillLength * BM_HRL_WORD_SIZE;
 				words->nwords--;
 
 				/* reset next tid to skip all empty words */
@@ -668,6 +668,15 @@ _bitmap_union(BMBatchWords **batches, uint32 numBatches, BMBatchWords *result)
 
 	/* save batch->startNo for each input bitmap vector */
 	prevstarts = (uint32 *)palloc0(numBatches * sizeof(uint32));
+
+	/*
+	 * Update the real firstTid for the bachwords with unioned batches.
+	 * This is required because we may result->firstTid is set to nextTid
+	 * to fetch in _bitmap_nextbatchwords for bitmap index scan, but the
+	 * read words may not reach this position yet, the below calculation
+	 * will set it back to the real first tid of current result batch.
+	 */
+	result->firstTid = ((batches[0]->nextread - 1) * BM_HRL_WORD_SIZE) + 1;
 
 	/* 
 	 * Compute the next read offset. We fast forward compressed

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -131,6 +131,7 @@
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/datum.h"
+#include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/index_selfuncs.h"
 #include "utils/lsyscache.h"
@@ -7047,6 +7048,16 @@ bmcostestimate(struct PlannerInfo *root,
 
 	*indexStartupCost = costs.indexStartupCost;
 	*indexTotalCost = costs.indexTotalCost;
+	#ifdef FAULT_INJECTOR
+		/* Simulate an bitmapAnd plan by changing bitmap cost. */
+		if (FaultInjector_InjectFaultIfSet("simulate_bitmap_and",
+									DDLNotSpecified,
+									"",
+									"") == FaultInjectorTypeSkip)
+		{
+			*indexTotalCost = 0;
+		}
+	#endif
 	*indexSelectivity = costs.indexSelectivity;
 	*indexCorrelation = costs.indexCorrelation;
 	*indexPages = costs.numIndexPages;

--- a/src/test/isolation2/expected/bitmap_union.out
+++ b/src/test/isolation2/expected/bitmap_union.out
@@ -1,0 +1,69 @@
+--
+-- Test union bitmap batch words for multivalues index scan like where x in (x1, x2) or x > v
+-- which creates BitmapAnd plan on two bitmap indexs that match multiple keys by using in in where clause
+--
+CREATE TABLE bmunion (a int, b int);
+CREATE
+INSERT INTO bmunion SELECT (r%53), (r%59) FROM generate_series(1,70000) r;
+INSERT 70000
+CREATE INDEX i_bmtest2_a ON bmunion USING BITMAP(a);
+CREATE
+CREATE INDEX i_bmtest2_b ON bmunion USING BITMAP(b);
+CREATE
+INSERT INTO bmunion SELECT 53, 1 FROM generate_series(1, 1000);
+INSERT 1000
+
+SET optimizer_enable_tablescan=OFF;
+SET
+SET optimizer_enable_dynamictablescan=OFF;
+SET
+-- Inject fault for planner so that it could produce bitMapAnd plan node.
+SELECT gp_inject_fault('simulate_bitmap_and', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+EXPLAIN (COSTS OFF) SELECT count(*) FROM bmunion WHERE a = 53 AND b < 3;
+ QUERY PLAN                                                     
+----------------------------------------------------------------
+ Finalize Aggregate                                             
+   ->  Gather Motion 3:1  (slice1; segments: 3)                 
+         ->  Partial Aggregate                                  
+               ->  Bitmap Heap Scan on bmunion                  
+                     Recheck Cond: ((b < 3) AND (a = 53))       
+                     ->  BitmapAnd                              
+                           ->  Bitmap Index Scan on i_bmtest2_b 
+                                 Index Cond: (b < 3)            
+                           ->  Bitmap Index Scan on i_bmtest2_a 
+                                 Index Cond: (a = 53)           
+ Optimizer: Postgres query optimizer                            
+(11 rows)
+SELECT gp_inject_fault('simulate_bitmap_and', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('simulate_bitmap_and', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT count(*) FROM bmunion WHERE a = 53 AND b < 3;
+ count 
+-------
+ 1000  
+(1 row)
+SELECT gp_inject_fault('simulate_bitmap_and', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+RESET optimizer_enable_tablescan;
+RESET
+RESET optimizer_enable_dynamictablescan;
+RESET
+
+DROP TABLE bmunion;
+DROP

--- a/src/test/isolation2/expected/bitmap_union_optimizer.out
+++ b/src/test/isolation2/expected/bitmap_union_optimizer.out
@@ -1,0 +1,68 @@
+--
+-- Test union bitmap batch words for multivalues index scan like where x in (x1, x2) or x > v
+-- which creates BitmapAnd plan on two bitmap indexs that match multiple keys by using in in where clause
+--
+CREATE TABLE bmunion (a int, b int);
+CREATE
+INSERT INTO bmunion SELECT (r%53), (r%59) FROM generate_series(1,70000) r;
+INSERT 70000
+CREATE INDEX i_bmtest2_a ON bmunion USING BITMAP(a);
+CREATE
+CREATE INDEX i_bmtest2_b ON bmunion USING BITMAP(b);
+CREATE
+INSERT INTO bmunion SELECT 53, 1 FROM generate_series(1, 1000);
+INSERT 1000
+
+SET optimizer_enable_tablescan=OFF;
+SET
+SET optimizer_enable_dynamictablescan=OFF;
+SET
+-- Inject fault for planner so that it could produce bitMapAnd plan node.
+SELECT gp_inject_fault('simulate_bitmap_and', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+EXPLAIN (COSTS OFF) SELECT count(*) FROM bmunion WHERE a = 53 AND b < 3;
+ QUERY PLAN                                               
+----------------------------------------------------------
+ Aggregate                                                
+   ->  Gather Motion 1:1  (slice1; segments: 1)           
+         ->  Bitmap Heap Scan on bmunion                  
+               Recheck Cond: ((a = 53) AND (b < 3))       
+               ->  BitmapAnd                              
+                     ->  Bitmap Index Scan on i_bmtest2_a 
+                           Index Cond: (a = 53)           
+                     ->  Bitmap Index Scan on i_bmtest2_b 
+                           Index Cond: (b < 3)            
+ Optimizer: Pivotal Optimizer (GPORCA)                    
+(10 rows)
+SELECT gp_inject_fault('simulate_bitmap_and', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('simulate_bitmap_and', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT count(*) FROM bmunion WHERE a = 53 AND b < 3;
+ count 
+-------
+ 1000  
+(1 row)
+SELECT gp_inject_fault('simulate_bitmap_and', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+RESET optimizer_enable_tablescan;
+RESET
+RESET optimizer_enable_dynamictablescan;
+RESET
+
+DROP TABLE bmunion;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -84,6 +84,7 @@ test: ao_upgrade
 test: bitmap_index_concurrent
 test: bitmap_index_crash
 test: bitmap_update_words_backup_block
+test: bitmap_union
 
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table

--- a/src/test/isolation2/sql/bitmap_union.sql
+++ b/src/test/isolation2/sql/bitmap_union.sql
@@ -1,0 +1,27 @@
+--
+-- Test union bitmap batch words for multivalues index scan like where x in (x1, x2) or x > v
+-- which creates BitmapAnd plan on two bitmap indexs that match multiple keys by using in in where clause
+--
+CREATE TABLE bmunion (a int, b int);
+INSERT INTO bmunion
+  SELECT (r%53), (r%59)
+  FROM generate_series(1,70000) r;
+CREATE INDEX i_bmtest2_a ON bmunion USING BITMAP(a);
+CREATE INDEX i_bmtest2_b ON bmunion USING BITMAP(b);
+INSERT INTO bmunion SELECT 53, 1 FROM generate_series(1, 1000);
+
+SET optimizer_enable_tablescan=OFF;
+SET optimizer_enable_dynamictablescan=OFF;
+-- Inject fault for planner so that it could produce bitMapAnd plan node.
+SELECT gp_inject_fault('simulate_bitmap_and', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+EXPLAIN (COSTS OFF) SELECT count(*) FROM bmunion WHERE a = 53 AND b < 3;
+SELECT gp_inject_fault('simulate_bitmap_and', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+SELECT gp_inject_fault('simulate_bitmap_and', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT count(*) FROM bmunion WHERE a = 53 AND b < 3;
+SELECT gp_inject_fault('simulate_bitmap_and', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_dynamictablescan;
+
+DROP TABLE bmunion;


### PR DESCRIPTION
In previous refactor which try to resolve issue:
https://github.com/greenplum-db/gpdb/issues/11308.
We change the way to calculate the firstTid holding in the
current position batch words, since concurrent insert will cause
the wrong tid matching in words_get_match().

To fix that issue in PR https://github.com/greenplum-db/gpdb/pull/11377,
we always get the correct firstTid from the bitmap index page.
But _bitmap_union is not touched. It was responsible to union bitmap
batch words for multivalues index scan like `where x in (x1, x2)` or `x > v`.

And also the logic for the catch up loop is not correct in
_bitmap_catchup_to_next_tid, it should check remain words number.

Co-authored-by: Junfeng Yang <yjerome@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
